### PR TITLE
CODING_CONVENTION.md: migrate to `#pragma once`

### DIFF
--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -311,7 +311,9 @@ is considered as unused. To avoid this, one should add
 
 ## Header Guards
 
-All files are required to have header guards of the form
+All header files are required to either contain the widely supported `#pragma once`
+preprocessor directive as the first line after the [copyright note](#documentation),
+or header guards of the form
 
 ```c
 #ifndef PATH_TO_FILE_FILENAME_H
@@ -320,6 +322,9 @@ All files are required to have header guards of the form
 ...
 #endif /* PATH_TO_FILE_FILENAME_H */
 ```
+
+Header guards are deprecated in RIOT header files and will gradually be converted
+to `#pragma once`.
 
 Rules for generating the guard name:
 


### PR DESCRIPTION
### Contribution description

As discussed in the previous to last VMA and last weekly, let's allow and promote `#pragma once` usage instead of header guards. Also see #21335


### Testing procedure

Read the coding convention.

### Related issues/PRs

#21367 
