### PR TITLE
drivers/mtd_default: remove deprecated `mtd_default_get_dev()`

### DIFF
--- a/drivers/include/mtd_default.h
+++ b/drivers/include/mtd_default.h
@@ -41,21 +41,6 @@ extern mtd_sdcard_t mtd_sdcard_dev0;
 extern mtd_emulated_t mtd_emulated_dev0;
 #endif
 
-/**
- * @brief   Get the default MTD device by index
- *
- * @deprecated  Use @ref mtd_dev_get instead
- *
- * @param[in] idx   Index of the MTD device
- *
- * @return  MTD_0 for @p idx 0 and so on
- *          NULL if no MTD device exists for the given index
- */
-static inline mtd_dev_t *mtd_default_get_dev(unsigned idx)
-{
-    return ((MTD_NUMOF != 0) && (idx < MTD_NUMOF)) ? mtd_dev_xfa[idx] : NULL;
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/pkg/flashdb/include/fal_cfg.h
+++ b/pkg/flashdb/include/fal_cfg.h
@@ -82,7 +82,7 @@ extern struct fal_flash_dev mtd_flash0;
 /**
  * @brief   Default MTD to use for flashdb
  */
-#define FAL_MTD                                     mtd_default_get_dev(0)
+#define FAL_MTD                                     mtd_dev_get(0)
 #endif
 
 #if !defined(FAL_PART0_LABEL) || defined(DOXYGEN)

--- a/sys/fido2/ctap/ctap_mem.c
+++ b/sys/fido2/ctap/ctap_mem.c
@@ -63,7 +63,7 @@ static ctap_status_code_t _flash_write(const void *buf, uint32_t addr, size_t le
 ctap_status_code_t fido2_ctap_mem_init(void)
 {
 #ifdef CPU_NATIVE
-    _mtd_dev = mtd_default_get_dev(0);
+    _mtd_dev = mtd_dev_get(0);
 #endif
 
     int ret = mtd_init(_mtd_dev);


### PR DESCRIPTION
use `mtd_dev_get()` instead


### Testing procedure

CI should catch errors.


### Issues/PRs references

deprecated more than a year ago in https://github.com/RIOT-OS/RIOT/pull/20078