### PR TITLE
sys/psa_crypto: add some missing doc

### DIFF
--- a/sys/psa_crypto/include/psa_crypto_algorithm_dispatch.h
+++ b/sys/psa_crypto/include/psa_crypto_algorithm_dispatch.h
@@ -38,9 +38,9 @@ extern "C" {
  * @brief   Dispatch a hash setup function to a specific backend.
  *          See @ref psa_hash_setup()
  *
- * @param operation
- * @param alg
- * @return @ref psa_status_t
+ * @param       operation       PSA hash operation to set up
+ * @param[in]   alg             PSA algorithm to use
+ * @return      @ref psa_status_t
  */
 psa_status_t psa_algorithm_dispatch_hash_setup(psa_hash_operation_t *operation,
                                                psa_algorithm_t alg);
@@ -49,10 +49,10 @@ psa_status_t psa_algorithm_dispatch_hash_setup(psa_hash_operation_t *operation,
  * @brief   Dispatch a hash update function to a specific backend.
  *          See @ref psa_hash_update()
  *
- * @param operation
- * @param input
- * @param input_length
- * @return @ref psa_status_t
+ * @param       operation       PSA hash operation to use
+ * @param[in]   input           Data to add
+ * @param[in]   input_length    Length of @p input
+ * @return      @ref psa_status_t
  */
 psa_status_t psa_algorithm_dispatch_hash_update(psa_hash_operation_t *operation,
                                                 const uint8_t *input,
@@ -62,11 +62,11 @@ psa_status_t psa_algorithm_dispatch_hash_update(psa_hash_operation_t *operation,
  * @brief   Dispatch a hash finish function to a specific backend.
  *          See @ref psa_hash_finish()
  *
- * @param operation
- * @param hash
- * @param hash_size
- * @param hash_length
- * @return @ref psa_status_t
+ * @param       operation     PSA hash operation to use
+ * @param[out]  hash          The generated hash will be written here
+ * @param[in]   hash_size     Size of the buffer in @p hash
+ * @param[out]  hash_length   The number of bytes actually written to @p hash
+ * @return      @ref psa_status_t
  */
 psa_status_t psa_algorithm_dispatch_hash_finish(psa_hash_operation_t *operation,
                                                 uint8_t *hash,

--- a/sys/psa_crypto/include/psa_crypto_location_dispatch.h
+++ b/sys/psa_crypto/include/psa_crypto_location_dispatch.h
@@ -44,14 +44,14 @@ extern "C" {
  * @param signature_length
  * @return psa_status_t
  */
-psa_status_t psa_location_dispatch_sign_hash(  const psa_key_attributes_t *attributes,
-                                               psa_algorithm_t alg,
-                                               const psa_key_slot_t *slot,
-                                               const uint8_t *hash,
-                                               size_t hash_length,
-                                               uint8_t *signature,
-                                               size_t signature_size,
-                                               size_t *signature_length);
+psa_status_t psa_location_dispatch_sign_hash(const psa_key_attributes_t *attributes,
+                                             psa_algorithm_t alg,
+                                             const psa_key_slot_t *slot,
+                                             const uint8_t *hash,
+                                             size_t hash_length,
+                                             uint8_t *signature,
+                                             size_t signature_size,
+                                             size_t *signature_length);
 
 /**
  * @brief   Dispatch call of a message signature function to a location specific backend.

--- a/sys/psa_crypto/include/psa_hashes.h
+++ b/sys/psa_crypto/include/psa_hashes.h
@@ -73,8 +73,8 @@ psa_status_t psa_hashes_md5_finish(psa_hashes_md5_ctx_t *ctx,
  * @brief   Low level wrapper function to call a driver for an SHA1 hash setup
  *          See @ref psa_hash_setup()
  *
- * @param ctx
- * @return psa_status_t
+ * @param   ctx         PSA SHA1 Context to set up
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha1_setup(psa_hashes_sha1_ctx_t *ctx);
 
@@ -82,10 +82,10 @@ psa_status_t psa_hashes_sha1_setup(psa_hashes_sha1_ctx_t *ctx);
  * @brief   Low level wrapper function to call a driver for an SHA1 hash update
  *          See @ref psa_hash_update()
  *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
+ * @param   ctx             PSA SHA1 context to update
+ * @param   input           Data to add
+ * @param   input_length    Length of @p input
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha1_update(psa_hashes_sha1_ctx_t *ctx,
                                     const uint8_t *input,
@@ -95,11 +95,11 @@ psa_status_t psa_hashes_sha1_update(psa_hashes_sha1_ctx_t *ctx,
  * @brief   Low level wrapper function to call a driver for an SHA1 hash finish
  *          See @ref psa_hash_finish()
  *
- * @param ctx
- * @param hash
- * @param hash_size
- * @param hash_length
- * @return psa_status_t
+ * @param   ctx         PSA SHA1 context to finalize
+ * @param   hash        The computed hash will be stored here
+ * @param   hash_size   Size of the buffer in @p hash
+ * @param   hash_length Actual number of bytes written to @p hash
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha1_finish(psa_hashes_sha1_ctx_t *ctx,
                                     uint8_t *hash,
@@ -112,8 +112,8 @@ psa_status_t psa_hashes_sha1_finish(psa_hashes_sha1_ctx_t *ctx,
  * @brief   Low level wrapper function to call a driver for an SHA224 hash setup
  *          See @ref psa_hash_setup()
  *
- * @param ctx
- * @return psa_status_t
+ * @param   ctx         PSA SHA224 Context to set up
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha224_setup(psa_hashes_sha224_ctx_t *ctx);
 
@@ -121,10 +121,10 @@ psa_status_t psa_hashes_sha224_setup(psa_hashes_sha224_ctx_t *ctx);
  * @brief   Low level wrapper function to call a driver for an SHA224 hash update
  *          See @ref psa_hash_update()
  *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
+ * @param   ctx             PSA SHA224 context to update
+ * @param   input           Data to add
+ * @param   input_length    Length of @p input
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha224_update(psa_hashes_sha224_ctx_t *ctx,
                                       const uint8_t *input,
@@ -134,11 +134,11 @@ psa_status_t psa_hashes_sha224_update(psa_hashes_sha224_ctx_t *ctx,
  * @brief   Low level wrapper function to call a driver for an SHA224 hash finish
  *          See @ref psa_hash_finish()
  *
- * @param ctx
- * @param hash
- * @param hash_size
- * @param hash_length
- * @return psa_status_t
+ * @param   ctx         PSA SHA224 context to finalize
+ * @param   hash        The computed hash will be stored here
+ * @param   hash_size   Size of the buffer in @p hash
+ * @param   hash_length Actual number of bytes written to @p hash
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha224_finish(psa_hashes_sha224_ctx_t *ctx,
                                       uint8_t *hash,
@@ -151,8 +151,8 @@ psa_status_t psa_hashes_sha224_finish(psa_hashes_sha224_ctx_t *ctx,
  * @brief   Low level wrapper function to call a driver for an SHA256 hash setup
  *          See @ref psa_hash_setup()
  *
- * @param ctx
- * @return psa_status_t
+ * @param   ctx         PSA SHA256 Context to set up
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha256_setup(psa_hashes_sha256_ctx_t *ctx);
 
@@ -160,10 +160,10 @@ psa_status_t psa_hashes_sha256_setup(psa_hashes_sha256_ctx_t *ctx);
  * @brief   Low level wrapper function to call a driver for an SHA256 hash update
  *          See @ref psa_hash_update()
  *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
+ * @param   ctx             PSA SHA256 context to update
+ * @param   input           Data to add
+ * @param   input_length    Length of @p input
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha256_update(psa_hashes_sha256_ctx_t *ctx,
                                       const uint8_t *input,
@@ -173,11 +173,11 @@ psa_status_t psa_hashes_sha256_update(psa_hashes_sha256_ctx_t *ctx,
  * @brief   Low level wrapper function to call a driver for an SHA256 hash finish
  *          See @ref psa_hash_finish()
  *
- * @param ctx
- * @param hash
- * @param hash_size
- * @param hash_length
- * @return psa_status_t
+ * @param   ctx         PSA SHA256 context to finalize
+ * @param   hash        The computed hash will be stored here
+ * @param   hash_size   Size of the buffer in @p hash
+ * @param   hash_length Actual number of bytes written to @p hash
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha256_finish(psa_hashes_sha256_ctx_t *ctx,
                                       uint8_t *hash,
@@ -190,8 +190,8 @@ psa_status_t psa_hashes_sha256_finish(psa_hashes_sha256_ctx_t *ctx,
  * @brief   Low level wrapper function to call a driver for an SHA384 hash setup
  *          See @ref psa_hash_setup()
  *
- * @param ctx
- * @return psa_status_t
+ * @param   ctx         PSA SHA384 Context to set up
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha384_setup(psa_hashes_sha384_ctx_t *ctx);
 
@@ -199,10 +199,10 @@ psa_status_t psa_hashes_sha384_setup(psa_hashes_sha384_ctx_t *ctx);
  * @brief   Low level wrapper function to call a driver for an SHA384 hash update
  *          See @ref psa_hash_update()
  *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
+ * @param   ctx             PSA SHA384 context to update
+ * @param   input           Data to add
+ * @param   input_length    Length of @p input
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha384_update(psa_hashes_sha384_ctx_t *ctx,
                                       const uint8_t *input,
@@ -212,11 +212,11 @@ psa_status_t psa_hashes_sha384_update(psa_hashes_sha384_ctx_t *ctx,
  * @brief   Low level wrapper function to call a driver for an SHA384 hash finish
  *          See @ref psa_hash_finish()
  *
- * @param ctx
- * @param hash
- * @param hash_size
- * @param hash_length
- * @return psa_status_t
+ * @param   ctx         PSA SHA384 context to finalize
+ * @param   hash        The computed hash will be stored here
+ * @param   hash_size   Size of the buffer in @p hash
+ * @param   hash_length Actual number of bytes written to @p hash
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha384_finish(psa_hashes_sha384_ctx_t *ctx,
                                       uint8_t *hash,
@@ -229,8 +229,8 @@ psa_status_t psa_hashes_sha384_finish(psa_hashes_sha384_ctx_t *ctx,
  * @brief   Low level wrapper function to call a driver for an SHA512 hash setup
  *          See @ref psa_hash_setup()
  *
- * @param ctx
- * @return psa_status_t
+ * @param   ctx         PSA SHA512 Context to set up
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha512_setup(psa_hashes_sha512_ctx_t *ctx);
 
@@ -238,10 +238,10 @@ psa_status_t psa_hashes_sha512_setup(psa_hashes_sha512_ctx_t *ctx);
  * @brief   Low level wrapper function to call a driver for an SHA512 hash update
  *          See @ref psa_hash_update()
  *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
+ * @param   ctx             PSA SHA512 context to update
+ * @param   input           Data to add
+ * @param   input_length    Length of @p input
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha512_update(psa_hashes_sha512_ctx_t *ctx,
                                       const uint8_t *input,
@@ -251,11 +251,11 @@ psa_status_t psa_hashes_sha512_update(psa_hashes_sha512_ctx_t *ctx,
  * @brief   Low level wrapper function to call a driver for an SHA512 hash finish
  *          See @ref psa_hash_finish()
  *
- * @param ctx
- * @param hash
- * @param hash_size
- * @param hash_length
- * @return psa_status_t
+ * @param   ctx         PSA SHA512 context to finalize
+ * @param   hash        The computed hash will be stored here
+ * @param   hash_size   Size of the buffer in @p hash
+ * @param   hash_length Actual number of bytes written to @p hash
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha512_finish(psa_hashes_sha512_ctx_t *ctx,
                                       uint8_t *hash,
@@ -268,8 +268,8 @@ psa_status_t psa_hashes_sha512_finish(psa_hashes_sha512_ctx_t *ctx,
  * @brief   Low level wrapper function to call a driver for an SHA512/224 hash setup
  *          See @ref psa_hash_setup()
  *
- * @param ctx
- * @return psa_status_t
+ * @param   ctx         PSA SHA512-224 Context to set up
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha512_224_setup(psa_hashes_sha512_224_ctx_t *ctx);
 
@@ -277,29 +277,29 @@ psa_status_t psa_hashes_sha512_224_setup(psa_hashes_sha512_224_ctx_t *ctx);
  * @brief   Low level wrapper function to call a driver for an SHA512/224 hash update
  *          See @ref psa_hash_update()
  *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
+ * @param   ctx             PSA SHA512-224 context to update
+ * @param   input           Data to add
+ * @param   input_length    Length of @p input
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha512_224_update(psa_hashes_sha512_224_ctx_t *ctx,
-                                      const uint8_t *input,
-                                      size_t input_length);
+                                          const uint8_t *input,
+                                          size_t input_length);
 
 /**
  * @brief   Low level wrapper function to call a driver for an SHA512/224 hash finish
  *          See @ref psa_hash_finish()
  *
- * @param ctx
- * @param hash
- * @param hash_size
- * @param hash_length
- * @return psa_status_t
+ * @param   ctx         PSA SHA512-224 context to finalize
+ * @param   hash        The computed hash will be stored here
+ * @param   hash_size   Size of the buffer in @p hash
+ * @param   hash_length Actual number of bytes written to @p hash
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha512_224_finish(psa_hashes_sha512_224_ctx_t *ctx,
-                                      uint8_t *hash,
-                                      size_t hash_size,
-                                      size_t *hash_length);
+                                          uint8_t *hash,
+                                          size_t hash_size,
+                                          size_t *hash_length);
 #endif /* MODULE_PSA_HASH_SHA_512_224 */
 
 #if IS_USED(MODULE_PSA_HASH_SHA_512_256) || defined(DOXYGEN)
@@ -307,8 +307,8 @@ psa_status_t psa_hashes_sha512_224_finish(psa_hashes_sha512_224_ctx_t *ctx,
  * @brief   Low level wrapper function to call a driver for an SHA512/256 hash setup
  *          See @ref psa_hash_setup()
  *
- * @param ctx
- * @return psa_status_t
+ * @param   ctx         PSA SHA512-256 Context to set up
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha512_256_setup(psa_hashes_sha512_256_ctx_t *ctx);
 
@@ -316,29 +316,29 @@ psa_status_t psa_hashes_sha512_256_setup(psa_hashes_sha512_256_ctx_t *ctx);
  * @brief   Low level wrapper function to call a driver for an SHA512/256 hash update
  *          See @ref psa_hash_update()
  *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
+ * @param   ctx             PSA SHA512-256 context to update
+ * @param   input           Data to add
+ * @param   input_length    Length of @p input
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha512_256_update(psa_hashes_sha512_256_ctx_t *ctx,
-                                      const uint8_t *input,
-                                      size_t input_length);
+                                          const uint8_t *input,
+                                          size_t input_length);
 
 /**
  * @brief   Low level wrapper function to call a driver for an SHA512/256 hash finish
  *          See @ref psa_hash_finish()
  *
- * @param ctx
- * @param hash
- * @param hash_size
- * @param hash_length
- * @return psa_status_t
+ * @param   ctx         PSA SHA512-256 context to finalize
+ * @param   hash        The computed hash will be stored here
+ * @param   hash_size   Size of the buffer in @p hash
+ * @param   hash_length Actual number of bytes written to @p hash
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha512_256_finish(psa_hashes_sha512_256_ctx_t *ctx,
-                                      uint8_t *hash,
-                                      size_t hash_size,
-                                      size_t *hash_length);
+                                          uint8_t *hash,
+                                          size_t hash_size,
+                                          size_t *hash_length);
 #endif /* MODULE_PSA_HASH_SHA_512_256 */
 
 #if IS_USED(MODULE_PSA_HASH_SHA3_256) || defined(DOXYGEN)
@@ -346,21 +346,21 @@ psa_status_t psa_hashes_sha512_256_finish(psa_hashes_sha512_256_ctx_t *ctx,
  * @brief   Low level wrapper function to call a driver for a general SHA3 hash update
  *          See @ref psa_hash_update()
  *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
+ * @param   ctx             PSA SHA3-256 context to update
+ * @param   input           Data to add
+ * @param   input_length    Length of @p input
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha3_256_update(psa_hashes_sha3_ctx_t *ctx,
-                                      const uint8_t *input,
-                                      size_t input_length);
+                                        const uint8_t *input,
+                                        size_t input_length);
 
 /**
  * @brief   Low level wrapper function to call a driver for a SHA3-256 hash setup
  *          See @ref psa_hash_setup()
  *
- * @param ctx
- * @return psa_status_t
+ * @param   ctx         PSA SHA3-256 Context to set up
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha3_256_setup(psa_hashes_sha3_ctx_t *ctx);
 
@@ -368,12 +368,12 @@ psa_status_t psa_hashes_sha3_256_setup(psa_hashes_sha3_ctx_t *ctx);
  * @brief   Low level wrapper function to call a driver for a SHA3-256 hash finish
  *          See @ref psa_hash_finish()
  *
- * @param ctx
- * @param hash
- * @return psa_status_t
+ * @param   ctx         PSA SHA3-256 context to finalize
+ * @param   hash        The computed hash will be stored here
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha3_256_finish(psa_hashes_sha3_ctx_t *ctx,
-                                      uint8_t *hash);
+                                        uint8_t *hash);
 #endif /* MODULE_PSA_HASH_SHA3_256 */
 
 #if IS_USED(MODULE_PSA_HASH_SHA3_384) || defined(DOXYGEN)
@@ -381,21 +381,21 @@ psa_status_t psa_hashes_sha3_256_finish(psa_hashes_sha3_ctx_t *ctx,
  * @brief   Low level wrapper function to call a driver for a general SHA3 hash update
  *          See @ref psa_hash_update()
  *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
+ * @param   ctx             PSA SHA3-384 context to update
+ * @param   input           Data to add
+ * @param   input_length    Length of @p input
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha3_384_update(psa_hashes_sha3_ctx_t *ctx,
-                                      const uint8_t *input,
-                                      size_t input_length);
+                                        const uint8_t *input,
+                                        size_t input_length);
 
 /**
  * @brief   Low level wrapper function to call a driver for a SHA3-384 hash setup
  *          See @ref psa_hash_setup()
  *
- * @param ctx
- * @return psa_status_t
+ * @param   ctx         PSA SHA3-384 Context to set up
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha3_384_setup(psa_hashes_sha3_ctx_t *ctx);
 
@@ -403,12 +403,12 @@ psa_status_t psa_hashes_sha3_384_setup(psa_hashes_sha3_ctx_t *ctx);
  * @brief   Low level wrapper function to call a driver for a SHA3-384 hash finish
  *          See @ref psa_hash_finish()
  *
- * @param ctx
- * @param hash
- * @return psa_status_t
+ * @param   ctx         PSA SHA3-384 context to finalize
+ * @param   hash        The computed hash will be stored here
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha3_384_finish(psa_hashes_sha3_ctx_t *ctx,
-                                      uint8_t *hash);
+                                        uint8_t *hash);
 #endif /* MODULE_PSA_HASH_SHA3_384 */
 
 #if IS_USED(MODULE_PSA_HASH_SHA3_512) || defined(DOXYGEN)
@@ -416,21 +416,21 @@ psa_status_t psa_hashes_sha3_384_finish(psa_hashes_sha3_ctx_t *ctx,
  * @brief   Low level wrapper function to call a driver for a general SHA3 hash update
  *          See @ref psa_hash_update()
  *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
+ * @param   ctx             PSA SHA3-512 context to update
+ * @param   input           Data to add
+ * @param   input_length    Length of @p input
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha3_512_update(psa_hashes_sha3_ctx_t *ctx,
-                                      const uint8_t *input,
-                                      size_t input_length);
+                                        const uint8_t *input,
+                                        size_t input_length);
 
 /**
  * @brief   Low level wrapper function to call a driver for a SHA3-512 hash setup
  *          See @ref psa_hash_setup()
  *
- * @param ctx
- * @return psa_status_t
+ * @param   ctx         PSA SHA3-384 Context to set up
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha3_512_setup(psa_hashes_sha3_ctx_t *ctx);
 
@@ -438,12 +438,12 @@ psa_status_t psa_hashes_sha3_512_setup(psa_hashes_sha3_ctx_t *ctx);
  * @brief   Low level wrapper function to call a driver for a SHA3-512 hash finish
  *          See @ref psa_hash_finish()
  *
- * @param ctx
- * @param hash
- * @return psa_status_t
+ * @param   ctx         PSA SHA3-512 context to finalize
+ * @param   hash        The computed hash will be stored here
+ * @return  psa_status_t
  */
 psa_status_t psa_hashes_sha3_512_finish(psa_hashes_sha3_ctx_t *ctx,
-                                      uint8_t *hash);
+                                        uint8_t *hash);
 #endif /* MODULE_PSA_HASH_SHA3_512 */
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

Most of the PSA Crypto API doc is a stub. This adds some of the missing doc.

### Testing procedure

Check the generated API doc / the code changes

### Issues/PRs references

None