### PR TITLE
sys/psa_crypto: drop no-op Doxygen statements

### DIFF
--- a/sys/psa_crypto/include/psa_ciphers.h
+++ b/sys/psa_crypto/include/psa_ciphers.h
@@ -15,7 +15,6 @@
  * @brief       Function declarations for low level wrapper functions for cipher operations.
  *
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
- *
  */
 
 #ifndef PSA_CIPHERS_H
@@ -32,17 +31,6 @@ extern "C" {
 /**
  * @brief   Low level wrapper function to call a driver for an AES 128 CBC encryption.
  *          See @ref psa_cipher_encrypt()
- *
- * @param attributes
- * @param key_buffer
- * @param key_buffer_size
- * @param alg
- * @param input
- * @param input_length
- * @param output
- * @param output_size
- * @param output_length
- * @return @ref psa_status_t
  */
 psa_status_t psa_cipher_cbc_aes_128_encrypt(const psa_key_attributes_t *attributes,
                                             const uint8_t *key_buffer,
@@ -57,17 +45,6 @@ psa_status_t psa_cipher_cbc_aes_128_encrypt(const psa_key_attributes_t *attribut
 /**
  * @brief   Low level wrapper function to call a driver for an AES 128 CBC decryption.
  *          See @ref psa_cipher_decrypt()
- *
- * @param attributes
- * @param key_buffer
- * @param key_buffer_size
- * @param alg
- * @param input
- * @param input_length
- * @param output
- * @param output_size
- * @param output_length
- * @return @ref psa_status_t
  */
 psa_status_t psa_cipher_cbc_aes_128_decrypt(const psa_key_attributes_t *attributes,
                                             const uint8_t *key_buffer,
@@ -84,17 +61,6 @@ psa_status_t psa_cipher_cbc_aes_128_decrypt(const psa_key_attributes_t *attribut
 /**
  * @brief   Low level wrapper function to call a driver for an AES 192 CBC encryption.
  *          See @ref psa_cipher_encrypt()
- *
- * @param attributes
- * @param key_buffer
- * @param key_buffer_size
- * @param alg
- * @param input
- * @param input_length
- * @param output
- * @param output_size
- * @param output_length
- * @return @ref psa_status_t
  */
 psa_status_t psa_cipher_cbc_aes_192_encrypt(const psa_key_attributes_t *attributes,
                                             const uint8_t *key_buffer,
@@ -111,17 +77,6 @@ psa_status_t psa_cipher_cbc_aes_192_encrypt(const psa_key_attributes_t *attribut
 /**
  * @brief   Low level wrapper function to call a driver for an AES 256 CBC encryption.
  *          See @ref psa_cipher_encrypt()
- *
- * @param attributes
- * @param key_buffer
- * @param key_buffer_size
- * @param alg
- * @param input
- * @param input_length
- * @param output
- * @param output_size
- * @param output_length
- * @return psa_status_t
  */
 psa_status_t psa_cipher_cbc_aes_256_encrypt(const psa_key_attributes_t *attributes,
                                             const uint8_t *key_buffer,

--- a/sys/psa_crypto/include/psa_crypto_algorithm_dispatch.h
+++ b/sys/psa_crypto/include/psa_crypto_algorithm_dispatch.h
@@ -15,7 +15,6 @@
  * @brief       Function declarations for PSA Crypto algorithm dispatcher
  *
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
- *
  */
 
 #ifndef PSA_CRYPTO_ALGORITHM_DISPATCH_H
@@ -37,10 +36,6 @@ extern "C" {
 /**
  * @brief   Dispatch a hash setup function to a specific backend.
  *          See @ref psa_hash_setup()
- *
- * @param operation
- * @param alg
- * @return @ref psa_status_t
  */
 psa_status_t psa_algorithm_dispatch_hash_setup(psa_hash_operation_t *operation,
                                                psa_algorithm_t alg);
@@ -48,11 +43,6 @@ psa_status_t psa_algorithm_dispatch_hash_setup(psa_hash_operation_t *operation,
 /**
  * @brief   Dispatch a hash update function to a specific backend.
  *          See @ref psa_hash_update()
- *
- * @param operation
- * @param input
- * @param input_length
- * @return @ref psa_status_t
  */
 psa_status_t psa_algorithm_dispatch_hash_update(psa_hash_operation_t *operation,
                                                 const uint8_t *input,
@@ -61,12 +51,6 @@ psa_status_t psa_algorithm_dispatch_hash_update(psa_hash_operation_t *operation,
 /**
  * @brief   Dispatch a hash finish function to a specific backend.
  *          See @ref psa_hash_finish()
- *
- * @param operation
- * @param hash
- * @param hash_size
- * @param hash_length
- * @return @ref psa_status_t
  */
 psa_status_t psa_algorithm_dispatch_hash_finish(psa_hash_operation_t *operation,
                                                 uint8_t *hash,
@@ -78,16 +62,6 @@ psa_status_t psa_algorithm_dispatch_hash_finish(psa_hash_operation_t *operation,
 /**
  * @brief   Dispatch a hash signature function to a specific backend.
  *          See @ref psa_sign_hash()
- *
- * @param attributes
- * @param alg
- * @param slot
- * @param hash
- * @param hash_length
- * @param signature
- * @param signature_size
- * @param signature_length
- * @return @ref psa_status_t
  */
 psa_status_t psa_algorithm_dispatch_sign_hash(  const psa_key_attributes_t *attributes,
                                                 psa_algorithm_t alg,
@@ -101,16 +75,6 @@ psa_status_t psa_algorithm_dispatch_sign_hash(  const psa_key_attributes_t *attr
 /**
  * @brief   Dispatch a message signature function to a specific backend.
  *          See @ref psa_sign_message()
- *
- * @param attributes
- * @param alg
- * @param slot
- * @param input
- * @param input_length
- * @param signature
- * @param signature_size
- * @param signature_length
- * @return @ref psa_status_t
  */
 psa_status_t psa_algorithm_dispatch_sign_message(const psa_key_attributes_t *attributes,
                                                 psa_algorithm_t alg,
@@ -124,15 +88,6 @@ psa_status_t psa_algorithm_dispatch_sign_message(const psa_key_attributes_t *att
 /**
  * @brief   Dispatch a hash verification function to a specific backend.
  *          See @ref psa_verify_hash()
- *
- * @param attributes
- * @param alg
- * @param slot
- * @param hash
- * @param hash_length
- * @param signature
- * @param signature_length
- * @return @ref psa_status_t
  */
 psa_status_t psa_algorithm_dispatch_verify_hash(  const psa_key_attributes_t *attributes,
                                                   psa_algorithm_t alg,
@@ -145,15 +100,6 @@ psa_status_t psa_algorithm_dispatch_verify_hash(  const psa_key_attributes_t *at
 /**
  * @brief   Dispatch a message verification function to a specific backend.
  *          See @ref psa_verify_message()
- *
- * @param attributes
- * @param alg
- * @param slot
- * @param input
- * @param input_length
- * @param signature
- * @param signature_length
- * @return @ref psa_status_t
  */
 psa_status_t psa_algorithm_dispatch_verify_message( const psa_key_attributes_t *attributes,
                                                     psa_algorithm_t alg,
@@ -168,10 +114,6 @@ psa_status_t psa_algorithm_dispatch_verify_message( const psa_key_attributes_t *
 /**
  * @brief   Dispatch the key generation function to a specific backend.
  *          See @ref psa_generate_key()
- *
- * @param attributes
- * @param slot
- * @return @ref psa_status_t
  */
 psa_status_t psa_algorithm_dispatch_generate_key(   const psa_key_attributes_t *attributes,
                                                     psa_key_slot_t *slot);
@@ -179,13 +121,6 @@ psa_status_t psa_algorithm_dispatch_generate_key(   const psa_key_attributes_t *
 /**
  * @brief   Dispatch the key import function to a specific backend.
  *          See psa_import_key()
- *
- * @param attributes
- * @param data
- * @param data_length
- * @param slot
- * @param bits
- * @return psa_status_t
  */
 psa_status_t psa_algorithm_dispatch_import_key(const psa_key_attributes_t *attributes,
                                                const uint8_t *data, size_t data_length,
@@ -196,16 +131,6 @@ psa_status_t psa_algorithm_dispatch_import_key(const psa_key_attributes_t *attri
 /**
  * @brief   Dispatch a cipher encrypt function to a specific backend.
  *          See @ref psa_cipher_encrypt()
- *
- * @param attributes
- * @param alg
- * @param slot
- * @param input
- * @param input_length
- * @param output
- * @param output_size
- * @param output_length
- * @return @ref psa_status_t
  */
 psa_status_t psa_algorithm_dispatch_cipher_encrypt( const psa_key_attributes_t *attributes,
                                                     psa_algorithm_t alg,
@@ -219,16 +144,6 @@ psa_status_t psa_algorithm_dispatch_cipher_encrypt( const psa_key_attributes_t *
 /**
  * @brief   Dispatch a cipher decrypt function to a specific backend.
  *          See @ref psa_cipher_decrypt()
- *
- * @param attributes
- * @param alg
- * @param slot
- * @param input
- * @param input_length
- * @param output
- * @param output_size
- * @param output_length
- * @return @ref psa_status_t
  */
 psa_status_t psa_algorithm_dispatch_cipher_decrypt( const psa_key_attributes_t *attributes,
                                                     psa_algorithm_t alg,
@@ -244,16 +159,6 @@ psa_status_t psa_algorithm_dispatch_cipher_decrypt( const psa_key_attributes_t *
 /**
  * @brief   Dispatch a mac computation function to a specific backend.
  *          See @ref psa_mac_compute()
- *
- * @param attributes
- * @param alg
- * @param slot
- * @param input
- * @param input_length
- * @param mac
- * @param mac_size
- * @param mac_length
- * @return @ref psa_status_t
  */
 psa_status_t psa_algorithm_dispatch_mac_compute(const psa_key_attributes_t *attributes,
                                                 psa_algorithm_t alg,

--- a/sys/psa_crypto/include/psa_crypto_location_dispatch.h
+++ b/sys/psa_crypto/include/psa_crypto_location_dispatch.h
@@ -15,7 +15,6 @@
  * @brief       Function declarations for the PSA Crypto location dispatcher.
  *
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
- *
  */
 
 #ifndef PSA_CRYPTO_LOCATION_DISPATCH_H
@@ -33,16 +32,6 @@ extern "C" {
 /**
  * @brief   Dispatch call of a hash signature function to a location specific backend.
  *          See psa_sign_hash()
- *
- * @param attributes
- * @param alg
- * @param slot
- * @param hash
- * @param hash_length
- * @param signature
- * @param signature_size
- * @param signature_length
- * @return psa_status_t
  */
 psa_status_t psa_location_dispatch_sign_hash(  const psa_key_attributes_t *attributes,
                                                psa_algorithm_t alg,
@@ -56,16 +45,6 @@ psa_status_t psa_location_dispatch_sign_hash(  const psa_key_attributes_t *attri
 /**
  * @brief   Dispatch call of a message signature function to a location specific backend.
  *          See psa_sign_message()
- *
- * @param attributes
- * @param alg
- * @param slot
- * @param input
- * @param input_length
- * @param signature
- * @param signature_size
- * @param signature_length
- * @return psa_status_t
  */
 psa_status_t psa_location_dispatch_sign_message(const psa_key_attributes_t *attributes,
                                                psa_algorithm_t alg,
@@ -79,15 +58,6 @@ psa_status_t psa_location_dispatch_sign_message(const psa_key_attributes_t *attr
 /**
  * @brief   Dispatch call of a hash verification function to a location specific backend.
  *          See psa_verify_hash()
- *
- * @param attributes
- * @param alg
- * @param slot
- * @param hash
- * @param hash_length
- * @param signature
- * @param signature_length
- * @return psa_status_t
  */
 psa_status_t psa_location_dispatch_verify_hash(  const psa_key_attributes_t *attributes,
                                                  psa_algorithm_t alg,
@@ -100,15 +70,6 @@ psa_status_t psa_location_dispatch_verify_hash(  const psa_key_attributes_t *att
 /**
  * @brief   Dispatch call of a message verification function to a location specific backend.
  *          See psa_verify_message()
- *
- * @param attributes
- * @param alg
- * @param slot
- * @param input
- * @param input_length
- * @param signature
- * @param signature_length
- * @return psa_status_t
  */
 psa_status_t psa_location_dispatch_verify_message(const psa_key_attributes_t *attributes,
                                                  psa_algorithm_t alg,
@@ -123,16 +84,6 @@ psa_status_t psa_location_dispatch_verify_message(const psa_key_attributes_t *at
 /**
  * @brief   Dispatch call of a mac computation function to a location specific backend.
  *          See psa_mac_compute()
- *
- * @param attributes
- * @param alg
- * @param slot
- * @param input
- * @param input_length
- * @param mac
- * @param mac_size
- * @param mac_length
- * @return psa_status_t
  */
 psa_status_t psa_location_dispatch_mac_compute(const psa_key_attributes_t *attributes,
                                                psa_algorithm_t alg,
@@ -148,10 +99,6 @@ psa_status_t psa_location_dispatch_mac_compute(const psa_key_attributes_t *attri
 /**
  * @brief   Dispatch call of the key generation function to a location specific backend.
  *          See psa_generate_key()
- *
- * @param attributes
- * @param slot
- * @return psa_status_t
  */
 psa_status_t psa_location_dispatch_generate_key(const psa_key_attributes_t *attributes,
                                                 psa_key_slot_t *slot);
@@ -159,13 +106,6 @@ psa_status_t psa_location_dispatch_generate_key(const psa_key_attributes_t *attr
 /**
  * @brief   Dispatch call of the key import function to a location specific backend.
  *          See psa_import_key()
- *
- * @param attributes
- * @param data
- * @param data_length
- * @param slot
- * @param bits
- * @return psa_status_t
  */
 psa_status_t psa_location_dispatch_import_key( const psa_key_attributes_t *attributes,
                                                const uint8_t *data, size_t data_length,
@@ -176,12 +116,6 @@ psa_status_t psa_location_dispatch_import_key( const psa_key_attributes_t *attri
 /**
  * @brief   Dispatch call of a cipher encrypt setup function to a location specific backend.
  *          See psa_cipher_setup()
- *
- * @param operation
- * @param attributes
- * @param slot
- * @param alg
- * @return psa_status_t
  */
 psa_status_t psa_location_dispatch_cipher_encrypt_setup(   psa_cipher_operation_t *operation,
                                                            const psa_key_attributes_t *attributes,
@@ -191,12 +125,6 @@ psa_status_t psa_location_dispatch_cipher_encrypt_setup(   psa_cipher_operation_
 /**
  * @brief   Dispatch call of a cipher decrypt setup function to a location specific backend.
  *          See psa_cipher_setup()
- *
- * @param operation
- * @param attributes
- * @param slot
- * @param alg
- * @return psa_status_t
  */
 psa_status_t psa_location_dispatch_cipher_decrypt_setup(psa_cipher_operation_t *operation,
                                                         const psa_key_attributes_t *attributes,
@@ -206,11 +134,6 @@ psa_status_t psa_location_dispatch_cipher_decrypt_setup(psa_cipher_operation_t *
 /**
  * @brief   Dispatch call of a function to set a cipher IV to a location specific backend.
  *          See psa_cipher_set_iv()
- *
- * @param operation
- * @param iv
- * @param iv_length
- * @return psa_status_t
  */
 psa_status_t psa_location_dispatch_cipher_set_iv(  psa_cipher_operation_t *operation,
                                                    const uint8_t *iv,
@@ -219,16 +142,6 @@ psa_status_t psa_location_dispatch_cipher_set_iv(  psa_cipher_operation_t *opera
 /**
  * @brief   Dispatch call of a cipher encrypt function to a location specific backend.
  *          See psa_cipher_encrypt()
- *
- * @param attributes
- * @param alg
- * @param slot
- * @param input
- * @param input_length
- * @param output
- * @param output_size
- * @param output_length
- * @return psa_status_t
  */
 psa_status_t psa_location_dispatch_cipher_encrypt(  const psa_key_attributes_t *attributes,
                                                     psa_algorithm_t alg,
@@ -242,16 +155,6 @@ psa_status_t psa_location_dispatch_cipher_encrypt(  const psa_key_attributes_t *
 /**
  * @brief   Dispatch call of a cipher decrypt function to a location specific backend.
  *          See psa_cipher_decrypt()
- *
- * @param attributes
- * @param alg
- * @param slot
- * @param input
- * @param input_length
- * @param output
- * @param output_size
- * @param output_length
- * @return psa_status_t
  */
 psa_status_t psa_location_dispatch_cipher_decrypt(  const psa_key_attributes_t *attributes,
                                                     psa_algorithm_t alg,
@@ -266,10 +169,6 @@ psa_status_t psa_location_dispatch_cipher_decrypt(  const psa_key_attributes_t *
 /**
  * @brief   Dispatch call of a random number generator to a specific backend.
  *          See psa_generate_random()
- *
- * @param output
- * @param output_size
- * @return psa_status_t
  */
 psa_status_t psa_location_dispatch_generate_random(uint8_t *output,
                                                    size_t output_size);

--- a/sys/psa_crypto/include/psa_ecc.h
+++ b/sys/psa_crypto/include/psa_ecc.h
@@ -15,7 +15,6 @@
  * @brief       Function declarations for low level wrapper functions for ECC operations.
  *
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
- *
  */
 
 #ifndef PSA_ECC_H
@@ -49,17 +48,6 @@ psa_status_t psa_generate_ecc_p192r1_key_pair(  const psa_key_attributes_t *attr
  * @brief   Low level wrapper function to call a driver for an ECC hash signature
  *          with a SECP 192 R1 key.
  *          See @ref psa_sign_hash()
- *
- * @param attributes
- * @param alg
- * @param key_buffer
- * @param key_buffer_size
- * @param hash
- * @param hash_length
- * @param signature
- * @param signature_size
- * @param signature_length
- * @return psa_status_t
  */
 psa_status_t psa_ecc_p192r1_sign_hash(  const psa_key_attributes_t *attributes,
                                         psa_algorithm_t alg,
@@ -72,17 +60,6 @@ psa_status_t psa_ecc_p192r1_sign_hash(  const psa_key_attributes_t *attributes,
  * @brief   Low level wrapper function to call a driver for an ECC hash signature
  *          with a SECP 192 R1 key.
  *          See @ref psa_sign_message()
- *
- * @param attributes
- * @param alg
- * @param key_buffer
- * @param key_buffer_size
- * @param input
- * @param input_length
- * @param signature
- * @param signature_size
- * @param signature_length
- * @return psa_status_t
  */
 psa_status_t psa_ecc_p192r1_sign_message(  const psa_key_attributes_t *attributes,
                                         psa_algorithm_t alg,
@@ -95,16 +72,6 @@ psa_status_t psa_ecc_p192r1_sign_message(  const psa_key_attributes_t *attribute
  * @brief   Low level wrapper function to call a driver for an ECC hash verification
  *          with a SECP 192 R1 key.
  *          See @ref psa_verify_hash()
- *
- * @param attributes
- * @param alg
- * @param key_buffer
- * @param key_buffer_size
- * @param hash
- * @param hash_length
- * @param signature
- * @param signature_length
- * @return psa_status_t
  */
 psa_status_t psa_ecc_p192r1_verify_hash(const psa_key_attributes_t *attributes,
                                         psa_algorithm_t alg,
@@ -116,16 +83,6 @@ psa_status_t psa_ecc_p192r1_verify_hash(const psa_key_attributes_t *attributes,
  * @brief   Low level wrapper function to call a driver for an ECC hash verification
  *          with a SECP 192 R1 key.
  *          See @ref psa_verify_message()
- *
- * @param attributes
- * @param alg
- * @param key_buffer
- * @param key_buffer_size
- * @param input
- * @param input_length
- * @param signature
- * @param signature_length
- * @return psa_status_t
  */
 psa_status_t psa_ecc_p192r1_verify_message(const psa_key_attributes_t *attributes,
                                         psa_algorithm_t alg,
@@ -154,17 +111,6 @@ psa_status_t psa_generate_ecc_p256r1_key_pair(  const psa_key_attributes_t *attr
  * @brief   Low level wrapper function to call a driver for an ECC hash signature
  *          with a SECP 256 R1 key.
  *          See @ref psa_sign_hash()
- *
- * @param attributes
- * @param alg
- * @param key_buffer
- * @param key_buffer_size
- * @param hash
- * @param hash_length
- * @param signature
- * @param signature_size
- * @param signature_length
- * @return psa_status_t
  */
 psa_status_t psa_ecc_p256r1_sign_hash(  const psa_key_attributes_t *attributes,
                                         psa_algorithm_t alg,
@@ -177,17 +123,6 @@ psa_status_t psa_ecc_p256r1_sign_hash(  const psa_key_attributes_t *attributes,
  * @brief   Low level wrapper function to call a driver for an ECC hash signature
  *          with a SECP 256 R1 key.
  *          See @ref psa_sign_message()
- *
- * @param attributes
- * @param alg
- * @param key_buffer
- * @param key_buffer_size
- * @param input
- * @param input_length
- * @param signature
- * @param signature_size
- * @param signature_length
- * @return psa_status_t
  */
 psa_status_t psa_ecc_p256r1_sign_message(  const psa_key_attributes_t *attributes,
                                         psa_algorithm_t alg,
@@ -200,16 +135,6 @@ psa_status_t psa_ecc_p256r1_sign_message(  const psa_key_attributes_t *attribute
  * @brief   Low level wrapper function to call a driver for an ECC hash verification
  *          with a SECP 256 R1 key.
  *          See @ref psa_verify_hash()
- *
- * @param attributes
- * @param alg
- * @param key_buffer
- * @param key_buffer_size
- * @param hash
- * @param hash_length
- * @param signature
- * @param signature_length
- * @return psa_status_t
  */
 psa_status_t psa_ecc_p256r1_verify_hash(const psa_key_attributes_t *attributes,
                                         psa_algorithm_t alg,
@@ -221,16 +146,6 @@ psa_status_t psa_ecc_p256r1_verify_hash(const psa_key_attributes_t *attributes,
  * @brief   Low level wrapper function to call a driver for an ECC hash verification
  *          with a SECP 256 R1 key.
  *          See @ref psa_verify_message()
- *
- * @param attributes
- * @param alg
- * @param key_buffer
- * @param key_buffer_size
- * @param input
- * @param input_length
- * @param signature
- * @param signature_length
- * @return psa_status_t
  */
 psa_status_t psa_ecc_p256r1_verify_message(const psa_key_attributes_t *attributes,
                                         psa_algorithm_t alg,
@@ -271,17 +186,6 @@ psa_status_t psa_derive_ecc_ed25519_public_key( const uint8_t *priv_key_buffer,
  * @brief   Low level wrapper function to call a driver for an ECC hash signature
  *          with an ed25519 key.
  *          See @ref psa_sign_message()
- *
- * @param priv_key_buffer
- * @param priv_key_buffer_size
- * @param pub_key_buffer
- * @param pub_key_buffer_size
- * @param input
- * @param input_length
- * @param signature
- * @param signature_size
- * @param signature_length
- * @return psa_status_t
  */
 psa_status_t psa_ecc_ed25519_sign_message(const uint8_t *priv_key_buffer,
                                         size_t priv_key_buffer_size,
@@ -295,14 +199,6 @@ psa_status_t psa_ecc_ed25519_sign_message(const uint8_t *priv_key_buffer,
  * @brief   Low level wrapper function to call a driver for an ECC hash verification
  *          with a ed25519 key.
  *          See @ref psa_verify_message()
- *
- * @param key_buffer
- * @param key_buffer_size
- * @param input
- * @param input_length
- * @param signature
- * @param signature_length
- * @return psa_status_t
  */
 psa_status_t psa_ecc_ed25519_verify_message(const uint8_t *key_buffer, size_t key_buffer_size,
                                             const uint8_t *input, size_t input_length,

--- a/sys/psa_crypto/include/psa_hashes.h
+++ b/sys/psa_crypto/include/psa_hashes.h
@@ -15,7 +15,6 @@
  * @brief       Function declarations for low level wrapper functions for hash operations.
  *
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
- *
  */
 
 #ifndef PSA_HASHES_H
@@ -42,11 +41,6 @@ psa_status_t psa_hashes_md5_setup(psa_hashes_md5_ctx_t *ctx);
 /**
  * @brief   Low level wrapper function to call a driver for an MD5 hash update
  *          See @ref psa_hash_update()
- *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_md5_update(psa_hashes_md5_ctx_t *ctx,
                                    const uint8_t *input,
@@ -55,12 +49,6 @@ psa_status_t psa_hashes_md5_update(psa_hashes_md5_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for an MD5 hash finish
  *          See @ref psa_hash_finish()
- *
- * @param ctx
- * @param hash
- * @param hash_size
- * @param hash_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_md5_finish(psa_hashes_md5_ctx_t *ctx,
                                    uint8_t *hash,
@@ -72,20 +60,12 @@ psa_status_t psa_hashes_md5_finish(psa_hashes_md5_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for an SHA1 hash setup
  *          See @ref psa_hash_setup()
- *
- * @param ctx
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha1_setup(psa_hashes_sha1_ctx_t *ctx);
 
 /**
  * @brief   Low level wrapper function to call a driver for an SHA1 hash update
  *          See @ref psa_hash_update()
- *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha1_update(psa_hashes_sha1_ctx_t *ctx,
                                     const uint8_t *input,
@@ -94,12 +74,6 @@ psa_status_t psa_hashes_sha1_update(psa_hashes_sha1_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for an SHA1 hash finish
  *          See @ref psa_hash_finish()
- *
- * @param ctx
- * @param hash
- * @param hash_size
- * @param hash_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha1_finish(psa_hashes_sha1_ctx_t *ctx,
                                     uint8_t *hash,
@@ -111,20 +85,12 @@ psa_status_t psa_hashes_sha1_finish(psa_hashes_sha1_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for an SHA224 hash setup
  *          See @ref psa_hash_setup()
- *
- * @param ctx
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha224_setup(psa_hashes_sha224_ctx_t *ctx);
 
 /**
  * @brief   Low level wrapper function to call a driver for an SHA224 hash update
  *          See @ref psa_hash_update()
- *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha224_update(psa_hashes_sha224_ctx_t *ctx,
                                       const uint8_t *input,
@@ -133,12 +99,6 @@ psa_status_t psa_hashes_sha224_update(psa_hashes_sha224_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for an SHA224 hash finish
  *          See @ref psa_hash_finish()
- *
- * @param ctx
- * @param hash
- * @param hash_size
- * @param hash_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha224_finish(psa_hashes_sha224_ctx_t *ctx,
                                       uint8_t *hash,
@@ -150,20 +110,12 @@ psa_status_t psa_hashes_sha224_finish(psa_hashes_sha224_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for an SHA256 hash setup
  *          See @ref psa_hash_setup()
- *
- * @param ctx
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha256_setup(psa_hashes_sha256_ctx_t *ctx);
 
 /**
  * @brief   Low level wrapper function to call a driver for an SHA256 hash update
  *          See @ref psa_hash_update()
- *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha256_update(psa_hashes_sha256_ctx_t *ctx,
                                       const uint8_t *input,
@@ -172,12 +124,6 @@ psa_status_t psa_hashes_sha256_update(psa_hashes_sha256_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for an SHA256 hash finish
  *          See @ref psa_hash_finish()
- *
- * @param ctx
- * @param hash
- * @param hash_size
- * @param hash_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha256_finish(psa_hashes_sha256_ctx_t *ctx,
                                       uint8_t *hash,
@@ -189,20 +135,12 @@ psa_status_t psa_hashes_sha256_finish(psa_hashes_sha256_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for an SHA384 hash setup
  *          See @ref psa_hash_setup()
- *
- * @param ctx
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha384_setup(psa_hashes_sha384_ctx_t *ctx);
 
 /**
  * @brief   Low level wrapper function to call a driver for an SHA384 hash update
  *          See @ref psa_hash_update()
- *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha384_update(psa_hashes_sha384_ctx_t *ctx,
                                       const uint8_t *input,
@@ -211,12 +149,6 @@ psa_status_t psa_hashes_sha384_update(psa_hashes_sha384_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for an SHA384 hash finish
  *          See @ref psa_hash_finish()
- *
- * @param ctx
- * @param hash
- * @param hash_size
- * @param hash_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha384_finish(psa_hashes_sha384_ctx_t *ctx,
                                       uint8_t *hash,
@@ -228,20 +160,12 @@ psa_status_t psa_hashes_sha384_finish(psa_hashes_sha384_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for an SHA512 hash setup
  *          See @ref psa_hash_setup()
- *
- * @param ctx
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha512_setup(psa_hashes_sha512_ctx_t *ctx);
 
 /**
  * @brief   Low level wrapper function to call a driver for an SHA512 hash update
  *          See @ref psa_hash_update()
- *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha512_update(psa_hashes_sha512_ctx_t *ctx,
                                       const uint8_t *input,
@@ -250,12 +174,6 @@ psa_status_t psa_hashes_sha512_update(psa_hashes_sha512_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for an SHA512 hash finish
  *          See @ref psa_hash_finish()
- *
- * @param ctx
- * @param hash
- * @param hash_size
- * @param hash_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha512_finish(psa_hashes_sha512_ctx_t *ctx,
                                       uint8_t *hash,
@@ -267,20 +185,12 @@ psa_status_t psa_hashes_sha512_finish(psa_hashes_sha512_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for an SHA512/224 hash setup
  *          See @ref psa_hash_setup()
- *
- * @param ctx
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha512_224_setup(psa_hashes_sha512_224_ctx_t *ctx);
 
 /**
  * @brief   Low level wrapper function to call a driver for an SHA512/224 hash update
  *          See @ref psa_hash_update()
- *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha512_224_update(psa_hashes_sha512_224_ctx_t *ctx,
                                       const uint8_t *input,
@@ -289,12 +199,6 @@ psa_status_t psa_hashes_sha512_224_update(psa_hashes_sha512_224_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for an SHA512/224 hash finish
  *          See @ref psa_hash_finish()
- *
- * @param ctx
- * @param hash
- * @param hash_size
- * @param hash_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha512_224_finish(psa_hashes_sha512_224_ctx_t *ctx,
                                       uint8_t *hash,
@@ -306,20 +210,12 @@ psa_status_t psa_hashes_sha512_224_finish(psa_hashes_sha512_224_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for an SHA512/256 hash setup
  *          See @ref psa_hash_setup()
- *
- * @param ctx
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha512_256_setup(psa_hashes_sha512_256_ctx_t *ctx);
 
 /**
  * @brief   Low level wrapper function to call a driver for an SHA512/256 hash update
  *          See @ref psa_hash_update()
- *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha512_256_update(psa_hashes_sha512_256_ctx_t *ctx,
                                       const uint8_t *input,
@@ -328,12 +224,6 @@ psa_status_t psa_hashes_sha512_256_update(psa_hashes_sha512_256_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for an SHA512/256 hash finish
  *          See @ref psa_hash_finish()
- *
- * @param ctx
- * @param hash
- * @param hash_size
- * @param hash_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha512_256_finish(psa_hashes_sha512_256_ctx_t *ctx,
                                       uint8_t *hash,
@@ -345,11 +235,6 @@ psa_status_t psa_hashes_sha512_256_finish(psa_hashes_sha512_256_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for a general SHA3 hash update
  *          See @ref psa_hash_update()
- *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha3_256_update(psa_hashes_sha3_ctx_t *ctx,
                                       const uint8_t *input,
@@ -358,19 +243,12 @@ psa_status_t psa_hashes_sha3_256_update(psa_hashes_sha3_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for a SHA3-256 hash setup
  *          See @ref psa_hash_setup()
- *
- * @param ctx
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha3_256_setup(psa_hashes_sha3_ctx_t *ctx);
 
 /**
  * @brief   Low level wrapper function to call a driver for a SHA3-256 hash finish
  *          See @ref psa_hash_finish()
- *
- * @param ctx
- * @param hash
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha3_256_finish(psa_hashes_sha3_ctx_t *ctx,
                                       uint8_t *hash);
@@ -380,11 +258,6 @@ psa_status_t psa_hashes_sha3_256_finish(psa_hashes_sha3_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for a general SHA3 hash update
  *          See @ref psa_hash_update()
- *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha3_384_update(psa_hashes_sha3_ctx_t *ctx,
                                       const uint8_t *input,
@@ -393,19 +266,12 @@ psa_status_t psa_hashes_sha3_384_update(psa_hashes_sha3_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for a SHA3-384 hash setup
  *          See @ref psa_hash_setup()
- *
- * @param ctx
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha3_384_setup(psa_hashes_sha3_ctx_t *ctx);
 
 /**
  * @brief   Low level wrapper function to call a driver for a SHA3-384 hash finish
  *          See @ref psa_hash_finish()
- *
- * @param ctx
- * @param hash
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha3_384_finish(psa_hashes_sha3_ctx_t *ctx,
                                       uint8_t *hash);
@@ -415,11 +281,6 @@ psa_status_t psa_hashes_sha3_384_finish(psa_hashes_sha3_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for a general SHA3 hash update
  *          See @ref psa_hash_update()
- *
- * @param ctx
- * @param input
- * @param input_length
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha3_512_update(psa_hashes_sha3_ctx_t *ctx,
                                       const uint8_t *input,
@@ -428,19 +289,12 @@ psa_status_t psa_hashes_sha3_512_update(psa_hashes_sha3_ctx_t *ctx,
 /**
  * @brief   Low level wrapper function to call a driver for a SHA3-512 hash setup
  *          See @ref psa_hash_setup()
- *
- * @param ctx
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha3_512_setup(psa_hashes_sha3_ctx_t *ctx);
 
 /**
  * @brief   Low level wrapper function to call a driver for a SHA3-512 hash finish
  *          See @ref psa_hash_finish()
- *
- * @param ctx
- * @param hash
- * @return psa_status_t
  */
 psa_status_t psa_hashes_sha3_512_finish(psa_hashes_sha3_ctx_t *ctx,
                                       uint8_t *hash);


### PR DESCRIPTION
### Contribution description

This drops a lot of "no-op" Doxygen statements, such as `@param foo <description>` where `<description>` is the empty string.

This now also provides no documentation, but a lot more compact.

### Testing procedure

The generated documentation should not contain any documentation about the parameters, but the headers should be a lot shorter.

### Issues/PRs references

None