### PR TITLE
treewide: update riot-wrappers and riot-sys

### DIFF
--- a/examples/lang_support/official/rust-async/Cargo.lock
+++ b/examples/lang_support/official/rust-async/Cargo.lock
@@ -544,8 +544,8 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "riot-sys"
-version = "0.7.14"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#eaa84f9033ef97fdeaf499824bfba639b029d6fe"
+version = "0.7.15"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#c5b900a0a5b973bb151c935664f9ad12cf9b5d55"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -559,8 +559,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.9.1"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#4861e4e4fd607767728117c3fbe023a41e6f03c8"
+version = "0.9.2"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#5b4ab3262aabe10c74f8f2a6dec39edd4eb780d7"
 dependencies = [
  "bare-metal",
  "coap-handler",

--- a/examples/lang_support/official/rust-gcoap/Cargo.lock
+++ b/examples/lang_support/official/rust-gcoap/Cargo.lock
@@ -758,8 +758,8 @@ dependencies = [
 
 [[package]]
 name = "riot-sys"
-version = "0.7.14"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#eaa84f9033ef97fdeaf499824bfba639b029d6fe"
+version = "0.7.15"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#c5b900a0a5b973bb151c935664f9ad12cf9b5d55"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -773,8 +773,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.9.1"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#4861e4e4fd607767728117c3fbe023a41e6f03c8"
+version = "0.9.2"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#5b4ab3262aabe10c74f8f2a6dec39edd4eb780d7"
 dependencies = [
  "bare-metal",
  "coap-handler",

--- a/examples/lang_support/official/rust-hello-world/Cargo.lock
+++ b/examples/lang_support/official/rust-hello-world/Cargo.lock
@@ -428,8 +428,8 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "riot-sys"
-version = "0.7.14"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#eaa84f9033ef97fdeaf499824bfba639b029d6fe"
+version = "0.7.15"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#c5b900a0a5b973bb151c935664f9ad12cf9b5d55"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -443,8 +443,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.9.1"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#4861e4e4fd607767728117c3fbe023a41e6f03c8"
+version = "0.9.2"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#5b4ab3262aabe10c74f8f2a6dec39edd4eb780d7"
 dependencies = [
  "bare-metal",
  "coap-handler",

--- a/sys/rust_riotmodules_standalone/Cargo.lock
+++ b/sys/rust_riotmodules_standalone/Cargo.lock
@@ -514,8 +514,8 @@ dependencies = [
 
 [[package]]
 name = "riot-sys"
-version = "0.7.14"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#eaa84f9033ef97fdeaf499824bfba639b029d6fe"
+version = "0.7.15"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#c5b900a0a5b973bb151c935664f9ad12cf9b5d55"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -529,8 +529,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.9.1"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#4861e4e4fd607767728117c3fbe023a41e6f03c8"
+version = "0.9.2"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#5b4ab3262aabe10c74f8f2a6dec39edd4eb780d7"
 dependencies = [
  "bare-metal",
  "coap-handler",

--- a/tests/rust_minimal/Cargo.lock
+++ b/tests/rust_minimal/Cargo.lock
@@ -428,8 +428,8 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "riot-sys"
-version = "0.7.14"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#eaa84f9033ef97fdeaf499824bfba639b029d6fe"
+version = "0.7.15"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#c5b900a0a5b973bb151c935664f9ad12cf9b5d55"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",
@@ -443,8 +443,8 @@ dependencies = [
 
 [[package]]
 name = "riot-wrappers"
-version = "0.9.1"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#4861e4e4fd607767728117c3fbe023a41e6f03c8"
+version = "0.9.2"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#5b4ab3262aabe10c74f8f2a6dec39edd4eb780d7"
 dependencies = [
  "bare-metal",
  "coap-handler",


### PR DESCRIPTION
### Contribution description

diff generated with `find -name Cargo.toml -exec cargo update --manifest-path "{}" --package riot-wrappers --package riot-sys ";"` according to https://github.com/RIOT-OS/RIOT/blob/master/doc/guides/managing-a-release/README.md?plain=1#L31


### Testing procedure

see what CI says


### Issues/PRs references

upcoming release version bump similar to https://github.com/RIOT-OS/RIOT/pull/21133
