### PR TITLE
net/hosts: add module for static hostname definitions

### DIFF
--- a/examples/networking/gnrc/gnrc_border_router/Makefile
+++ b/examples/networking/gnrc/gnrc_border_router/Makefile
@@ -54,6 +54,7 @@ ifneq (0,$(ENABLE_DNS))
   ifneq (0,$(ENABLE_DNS_CACHING))
     USEMODULE += dns_cache             # cache DNS responses
   endif
+  USEMODULE += hosts                 # enable static hostnames
 endif
 
 # When using a regular network uplink we should use DHCPv6

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -77,6 +77,9 @@ endif
 ifneq (,$(filter gnrc_uhcpc,$(USEMODULE)))
   DIRS += net/gnrc/application_layer/uhcpc
 endif
+ifneq (,$(filter hosts,$(USEMODULE)))
+  DIRS += net/application_layer/hosts
+endif
 ifneq (,$(filter icmpv6,$(USEMODULE)))
   DIRS += net/network_layer/icmpv6
 endif

--- a/sys/include/net/dns.h
+++ b/sys/include/net/dns.h
@@ -21,10 +21,19 @@
  */
 
 #include "modules.h"
-#include "net/hosts.h"
-#include "net/sock/dns.h"
-#include "net/sock/dodtls.h"
-#include "net/gcoap/dns.h"
+#include "net/af.h"
+#if IS_USED(MODULE_HOSTS)
+#  include "net/hosts.h"
+#endif
+#if IS_USED(MODULE_SOCK_DNS) || IS_USED(MODULE_SOCK_DNS_MOCK)
+#  include "net/sock/dns.h"
+#endif
+#if IS_USED(MODULE_SOCK_DODTLS)
+#  include "net/sock/dodtls.h"
+#endif
+#if IS_USED(MODULE_GCOAP_DNS)
+#  include "net/gcoap/dns.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -73,6 +82,9 @@ extern "C" {
  */
 static inline int dns_query(const char *domain_name, void *addr_out, int family)
 {
+    (void)domain_name;
+    (void)addr_out;
+
     int res = -ENOTSUP;
 
     if (family == AF_UNSPEC) {
@@ -84,18 +96,26 @@ static inline int dns_query(const char *domain_name, void *addr_out, int family)
         }
     }
 
-    if (res <= 0 && IS_USED(MODULE_HOSTS)) {
+#if IS_USED(MODULE_HOSTS)
+    if (res <= 0) {
         res = hosts_query(domain_name, addr_out, family);
     }
-    if (res <= 0 && IS_USED(MODULE_GCOAP_DNS)) {
+#endif
+#if IS_USED(MODULE_GCOAP_DNS)
+    if (res <= 0) {
         res = gcoap_dns_query(domain_name, addr_out, family);
     }
-    if (res <= 0 && IS_USED(MODULE_SOCK_DODTLS)) {
+#endif
+#if IS_USED(MODULE_SOCK_DODTLS)
+    if (res <= 0) {
         res = sock_dodtls_query(domain_name, addr_out, family);
     }
-    if (res <= 0 && (IS_USED(MODULE_SOCK_DNS) || IS_USED(MODULE_SOCK_DNS_MOCK))) {
+#endif
+#if IS_USED(MODULE_SOCK_DNS) || IS_USED(MODULE_SOCK_DNS_MOCK)
+    if (res <= 0) {
         res = sock_dns_query(domain_name, addr_out, family);
     }
+#endif
 
     return res;
 }

--- a/sys/include/net/dns.h
+++ b/sys/include/net/dns.h
@@ -21,6 +21,7 @@
  */
 
 #include "modules.h"
+#include "net/hosts.h"
 #include "net/sock/dns.h"
 #include "net/sock/dodtls.h"
 #include "net/gcoap/dns.h"
@@ -83,6 +84,9 @@ static inline int dns_query(const char *domain_name, void *addr_out, int family)
         }
     }
 
+    if (res <= 0 && IS_USED(MODULE_HOSTS)) {
+        res = hosts_query(domain_name, addr_out, family);
+    }
     if (res <= 0 && IS_USED(MODULE_GCOAP_DNS)) {
         res = gcoap_dns_query(domain_name, addr_out, family);
     }

--- a/sys/include/net/hosts.h
+++ b/sys/include/net/hosts.h
@@ -1,0 +1,159 @@
+/*
+ * SPDX-FileCopyrightText: 2025 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @defgroup    net_hosts   Static Hostname definitions
+ * @ingroup     net
+ * @brief       This enables functionality like `/etc/hosts` for @ref dns_query()
+ *
+ * This module allows to make static hostname - IP address mappings that will
+ * be taken into consideration when using `dns_query()` or a higher level API that
+ * makes use of `dns_query()`.
+ *
+ * To enable this, add the `hosts` module to your `Makefile`:
+ *
+ * ```
+ * USEMODULE += hosts
+ * ```
+ *
+ * # Usage
+ * To add a static hostname mapping to your code, just declare it with `HOST_IPV4()`
+ * or `HOST_IPV6()` anywhere in a `.c` file
+ *
+ * ```C
+ * #define IPV4_ADDR_EXAMPLE_COM IPV4_ADDR_INIT(192,168,42,23)
+ * #define IPV6_ADDR_EXAMPLE_COM {{ 0xfd, 0x00, 0x00, 0x00, \
+ *                                  0x00, 0x00, 0x00, 0x00, \
+ *                                  0x00, 0x00, 0x00, 0x00, \
+ *                                  0x00, 0x00, 0x42, 0x23 }}
+ *
+ * HOST_IPV4(example.com, IPV4_ADDR_EXAMPLE_COM);
+ * HOST_IPV6(example.com, IPV6_ADDR_EXAMPLE_COM);
+ * ```
+ *
+ * The hostname should then be resolved by any tool or function that makes
+ * use of `dns_query()`:
+ *
+ * ```
+ * > ping example.com
+ * 12 bytes from fd::42:23: icmp_seq=0 ttl=64 time=1.202 ms
+ * 12 bytes from fd::42:23: icmp_seq=1 ttl=64 time=1.202 ms
+ * 12 bytes from fd::42:23: icmp_seq=2 ttl=64 time=1.202 ms
+ *
+ * --- example.com PING statistics ---
+ * 3 packets transmitted, 3 packets received, 0% packet loss
+ * round-trip min/avg/max = 1.202/1.202/1.202 ms
+ * ```
+ *
+ * @{
+ *
+ * @file
+ * @brief       Static mappings from hostnames to IP addresses
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#include "flash_utils.h"
+#include "net/ipv4/addr.h"
+#include "net/ipv6/addr.h"
+#include "xfa.h"
+
+#ifdef __cplusplus
+extern "C" {
+#else
+
+/**
+ * @brief           A single IPv4 host in the list of hostnames.
+ *
+ * This type is used internally by the @ref HOST_IPV4 macro.
+ */
+typedef struct {
+    FLASH_ATTR const char *name; /**< Name of the host    */
+    const ipv4_addr_t addr;      /**< Address of the host */
+} hostnames_v4_xfa_t;
+
+/**
+ * @brief           A single IPv6 host in the list of hostnames.
+ *
+ * This type is used internally by the @ref HOST_IPV6 macro.
+ */
+typedef struct {
+    FLASH_ATTR const char *name; /**< Name of the host    */
+    const ipv6_addr_t addr;      /**< Address of the host */
+} hostnames_v6_xfa_t;
+
+/**
+ * @brief   Define IPv4 host
+ *
+ * @note    This is not available from C++, but a trivial C++ file can easily
+ *          hook up a `extern "C"` function implemented in C.
+ *
+ * This macro is a helper for defining a hostname -> address mapping and adding
+ * it to the host names XFA (cross file array).
+ *
+ * Example:
+ *
+ * ```.c
+ * #include "hosts.h"
+ * HOST_IPV4(localhost, IPV4_ADDR_LOOPBACK);
+ * ```
+ */
+#define HOST_IPV4(host, ip) \
+    XFA_USE_CONST(hostnames_v4_xfa_t, hostnames_v4_xfa); \
+    static FLASH_ATTR const char _xfa_ ## host ## _hostname[] = #host; \
+    XFA_CONST(hostnames_v4_xfa_t, hostnames_v4_xfa, 0) _xfa_ ## host ## _host = { \
+        .name = _xfa_ ## host ## _hostname, \
+        .addr = ip, \
+    };
+
+/**
+ * @brief   Define IPv6 host
+ *
+ * @note    This is not available from C++, but a trivial C++ file can easily
+ *          hook up a `extern "C"` function implemented in C.
+ *
+ * This macro is a helper for defining a hostname -> address mapping and adding
+ * it to the host names XFA (cross file array).
+ *
+ * Example:
+ *
+ * ```.c
+ * #include "hosts.h"
+ * HOST_IPV6(localhost, IPV6_ADDR_LOOPBACK);
+ * ```
+ */
+#define HOST_IPV6(host, ip) \
+    XFA_USE_CONST(hostnames_v6_xfa_t, hostnames_v6_xfa); \
+    static FLASH_ATTR const char _xfa_ ## host ## _hostname[] = #host; \
+    XFA_CONST(hostnames_v6_xfa_t, hostnames_v6_xfa, 0) _xfa_ ## host ## _host = { \
+        .name = _xfa_ ## host ## _hostname, \
+        .addr = ip, \
+    };
+#endif /* __cplusplus */
+
+/**
+ * @brief Get IP address for a host name
+ *
+ * Host Name <-> IP address mappings can be statically defined with the
+ * @ref HOST_IPV6 macro.
+ *
+ * @param[in]   host_name       Host name to resolve into address
+ * @param[out]  addr_out        Buffer to write result into, but be able to accommodate
+ *                              an address of the selected family
+ * @param[in]   family          Either AF_INET (IPv4), AF_INET6 (IPv6) or AF_UNSPEC
+ *                              (either IPv4 or IPv6)
+ *
+ * @return      the size of the resolved address on success or an error code
+ * @retval      -ENOENT if no matching entry could be found
+ */
+int hosts_query(const char *host_name, void *addr_out, int family);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/sys/include/net/ipv4/addr.h
+++ b/sys/include/net/ipv4/addr.h
@@ -48,6 +48,11 @@ extern "C" {
 #define IPV4_ADDR_INIT(a, b, c, d) { .u8 = {a, b, c, d} }
 
 /**
+ * @brief   Static initializer for the loopback IPv4 address (127.0.0.1)
+ */
+#define IPV4_ADDR_LOOPBACK          IPV4_ADDR_INIT(127, 0, 0, 1)
+
+/**
  * @brief Data type to represent an IPv4 address.
  */
 typedef union {

--- a/sys/net/application_layer/hosts/Makefile
+++ b/sys/net/application_layer/hosts/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/application_layer/hosts/hosts.c
+++ b/sys/net/application_layer/hosts/hosts.c
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: 2025 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include <errno.h>
+#include <string.h>
+#include "net/af.h"
+#include "net/hosts.h"
+
+#ifdef MODULE_IPV4_ADDR
+/* define IPv4 hostnames cross file array */
+XFA_INIT_CONST(hostnames_v4_xfa_t, hostnames_v4_xfa);
+/* always add localhost */
+HOST_IPV4(localhost, IPV4_ADDR_LOOPBACK);
+
+static int _resolve_v4(const char *domain_name, ipv4_addr_t *dst)
+{
+    unsigned n = XFA_LEN(hostnames_v4_xfa_t, hostnames_v4_xfa);
+    for (unsigned i = 0; i < n; i++) {
+        const volatile hostnames_v4_xfa_t *entry = &hostnames_v4_xfa[i];
+        if (flash_strcmp(domain_name, entry->name) != 0) {
+            continue;
+        }
+        const ipv4_addr_t *addr = (ipv4_addr_t *)&entry->addr;
+        *dst = *addr;
+        return sizeof(*dst);
+    }
+
+    return -ENOENT;
+}
+#else
+static int _resolve_v4(const char *domain_name, ipv4_addr_t *dst)
+{
+    (void)domain_name;
+    (void)dst;
+    return -ENOENT;
+}
+#endif
+
+#ifdef MODULE_IPV6_ADDR
+/* define IPv6 hostnames cross file array */
+XFA_INIT_CONST(hostnames_v6_xfa_t, hostnames_v6_xfa);
+/* always add localhost */
+HOST_IPV6(localhost, IPV6_ADDR_LOOPBACK);
+
+static int _resolve_v6(const char *domain_name, ipv6_addr_t *dst)
+{
+    unsigned n = XFA_LEN(hostnames_v6_xfa_t, hostnames_v6_xfa);
+    for (unsigned i = 0; i < n; i++) {
+        const volatile hostnames_v6_xfa_t *entry = &hostnames_v6_xfa[i];
+        if (flash_strcmp(domain_name, entry->name) != 0) {
+            continue;
+        }
+        const ipv6_addr_t *addr = (ipv6_addr_t *)&entry->addr;
+        *dst = *addr;
+        return sizeof(*dst);
+    }
+
+    return -ENOENT;
+}
+#else
+static int _resolve_v6(const char *domain_name, ipv6_addr_t *dst)
+{
+
+    (void)domain_name;
+    (void)dst;
+    return -ENOENT;
+}
+#endif
+
+int hosts_query(const char *domain_name, void *addr_out, int family)
+{
+    int res = -ENOENT;
+
+    if (res < 0 && (family == AF_UNSPEC || family == AF_INET6)) {
+        res = _resolve_v6(domain_name, addr_out);
+    }
+    if (res < 0 && (family == AF_UNSPEC || family == AF_INET)) {
+        res = _resolve_v4(domain_name, addr_out);
+    }
+
+    return res;
+}

--- a/sys/net/netutils/util.c
+++ b/sys/net/netutils/util.c
@@ -22,8 +22,8 @@
 #include "net/utils.h"
 #if defined(MODULE_DNS)
 #include "net/af.h"
-#include "net/dns.h"
 #endif
+#include "net/dns.h"
 
 /* get the next netif, returns true if there are more */
 static bool _netif_get(netif_t **current_netif)
@@ -44,7 +44,6 @@ int netutils_get_ipv4(ipv4_addr_t *addr, const char *hostname)
     for (size_t i = 0; i < strlen(hostname); i++) {
         bool is_not_ipv4 = (hostname[i] < '0' || hostname[i] > '9') && hostname[i] != '.';
 
-#if defined(MODULE_SOCK_DNS) || defined(MODULE_SOCK_DNS_MOCK)
         /* once we see an invalid character for an IPv4 address try to
          * resolve the hostname by DNS */
         if (is_not_ipv4) {
@@ -54,11 +53,6 @@ int netutils_get_ipv4(ipv4_addr_t *addr, const char *hostname)
             }
             return 0;
         }
-#else
-        if (is_not_ipv4) {
-            return -EINVAL;
-        }
-#endif
     }
 
     size_t len = strlen(hostname);
@@ -77,7 +71,6 @@ int netutils_get_ipv6(ipv6_addr_t *addr, netif_t **netif, const char *hostname)
         return -EINVAL;
     }
 
-#if defined(MODULE_SOCK_DNS) || defined(MODULE_SOCK_DNS_MOCK)
     /* hostname is not an IPv6 address */
     if (strchr(hostname, ':') == NULL) {
         int res = dns_query(hostname, addr, AF_INET6);
@@ -86,7 +79,6 @@ int netutils_get_ipv6(ipv6_addr_t *addr, netif_t **netif, const char *hostname)
         }
         return 0;
     }
-#endif
 
     /* search for interface ID */
     size_t len = strlen(hostname);

--- a/sys/net/sock/sock_util.c
+++ b/sys/net/sock/sock_util.c
@@ -26,15 +26,12 @@
 #include <string.h>
 #include <assert.h>
 
+#include "net/dns.h"
 #include "net/sock/util.h"
 #include "net/iana/portrange.h"
 
 #if MODULE_GNRC_SOCK_UDP || MODULE_LWIP_SOCK_UDP
 #  include "net/sock/udp.h"
-#endif
-
-#if MODULE_DNS
-#  include "net/dns.h"
 #endif
 
 #if MODULE_RANDOM
@@ -287,7 +284,6 @@ int sock_tl_name2ep(struct _sock_tl_ep *ep_out, const char *str)
         return 0;
     }
 
-#  if MODULE_SOCK_DNS || MODULE_SOCK_DNS_MOCK
     int family;
     char hostbuf[CONFIG_SOCK_HOSTPORT_MAXLEN];
     const char *host;
@@ -331,7 +327,6 @@ int sock_tl_name2ep(struct _sock_tl_ep *ep_out, const char *str)
     default:
         return -EINVAL;
     }
-#  endif
     return res;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Operating with hostnames instead of raw IP addresses can be more convenient in applications.
On Linux we have `/etc/hosts` where we can statically define hostname -> IP mappings.

This module adds something similar to RIOT.

### Testing procedure

Enable the `hosts` module. The XFA is by default populated with a `localhost` entry:

```
2025-04-11 17:49:05,409 # > ping localhost
2025-04-11 17:49:05,414 # 12 bytes from ::1: icmp_seq=0 ttl=64 time=0.202 ms
2025-04-11 17:49:06,414 # 12 bytes from ::1: icmp_seq=1 ttl=64 time=0.202 ms
2025-04-11 17:49:07,414 # 12 bytes from ::1: icmp_seq=2 ttl=64 time=0.202 ms
2025-04-11 17:49:07,415 # 
2025-04-11 17:49:07,417 # --- localhost PING statistics ---
2025-04-11 17:49:07,422 # 3 packets transmitted, 3 packets received, 0% packet loss
2025-04-11 17:49:07,426 # round-trip min/avg/max = 0.202/0.202/0.202 ms
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
