### PR TITLE
sys/can: fix compilation issues under native

### DIFF
--- a/cpu/native/Makefile.include
+++ b/cpu/native/Makefile.include
@@ -7,6 +7,12 @@ ifneq (,$(filter periph_can,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter can,$(USEMODULE)))
+  # In case of native, we rely on the real CAN implementation to handle
+  # the nitty-gritty details such as loop delay.
+  CFLAGS += -DCONFIG_FDCAN_DEVICE_TRANSCEIVER_LOOP_DELAY=0
+endif
+
 ifneq (,$(filter periph_timer,$(USEMODULE)))
   # using timer_settime requires -lrt
   LINKFLAGS += -lrt

--- a/pkg/libsocketcan/Makefile
+++ b/pkg/libsocketcan/Makefile
@@ -7,5 +7,10 @@ include $(RIOTBASE)/pkg/pkg.mk
 
 CFLAGS += -Wno-cast-align
 
+# HACK: Ignore `posix_headers` module here: libsocketcan needs to use the
+#       host's OS's socket implementation rather than the RIOT one, as we
+#       rely on the host's CAN implementation to provide CAN on native
+INCLUDES := $(filter-out -I%/sys/posix/include,$(INCLUDES))
+
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(CURDIR)/Makefile.$(PKG_NAME)

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -355,9 +355,6 @@ ifneq (,$(filter evtimer_mbox,$(USEMODULE)))
   USEMODULE += core_mbox
 endif
 
-ifneq (,$(filter can_%,$(USEMODULE)))
-endif
-
 ifneq (,$(filter conn_can,$(USEMODULE)))
   USEMODULE += can
 endif

--- a/sys/can/Makefile.dep
+++ b/sys/can/Makefile.dep
@@ -16,4 +16,10 @@ ifneq (,$(filter can_mbox,$(USEMODULE)))
   USEMODULE += core_mbox
 endif
 
+# on native32/native64/native, the can headers include libsocketcan.h for
+# some definitions, so we actually need to use that package
+ifneq (,$(filter native%,$(BOARD)))
+  USEPKG += libsocketcan
+endif
+
 USEMODULE += memarray


### PR DESCRIPTION
### Contribution description

This fixes two related compilation issues when using the `can` module under native:

1. `can/can.h` from the `can` module includes `libsocketcan.h` from the `libsocketcan` package on `native%`, but does not depend on it. The missing dep is added
2. The `libsocketcan` package does not compile with the `posix_headers` package is used, as it really needs to include the host headers. The `INCLUDES` variable is stripped of the posix headers include path locally within the package's `Makefile` (so with no side-effect on other packages and modules).

### Testing procedure

```
$ USEMODULE=posix_headers BOARD=native64 RIOT_CI_BUILD=1 make -C tests/drivers/candev
```

Will fail spectacularly on `master`, but work fine with this PR.

### Issues/PRs references

None