### PR TITLE
makefiles/docker.inc.mk: bump tagged container [backport 2025.01]

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -5,7 +5,7 @@
 # When the docker image is updated, checks at
 # dist/tools/buildsystem_sanity_check/check.sh start complaining in CI, and
 # provide the latest values to verify and fill in.
-DOCKER_TESTED_IMAGE_REPO_DIGEST := 0993a39a90e0b573637ea488d51fb33ba1cbeacbfbae4a27cca2091d0873d383
+DOCKER_TESTED_IMAGE_REPO_DIGEST := 63a87608742890b1ecfc2eea5289d32298d6696a4bd1d9d11a9da2fd32071e4f
 
 DOCKER_PULL_IDENTIFIER := docker.io/riot/riotbuild@sha256:$(DOCKER_TESTED_IMAGE_REPO_DIGEST)
 export DOCKER_IMAGE ?= $(DOCKER_PULL_IDENTIFIER)


### PR DESCRIPTION
# Backport of #21378

### Contribution description

This updates the tagged container due to the merge of https://github.com/RIOT-OS/riotdocker/pull/255

### Testing procedure

Green CI

### Issues/PRs references

https://github.com/RIOT-OS/riotdocker/pull/255