### PR TITLE
sys/ztimer: add hint for setting static sleep adjustment

### DIFF
--- a/sys/include/ztimer/config.h
+++ b/sys/include/ztimer/config.h
@@ -176,7 +176,8 @@ extern "C" {
 
 /**
  * @brief   An offset for ZTIMER_USEC allowing to compentsate for the offset
- *          of @ref ztimer_sleep().
+ *          of @ref ztimer_sleep(). It can be measured with @ref
+ *          ztimer_overhead_sleep()
  *
  * @note    As internally @ref ztimer_sleep() uses @ref ztimer_set()
  *          @ref CONFIG_ZTIMER_USEC_ADJUST_SET should be tuned before.


### PR DESCRIPTION

### Contribution description

This patch adds a hint to users for how to set `CONFIG_ZTIMER_USEC_ADJUST_SLEEP`. The doc for `CONFIG_ZTIMER_USEC_ADJUST_SET` already contained a similar hint.


### Testing procedure

no code change

### Issues/PRs references

non known
