### PR TITLE
examples/nanocoap_server: fix typo in LWIP interface name

### DIFF
--- a/examples/networking/coap/nanocoap_server/Makefile
+++ b/examples/networking/coap/nanocoap_server/Makefile
@@ -27,7 +27,6 @@ else
 
     USEMODULE += lwip_arp
     USEMODULE += lwip_ipv4
-    USEMODULE += netdev_legacy_api
 
 # If this module will be disabled, example set IPv4 192.168.100.150 address.
     USEMODULE += lwip_dhcp_auto

--- a/examples/networking/coap/nanocoap_server/main.c
+++ b/examples/networking/coap/nanocoap_server/main.c
@@ -53,7 +53,7 @@ int main(void)
 #define _TEST_ADDR4_MASK   (0x00ffffffU)   /* 255.255.255.0 */
 
     sys_lock_tcpip_core();
-    struct netif *iface = netif_find("ET0aa");
+    struct netif *iface = netif_find("ET0");
 
 #ifndef MODULE_LWIP_DHCP_AUTO
     ip4_addr_t ip, subnet;


### PR DESCRIPTION
### Contribution description

This PR fix small typo in the LWIP interface - in the current code is `ET0aa` should be `ET0`.

### Testing procedure

Run `nanocoap_server` for LWIP IPv4 (set `LWIP_IPV4 ?= 1`in `Makefile`) and check if printed IPv4 address received from DHCP server is correct.

Without this PR some strange/random addresses are shown.

### Issues/PRs references

PR #21333 - added fixed code
