### PR TITLE
build-system: Drop -Wno-error=documentation

### DIFF
--- a/boards/common/native/include/board.h
+++ b/boards/common/native/include/board.h
@@ -153,8 +153,6 @@ void _native_LED_RED_TOGGLE(void);
  * @param[in] motor_driver      motor driver to which motor is attached
  * @param[in] motor_id          motor ID on driver
  * @param[in] pwm_duty_cycle    Signed PWM duty_cycle to set motor speed and direction
- *
- * @return                      0 on success
  */
 void native_motor_driver_qdec_simulation( \
     const motor_driver_t motor_driver, uint8_t motor_id, \

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -456,9 +456,9 @@ typedef struct {
  */
 #define HAVE_PWM_MODE_T
 typedef enum {
-    PWM_LEFT = timerModeUp,           /*< use left aligned PWM */
-    PWM_RIGHT = timerModeDown,        /*< use right aligned PWM */
-    PWM_CENTER = timerModeUp          /*< not supported, use left aligned */
+    PWM_LEFT = timerModeUp,           /**< use left aligned PWM */
+    PWM_RIGHT = timerModeDown,        /**< use right aligned PWM */
+    PWM_CENTER = timerModeUp          /**< not supported, use left aligned */
 } pwm_mode_t;
 /** @} */
 #endif /* ndef DOXYGEN */

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -157,7 +157,7 @@ static const struct option long_opts[] = {
 /**
  * @brief   initialize _native_null_in_pipe to allow for reading from stdin
  *
- * @param[in] stdiotype _STDIOTYPE_STDIO to to just initialize pipe, any other
+ * @param[in] stdintype _STDIOTYPE_STDIO to to just initialize pipe, any other
  *                      value to also redirect stdin to that pipe
  */
 void _native_input(_stdiotype_t stdintype)
@@ -251,7 +251,7 @@ void daemonize(void)
 /**
  * Remove any -d options from an argument vector.
  *
- * @param[in][out]  argv    an argument vector
+ * @param[in,out]   argv    an argument vector
  */
 static void filter_daemonize_argv(char **argv)
 {

--- a/cpu/nrf5x_common/include/periph_cpu_common.h
+++ b/cpu/nrf5x_common/include/periph_cpu_common.h
@@ -197,7 +197,7 @@ union gpio_conf_nrf5x {
          * consulted.
          */
         bool initial_value                      : 1;
-        uint8_t                                 : 1; /*< padding */
+        uint8_t                                 : 1; /**< padding */
     };
 };
 /* END: GPIO LL overwrites */

--- a/cpu/stm32/include/periph/cpu_dma.h
+++ b/cpu/stm32/include/periph/cpu_dma.h
@@ -180,7 +180,7 @@ uint16_t dma_suspend(dma_t dma);
  * @brief   Resume a suspended DMA transfer on a stream
  *
  * @param[in] dma         logical DMA stream
- * @param[in] reamaining  the remaining number of transfers to perform
+ * @param[in] remaining   the remaining number of transfers to perform
  */
 void dma_resume(dma_t dma, uint16_t remaining);
 
@@ -260,7 +260,7 @@ void dma_setup_ext(dma_t dma, dma_burst_t pburst, dma_burst_t mburst,
  * @param[in]   dma         Logical DMA stream
  * @param[in]   mem         Memory address
  * @param[in]   len         Number of transfers to perform
- * @param[in]   inc_mem     Increment the memory address (by the transfer width) after read/write
+ * @param[in]   incr_mem    Increment the memory address (by the transfer width) after read/write
  */
 void dma_prepare(dma_t dma, void *mem, size_t len, bool incr_mem);
 

--- a/cpu/stm32/periph/qdec.c
+++ b/cpu/stm32/periph/qdec.c
@@ -39,8 +39,8 @@ static qdec_isr_ctx_t isr_ctx[QDEC_NUMOF];
 /**
  * @brief Read the current value of the given qdec device. Internal use.
  *
- * @param[in] dev           the qdec to read the current value from
- * @param[in] dev           perform a reset of qdec counter if not 0
+ * @param[in] qdec          the qdec to read the current value from
+ * @param[in] reset         perform a reset of qdec counter if not 0
  *
  * @return                  the qdecs current value
  */

--- a/drivers/cc110x/cc110x_chanmaps.c
+++ b/drivers/cc110x/cc110x_chanmaps.c
@@ -23,52 +23,52 @@
 
 const cc110x_chanmap_t cc110x_chanmap_433mhz_300khz = {
     .map =  {
-        0,      /*< base + 0.000MHz = 433.225 MHz (up to 350 kHz wide channel) */
-        7,      /*< base + 0.350MHz = 433.575 MHz (up to 350 kHz wide channel) */
-        14,     /*< base + 0.700MHz = 433.925 MHz (up to 350 kHz wide channel) */
-        21,     /*< base + 1.050MHz = 434.275 MHz (up to 350 kHz wide channel) */
-        28,     /*< base + 1.400MHz = 434.625 MHz (only up to *330* kHz wide) */
-        255,    /*< License free range (433.05 MHz - 434.79 MHz) exhausted :-( */
-        255,    /*< License free range (433.05 MHz - 434.79 MHz) exhausted :-( */
-        255,    /*< License free range (433.05 MHz - 434.79 MHz) exhausted :-( */
+        0,      /**< base + 0.000MHz = 433.225 MHz (up to 350 kHz wide channel) */
+        7,      /**< base + 0.350MHz = 433.575 MHz (up to 350 kHz wide channel) */
+        14,     /**< base + 0.700MHz = 433.925 MHz (up to 350 kHz wide channel) */
+        21,     /**< base + 1.050MHz = 434.275 MHz (up to 350 kHz wide channel) */
+        28,     /**< base + 1.400MHz = 434.625 MHz (only up to *330* kHz wide) */
+        255,    /**< License free range (433.05 MHz - 434.79 MHz) exhausted :-( */
+        255,    /**< License free range (433.05 MHz - 434.79 MHz) exhausted :-( */
+        255,    /**< License free range (433.05 MHz - 434.79 MHz) exhausted :-( */
     }
 };
 
 const cc110x_chanmap_t cc110x_chanmap_433mhz_50khz = {
     .map =  {
-        0,      /*< base + 0.000MHz = 433.100 MHz (LDP433 Channel 2) */
-        4,      /*< base + 0.200MHz = 433.300 MHz (LDP433 Channel 10)*/
-        8,      /*< base + 0.400MHz = 433.500 MHz (LDP433 Channel 18) */
-        12,     /*< base + 0.600MHz = 433.700 MHz (LDP433 Channel 26) */
-        16,     /*< base + 0.800MHz = 433.900 MHz (LDP433 Channel 34) */
-        20,     /*< base + 1.000MHz = 434.100 MHz (LDP433 Channel 42) */
-        24,     /*< base + 1.200MHz = 434.300 MHz (LDP433 Channel 50) */
-        28,     /*< base + 1.400MHz = 434.500 MHz (LDP433 Channel 58) */
+        0,      /**< base + 0.000MHz = 433.100 MHz (LDP433 Channel 2) */
+        4,      /**< base + 0.200MHz = 433.300 MHz (LDP433 Channel 10)*/
+        8,      /**< base + 0.400MHz = 433.500 MHz (LDP433 Channel 18) */
+        12,     /**< base + 0.600MHz = 433.700 MHz (LDP433 Channel 26) */
+        16,     /**< base + 0.800MHz = 433.900 MHz (LDP433 Channel 34) */
+        20,     /**< base + 1.000MHz = 434.100 MHz (LDP433 Channel 42) */
+        24,     /**< base + 1.200MHz = 434.300 MHz (LDP433 Channel 50) */
+        28,     /**< base + 1.400MHz = 434.500 MHz (LDP433 Channel 58) */
     }
 };
 
 const cc110x_chanmap_t cc110x_chanmap_433mhz_50khz_alt = {
     .map =  {
-        2,      /*< base + 0.100MHz = 433.200 MHz (LDP433 Channel 6) */
-        6,      /*< base + 0.300MHz = 433.400 MHz (LDP433 Channel 14)*/
-        10,     /*< base + 0.500MHz = 433.600 MHz (LDP433 Channel 22) */
-        14,     /*< base + 0.700MHz = 433.800 MHz (LDP433 Channel 30) */
-        18,     /*< base + 0.900MHz = 434.000 MHz (LDP433 Channel 38) */
-        22,     /*< base + 1.100MHz = 434.200 MHz (LDP433 Channel 46) */
-        26,     /*< base + 1.300MHz = 434.400 MHz (LDP433 Channel 54) */
-        30,     /*< base + 1.500MHz = 434.600 MHz (LDP433 Channel 62) */
+        2,      /**< base + 0.100MHz = 433.200 MHz (LDP433 Channel 6) */
+        6,      /**< base + 0.300MHz = 433.400 MHz (LDP433 Channel 14)*/
+        10,     /**< base + 0.500MHz = 433.600 MHz (LDP433 Channel 22) */
+        14,     /**< base + 0.700MHz = 433.800 MHz (LDP433 Channel 30) */
+        18,     /**< base + 0.900MHz = 434.000 MHz (LDP433 Channel 38) */
+        22,     /**< base + 1.100MHz = 434.200 MHz (LDP433 Channel 46) */
+        26,     /**< base + 1.300MHz = 434.400 MHz (LDP433 Channel 54) */
+        30,     /**< base + 1.500MHz = 434.600 MHz (LDP433 Channel 62) */
     }
 };
 
 const cc110x_chanmap_t cc110x_chanmap_868mhz_lora = {
     .map =  {
-        0,      /*< base + 0.000MHz = 865.20 MHz = LoRa868 Channel 10 */
-        6,      /*< base + 0.300MHz = 865.50 MHz = LoRa868 Channel 11 */
-        12,     /*< base + 0.600MHz = 865.80 MHz = LoRa868 Channel 12 */
-        18,     /*< base + 0.900MHz = 866.10 MHz = LoRa868 Channel 13 */
-        24,     /*< base + 1.200MHz = 866.40 MHz = LoRa868 Channel 14 */
-        30,     /*< base + 1.500MHz = 866.70 MHz = LoRa868 Channel 15 */
-        36,     /*< base + 1.800MHz = 867.00 MHz = LoRa868 Channel 16 */
-        56,     /*< base + 2.800MHz = 868.00 MHz = LoRa868 Channel 17 */
+        0,      /**< base + 0.000MHz = 865.20 MHz = LoRa868 Channel 10 */
+        6,      /**< base + 0.300MHz = 865.50 MHz = LoRa868 Channel 11 */
+        12,     /**< base + 0.600MHz = 865.80 MHz = LoRa868 Channel 12 */
+        18,     /**< base + 0.900MHz = 866.10 MHz = LoRa868 Channel 13 */
+        24,     /**< base + 1.200MHz = 866.40 MHz = LoRa868 Channel 14 */
+        30,     /**< base + 1.500MHz = 866.70 MHz = LoRa868 Channel 15 */
+        36,     /**< base + 1.800MHz = 867.00 MHz = LoRa868 Channel 16 */
+        56,     /**< base + 2.800MHz = 868.00 MHz = LoRa868 Channel 17 */
     }
 };

--- a/drivers/cc110x/cc110x_netdev.c
+++ b/drivers/cc110x/cc110x_netdev.c
@@ -327,7 +327,7 @@ static int cc110x_init(netdev_t *netdev)
     dev->state = CC110X_STATE_IDLE;
     cc110x_release(dev);
 
-    int retval; /*< Store return value to be able to pass through error code */
+    int retval; /**< Store return value to be able to pass through error code */
     /* Apply configuration (if non-NULL) and channel map, which also calls
      * cc110x_full_calibration
      */

--- a/drivers/cc110x/cc110x_patables.c
+++ b/drivers/cc110x/cc110x_patables.c
@@ -27,41 +27,41 @@
 const cc110x_patable_t cc110x_patable_433mhz = {
     .data =  {
         /* Settings for 433 MHz */
-        0x12,   /*< -30 dBm */
-        0x0E,   /*< -20 dBm */
-        0x1D,   /*< -15 dBm */
-        0x34,   /*< -10 dBm */
-        0x60,   /*<   0 dBm */
-        0x84,   /*<   5 dBm */
-        0xC8,   /*<   7 dBm */
-        0xC0,   /*<  10 dBm */
+        0x12,   /**< -30 dBm */
+        0x0E,   /**< -20 dBm */
+        0x1D,   /**< -15 dBm */
+        0x34,   /**< -10 dBm */
+        0x60,   /**<   0 dBm */
+        0x84,   /**<   5 dBm */
+        0xC8,   /**<   7 dBm */
+        0xC0,   /**<  10 dBm */
     }
 };
 
 const cc110x_patable_t cc110x_patable_868mhz = {
     .data =  {
         /* Settings for 868 MHz */
-        0x03,   /*< -30 dBm */
-        0x0F,   /*< -20 dBm */
-        0x1E,   /*< -15 dBm */
-        0x27,   /*< -10 dBm */
-        0x50,   /*<   0 dBm */
-        0x81,   /*<   5 dBm */
-        0xCB,   /*<   7 dBm */
-        0xC2,   /*<  10 dBm */
+        0x03,   /**< -30 dBm */
+        0x0F,   /**< -20 dBm */
+        0x1E,   /**< -15 dBm */
+        0x27,   /**< -10 dBm */
+        0x50,   /**<   0 dBm */
+        0x81,   /**<   5 dBm */
+        0xCB,   /**<   7 dBm */
+        0xC2,   /**<  10 dBm */
     }
 };
 
 const cc110x_patable_t cc110x_patable_915mhz = {
     .data =  {
         /* Settings for 915 MHz */
-        0x03,   /*< -30 dBm */
-        0x0E,   /*< -20 dBm */
-        0x1E,   /*< -15 dBm */
-        0x27,   /*< -10 dBm */
-        0x8E,   /*<   0 dBm */
-        0xCD,   /*<   5 dBm */
-        0xC7,   /*<   7 dBm */
-        0xC0,   /*<  10 dBm */
+        0x03,   /**< -30 dBm */
+        0x0E,   /**< -20 dBm */
+        0x1E,   /**< -15 dBm */
+        0x27,   /**< -10 dBm */
+        0x8E,   /**<   0 dBm */
+        0xCD,   /**<   5 dBm */
+        0xC7,   /**<   7 dBm */
+        0xC0,   /**<  10 dBm */
     }
 };

--- a/drivers/cc110x/cc110x_settings.c
+++ b/drivers/cc110x/cc110x_settings.c
@@ -61,8 +61,8 @@ const uint8_t cc110x_conf[CC110X_CONF_SIZE] = {
      * SYNC1, SYNC0; defaults: 0xD3, 0x91
      * Use 0xD3,0x91 as sync word
      */
-    0xD3,   /*< SYNC1 */
-    0x91,   /*< SYNC0 */
+    0xD3,   /**< SYNC1 */
+    0x91,   /**< SYNC0 */
     /*
      * PKTLEN; default: 0xFF
      * Packet length in bytes in fixed length mode, else maximum length
@@ -126,9 +126,9 @@ const uint8_t cc110x_conf[CC110X_CONF_SIZE] = {
      * Default is 800.000 MHz, which is not in a license free frequency band.
      * Using LoRa channel 10 instead.
      */
-    0x21,   /*< FREQ2 */
-    0x46,   /*< FREQ1 */
-    0xE4,   /*< FREQ0 */
+    0x21,   /**< FREQ2 */
+    0x46,   /**< FREQ1 */
+    0xE4,   /**< FREQ0 */
     /*
      * MDMCFG4, MDMCFG3; defaults: 0x8C, 0x22
      * 541.67 kHz channel filter bandwidth,
@@ -144,8 +144,8 @@ const uint8_t cc110x_conf[CC110X_CONF_SIZE] = {
      *  - 540 kHz channel filter bandwidth
      *  - 127 kHz deviation
      */
-    0x2D,   /*< MDMCFG4 */
-    0x3B,   /*< MDMCFG3 */
+    0x2D,   /**< MDMCFG4 */
+    0x3B,   /**< MDMCFG3 */
     /*
      * MDMCFG2; default: 0x02
      * DC blocking filter on,
@@ -176,8 +176,8 @@ const uint8_t cc110x_conf[CC110X_CONF_SIZE] = {
      * a resolution of 50kHz - this seems to allow to configure all desired
      * channel layouts.
      */
-    0x20,   /*< MDMCFG1 */
-    0xF8,   /*< MDMCFG0 */
+    0x20,   /**< MDMCFG1 */
+    0xF8,   /**< MDMCFG0 */
     /*
      * DEVIATN; default: 0x47
      * Deviation of frequency to encode data: +- 126.953kHz in 2-FSK/4-FSK/GFSK
@@ -272,9 +272,9 @@ const uint8_t cc110x_conf[CC110X_CONF_SIZE] = {
      * RC oscillator calibration: Enabled
      * WOR_RES: 0 (Relevant for Event0 resolution and maximum timeout)
      */
-    0x87,   /*< WOREVT1 */
-    0x6B,   /*< WOREVT0 */
-    0xF8,   /*< WORCTRL */
+    0x87,   /**< WOREVT1 */
+    0x6B,   /**< WOREVT0 */
+    0xF8,   /**< WORCTRL */
     /*
      * FREND1; default: 0x56
      * LNA_CURRENT: 0b01
@@ -315,16 +315,16 @@ const uint8_t cc110x_conf[CC110X_CONF_SIZE] = {
      * Using "magic" values obtained with SmartRF Studio software for 868 MHz
      * band.
      */
-    0xEA,   /*< FSCAL3: charge pump current calibration, frequency independent */
-    0x2A,   /*< FSCAL2: VCO current calibration, frequency independent */
-    0x00,   /*< FSCAL1: VCO capacitance calibration, frequency dependent */
-    0x1F,   /*< FSCAL0: "Magic number", use SmartRF Studio to obtain */
+    0xEA,   /**< FSCAL3: charge pump current calibration, frequency independent */
+    0x2A,   /**< FSCAL2: VCO current calibration, frequency independent */
+    0x00,   /**< FSCAL1: VCO capacitance calibration, frequency dependent */
+    0x1F,   /**< FSCAL0: "Magic number", use SmartRF Studio to obtain */
     /*
      * RCCTRL1, RCCTRL0; defaults: 0x41, 0x00
      * RC oscillator configuration, no explanation given in data sheet.
      */
-    0x41,   /*< RCCTRL1 */
-    0x00,   /*< RCCTRL0 */
+    0x41,   /**< RCCTRL1 */
+    0x00,   /**< RCCTRL0 */
 };
 
 const uint8_t cc110x_magic_registers[3] = { 0x88, 0x31, 0x09 };

--- a/drivers/hts221/hts221.c
+++ b/drivers/hts221/hts221.c
@@ -39,7 +39,7 @@ static int _set_power(const hts221_t *dev, const bool active);
  * @note This function does not acquire or release the I2C bus, must be done
  *       in calling function!
  *
- * @param[in|out] dev   device descriptor of sensor
+ * @param[in,out] dev   device descriptor of sensor
  *
  * @returns             HTS221_OK on success, or error otherwise
  */
@@ -88,7 +88,7 @@ int _humidity_calibration(hts221_t *dev)
  * @note This function does not acquire or release the I2C bus, must be done
  *       in calling function!
  *
- * @param[in|out] dev   device descriptor of sensor
+ * @param[in,out] dev   device descriptor of sensor
  *
  * @returns             HTS221_OK on success, or error otherwise
  */

--- a/drivers/ina3221/ina3221.c
+++ b/drivers/ina3221/ina3221.c
@@ -54,7 +54,7 @@
  *
  * @return      0, on success
  * @return      -EIO, if i2c bus acquirement failed
- * @return      @see i2c_read_regs
+ * @return      Same as @ref i2c_read_regs
  */
 static int _read_reg(const ina3221_t *dev, uint8_t reg, uint16_t *out)
 {
@@ -80,7 +80,7 @@ static int _read_reg(const ina3221_t *dev, uint8_t reg, uint16_t *out)
  *
  * @return      0, on success
  * @return      -EIO, if i2c bus acquirement failed
- * @return      @see i2c_write_regs
+ * @return      Same as @ref i2c_write_regs
  */
 static int _write_reg(const ina3221_t *dev, uint8_t reg, uint16_t in)
 {

--- a/drivers/include/cc2420.h
+++ b/drivers/include/cc2420.h
@@ -103,9 +103,6 @@ typedef struct {
  * @param[in]  params       device parameters
  * @param[in]  index        index of @p params in a global parameter struct array.
  *                          If initialized manually, pass a unique identifier instead.
- *
- * @return                  0 on success
- * @return                  -1 on error
  */
 void cc2420_setup(cc2420_t *dev, const cc2420_params_t *params, uint8_t index);
 
@@ -159,8 +156,6 @@ void cc2420_set_addr_short(cc2420_t *dev, const uint8_t *addr);
  *
  * @param[in]  dev           device to read from
  * @param[out] addr_long     buffer to save the read address
- *
- * @return                  the currently set (8-byte) long address
  */
 void cc2420_get_addr_long(cc2420_t *dev, uint8_t *addr_long);
 

--- a/drivers/include/ina3221.h
+++ b/drivers/include/ina3221.h
@@ -354,8 +354,8 @@ typedef struct {
  * @return      0, on success
  * @return      -EIO, if I2C bus acquirement failed
  * @return      -ENODEV, if device could not be reset
- * @return      @see i2c_read_regs
- * @return      @see i2c_write_regs
+ * @return      See @ref i2c_read_regs
+ * @return      See @ref i2c_write_regs
  */
 int ina3221_reset(ina3221_t *dev);
 
@@ -371,8 +371,8 @@ int ina3221_reset(ina3221_t *dev);
  * @return      -ENXIO, if manufacturer ID or DIE ID does not match
  * @return      -ENODEV, if reset failed
  * @return      -EINVAL, if configuration could not be applied
- * @return      @see i2c_read_regs
- * @return      @see i2c_write_regs
+ * @return      See @ref i2c_read_regs
+ * @return      See @ref i2c_write_regs
  */
 int ina3221_init(ina3221_t *dev, const ina3221_params_t *params);
 
@@ -672,7 +672,7 @@ static inline void ina3221_config_set_mode(uint16_t *cfg,
  *
  * @return      0, on success
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_write_regs
+ * @return      See @ref i2c_write_regs
  */
 int ina3221_set_config(ina3221_t *dev, uint16_t cfg);
 
@@ -684,7 +684,7 @@ int ina3221_set_config(ina3221_t *dev, uint16_t cfg);
  *
  * @return      0, on success
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_read_regs
+ * @return      See @ref i2c_read_regs
  */
 int ina3221_get_config(const ina3221_t *dev, uint16_t *cfg);
 
@@ -696,8 +696,8 @@ int ina3221_get_config(const ina3221_t *dev, uint16_t *cfg);
  *
  * @return      0, on success
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_read_regs
- * @return      @see i2c_write_regs
+ * @return      See @ref i2c_read_regs
+ * @return      See @ref i2c_write_regs
  */
 int ina3221_set_enable_channel(ina3221_t *dev, ina3221_ch_t ch);
 
@@ -721,8 +721,8 @@ static inline void ina3221_get_enable_channel(const ina3221_t *dev,
  *
  * @return      0, on success
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_read_regs
- * @return      @see i2c_write_regs
+ * @return      See @ref i2c_read_regs
+ * @return      See @ref i2c_write_regs
  */
 int ina3221_set_num_samples(ina3221_t *dev, ina3221_num_samples_t ns);
 
@@ -746,8 +746,8 @@ static inline void ina3221_get_num_samples(const ina3221_t *dev,
  *
  * @return      0, on success
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_read_regs
- * @return      @see i2c_write_regs
+ * @return      See @ref i2c_read_regs
+ * @return      See @ref i2c_write_regs
  */
 int ina3221_set_conv_time_bus_adc(ina3221_t *dev,
                                   ina3221_conv_time_bus_adc_t ctb);
@@ -772,8 +772,8 @@ static inline void ina3221_get_conv_time_bus_adc(const ina3221_t *dev,
  *
  * @return      0, on success
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_read_regs
- * @return      @see i2c_write_regs
+ * @return      See @ref i2c_read_regs
+ * @return      See @ref i2c_write_regs
  */
 int ina3221_set_conv_time_shunt_adc(ina3221_t *dev,
                                     ina3221_conv_time_shunt_adc_t cts);
@@ -798,8 +798,8 @@ static inline void ina3221_get_conv_time_shunt_adc(const ina3221_t *dev,
  *
  * @return      0, on success
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_read_regs
- * @return      @see i2c_write_regs
+ * @return      See @ref i2c_read_regs
+ * @return      See @ref i2c_write_regs
  */
 int ina3221_set_mode(ina3221_t *dev, ina3221_mode_t mode);
 
@@ -825,8 +825,8 @@ static inline void ina3221_get_mode(const ina3221_t *dev, ina3221_mode_t *mode)
  *
  * @return      0, on success
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_read_regs
- * @return      @see i2c_write_regs
+ * @return      See @ref i2c_read_regs
+ * @return      See @ref i2c_write_regs
  */
 int ina3221_set_enable_sum_channel(const ina3221_t *dev, ina3221_ch_t ch);
 
@@ -838,7 +838,7 @@ int ina3221_set_enable_sum_channel(const ina3221_t *dev, ina3221_ch_t ch);
  *
  * @return      0, on success
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_read_regs
+ * @return      See @ref i2c_read_regs
  */
 int ina3221_get_enable_sum_channel(const ina3221_t *dev, ina3221_ch_t *ch);
 
@@ -851,8 +851,8 @@ int ina3221_get_enable_sum_channel(const ina3221_t *dev, ina3221_ch_t *ch);
  *
  * @return      0, on success
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_read_regs
- * @return      @see i2c_write_regs
+ * @return      See @ref i2c_read_regs
+ * @return      See @ref i2c_write_regs
  */
 int ina3221_set_latch(const ina3221_t *dev, bool warn, bool crit);
 
@@ -865,7 +865,7 @@ int ina3221_set_latch(const ina3221_t *dev, bool warn, bool crit);
  *
  * @return      0, on success
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_read_regs
+ * @return      See @ref i2c_read_regs
  */
 int ina3221_get_latch(const ina3221_t *dev, bool *warn, bool *crit);
 
@@ -926,7 +926,7 @@ ina3221_ch_t ina3221_get_warn_alert_limit(const ina3221_t *dev, ina3221_ch_t ch,
  * @return      0, on success
  * @return      -ERANGE, if @p in_uv was not in [INA3221_MIN_SHUNT_SUM_UV; INA3221_MAX_SHUNT_SUM_UV]
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_write_regs
+ * @return      See @ref i2c_write_regs
  */
 int ina3221_set_shunt_voltage_sum_alert_limit(const ina3221_t *dev,
                                               int32_t in_uv);
@@ -939,7 +939,7 @@ int ina3221_set_shunt_voltage_sum_alert_limit(const ina3221_t *dev,
  *
  * @return      0, on success
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_read_regs
+ * @return      See @ref i2c_read_regs
  */
 int ina3221_get_shunt_voltage_sum_alert_limit(const ina3221_t *dev,
                                               int32_t *out_uv);
@@ -953,7 +953,7 @@ int ina3221_get_shunt_voltage_sum_alert_limit(const ina3221_t *dev,
  * @return      0, on success
  * @return      -ERANGE, if @p in_mv was not in [INA3221_MIN_BUS_MV; INA3221_MAX_BUS_MV]
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_write_regs
+ * @return      See @ref i2c_write_regs
  */
 int ina3221_set_power_valid_upper_limit(const ina3221_t *dev, int32_t in_mv);
 
@@ -965,7 +965,7 @@ int ina3221_set_power_valid_upper_limit(const ina3221_t *dev, int32_t in_mv);
  *
  * @return      0, on success
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_read_regs
+ * @return      See @ref i2c_read_regs
  */
 int ina3221_get_power_valid_upper_limit(const ina3221_t *dev, int32_t *out_mv);
 
@@ -978,7 +978,7 @@ int ina3221_get_power_valid_upper_limit(const ina3221_t *dev, int32_t *out_mv);
  * @return      0, on success
  * @return      -ERANGE, if @p in_mv was not in [INA3221_MIN_BUS_MV; INA3221_MAX_BUS_MV]
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_write_regs
+ * @return      See @ref i2c_write_regs
  */
 int ina3221_set_power_valid_lower_limit(const ina3221_t *dev, int32_t in_mv);
 
@@ -990,7 +990,7 @@ int ina3221_set_power_valid_lower_limit(const ina3221_t *dev, int32_t in_mv);
  *
  * @return      0, on success
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_read_regs
+ * @return      See @ref i2c_read_regs
  */
 int ina3221_get_power_valid_lower_limit(const ina3221_t *dev, int32_t *out_mv);
 
@@ -1002,7 +1002,7 @@ int ina3221_get_power_valid_lower_limit(const ina3221_t *dev, int32_t *out_mv);
  *
  * @return      0, on success
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_read_regs
+ * @return      See @ref i2c_read_regs
  */
 int ina3221_read_flags(const ina3221_t *dev, uint16_t *flags);
 
@@ -1015,7 +1015,7 @@ int ina3221_read_flags(const ina3221_t *dev, uint16_t *flags);
  *
  * @return      0, on success
  * @return      -EIO, if I2C bus acquirement failed
- * @return      @see i2c_read_regs
+ * @return      See @ref i2c_read_regs
  */
 int ina3221_read_shunt_sum_uv(const ina3221_t *dev, int32_t *out_uv,
                               uint16_t *flags);

--- a/drivers/include/lc709203f.h
+++ b/drivers/include/lc709203f.h
@@ -141,8 +141,8 @@ typedef struct {
 /**
  * @brief initializes the sensor and i2c
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
- * @param[in] *params   pointer to lc709203f_param_t struct containing the interrupt pin and callback
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] params    pointer to lc709203f_param_t struct containing the interrupt pin and callback
  *
  * @return              LC709203F_OK on a working initialization
  * @return              LC709203F_NOI2C on undefined i2c device given in periph_conf
@@ -152,7 +152,7 @@ int lc709203f_init(lc709203f_t *dev, const lc709203f_params_t *params);
 /**
  * @brief  reads battery voltage from Sensor
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  *
  * @return              voltage in mV
  */
@@ -161,7 +161,7 @@ int16_t lc709203f_get_voltage(const lc709203f_t *dev);
 /**
  * @brief  reads battery state of charge from Sensor
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  *
  * @return              rsoc in %
  */
@@ -170,7 +170,7 @@ int16_t lc709203f_get_rsoc(const lc709203f_t *dev);
 /**
  * @brief  reads battery indicator to empty from Sensor
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  *
  * @return              ite in 0.1%
  */
@@ -179,7 +179,7 @@ int16_t lc709203f_get_ite(const lc709203f_t *dev);
 /**
  * @brief  reads Sensor id
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  *
  * @return              id value
  */
@@ -188,7 +188,7 @@ int16_t lc709203f_get_id(const lc709203f_t *dev);
 /**
  * @brief  reads cell temperature from sensor
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  *
  * @return              temp in 0.1°C steps
  */
@@ -197,7 +197,7 @@ int16_t lc709203f_get_cell_temp(const lc709203f_t *dev);
 /**
  * @brief  reads status bit register (Temperature obtaining mode)
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  *
  * @return              THERMISTOR_MODE Thermistor mode
  * @return              I2C_MODE I2C Mode
@@ -207,7 +207,7 @@ lc709203f_temp_obtaining_mode_t lc709203f_get_status_bit(const lc709203f_t *dev)
 /**
  * @brief  reads IC Power Mode register
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  *
  * @return              OPERATIONAL_MODE Operational Mode
  * @return              SLEEP_MODE Sleep mode
@@ -217,7 +217,7 @@ lc709203f_power_mode_t lc709203f_get_power_mode(const lc709203f_t *dev);
 /**
  * @brief  reads Alarm Low Cell Voltage Register
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  *
  * @return              0 Disable
  * @return              Threshold value in 1mV steps
@@ -227,7 +227,7 @@ int16_t lc709203f_get_alarm_low_voltage(const lc709203f_t *dev);
 /**
  * @brief  reads Alarm Low RSOC Register
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  *
  * @return              0 Disable
  * @return              Threshold value in %
@@ -237,7 +237,7 @@ int16_t lc709203f_get_alarm_low_rsoc(const lc709203f_t *dev);
 /**
  * @brief  reads Change of the Parameter register, Battery Profile selection
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  *
  * @return              Battery profile number (1 or 0)
  */
@@ -247,7 +247,7 @@ int16_t lc709203f_get_change_of_parameter(const lc709203f_t *dev);
  * @brief  reads APT (Adjustment Pack Thermistor)
  * value to adjust temperature measurement delay timing.
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  *
  * @return              value to adjust temperature measurement delay timing.
  */
@@ -257,7 +257,7 @@ int16_t lc709203f_get_apt(const lc709203f_t *dev);
  * @brief  reads APA (Adjustment Pack Application) in 1mOhm steps
  * value to adjust temperature measurement delay timing.
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  *
  * @return              parasitic impedance
  */
@@ -266,7 +266,7 @@ int16_t lc709203f_get_apa(const lc709203f_t *dev);
 /**
  * @brief  reads Current Direction Register
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  *
  * @return              AUTO_MODE Auto mode
  * @return              CHARGE_MODE charge mode
@@ -277,7 +277,7 @@ lc709203f_current_direction_t lc709203f_get_current_direction(const lc709203f_t 
 /**
  * @brief  reads Thermistor-B register (Thermistor B constant to be measured)
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  *
  * @return              B Value in 1K steps
  */
@@ -286,14 +286,14 @@ int16_t lc709203f_get_thermistor_b(const lc709203f_t *dev);
 /**
  * @brief  Executes RSOC initialization with sampled maximum voltage
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  */
 void lc709203f_set_rsoc_before(const lc709203f_t *dev);
 
 /**
  * @brief  Sets B constant of the Thermistor
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  * @param[in] value     Bconstant of thermistor
  */
 void lc709203f_set_thermistor_b(const lc709203f_t *dev, const unsigned int value);
@@ -301,14 +301,14 @@ void lc709203f_set_thermistor_b(const lc709203f_t *dev, const unsigned int value
 /**
  * @brief  Executes RSOC initialization
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  */
 void lc709203f_set_rsoc_initial(const lc709203f_t *dev);
 
 /**
  * @brief  Sets cell temperature in I2C-mode
  *
- * @param[in] *dev		pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev 		pointer to lc709203f_t struct containing the i2c device and the address
  * @param[in] value		temp in 0.1K 0xAAC=0°C
  *
  * @return              LC709203F_CELL_TEMP_INVALID Invalid cell temp
@@ -319,7 +319,7 @@ int8_t lc709203f_set_cell_temp(const lc709203f_t *dev, const unsigned int value)
 /**
  * @brief  Sets current direction
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  * @param[in] direction current direction, AUTO_MODE, CHARGE_MODE, DISCHARGE_MODE
  */
 void lc709203f_set_current_direction(const lc709203f_t *dev, const lc709203f_current_direction_t direction);
@@ -327,7 +327,7 @@ void lc709203f_set_current_direction(const lc709203f_t *dev, const lc709203f_cur
 /**
  * @brief  Sets parasitic impedance (adjustment pack application)
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  * @param[in] value     impedance in 1mOhm steps
  */
 void lc709203f_set_apa(const lc709203f_t *dev, const uint8_t value);
@@ -335,7 +335,7 @@ void lc709203f_set_apa(const lc709203f_t *dev, const uint8_t value);
 /**
  * @brief  Sets value to adjust temperature measurement delay timing (adjusmtent pack thermistor)
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  * @param[in] value     adjustment value
  */
 void lc709203f_set_apt(const lc709203f_t *dev, const unsigned int value);
@@ -343,7 +343,7 @@ void lc709203f_set_apt(const lc709203f_t *dev, const unsigned int value);
 /**
  * @brief  Sets battery profile
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  * @param[in] value     profile (enum) BAT_PROFILE_1 BAT_PROFILE_2
  */
 void lc709203f_set_change_of_parameter(const lc709203f_t *dev, const lc709203f_battery_profile_t value);
@@ -351,7 +351,7 @@ void lc709203f_set_change_of_parameter(const lc709203f_t *dev, const lc709203f_b
 /**
  * @brief  Sets threshold for low rsoc alert
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  * @param[in] value     alert threshold (0-100%)
  */
 void lc709203f_set_alarm_low_rsoc(const lc709203f_t *dev, const uint8_t value);
@@ -359,7 +359,7 @@ void lc709203f_set_alarm_low_rsoc(const lc709203f_t *dev, const uint8_t value);
 /**
  * @brief  Sets threshold for low cell voltage alert
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  * @param[in] value     alert threshold in 1mV steps
  */
 void lc709203f_set_alarm_low_cell_voltage(const lc709203f_t *dev, const unsigned int value);
@@ -367,7 +367,7 @@ void lc709203f_set_alarm_low_cell_voltage(const lc709203f_t *dev, const unsigned
 /**
  * @brief  Sets power mode
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  * @param[in] value     Power mode (enum) OPERATIONAL_MODE, SLEEP_MODE
  */
 void lc709203f_set_power_mode(const lc709203f_t *dev, const lc709203f_power_mode_t value);
@@ -375,7 +375,7 @@ void lc709203f_set_power_mode(const lc709203f_t *dev, const lc709203f_power_mode
 /**
  * @brief  Sets temperature obtaining method
  *
- * @param[in] *dev      pointer to lc709203f_t struct containing the i2c device and the address
+ * @param[in] dev       pointer to lc709203f_t struct containing the i2c device and the address
  * @param[in] value     method to be used (enum) I2C_MODE, THERMISTOR_MODE
  */
 void lc709203f_set_status_bit(const lc709203f_t *dev, const lc709203f_temp_obtaining_mode_t value);

--- a/drivers/include/lm75.h
+++ b/drivers/include/lm75.h
@@ -136,7 +136,7 @@ int lm75_get_temperature(lm75_t *dev, int *temperature);
  * @param[in] temp_os       desired OS temperature in mºC
  * @param[in] temp_hyst     desired HYST temperature in mºC
  * @param[in] cb            callback that is called from interrupt context
- * @param[in] *arg          optional arguments for the gpio_init_int function
+ * @param[in] arg           optional arguments for the gpio_init_int function
  *
  * @return LM75_SUCCESS, on success
  * @return LM75_ERROR_I2C, on I2C related error

--- a/drivers/include/mcp47xx.h
+++ b/drivers/include/mcp47xx.h
@@ -284,8 +284,6 @@ int mcp47xx_dac_init(mcp47xx_t *dev, uint8_t chn);
  * @param[in]   dev     descriptor of the MCP47xx DAC device
  * @param[in]   chn     channel to set
  * @param[in]   value   value to set line to
- *
- * @retval  none
  */
 void mcp47xx_dac_set(mcp47xx_t *dev, uint8_t chn, uint16_t value);
 
@@ -298,8 +296,6 @@ void mcp47xx_dac_set(mcp47xx_t *dev, uint8_t chn, uint16_t value);
  * @param[in]   dev     descriptor of the MCP47xx DAC device
  * @param[in]   chn     channel to set
  * @param[out]  value   value to set line to
- *
- * @retval  none
  */
 void mcp47xx_dac_get(mcp47xx_t *dev, uint8_t chn, uint16_t *value);
 
@@ -310,7 +306,6 @@ void mcp47xx_dac_get(mcp47xx_t *dev, uint8_t chn, uint16_t *value);
  *
  * @param[in]   dev     descriptor of the MCP47xx DAC device
  * @param[in]   chn     channel to power on
- * @retval      none
  */
 void mcp47xx_dac_poweron(mcp47xx_t *dev, uint8_t chn);
 
@@ -326,7 +321,6 @@ void mcp47xx_dac_poweron(mcp47xx_t *dev, uint8_t chn);
  *
  * @param[in]   dev     descriptor of the MCP47xx DAC device
  * @param[in]   chn     channel to power on
- * @retval      none
  */
 void mcp47xx_dac_poweroff(mcp47xx_t *dev, uint8_t chn);
 

--- a/drivers/include/motor_driver.h
+++ b/drivers/include/motor_driver.h
@@ -216,8 +216,6 @@ int motor_brake(const motor_driver_t motor_driver, uint8_t motor_id);
  *
  * @param[in] motor_driver      motor driver to which motor is attached
  * @param[in] motor_id          motor ID on driver
- *
- * @return
  */
 void motor_enable(const motor_driver_t motor_driver, uint8_t motor_id);
 
@@ -226,8 +224,6 @@ void motor_enable(const motor_driver_t motor_driver, uint8_t motor_id);
  *
  * @param[in] motor_driver      motor driver to which motor is attached
  * @param[in] motor_id          motor ID on driver
- *
- * @return
  */
 void motor_disable(const motor_driver_t motor_driver, uint8_t motor_id);
 

--- a/drivers/include/periph/gpio_ll.h
+++ b/drivers/include/periph/gpio_ll.h
@@ -393,7 +393,7 @@ union gpio_conf_minimal {
          * consulted.
          */
         bool initial_value              : 1;
-        uint8_t                         : 2; /*< padding */
+        uint8_t                         : 2; /**< padding */
     };
 };
 

--- a/drivers/include/periph/pwm.h
+++ b/drivers/include/periph/pwm.h
@@ -97,9 +97,9 @@ typedef uint_fast8_t pwm_t;
  */
 #ifndef HAVE_PWM_MODE_T
 typedef enum {
-    PWM_LEFT,           /*< use left aligned PWM */
-    PWM_RIGHT,          /*< use right aligned PWM */
-    PWM_CENTER          /*< use center aligned PWM */
+    PWM_LEFT,           /**< use left aligned PWM */
+    PWM_RIGHT,          /**< use right aligned PWM */
+    PWM_CENTER          /**< use center aligned PWM */
 } pwm_mode_t;
 #endif
 

--- a/drivers/include/ph_oem.h
+++ b/drivers/include/ph_oem.h
@@ -136,10 +136,9 @@ typedef struct ph_oem {
  * @param[in,out]   dev      device descriptor
  * @param[in]       params   device configuration
  *
- * @return @ref PH_OEM_OK on success
- * @return @ref PH_OEM_NODEV if no device is found on the bus
- * @return @ref PH_OEM_NOT_PH if the device found at the address is not a pH OEM device
- * @return
+ * @retval  PH_OEM_OK       on success
+ * @retval  PH_OEM_NODEV    if no device is found on the bus
+ * @retval  PH_OEM_NOT_PH   if the device found at the address is not a pH OEM device
  */
 int ph_oem_init(ph_oem_t *dev, const ph_oem_params_t *params);
 

--- a/drivers/include/sen5x.h
+++ b/drivers/include/sen5x.h
@@ -82,8 +82,8 @@ typedef struct {
 /**
  * @brief   Initialize the given device
  *
- * @param[inout] dev        Device descriptor of the driver
- * @param[in]    params     Initialization parameters
+ * @param[in,out] dev       Device descriptor of the driver
+ * @param[in]     params    Initialization parameters
  *
  * @return 0 on success
  * @return > 0 on error
@@ -93,7 +93,7 @@ int sen5x_init(sen5x_t *dev, const sen5x_params_t *params);
 /**
  * @brief   Execute a reset on the given device
  *
- * @param[inout] dev        Device descriptor of the driver
+ * @param[in,out] dev       Device descriptor of the driver
  *
  * @return 0 on success
  * @return > 0 on error
@@ -103,7 +103,7 @@ int sen5x_reset(const sen5x_t *dev);
 /**
  * @brief   Starts a continuous measurement
  *
- * @param[inout] dev        Device descriptor of the driver
+ * @param[in,out] dev       Device descriptor of the driver
  */
 void sen5x_wake(const sen5x_t *dev);
 
@@ -111,28 +111,28 @@ void sen5x_wake(const sen5x_t *dev);
  * @brief   Starts a continuous measurement without PM. Only humidity,
  *          temperature, VOC and NOx are measured.
  *
- * @param[inout] dev        Device descriptor of the driver
+ * @param[in,out] dev       Device descriptor of the driver
  */
 void sen5x_wake_no_pm(const sen5x_t *dev);
 
 /**
  * @brief   Stops the measurement and returns to idle mode
  *
- * @param[inout] dev        Device descriptor of the driver
+ * @param[in,out] dev       Device descriptor of the driver
  */
 void sen5x_sleep(const sen5x_t *dev);
 
 /**
  * @brief   Sets the fan to maximum speed, to clean it within 10 seconds
  *
- * @param[inout] dev        Device descriptor of the driver
+ * @param[in,out] dev       Device descriptor of the driver
  */
 void sen5x_clean_fan(const sen5x_t *dev);
 
 /**
  * @brief   Sets the fan to maximum speed, to clean it within 10 seconds
  *
- * @param[inout] dev        Device descriptor of the driver
+ * @param[in,out] dev       Device descriptor of the driver
  *
  * @return 0 if no new measurements are available
  * @return 1 if new measuremtns are ready to be read
@@ -142,26 +142,26 @@ bool sen5x_data_ready_flag(const sen5x_t *dev);
 /**
  * @brief   Read measured mass concentration, humidity and temperature values
  *
- * @param[inout] dev        Device descriptor of the driver
- * @param[out]   values     Pointer to wrapper containing all measured values
+ * @param[in,out] dev       Device descriptor of the driver
+ * @param[out]    values    Pointer to wrapper containing all measured values
  */
 void sen5x_read_values(const sen5x_t *dev, sen5x_measurement_t *values);
 
 /**
  * @brief   Read measured particle matter values
  *
- * @param[inout] dev        Device descriptor of the driver
- * @param[out]   values     Pointer to wrapper containing all measured values
+ * @param[in,out] dev       Device descriptor of the driver
+ * @param[out]    values    Pointer to wrapper containing all measured values
  */
 void sen5x_read_pm_values(const sen5x_t *dev, sen5x_measurement_t *values);
 
 /**
  * @brief   Set a custom temperature offset to the ambient temperature
  *
- * @param[inout] dev            Device descriptor of the driver
- * @param[in]    temp_offset    Temperature offset in °C
- * @param[in]    slope          Normalized temperature offset slope
- * @param[in]    time_constant  Time constant in seconds
+ * @param[in,out] dev           Device descriptor of the driver
+ * @param[in]     temp_offset   Temperature offset in °C
+ * @param[in]     slope         Normalized temperature offset slope
+ * @param[in]     time_constant Time constant in seconds
  */
 void sen5x_set_temperature_offset(const sen5x_t *dev, int16_t temp_offset,
                                     int16_t slope, uint16_t time_constant);
@@ -169,7 +169,7 @@ void sen5x_set_temperature_offset(const sen5x_t *dev, int16_t temp_offset,
 /**
  * @brief   Set a custom temperature offset to the ambient temperature
  *
- * @param[inout]  dev            Device descriptor of the driver
+ * @param[in,out] dev            Device descriptor of the driver
  * @param[out]    temp_offset    Temperature offset in °C
  * @param[out]    slope          Normalized temperature offset slope
  * @param[out]    time_constant  Time constant in seconds
@@ -181,8 +181,8 @@ void sen5x_get_temperature_offset(const sen5x_t *dev, int16_t *temp_offset,
  * @brief   Set the parameter for a warm start on the device, to improve initial
  *          accuracy of the ambient temperature output
  *
- * @param[inout] dev            Device descriptor of the driver
- * @param[in]    warm_start     Warm start behavior as a value in the range from
+ * @param[in,out] dev           Device descriptor of the driver
+ * @param[in]     warm_start    Warm start behavior as a value in the range from
  *                              0 (cold start, default) to 65535 (warm start).
  */
 void sen5x_set_warm_start(const sen5x_t *dev, uint16_t warm_start);
@@ -190,8 +190,8 @@ void sen5x_set_warm_start(const sen5x_t *dev, uint16_t warm_start);
 /**
  * @brief   Get the warm start parameter
  *
- * @param[inout] dev            Device descriptor of the driver
- * @param[out]   warm_start     Warm start behavior as a value in the range from
+ * @param[in,out] dev           Device descriptor of the driver
+ * @param[out]    warm_start    Warm start behavior as a value in the range from
  *                              0 (cold start, default) to 65535 (warm start).
  */
 void sen5x_get_warm_start(const sen5x_t *dev, uint16_t *warm_start);
@@ -199,15 +199,15 @@ void sen5x_get_warm_start(const sen5x_t *dev, uint16_t *warm_start);
 /**
  * @brief   Set the parameters for the VOC Algorithm tuning
  *
- * @param[inout] dev                            Device descriptor of the driver
- * @param[in]    index_offset                   VOC index representing typical (average) conditions
- * @param[in]    learning_time_offset_hours     Time constant to estimate the VOC
+ * @param[in,out] dev                           Device descriptor of the driver
+ * @param[in]     index_offset                  VOC index representing typical (average) conditions
+ * @param[in]     learning_time_offset_hours    Time constant to estimate the VOC
  *                                              algorithm offset from the history in hours
- * @param[in]    learning_time_gain_hours       Time constant to estimate the VOC
+ * @param[in]     learning_time_gain_hours      Time constant to estimate the VOC
  *                                              algorithm gain from the history in hours
- * @param[in]    gating_max_duration_minutes    Maximum duration of gating in minutes
- * @param[in]    std_initial                    Initial estimate for standard deviation
- * @param[in]    gain_factor                    Gain factor to amplify or to attenuate
+ * @param[in]     gating_max_duration_minutes   Maximum duration of gating in minutes
+ * @param[in]     std_initial                   Initial estimate for standard deviation
+ * @param[in]     gain_factor                   Gain factor to amplify or to attenuate
  *                                              the VOC index output
  */
 void sen5x_set_voc_algorithm_tuning(
@@ -218,7 +218,7 @@ void sen5x_set_voc_algorithm_tuning(
 /**
  * @brief   Get the VOC Algorithm tuning parameters
  *
- * @param[inout]  dev                            Device descriptor of the driver
+ * @param[in,out] dev                            Device descriptor of the driver
  * @param[out]    index_offset                   VOC index representing typical
  *                                               (average) conditions
  * @param[out]    learning_time_offset_hours     Time constant to estimate the VOC
@@ -238,19 +238,19 @@ void sen5x_get_voc_algorithm_tuning(
 /**
  * @brief   Set the parameters for the NOx Algorithm tuning
  *
- * @param[inout] dev                            Device descriptor of the driver
- * @param[in]    index_offset                   NOx index representing typical (average) conditions
- * @param[in]    learning_time_offset_hours     Time constant to estimate the NOx algorithm offset
+ * @param[in,out] dev                           Device descriptor of the driver
+ * @param[in]     index_offset                  NOx index representing typical (average) conditions
+ * @param[in]     learning_time_offset_hours    Time constant to estimate the NOx algorithm offset
  *                                              from the history in hours
- * @param[in]    learning_time_gain_hours       The time constant to estimate the
+ * @param[in]     learning_time_gain_hours      The time constant to estimate the
  *                                              NOx algorithm gain from the history has no
  *                                              impact for NOx. This parameter is still in place
  *                                              for consistency reasons with the VOC tuning
  *                                              parameters command.
  *                                              This parameter must always be set to 12 hours
- * @param[in]    gating_max_duration_minutes    Maximum duration of gating in minutes
- * @param[in]    std_initial                    Initial estimate for standard deviation
- * @param[in]    gain_factor                    Gain factor to amplify or to attenuate
+ * @param[in]     gating_max_duration_minutes   Maximum duration of gating in minutes
+ * @param[in]     std_initial                   Initial estimate for standard deviation
+ * @param[in]     gain_factor                   Gain factor to amplify or to attenuate
  *                                              the NOx index output
  */
 void sen5x_set_nox_algorithm_tuning(
@@ -261,7 +261,7 @@ void sen5x_set_nox_algorithm_tuning(
 /**
  * @brief   Get the NOx Algorithm tuning parameters
  *
- * @param[inout]  dev                            Device descriptor of the driver
+ * @param[in,out] dev                            Device descriptor of the driver
  * @param[out]    index_offset                   NOx index representing typical(average) conditions
  * @param[out]    learning_time_offset_hours     Time constant to estimate the NOx algorithm
  *                                               offset from the history in hours
@@ -284,8 +284,8 @@ void sen5x_get_nox_algorithm_tuning(
 /**
  * @brief   Set the mode for the RH/T acceleration algorithm
  *
- * @param[inout] dev        Device descriptor of the driver
- * @param[in]    mode       RH/T acceleration mode:
+ * @param[in,out] dev       Device descriptor of the driver
+ * @param[in]     mode      RH/T acceleration mode:
  *                              = 0: Low Acceleration
  *                              = 1: High Acceleration
  *                              = 2: Medium Acceleration
@@ -295,8 +295,8 @@ void sen5x_set_rht_acceleration(const sen5x_t *dev, uint16_t mode);
 /**
  * @brief   Get the mode for the RH/T acceleration algorithm
  *
- * @param[inout] dev        Device descriptor of the driver
- * @param[out]   mode       RH/T acceleration mode:
+ * @param[in,out] dev       Device descriptor of the driver
+ * @param[out]    mode      RH/T acceleration mode:
  *                              = 0: Low Acceleration
  *                              = 1: High Acceleration
  *                              = 2: Medium Acceleration
@@ -306,18 +306,18 @@ void sen5x_get_rht_acceleration(const sen5x_t *dev, uint16_t *mode);
 /**
  * @brief   Get the VOC Algorithm state
  *
- * @param[inout] dev        Device descriptor of the driver
- * @param[in]    state      VOC Algorithm state
- * @param[in]    state_size Size of the VOC Algorithm state
+ * @param[in,out] dev           Device descriptor of the driver
+ * @param[in]     state         VOC Algorithm state
+ * @param[in]     state_size    Size of the VOC Algorithm state
  */
 void sen5x_set_voc_state(const sen5x_t *dev, const uint8_t *state, uint8_t state_size);
 
 /**
  * @brief   Set the VOC Algorithm state
  *
- * @param[inout] dev        Device descriptor of the driver
- * @param[out]   state      VOC Algorithm state
- * @param[in]    state_size Size of the VOC Algorithm state
+ * @param[in,out] dev           Device descriptor of the driver
+ * @param[out]    state         VOC Algorithm state
+ * @param[in]     state_size    Size of the VOC Algorithm state
  */
 void sen5x_get_voc_state(const sen5x_t *dev, uint8_t *state, uint8_t state_size);
 

--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -338,8 +338,6 @@ uint8_t sx127x_get_state(const sx127x_t *dev);
  *
  * @param[in] dev                      The sx127x device descriptor
  * @param[in] state                    The new radio state
- *
- * @return radio state [RF_IDLE, RF_RX_RUNNING, RF_TX_RUNNING]
  */
 void sx127x_set_state(sx127x_t *dev, uint8_t state);
 

--- a/drivers/include/xbee.h
+++ b/drivers/include/xbee.h
@@ -178,10 +178,6 @@ extern const netdev_driver_t xbee_driver;
  *
  * @param[out] dev          Xbee device to initialize
  * @param[in]  params       parameters for device initialization
- *
- * @return                  0 on success
- * @return                  -ENODEV on invalid device descriptor
- * @return                  -ENXIO on invalid UART or GPIO pins
  */
 void xbee_setup(xbee_t *dev, const xbee_params_t *params);
 

--- a/drivers/lis3dh/lis3dh.c
+++ b/drivers/lis3dh/lis3dh.c
@@ -274,7 +274,7 @@ static int lis3dh_write_reg(const lis3dh_t *dev, const uint8_t reg,
 /**
  * @brief Write (both set and clear) bits of an 8-bit register on the LIS3DH.
  *
- * @param[in]  addr         Register address on the LIS3DH.
+ * @param[in]  reg          Register address on the LIS3DH.
  * @param[in]  mask         Bitmask for the bits to modify.
  * @param[in]  values       The values to write to the masked bits.
  *

--- a/drivers/mcp2515/mcp2515.c
+++ b/drivers/mcp2515/mcp2515.c
@@ -75,7 +75,7 @@ static int _mcp2515_enable_irq(candev_mcp2515_t *dev, uint8_t irq);
  * the “ID” or “data” address of any of the three transmit buffers.
  *
  * @param[in]  id           filter identifier in the MCP2515 mailbox
- * @param|out] bytebuf      buffer instruction
+ * @param[out] bytebuf      buffer instruction
  */
 static void _fill_standard_id(uint32_t id, uint8_t *bytebuf);
 
@@ -85,7 +85,7 @@ static void _fill_standard_id(uint32_t id, uint8_t *bytebuf);
  * for more details see _fill_standard_id.
  *
  * @param[in]  id           filter identifier in the MCP2515 mailbox
- * @param|out] bytebuf      buffer instruction
+ * @param[out] bytebuf      buffer instruction
  */
 static void _fill_extended_id(uint32_t id, uint8_t *bytebuf);
 

--- a/drivers/mfrc522/mfrc522.c
+++ b/drivers/mfrc522/mfrc522.c
@@ -152,9 +152,9 @@ static void _device_read_n(mfrc522_t *dev, mfrc522_pcd_register_t reg,
 /**
  * @brief Read single byte from a given register of the device.
  *
- * @param[in] dev     Device descriptor of the MFRC522
- * @param[in] reg     Register to read from
- * @param[in] byte    uint8_t pointer to store the value in
+ * @param[in]   dev       Device descriptor of the MFRC522
+ * @param[in]   reg       Register to read from
+ * @param[in]   value     uint8_t pointer to store the value in
  */
 static void _device_read(mfrc522_t *dev, mfrc522_pcd_register_t reg,
                          uint8_t *value)

--- a/drivers/mtd/mtd.c
+++ b/drivers/mtd/mtd.c
@@ -190,7 +190,7 @@ int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count)
  * @param[in]  data     Pointer to the data to be written
  * @param[in]  sector   Sector to write
  * @param[in]  offset   Byte offset from the start of the sector
- * @param[in]  size     Number of bytes
+ * @param[in]  len      Number of bytes
  *
  * @return bytes written on success
  * @return < 0 value on error

--- a/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
+++ b/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
@@ -265,7 +265,7 @@ static int _init(netdev_t *netdev)
 /**
  * @brief   NRF24L01+ @ref netdev_driver_t::recv routine
  *
- * @pre @see nrf24l01p_ng_acquire must have been called before.
+ * @pre @ref nrf24l01p_ng_acquire must have been called before.
  * @pre Interrupts should be disabled
  *
  * The SPI bus is not acquired in this function because it is called from
@@ -273,10 +273,10 @@ static int _init(netdev_t *netdev)
  * device acquired the SPI bus within the ISR, the ISR would block
  * until that device releases the bus.
  *
- * @param[in] netdev        Abstract network device handle
- * @param[out] buf          Rx buffer
- * @param[in] len           Size of Rx buffer
- * @param[out]              LQI and RSSI information (unused)
+ * @param[in]   netdev      Abstract network device handle
+ * @param[out]  buf         Rx buffer
+ * @param[in]   len         Size of Rx buffer
+ * @param[out]  info        LQI and RSSI information (unused)
  *
  * @return                  Size of received frame in @p buf
  * @return                  Upper estimation of the frame width,

--- a/drivers/sdp3x/sdp3x.c
+++ b/drivers/sdp3x/sdp3x.c
@@ -439,10 +439,11 @@ static void _sdp3x_irq_callback(void *arg)
 #endif
 
 /**
- *      Function to check if the product number set
- *      is the one we get from the sensor
- *      @param  data  data read from the sensor
- *      @return true  if values from sensor were correct
+ * @brief   Function to check if the product number set is the one we get from
+ *          the sensor
+ * @param  readData     data read from the sensor
+ * @retval true         values from sensor are correct
+ * @retval false        values from sensor are incorrect
  */
 static bool _check_product_number(uint8_t *readData)
 {

--- a/drivers/servo/pwm.c
+++ b/drivers/servo/pwm.c
@@ -38,9 +38,9 @@
 /**
  * @brief   Calculate the duty cycle corresponding to the given duration of the
  *          "on duration"
- * @param   pwm_freq        frequency of the PWM peripheral
- * @param   pwm_res         resolution of the PWM peripheral
- * @param   duration        duration of the "on phase" in microseconds
+ * @param   freq            frequency of the PWM peripheral
+ * @param   res             resolution of the PWM peripheral
+ * @param   duration_us     duration of the "on phase" in microseconds
  *
  * @note    Scientific rounding is used
  */

--- a/drivers/sht2x/sht2x.c
+++ b/drivers/sht2x/sht2x.c
@@ -300,7 +300,7 @@ int sht2x_write_userreg(const sht2x_t *dev, uint8_t userreg)
  * @brief       Read a sensor value from the given SHT2X device
  *
  * @param[in]  dev          Device descriptor of SHT2X device to read from
- * @param[in]  cmd          The SHT2x command (hold mode only)
+ * @param[in]  command      The SHT2x command (hold mode only)
  * @param[out] val          The raw sensor value (only valid if no error)
  *
  * @return                  SHT2X_OK value is returned in @p val
@@ -346,7 +346,7 @@ static int read_sensor(const sht2x_t* dev, cmd_t command, uint16_t *val)
  * @brief       Read a sensor value from the given SHT2X device, polling mode
  *
  * @param[in]  dev          Device descriptor of SHT2X device to read from
- * @param[in]  cmd          The SHT2x command (hold mode only)
+ * @param[in]  command      The SHT2x command (hold mode only)
  * @param[out] val          The raw sensor value (only valid if no error)
  *
  * @return                  SHT2X_OK value is returned in @p val

--- a/drivers/sps30/sps30.c
+++ b/drivers/sps30/sps30.c
@@ -129,7 +129,7 @@ static inline bool _cpy_check_crc(uint8_t *data, size_t len, const uint8_t *crcd
  *
  * @param[in]      dev        Pointer to SPS30 device handle
  * @param[in]      ptr_addr   16 bit pointer address used as command
- * @param[in/out]  data       Pre-allocated memory pointing to either the data
+ * @param[in,out]  data       Pre-allocated memory pointing to either the data
  *                            that will be sent to the device or to memory that
  *                            will hold the response. For type (1) transfers
  *                            this parameter will be ignored.

--- a/examples/lang_support/official/riot_and_cpp/c_functions.h
+++ b/examples/lang_support/official/riot_and_cpp/c_functions.h
@@ -38,9 +38,9 @@ int hello(void);
 /**
  * @brief   Get day of week from given date (day, month, year >= 1/1/2000).
  *
- * @param[in]   day
- * @param[in]   month
- * @param[in]   year
+ * @param[in]   day     day of the date
+ * @param[in]   month   month of the date
+ * @param[in]   year    year f the date
  *
  * @return      day of week (0 means Sunday, ... 6 means Saturday)
  */

--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -40,7 +40,7 @@ CFLAGS += -Wstrict-overflow
 # Worse yet they hide errors by accepting wildcard argument types.
 OPTIONAL_CFLAGS += -Wstrict-prototypes
 OPTIONAL_CFLAGS += -Wold-style-definition
-OPTIONAL_CFLAGS += -Wdocumentation -Wno-error=documentation -Wno-documentation-deprecated-sync
+OPTIONAL_CFLAGS += -Wdocumentation -Wno-documentation-deprecated-sync
 
 # Unwanted flags for c++
 CXXUWFLAGS += -std=%

--- a/pkg/ccn-lite/Makefile.include
+++ b/pkg/ccn-lite/Makefile.include
@@ -1,7 +1,8 @@
-INCLUDES += -I$(PKGDIRBASE)/ccn-lite/src/ccnl-riot/include
-INCLUDES += -I$(PKGDIRBASE)/ccn-lite/src/ccnl-core/include
-INCLUDES += -I$(PKGDIRBASE)/ccn-lite/src/ccnl-pkt/include
-INCLUDES += -I$(PKGDIRBASE)/ccn-lite/src/ccnl-fwd/include
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/ccn-lite/src/ccnl-riot/include
+INCLUDES += -isystem$(PKGDIRBASE)/ccn-lite/src/ccnl-core/include
+INCLUDES += -isystem$(PKGDIRBASE)/ccn-lite/src/ccnl-pkt/include
+INCLUDES += -isystem$(PKGDIRBASE)/ccn-lite/src/ccnl-fwd/include
 
 CFLAGS += -DCCNL_RIOT
 ARCHIVES += $(BINDIR)/ccn-lite.a

--- a/pkg/cmsis/Makefile.include
+++ b/pkg/cmsis/Makefile.include
@@ -1,14 +1,15 @@
-INCLUDES += -I$(PKGDIRBASE)/cmsis/CMSIS/Core/Include
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/cmsis/CMSIS/Core/Include
 
 ifneq (,$(filter cmsis-dsp,$(USEMODULE)))
-  INCLUDES += -I$(PKGDIRBASE)/cmsis/CMSIS/DSP/Include
-  INCLUDES += -I$(PKGDIRBASE)/cmsis/CMSIS/DSP/PrivateInclude
+  INCLUDES += -isystem$(PKGDIRBASE)/cmsis/CMSIS/DSP/Include
+  INCLUDES += -isystem$(PKGDIRBASE)/cmsis/CMSIS/DSP/PrivateInclude
   CFLAGS += -DARM_CPU="cortex-m4"
 endif
 
 ifneq (,$(filter cmsis-nn,$(USEMODULE)))
-  INCLUDES += -I$(PKGDIRBASE)/cmsis/CMSIS/DSP/Include
-  INCLUDES += -I$(PKGDIRBASE)/cmsis/CMSIS/NN/Include
+  INCLUDES += -isystem$(PKGDIRBASE)/cmsis/CMSIS/DSP/Include
+  INCLUDES += -isystem$(PKGDIRBASE)/cmsis/CMSIS/NN/Include
   # Required for some basic math functions
   CFLAGS += -Wno-sign-compare
 endif

--- a/pkg/cn-cbor/Makefile.include
+++ b/pkg/cn-cbor/Makefile.include
@@ -1,4 +1,5 @@
-INCLUDES += -I$(PKGDIRBASE)/cn-cbor/include
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/cn-cbor/include
 
 #enable context pointer
 CFLAGS += -DUSE_CBOR_CONTEXT

--- a/pkg/cryptoauthlib/Makefile.include
+++ b/pkg/cryptoauthlib/Makefile.include
@@ -1,30 +1,31 @@
 PKG_SOURCE_DIR ?= $(PKGDIRBASE)/cryptoauthlib
 PKG_TESTINCLDIR = $(PKG_SOURCE_DIR)/test
 
-INCLUDES += -I$(PKG_SOURCE_DIR)
-INCLUDES += -I$(PKG_SOURCE_DIR)/lib
-INCLUDES += -I$(PKG_SOURCE_DIR)/app
-INCLUDES += -I$(PKG_SOURCE_DIR)/lib/calib
-INCLUDES += -I$(RIOTPKG)/cryptoauthlib/include
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKG_SOURCE_DIR)
+INCLUDES += -isystem$(PKG_SOURCE_DIR)/lib
+INCLUDES += -isystem$(PKG_SOURCE_DIR)/app
+INCLUDES += -isystem$(PKG_SOURCE_DIR)/lib/calib
+INCLUDES += -isystem$(RIOTPKG)/cryptoauthlib/include
 
 ifneq (,$(filter psa_crypto, $(USEMODULE)))
   DIRS += $(RIOTPKG)/cryptoauthlib/psa_atca_driver
-  INCLUDES += -I$(RIOTBASE)/sys/psa_crypto/include
+  INCLUDES += -isystem$(RIOTBASE)/sys/psa_crypto/include
 endif
 
 DIRS += $(RIOTPKG)/cryptoauthlib/contrib
 ARCHIVES += $(BINDIR)/cryptoauthlib.a
 
 ifneq (,$(filter cryptoauthlib_test,$(USEMODULE)))
-  INCLUDES += -I$(PKG_TESTINCLDIR)
-  INCLUDES += -I$(PKG_TESTINCLDIR)/jwt
-  INCLUDES += -I$(PKG_TESTINCLDIR)/tng
-  INCLUDES += -I$(PKG_TESTINCLDIR)/atcacert
-  INCLUDES += -I$(PKG_TESTINCLDIR)/api_atcab
-  INCLUDES += -I$(PKG_TESTINCLDIR)/api_calib
-  INCLUDES += -I$(PKG_TESTINCLDIR)/api_crypto
-  INCLUDES += -I$(PKG_TESTINCLDIR)/vectors
-  INCLUDES += -I$(PKG_SOURCE_DIR)/third_party/unity
+  INCLUDES += -isystem$(PKG_TESTINCLDIR)
+  INCLUDES += -isystem$(PKG_TESTINCLDIR)/jwt
+  INCLUDES += -isystem$(PKG_TESTINCLDIR)/tng
+  INCLUDES += -isystem$(PKG_TESTINCLDIR)/atcacert
+  INCLUDES += -isystem$(PKG_TESTINCLDIR)/api_atcab
+  INCLUDES += -isystem$(PKG_TESTINCLDIR)/api_calib
+  INCLUDES += -isystem$(PKG_TESTINCLDIR)/api_crypto
+  INCLUDES += -isystem$(PKG_TESTINCLDIR)/vectors
+  INCLUDES += -isystem$(PKG_SOURCE_DIR)/third_party/unity
 endif
 
 PSEUDOMODULES += psa_secure_element_ateccx08a

--- a/pkg/cryptoauthlib/psa_atca_driver/psa_atca_se_driver.c
+++ b/pkg/cryptoauthlib/psa_atca_driver/psa_atca_se_driver.c
@@ -82,10 +82,6 @@
 
 /**
  * @brief   Convert ATCA status values to PSA errors
- *
- * @param   error
- *
- * @return  @ref psa_status_t
  */
 static psa_status_t atca_to_psa_error(ATCA_STATUS error)
 {
@@ -172,10 +168,6 @@ const char *atca_status_to_humanly_readable(ATCA_STATUS status)
 /* Secure Element Cipher Functions */
 /**
  * @brief   Set up a driver specific AES CBC mode operation
- *
- * @param   ctx
- * @param   dev
- * @param   key_slot
  */
 static void atca_cbc_setup(atca_aes_cbc_ctx_t *ctx,
                            ATCADevice dev,

--- a/pkg/driver_atwinc15x0/Makefile.include
+++ b/pkg/driver_atwinc15x0/Makefile.include
@@ -1,1 +1,2 @@
-INCLUDES += -I$(PKGDIRBASE)/driver_atwinc15x0/src
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/driver_atwinc15x0/src

--- a/pkg/driver_bme680/Makefile.include
+++ b/pkg/driver_bme680/Makefile.include
@@ -1,4 +1,5 @@
-INCLUDES += -I$(PKGDIRBASE)/driver_bme680
-INCLUDES += -I$(RIOTPKG)/driver_bme680/include
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/driver_bme680
+INCLUDES += -isystem$(RIOTPKG)/driver_bme680/include
 
 DIRS += $(RIOTPKG)/driver_bme680/contrib

--- a/pkg/driver_cryptocell_310/Makefile.include
+++ b/pkg/driver_cryptocell_310/Makefile.include
@@ -1,5 +1,6 @@
-INCLUDES += -I$(PKGDIRBASE)/driver_cryptocell_310/include
-INCLUDES += -I$(RIOTPKG)/driver_cryptocell_310/include
+# using -isystem instead of -I to avoid warnings on the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/driver_cryptocell_310/include
+INCLUDES += -isystem$(RIOTPKG)/driver_cryptocell_310/include
 DIRS += $(RIOTPKG)/driver_cryptocell_310/contrib
 
 ARCHIVES += $(PKGDIRBASE)/driver_cryptocell_310/libnrf_cc310_0.9.13.a

--- a/pkg/driver_sen5x/Makefile.include
+++ b/pkg/driver_sen5x/Makefile.include
@@ -1,1 +1,2 @@
-INCLUDES += -I$(PKGDIRBASE)/driver_sen5x
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/driver_sen5x

--- a/pkg/driver_sx126x/Makefile.include
+++ b/pkg/driver_sx126x/Makefile.include
@@ -1,3 +1,4 @@
-INCLUDES += -I$(PKGDIRBASE)/driver_sx126x/src
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/driver_sx126x/src
 
 DIRS += $(RIOTBASE)/pkg/driver_sx126x/contrib

--- a/pkg/edhoc-c/Makefile.include
+++ b/pkg/edhoc-c/Makefile.include
@@ -1,6 +1,7 @@
-INCLUDES += -I$(PKGDIRBASE)/EDHOC-C/include \
-            -I$(PKGDIRBASE)/EDHOC-C/src \
-            -I$(RIOTBASE)/pkg/edhoc-c/include \
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/EDHOC-C/include \
+            -isystem$(PKGDIRBASE)/EDHOC-C/src \
+            -isystem$(RIOTBASE)/pkg/edhoc-c/include \
             #
 
 ifneq (,$(filter edhoc-c_crypto_wolfssl,$(USEMODULE)))

--- a/pkg/etl/Makefile.include
+++ b/pkg/etl/Makefile.include
@@ -1,5 +1,15 @@
-INCLUDES += -I$(PKGDIRBASE)/etl/include
-INCLUDES += -I$(RIOTPKG)/etl/config
+# Hack: On LLVM, use `-isystem` instead of -I to ignore warnings about the
+#       package's headers. On g++ (at least the AVR variant), `-system` is C
+#       only. But luckily, g++ does not emit the warnings we need to ignore
+#       anyway.
+
+ifeq (llvm,$(TOOLCHAIN))
+  INCLUDES += -isystem$(PKGDIRBASE)/etl/include
+  INCLUDES += -isystem$(RIOTPKG)/etl/config
+else
+  INCLUDES += -I$(PKGDIRBASE)/etl/include
+  INCLUDES += -I$(RIOTPKG)/etl/config
+endif
 
 # There's nothing to build in this package, it's used as a header only library.
 # So it's declared as a pseudo-module

--- a/pkg/gecko_sdk/Makefile.include
+++ b/pkg/gecko_sdk/Makefile.include
@@ -1,16 +1,17 @@
-INCLUDES += -I$(PKGDIRBASE)/gecko_sdk/dist/common/inc
-INCLUDES += -I$(PKGDIRBASE)/gecko_sdk/dist/emlib/inc
-INCLUDES += -I$(PKGDIRBASE)/gecko_sdk/dist/emlib-extra/inc
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/gecko_sdk/dist/common/inc
+INCLUDES += -isystem$(PKGDIRBASE)/gecko_sdk/dist/emlib/inc
+INCLUDES += -isystem$(PKGDIRBASE)/gecko_sdk/dist/emlib-extra/inc
 
 ifneq (,$(filter gecko_sdk_librail,$(USEMODULE)))
   ARCHIVES += $(BINDIR)/gecko_sdk_librail.a
-  INCLUDES += -I$(PKGDIRBASE)/gecko_sdk/dist/radio/rail_lib/common
-  INCLUDES += -I$(PKGDIRBASE)/gecko_sdk/dist/radio/rail_lib/chip/efr32/$(EFM32_LIBRAIL_HEADER_NAME)
+  INCLUDES += -isystem$(PKGDIRBASE)/gecko_sdk/dist/radio/rail_lib/common
+  INCLUDES += -isystem$(PKGDIRBASE)/gecko_sdk/dist/radio/rail_lib/chip/efr32/$(EFM32_LIBRAIL_HEADER_NAME)
 endif
 
 ifneq (,$(filter gecko_sdk_librail_pa,$(USEMODULE)))
-  INCLUDES += -I$(PKGDIRBASE)/gecko_sdk/dist/radio/rail_lib/plugin/pa-conversions
-  INCLUDES += -I$(PKGDIRBASE)/gecko_sdk/dist/radio/rail_lib/plugin/pa-conversions/$(EFM32_LIBRAIL_PA_HEADER_NAME)/config
+  INCLUDES += -isystem$(PKGDIRBASE)/gecko_sdk/dist/radio/rail_lib/plugin/pa-conversions
+  INCLUDES += -isystem$(PKGDIRBASE)/gecko_sdk/dist/radio/rail_lib/plugin/pa-conversions/$(EFM32_LIBRAIL_PA_HEADER_NAME)/config
 endif
 
 ifeq ($(CPU_CORE),cortex-m33)

--- a/pkg/libcose/Makefile.include
+++ b/pkg/libcose/Makefile.include
@@ -1,5 +1,6 @@
-INCLUDES += -I$(PKGDIRBASE)/libcose/include \
-            -I$(RIOTBASE)/pkg/libcose/include \
+# using -isystem to avoid warnings about these headers
+INCLUDES += -isystem$(PKGDIRBASE)/libcose/include \
+            -isystem$(RIOTBASE)/pkg/libcose/include \
             #
 
 CFLAGS += -DUSE_CBOR_CONTEXT

--- a/pkg/lorabasics/Makefile.include
+++ b/pkg/lorabasics/Makefile.include
@@ -1,4 +1,5 @@
-INCLUDES += -I$(PKGDIRBASE)/lorabasicsmodem \
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/lorabasicsmodem \
             #
 
 ifneq (,$(filter lorabasics_driver_sx1280_hal,$(USEMODULE)))

--- a/pkg/lua/Makefile.include
+++ b/pkg/lua/Makefile.include
@@ -1,3 +1,4 @@
-INCLUDES += -I$(PKGDIRBASE)/lua
-INCLUDES += -I$(RIOTPKG)/lua/include
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/lua
+INCLUDES += -isystem$(RIOTPKG)/lua/include
 DIRS += $(RIOTPKG)/lua/contrib

--- a/pkg/lua/include/lua_run.h
+++ b/pkg/lua/include/lua_run.h
@@ -182,14 +182,14 @@ LUALIB_API int lua_riot_openlibs(lua_State *L, uint16_t modmask);
  * or to manually reset the heap (only if there's no other thread using it).
  *
  * @param       modname     name of the module.
- * @param       memory      @see lua_riot_newstate()
- * @param       mem_size    @see lua_riot_newstate()
- * @param       modmask     @see lua_riot_newstate()
+ * @param       memory      See @ref lua_riot_newstate()
+ * @param       mem_size    See @ref lua_riot_newstate()
+ * @param       modmask     See @ref lua_riot_newstate()
  * @param[out]  retval      Value returned by the lua code, if it is a number,
  *                          or zero if no value is returned or the value is not
  *                          a number. If retval is null, the value is not stored.
  *
- * @return      An error code ( @see LUAR_ERRORS). LUAR_EXIT indicates no error.
+ * @return      An error code ( See @ref LUAR_ERRORS). LUAR_EXIT indicates no error.
  */
 LUALIB_API int lua_riot_do_module(const char *modname, void *memory, size_t mem_size,
                                   uint16_t modmask, int *retval);
@@ -200,16 +200,16 @@ LUALIB_API int lua_riot_do_module(const char *modname, void *memory, size_t mem_
  * Only text data (i.e. lua source code) can be loaded by this function. The
  * lua interpreter is not robust against corrupt binary code.
  *
- * @see lua_riot_do_module() for more information on internal errors.
+ * See @ref lua_riot_do_module() for more information on internal errors.
  *
  * @param       buf     Text data (lua source code).
  * @param       buflen  Size of the text data in bytes. If buf is
  *                      a zero-terminated string, the zero must not be counted.
- * @param       memory      @see lua_riot_newstate()
- * @param       mem_size    @see lua_riot_newstate()
- * @param       modmask     @see lua_riot_newstate()
- * @param[out]  retval      @see lua_riot_do_module()
- * @return      @see lua_riot_do_module().
+ * @param       memory      See @ref lua_riot_newstate()
+ * @param       mem_size    See @ref lua_riot_newstate()
+ * @param       modmask     See @ref lua_riot_newstate()
+ * @param[out]  retval      See @ref lua_riot_do_module()
+ * @return      See @ref lua_riot_do_module().
  */
 LUALIB_API int lua_riot_do_buffer(const uint8_t *buf, size_t buflen, void *memory,
                                   size_t mem_size, uint16_t modmask, int *retval);

--- a/pkg/lv_drivers/Makefile.include
+++ b/pkg/lv_drivers/Makefile.include
@@ -1,5 +1,6 @@
-INCLUDES += -I$(PKGDIRBASE)/lv_drivers \
-            -I$(RIOTBASE)/pkg/lv_drivers/include \
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/lv_drivers \
+            -isystem$(RIOTBASE)/pkg/lv_drivers/include \
             #
 
 # Don't use relative includes in lv_drivers, already set in LVGL package

--- a/pkg/lvgl/Makefile.include
+++ b/pkg/lvgl/Makefile.include
@@ -1,5 +1,6 @@
-INCLUDES += -I$(RIOTBASE)/pkg/lvgl/include
-INCLUDES += -I$(PKGDIRBASE)
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(RIOTBASE)/pkg/lvgl/include
+INCLUDES += -isystem$(PKGDIRBASE)
 
 # Don't use relative includes in lvgl
 CFLAGS += -DLV_CONF_INCLUDE_SIMPLE

--- a/pkg/mynewt-core/Makefile.include
+++ b/pkg/mynewt-core/Makefile.include
@@ -1,8 +1,9 @@
-INCLUDES += -I$(RIOTPKG)/mynewt-core/include \
-            -I$(PKGDIRBASE)/mynewt-core/kernel/os/include \
-            -I$(PKGDIRBASE)/mynewt-core/hw/hal/include \
-            -I$(PKGDIRBASE)/mynewt-core/util/mem/include \
-            -I$(PKGDIRBASE)/mynewt-core/sys/stats/stub/include \
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(RIOTPKG)/mynewt-core/include \
+            -isystem$(PKGDIRBASE)/mynewt-core/kernel/os/include \
+            -isystem$(PKGDIRBASE)/mynewt-core/hw/hal/include \
+            -isystem$(PKGDIRBASE)/mynewt-core/util/mem/include \
+            -isystem$(PKGDIRBASE)/mynewt-core/sys/stats/stub/include \
             #
 
 DIRS += $(RIOTPKG)/mynewt-core/contrib \

--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -1,7 +1,8 @@
-NIMIBASE = -I$(PKGDIRBASE)/nimble
+# Using -isystem instead of -I to prevent warnings for the following headers
+NIMIBASE = -isystem$(PKGDIRBASE)/nimble
 
 # include RIOT glue code headers
-INCLUDES += -I$(RIOTPKG)/nimble/contrib/include
+INCLUDES += -isystem$(RIOTPKG)/nimble/contrib/include
 
 # include generic nimble headers
 INCLUDES += $(NIMIBASE)/nimble/include
@@ -11,7 +12,7 @@ ifneq (,$(filter nimble_npl_riot,$(USEMODULE)))
   INCLUDES += $(NIMIBASE)/porting/npl/riot/include
 else
   INCLUDES += $(NIMIBASE)/porting/npl/riot/include/npl_syscfg
-  INCLUDES += -I$(RIOTPKG)/nimble/npl/include
+  INCLUDES += -isystem$(RIOTPKG)/nimble/npl/include
 endif
 INCLUDES += $(NIMIBASE)/porting/nimble/include
 
@@ -85,16 +86,16 @@ endif
 
 # include additional headers for RIOT specific NimBLE submodules
 ifneq (,$(filter nimble_addr,$(USEMODULE)))
-  INCLUDES += -I$(RIOTPKG)/nimble/addr/include
+  INCLUDES += -isystem$(RIOTPKG)/nimble/addr/include
 endif
 
 ifneq (,$(filter nimble_autoadv,$(USEMODULE)))
-  INCLUDES += -I$(RIOTPKG)/nimble/autoadv/include
+  INCLUDES += -isystem$(RIOTPKG)/nimble/autoadv/include
   DIRS += $(RIOTPKG)/nimble/autoadv
 endif
 
 ifneq (,$(filter nimble_autoconn,$(USEMODULE)))
-  INCLUDES += -I$(RIOTPKG)/nimble/autoconn/include
+  INCLUDES += -isystem$(RIOTPKG)/nimble/autoconn/include
 endif
 
 ifneq (,$(filter nimble_adv_ext,$(USEMODULE)))
@@ -124,7 +125,7 @@ else
 endif
 
 ifneq (,$(filter nimble_netif,$(USEMODULE)))
-  INCLUDES += -I$(RIOTPKG)/nimble/netif/include
+  INCLUDES += -isystem$(RIOTPKG)/nimble/netif/include
 
   # configure NimBLE's internals
   NIMBLE_MAX_CONN ?= 3
@@ -166,17 +167,17 @@ else
 endif
 
 ifneq (,$(filter nimble_rpble,$(USEMODULE)))
-  INCLUDES += -I$(RIOTPKG)/nimble/rpble/include
+  INCLUDES += -isystem$(RIOTPKG)/nimble/rpble/include
 endif
 
 ifneq (,$(filter nimble_scanlist,$(USEMODULE)))
-  INCLUDES += -I$(RIOTPKG)/nimble/scanlist/include
+  INCLUDES += -isystem$(RIOTPKG)/nimble/scanlist/include
 endif
 
 ifneq (,$(filter nimble_scanner,$(USEMODULE)))
-  INCLUDES += -I$(RIOTPKG)/nimble/scanner/include
+  INCLUDES += -isystem$(RIOTPKG)/nimble/scanner/include
 endif
 
 ifneq (,$(filter nimble_statconn,$(USEMODULE)))
-  INCLUDES += -I$(RIOTPKG)/nimble/statconn/include
+  INCLUDES += -isystem$(RIOTPKG)/nimble/statconn/include
 endif

--- a/pkg/opendsme/Makefile.include
+++ b/pkg/opendsme/Makefile.include
@@ -1,4 +1,5 @@
-INCLUDES += -I$(PKGDIRBASE)/opendsme
-INCLUDES += -I$(RIOTBASE)/pkg/opendsme/include
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/opendsme
+INCLUDES += -isystem$(RIOTBASE)/pkg/opendsme/include
 
 DIRS += $(RIOTBASE)/pkg/opendsme/contrib

--- a/pkg/openwsn/Makefile.include
+++ b/pkg/openwsn/Makefile.include
@@ -15,32 +15,33 @@ PSEUDOMODULES += openwsn_serial \
 
 DIRS += $(RIOTBASE)/pkg/openwsn/contrib
 
-INCLUDES += -I$(PKGDIRBASE)/openwsn \
-            -I$(PKGDIRBASE)/openwsn/kernel \
-            -I$(PKGDIRBASE)/openwsn/inc \
-            -I$(PKGDIRBASE)/openwsn/drivers/common \
-            -I$(PKGDIRBASE)/openwsn/drivers/common/crypto \
-            -I$(PKGDIRBASE)/openwsn/bsp/boards/ \
-            -I$(PKGDIRBASE)/openwsn/openstack/ \
-            -I$(PKGDIRBASE)/openwsn/openstack/02a-MAClow \
-            -I$(PKGDIRBASE)/openwsn/openstack/02b-MAChigh \
-            -I$(PKGDIRBASE)/openwsn/openstack/03a-IPHC \
-            -I$(PKGDIRBASE)/openwsn/openstack/03b-IPv6 \
-            -I$(PKGDIRBASE)/openwsn/openstack/04-TRAN \
-            -I$(PKGDIRBASE)/openwsn/openstack/cross-layers \
-            -I$(PKGDIRBASE)/openwsn/openapps \
-            -I$(PKGDIRBASE)/openwsn/openapps/cjoin \
-            -I$(PKGDIRBASE)/openwsn/openweb \
-            -I$(PKGDIRBASE)/openwsn/openweb/opencoap \
-            -I$(RIOTBASE)/pkg/openwsn/include \
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/openwsn \
+            -isystem$(PKGDIRBASE)/openwsn/kernel \
+            -isystem$(PKGDIRBASE)/openwsn/inc \
+            -isystem$(PKGDIRBASE)/openwsn/drivers/common \
+            -isystem$(PKGDIRBASE)/openwsn/drivers/common/crypto \
+            -isystem$(PKGDIRBASE)/openwsn/bsp/boards/ \
+            -isystem$(PKGDIRBASE)/openwsn/openstack/ \
+            -isystem$(PKGDIRBASE)/openwsn/openstack/02a-MAClow \
+            -isystem$(PKGDIRBASE)/openwsn/openstack/02b-MAChigh \
+            -isystem$(PKGDIRBASE)/openwsn/openstack/03a-IPHC \
+            -isystem$(PKGDIRBASE)/openwsn/openstack/03b-IPv6 \
+            -isystem$(PKGDIRBASE)/openwsn/openstack/04-TRAN \
+            -isystem$(PKGDIRBASE)/openwsn/openstack/cross-layers \
+            -isystem$(PKGDIRBASE)/openwsn/openapps \
+            -isystem$(PKGDIRBASE)/openwsn/openapps/cjoin \
+            -isystem$(PKGDIRBASE)/openwsn/openweb \
+            -isystem$(PKGDIRBASE)/openwsn/openweb/opencoap \
+            -isystem$(RIOTBASE)/pkg/openwsn/include \
 
 ifneq (,$(filter openwsn_riotos,$(USEMODULE)))
-  INCLUDES += -I$(RIOTBASE)/pkg/openwsn/scheduler
+  INCLUDES += -isystem$(RIOTBASE)/pkg/openwsn/scheduler
   DIRS += $(RIOTBASE)/pkg/openwsn/scheduler
 endif
 
 ifneq (,$(filter openwsn_sock_udp,$(USEMODULE)))
-  INCLUDES += -I$(RIOTBASE)/pkg/openwsn/sock
+  INCLUDES += -isystem$(RIOTBASE)/pkg/openwsn/sock
   DIRS += $(RIOTBASE)/pkg/openwsn/sock
 endif
 

--- a/pkg/paho-mqtt/Makefile.include
+++ b/pkg/paho-mqtt/Makefile.include
@@ -1,6 +1,7 @@
-INCLUDES += -I$(PKGDIRBASE)/paho-mqtt/MQTTClient-C/src/
-INCLUDES += -I$(PKGDIRBASE)/paho-mqtt/MQTTPacket/src
-INCLUDES += -I$(RIOTBASE)/pkg/paho-mqtt/include
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/paho-mqtt/MQTTClient-C/src/
+INCLUDES += -isystem$(PKGDIRBASE)/paho-mqtt/MQTTPacket/src
+INCLUDES += -isystem$(RIOTBASE)/pkg/paho-mqtt/include
 
 DIRS += $(RIOTBASE)/pkg/paho-mqtt/contrib
 

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -195,3 +195,8 @@ distclean:: clean
 # Reset goal for package
 .DEFAULT_GOAL =
 endif
+
+# Disabling some diagnostics: These issues needs to be fixed upstream
+ifeq (llvm,$(TOOLCHAIN))
+  CFLAGS += -Wno-documentation
+endif

--- a/pkg/relic/Makefile.include
+++ b/pkg/relic/Makefile.include
@@ -1,3 +1,4 @@
-INCLUDES += -I$(PKGDIRBASE)/relic/include
-INCLUDES += -I$(BINDIR)/pkg-build/relic/include
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/relic/include
+INCLUDES += -isystem$(BINDIR)/pkg-build/relic/include
 ARCHIVES += $(BINDIR)/relic.a

--- a/pkg/semtech-loramac/Makefile
+++ b/pkg/semtech-loramac/Makefile
@@ -5,10 +5,11 @@ PKG_LICENSE=BSD-3-Clause
 
 include $(RIOTBASE)/pkg/pkg.mk
 
-INCLUDES += -I$(PKGDIRBASE)/semtech-loramac/src/mac \
-            -I$(PKGDIRBASE)/semtech-loramac/src/boards/mcu \
-            -I$(PKGDIRBASE)/semtech-loramac/src/system/crypto \
-            -I$(PKGDIRBASE)/semtech-loramac/src
+# Use -isystem instead of -I to disable warnings for these headers
+INCLUDES += -isystem$(PKGDIRBASE)/semtech-loramac/src/mac \
+            -isystem$(PKGDIRBASE)/semtech-loramac/src/boards/mcu \
+            -isystem$(PKGDIRBASE)/semtech-loramac/src/system/crypto \
+            -isystem$(PKGDIRBASE)/semtech-loramac/src
 
 LORAMAC_MODULES = loramac_arch loramac_crypto loramac_mac loramac_region
 

--- a/pkg/semtech-loramac/Makefile.include
+++ b/pkg/semtech-loramac/Makefile.include
@@ -1,4 +1,5 @@
-INCLUDES += -I$(RIOTBASE)/pkg/semtech-loramac/include
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(RIOTBASE)/pkg/semtech-loramac/include
 
 DIRS += $(RIOTBASE)/pkg/semtech-loramac/contrib
 

--- a/pkg/semtech-loramac/contrib/Makefile
+++ b/pkg/semtech-loramac/contrib/Makefile
@@ -1,9 +1,10 @@
 MODULE := semtech_loramac_contrib
 
-INCLUDES += -I$(PKGDIRBASE)/semtech-loramac/src/mac \
-            -I$(PKGDIRBASE)/semtech-loramac/src/boards \
-            -I$(PKGDIRBASE)/semtech-loramac/src/radio \
-            -I$(PKGDIRBASE)/semtech-loramac/src/system/crypto \
-            -I$(PKGDIRBASE)/semtech-loramac/src
+# Use -isystem instead of -I to disable warnings about these headers
+INCLUDES += -isystem$(PKGDIRBASE)/semtech-loramac/src/mac \
+            -isystem$(PKGDIRBASE)/semtech-loramac/src/boards \
+            -isystem$(PKGDIRBASE)/semtech-loramac/src/radio \
+            -isystem$(PKGDIRBASE)/semtech-loramac/src/system/crypto \
+            -isystem$(PKGDIRBASE)/semtech-loramac/src
 
 include $(RIOTBASE)/Makefile.base

--- a/pkg/tinycrypt/Makefile.include
+++ b/pkg/tinycrypt/Makefile.include
@@ -1,1 +1,2 @@
-INCLUDES += -I$(PKGDIRBASE)/tinycrypt/lib/include
+# Using -isyste instead of -I to avoid warnings about these headers
+INCLUDES += -isystem$(PKGDIRBASE)/tinycrypt/lib/include

--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -1,13 +1,14 @@
 PKG_BUILDDIR ?= $(PKGDIRBASE)/tinydtls
 
-INCLUDES += -I$(PKG_BUILDDIR)
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKG_BUILDDIR)
 
 ifeq ($(TOOLCHAIN), llvm)
   CFLAGS += -Wno-gnu-zero-variadic-macro-arguments -Wno-unused-function
 endif
 
-INCLUDES += -I$(RIOTBASE)/pkg/tinydtls/include
-INCLUDES += -I$(PKG_BUILDDIR)
+INCLUDES += -isystem$(RIOTBASE)/pkg/tinydtls/include
+INCLUDES += -isystem$(PKG_BUILDDIR)
 # Mandatory for tinyDTLS
 CFLAGS += -DDTLSv12 -DWITH_SHA256
 

--- a/pkg/umorse/Makefile.include
+++ b/pkg/umorse/Makefile.include
@@ -1,1 +1,2 @@
-INCLUDES += -I$(PKGDIRBASE)/umorse
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/umorse

--- a/pkg/uwb-core/Makefile.include
+++ b/pkg/uwb-core/Makefile.include
@@ -1,17 +1,18 @@
-INCLUDES += -I$(PKGDIRBASE)/uwb-core/hw/drivers/uwb/include/ \
-            -I$(PKGDIRBASE)/uwb-core/lib/euclid/include \
-            -I$(PKGDIRBASE)/uwb-core/lib/dsp/include \
-            -I$(PKGDIRBASE)/uwb-core/lib/json/include \
-            -I$(PKGDIRBASE)/uwb-core/lib/rng_math/include \
-            -I$(PKGDIRBASE)/uwb-core/lib/twr_ss/include \
-            -I$(PKGDIRBASE)/uwb-core/lib/twr_ss_ext/include \
-            -I$(PKGDIRBASE)/uwb-core/lib/twr_ss_ack/include \
-            -I$(PKGDIRBASE)/uwb-core/lib/twr_ds/include \
-            -I$(PKGDIRBASE)/uwb-core/lib/twr_ds_ext/include \
-            -I$(PKGDIRBASE)/uwb-core/lib/uwb_rng/include \
-            -I$(PKGDIRBASE)/uwb-core/porting/dpl/riot/include/ \
-            -I$(PKGDIRBASE)/uwb-core/sys/uwbcfg/include \
-            -I$(RIOTPKG)/uwb-core/include \
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(PKGDIRBASE)/uwb-core/hw/drivers/uwb/include/ \
+            -isystem$(PKGDIRBASE)/uwb-core/lib/euclid/include \
+            -isystem$(PKGDIRBASE)/uwb-core/lib/dsp/include \
+            -isystem$(PKGDIRBASE)/uwb-core/lib/json/include \
+            -isystem$(PKGDIRBASE)/uwb-core/lib/rng_math/include \
+            -isystem$(PKGDIRBASE)/uwb-core/lib/twr_ss/include \
+            -isystem$(PKGDIRBASE)/uwb-core/lib/twr_ss_ext/include \
+            -isystem$(PKGDIRBASE)/uwb-core/lib/twr_ss_ack/include \
+            -isystem$(PKGDIRBASE)/uwb-core/lib/twr_ds/include \
+            -isystem$(PKGDIRBASE)/uwb-core/lib/twr_ds_ext/include \
+            -isystem$(PKGDIRBASE)/uwb-core/lib/uwb_rng/include \
+            -isystem$(PKGDIRBASE)/uwb-core/porting/dpl/riot/include/ \
+            -isystem$(PKGDIRBASE)/uwb-core/sys/uwbcfg/include \
+            -isystem$(RIOTPKG)/uwb-core/include \
             #
 
 PSEUDOMODULES += uwb-core_dpl

--- a/pkg/wakaama/Makefile.include
+++ b/pkg/wakaama/Makefile.include
@@ -1,10 +1,11 @@
 DIRS += $(RIOTBASE)/pkg/wakaama/contrib
 
-INCLUDES += -I$(RIOTBASE)/pkg/wakaama/include
-INCLUDES += -I$(PKGDIRBASE)/wakaama/include
-INCLUDES += -I$(PKGDIRBASE)/wakaama/core
-INCLUDES += -I$(PKGDIRBASE)/wakaama/data
-INCLUDES += -I$(PKGDIRBASE)/wakaama/coap/er-coap-13
+# Using -isystem instead of -I to prevent warnings for the following headers
+INCLUDES += -isystem$(RIOTBASE)/pkg/wakaama/include
+INCLUDES += -isystem$(PKGDIRBASE)/wakaama/include
+INCLUDES += -isystem$(PKGDIRBASE)/wakaama/core
+INCLUDES += -isystem$(PKGDIRBASE)/wakaama/data
+INCLUDES += -isystem$(PKGDIRBASE)/wakaama/coap/er-coap-13
 
 # NOTE: Use wakaama in client mode
 CFLAGS += -DLWM2M_CLIENT_MODE

--- a/pkg/wakaama/contrib/lwm2m_client_connection.c
+++ b/pkg/wakaama/contrib/lwm2m_client_connection.c
@@ -65,8 +65,8 @@
  * @brief Creates a new connection object based on the security instance
  *        represented by @p instance_id.
  *
- * @param[in] instance_id ID number of the instance of security object
- * @param[in, out] client_data LwM2M client data
+ * @param[in]     sec_obj_inst_id   ID number of the instance of security object
+ * @param[in,out] client_data       LwM2M client data
  *
  * @return Pointer to the new connection
  */
@@ -97,7 +97,7 @@ static int _connection_send(lwm2m_client_connection_t *conn, uint8_t *buffer,
  * @return  pointer to the interface to use on success
  * @retval  NULL on error
  */
-static netif_t *_get_interface(const char *iface, size_t len);
+static netif_t *_get_interface(const char *iface, size_t iface_len);
 
 void *lwm2m_connect_server(uint16_t sec_obj_inst_id, void *user_data)
 {

--- a/pkg/wakaama/contrib/objects/common.c
+++ b/pkg/wakaama/contrib/objects/common.c
@@ -270,12 +270,12 @@ out:
  * Convenience function to call @ref _set_resource_data with a string representing the resource's
  * path.
  *
- * @param[in]  client_data       Pointer to the LwM2M client data.
- * @param[in]  path              Array containing the path to the resource to get.
- * @param[in]  path_len          Length of @p path.
- * @param[in]  expected_type     Type of data that is expected from the specified resource.
- * @param[in]  in               Pointer where to store the data.
- * @param[in]  in_len           Length of @p out.
+ * @param[in]   client_data     Pointer to the LwM2M client data.
+ * @param[in]   path            Array containing the path to the resource to get.
+ * @param[in]   path_len        Length of @p path.
+ * @param[in]   type            Type of data that is expected from the specified resource.
+ * @param[in]   in              Pointer where to store the data.
+ * @param[in]   in_len          Length of @p out.
  *
  * @retval 0 on success
  * @retval -EINVAL when the path is malformed, the value can not be set

--- a/pkg/wakaama/contrib/objects/security.c
+++ b/pkg/wakaama/contrib/objects/security.c
@@ -180,10 +180,10 @@ static uint8_t _create_cb(lwm2m_context_t * context, uint16_t instance_id, int n
 /**
  * @brief Get a value from a security object instance.
  *
- * @param data[in, out]     Data structure indicating the id of the resource
- *                          to get the value of. It will contain the value if
- *                          successful.
- * @param instance[in]      Instance to get the data from.
+ * @param[in,out]   data        Data structure indicating the id of the resource
+ *                              to get the value of. It will contain the value
+ *                              if successful.
+ * @param[in]       instance    Instance to get the data from.
  * @retval 0 on success
  * @retval <0 otherwise
  */
@@ -192,9 +192,9 @@ static int _get_value(lwm2m_data_t *data, lwm2m_obj_security_inst_t *instance);
 /**
  * @brief Initialize a new instance with the given arguments.
  *
- * @param instance[out]     Instance to initialize.
- * @param instance_id[in]   ID of the instance.
- * @param args[in]          Arguments to initialize the instance with.
+ * @param[out]  instance        Instance to initialize.
+ * @param[in]   instance_id     ID of the instance.
+ * @param[in]   args            Arguments to initialize the instance with.
  *
  * @retval 0 on success
  * @retval -ENOMEM if there is no memory available to copy credentials

--- a/pkg/wamr/Makefile
+++ b/pkg/wamr/Makefile
@@ -21,7 +21,7 @@ CFLAGS += -Wno-old-style-definition
 CFLAGS += -Wno-cast-function-type
 
 #Prepapre includes for cmake
-RIOT_INCLUDES = $(filter-out -%,$(subst -I,,$(INCLUDES)))
+RIOT_INCLUDES = $(filter-out -%,$(subst -isystem,,$(subst -I,,$(INCLUDES))))
 
 #translate (CPU_ARCH) to Build Target
 #WAMR_BUILD_TARGET is "X86_32", "X86_64", "AARCH64[sub]", "ARM[sub]",

--- a/sys/crypto/psa_riot_cipher/aes_common.h
+++ b/sys/crypto/psa_riot_cipher/aes_common.h
@@ -29,9 +29,6 @@ extern "C" {
 
 /**
  * @brief   Converts errors of the RIOT cipher module to PSA status values
- *
- * @param   error
- * @return  @ref psa_status_t
  */
 psa_status_t cipher_to_psa_error(int error);
 

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -534,7 +534,7 @@ static inline bool GNRC_RPL_COUNTER_GREATER_THAN(uint8_t A, uint8_t B)
 extern kernel_pid_t gnrc_rpl_pid;
 
 /**
- * @brief @see @ref GNRC_RPL_ALL_NODES_ADDR
+ * @brief   See @ref GNRC_RPL_ALL_NODES_ADDR
  */
 extern const ipv6_addr_t ipv6_addr_all_rpl_nodes;
 

--- a/sys/include/psa_crypto/psa/crypto.h
+++ b/sys/include/psa_crypto/psa/crypto.h
@@ -1744,12 +1744,6 @@ psa_status_t psa_export_public_key(psa_key_id_t key,
  *
  * @details This function generates a random symmetric key. As of yet it does not implement
  *          asymmetric key generation.
- *
- * @param attributes
- * @param key_buffer
- * @param key_buffer_size
- * @param key_buffer_length
- * @return psa_status_t
  */
 psa_status_t psa_builtin_generate_key(const psa_key_attributes_t *attributes, uint8_t *key_buffer,
                                       size_t key_buffer_size, size_t *key_buffer_length);

--- a/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
+++ b/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
@@ -563,7 +563,7 @@ void gnrc_lorawan_open_rx_window(gnrc_lorawan_t *mac);
  * @brief save internal MAC state in non-volatile storage and shutdown
  *        the MAC layer gracefully.
  *
- * @param mac
+ * @param[in] mac pointer to the MAC descriptor
  */
 void gnrc_lorawan_perform_save(gnrc_lorawan_t *mac);
 

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -771,8 +771,8 @@ void rtt_handler(uint32_t event, gnrc_netif_t *netif)
 /**
  * @brief   Function called by the device driver on device events
  *
+ * @param     dev           netdev causing the event
  * @param[in] event         type of event
- * @param[in] data          optional parameter
  */
 static void _lwmac_event_cb(netdev_t *dev, netdev_event_t event)
 {

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/sfr/gnrc_sixlowpan_frag_sfr.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/sfr/gnrc_sixlowpan_frag_sfr.c
@@ -102,10 +102,11 @@ static const gnrc_sixlowpan_frag_sfr_bitmap_t _null_bitmap = { .u32 = 0U };
 static gnrc_sixlowpan_frag_sfr_stats_t _stats;
 
 /**
- * @brief   Converts a @ref sys_bitmap based bitmap to a
- *          gnrc_sixlowpan_frag_sfr_bitmap_t
+ * @brief   Get the @ref gnrc_sixlowpan_frag_sfr_bitmap_t from an
+ *          @ref gnrc_sixlowpan_frag_rb_t
  *
- * @param[in] bitmap A @ref sys_bitmap
+ * @param[in]   frag_rb       Fragment containing the bitmap tracking received
+ *                            fragments
  *
  * @return  A gnrc_sixlowpan_frag_sfr_bitmap_t.
  */

--- a/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
+++ b/sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c
@@ -540,8 +540,8 @@ void gnrc_ipv6_nib_rtr_adv_pio_cb(gnrc_netif_t *upstream, const ndp_opt_pi_t *pi
 /**
  * @brief Check if memory region is set to 0
  *
- * @param[in]   The memory array to check
- * @param[in]   The size of the memory array
+ * @param[in]   addr    The memory array to check
+ * @param[in]   len     The size of the memory array
  *
  * @return  true if all bytes are set to 0
  */
@@ -593,13 +593,13 @@ static int _alloc_l2addr_entry(const void *addr, size_t len)
  *        Only the first packet from a host generates a comparison, all subsequent
  *        packets will be ignored until the `l2addrs` array is reset.
  *
- * @param[in] upstream interface, ignore if the source does not match
- * @param[in] pkt   a received packet
+ * @param[in]   iface   upstream interface, ignore if the source does not match
+ * @param[in]   pkt     a received packet
  *
- * @return  1 if the sender l2 address is in order before the local l2 address
- * @return  0 if the order could not be determined or a packet from the sender
- *            was already processed
- * @return -1 if the sender l2 address is in order behind the local l2 address
+ * @retval      1       the sender l2 address is in order before the local l2 address
+ * @retval      0       the order could not be determined or a packet from the sender
+ *                      was already processed
+ * @retval      -1      the sender l2 address is in order behind the local l2 address
  */
 static int _get_my_l2addr_rank(gnrc_netif_t *iface, gnrc_pktsnip_t *pkt)
 {

--- a/sys/posix/pthread/include/pthread_threading.h
+++ b/sys/posix/pthread/include/pthread_threading.h
@@ -53,7 +53,6 @@ int pthread_create(pthread_t *newthread, const pthread_attr_t *attr, void *(*sta
  *               Native threads must call sched_thread_exit().
  *               A pthread must not call sched_thread_exit().
  * @param[out]   retval   Return value, supplied to a joining thread.
- * @return       This function does not return.
  */
 void pthread_exit(void *retval) NORETURN;
 

--- a/sys/psa_crypto/include/psa_ecc.h
+++ b/sys/psa_crypto/include/psa_ecc.h
@@ -31,13 +31,6 @@ extern "C" {
  * @brief   Low level wrapper function to call a driver for an ECC key generation
  *          with a SECP 192 R1 key.
  *          See @ref psa_generate_key()
- *
- * @param   attributes
- * @param   priv_key_buffer
- * @param   pub_key_buffer
- * @param   priv_key_buffer_length
- * @param   pub_key_buffer_length
- * @return  @ref psa_status_t
  */
 psa_status_t psa_generate_ecc_p192r1_key_pair(  const psa_key_attributes_t *attributes,
                                                 uint8_t *priv_key_buffer, uint8_t *pub_key_buffer,
@@ -94,13 +87,6 @@ psa_status_t psa_ecc_p192r1_verify_message(const psa_key_attributes_t *attribute
  * @brief   Low level wrapper function to call a driver for an ECC key generation
  *          with a SECP 192 R1 key.
  *          See @ref psa_generate_key()
- *
- * @param   attributes
- * @param   priv_key_buffer
- * @param   pub_key_buffer
- * @param   priv_key_buffer_length
- * @param   pub_key_buffer_length
- * @return  @ref psa_status_t
  */
 psa_status_t psa_generate_ecc_p256r1_key_pair(  const psa_key_attributes_t *attributes,
                                                 uint8_t *priv_key_buffer, uint8_t *pub_key_buffer,
@@ -157,12 +143,6 @@ psa_status_t psa_ecc_p256r1_verify_message(const psa_key_attributes_t *attribute
  * @brief   Low level wrapper function to call a driver for an ECC key generation
  *          with an ed25519 key.
  *          See @ref psa_generate_key()
- *
- * @param   priv_key_buffer
- * @param   pub_key_buffer
- * @param   priv_key_buffer_length
- * @param   pub_key_buffer_length
- * @return  @ref psa_status_t
  */
 psa_status_t psa_generate_ecc_ed25519_key_pair( uint8_t *priv_key_buffer, uint8_t *pub_key_buffer,
                                                 size_t *priv_key_buffer_length,
@@ -170,12 +150,6 @@ psa_status_t psa_generate_ecc_ed25519_key_pair( uint8_t *priv_key_buffer, uint8_
 
 /**
  * @brief   Low level wrapper function for deriving an ed25519 public key from the private key.
- *
- * @param[in]       priv_key_buffer
- * @param[out]      pub_key_buffer
- * @param[in]       priv_key_buffer_length
- * @param[in,out]   pub_key_buffer_length
- * @return          @ref psa_status_t
  */
 psa_status_t psa_derive_ecc_ed25519_public_key( const uint8_t *priv_key_buffer,
                                                 uint8_t *pub_key_buffer,

--- a/sys/psa_crypto/include/psa_mac.h
+++ b/sys/psa_crypto/include/psa_mac.h
@@ -32,16 +32,6 @@ extern "C" {
 /**
  * @brief   Low level wrapper function to call a driver for a HMAC SHA256 computation
  *          See psa_mac_compute()
- *
- * @param   attributes
- * @param   key_buffer
- * @param   key_buffer_size
- * @param   input
- * @param   input_length
- * @param   mac
- * @param   mac_size
- * @param   mac_length
- * @return  psa_status_t
  */
 psa_status_t psa_mac_compute_hmac_sha256(   const psa_key_attributes_t *attributes,
                                             const uint8_t *key_buffer,

--- a/sys/psa_crypto/psa_crypto.c
+++ b/sys/psa_crypto/psa_crypto.c
@@ -451,12 +451,6 @@ psa_status_t psa_cipher_abort(psa_cipher_operation_t *operation)
  *
  *          See @ref psa_cipher_encrypt_setup(...)
  *          See @ref psa_cipher_decrypt_setup(...)
- *
- * @param   operation
- * @param   key
- * @param   alg
- * @param   direction   Whether encrypt or decrypt, see @ref psa_encrypt_or_decrypt_t
- * @return  @ref psa_status_t
  */
 static psa_status_t psa_cipher_setup(   psa_cipher_operation_t *operation,
                                         psa_key_id_t key,
@@ -520,16 +514,6 @@ static psa_status_t psa_cipher_setup(   psa_cipher_operation_t *operation,
  *
  *          See @ref psa_cipher_encrypt(...)
  *          See @ref psa_cipher_decrypt(...)
- *
- * @param   key
- * @param   alg
- * @param   input
- * @param   input_length
- * @param   output
- * @param   output_size
- * @param   output_length
- * @param   direction       Whether to encrypt or decrypt, see @ref psa_encrypt_or_decrypt_t
- * @return  @ref psa_status_t
  */
 static psa_status_t psa_cipher_encrypt_decrypt( psa_key_id_t key,
                                                 psa_algorithm_t alg,
@@ -1254,12 +1238,6 @@ psa_status_t psa_destroy_key(psa_key_id_t key)
  *
  *          See @ref psa_export_key
  *
- * @param   key_buffer
- * @param   key_buffer_size
- * @param   data
- * @param   data_size
- * @param   data_length
- *
  * @return  @ref PSA_SUCCESS
  *          @ref PSA_ERROR_INVALID_ARGUMENT
  */
@@ -1351,12 +1329,6 @@ psa_status_t psa_export_key(psa_key_id_t key,
  * @brief   Export asymmetric public key that is stored in local memory
  *
  *          See @ref psa_export_public_key
- *
- * @param   key_buffer
- * @param   key_buffer_size
- * @param   data
- * @param   data_size
- * @param   data_length
  *
  * @return  @ref PSA_SUCCESS
  *          @ref PSA_ERROR_INVALID_ARGUMENT

--- a/sys/psa_crypto/psa_crypto_location_dispatch.c
+++ b/sys/psa_crypto/psa_crypto_location_dispatch.c
@@ -166,19 +166,6 @@ psa_status_t psa_location_dispatch_cipher_decrypt_setup(psa_cipher_operation_t *
  *
  *          Some secure elements don't provide single part operations for cipher encryption.
  *          This is a wrapper function, to support those.
- *
- * @param   drv
- * @param   drv_context
- * @param   attributes
- * @param   alg
- * @param   direction
- * @param   slot
- * @param   input
- * @param   input_length
- * @param   output
- * @param   output_size
- * @param   output_length
- * @return  @ref psa_status_t
  */
 static psa_status_t psa_se_cipher_encrypt_decrypt(  const psa_drv_se_t *drv,
                                                     psa_drv_se_context_t *drv_context,

--- a/sys/psa_crypto/psa_key_slot_mgmt/psa_crypto_slot_management.c
+++ b/sys/psa_crypto/psa_key_slot_mgmt/psa_crypto_slot_management.c
@@ -96,7 +96,6 @@ static psa_key_id_t key_id_count = PSA_KEY_ID_VOLATILE_MIN;
 /**
  * @brief   Get the correct empty slot list, depending on the key type
  *
- * @param   attr
  * @return  clist_node_t*   Pointer to the list the key is supposed to be stored in,
  *                          according to its attributes
  */


### PR DESCRIPTION
### Contribution description

Treat documentation issues flagged by LLVM as hard errors.

LLVM tends to be a lot less picky about documentation issues compared to Doxygen (e.g. no warning about missing doc), but warns about things that really are not intentional (e.g. `@param foo` when the argument has been renamed to `bar`, `@return` when the return type is `void`, ...).

Having this as a base line requirement seems pretty sane.

### Testing procedure

- Green CI
- Code Review

### Issues/PRs references

None