### PR TITLE
core/clist: use insertion sort

### DIFF
--- a/core/lib/clist.c
+++ b/core/lib/clist.c
@@ -1,38 +1,9 @@
 /*
- * Copyright (C) 2017 Inria
- *               2017 Freie Universität Berlin
- *               2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * Copyright (C) 2025 Marian Buschsieweke <marian.buschsieweke@posteo.net>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
- *
- * The code of _clist_sort() has been imported from
- * https://www.chiark.greenend.org.uk/~sgtatham/algorithms/listsort.html.
- * Original copyright notice:
- *
- * This file is copyright 2001 Simon Tatham.
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or
- * sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT.  IN NO EVENT SHALL SIMON TATHAM BE LIABLE FOR
- * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
- * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
  */
 
 /**
@@ -42,7 +13,7 @@
  * @file
  * @brief       clist helper implementations
  *
- * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
  *
  * @}
  */
@@ -51,103 +22,60 @@
 
 clist_node_t *_clist_sort(clist_node_t *list, clist_cmp_func_t cmp)
 {
-    clist_node_t *p, *q, *e;
-    int insize, psize, qsize, i;
+    clist_node_t *sorted, *unsorted;
 
-    /*
-     * Silly special case: if `list' was passed in as NULL, return
-     * NULL immediately.
-     */
+    /* Special case: Empty list */
     if (!list) {
         return NULL;
     }
 
-    insize = 1;
-
-    while (1) {
-        clist_node_t *tail = NULL;
-        clist_node_t *oldhead = list;
-        p = list;
-        list = NULL;
-
-        int nmerges = 0;  /* count number of merges we do in this pass */
-
-        while (p) {
-            nmerges++;  /* there exists a merge to be done */
-            /* step `insize' places along from p */
-            q = p;
-            psize = 0;
-            for (i = 0; i < insize; i++) {
-                psize++;
-                q = (q->next == oldhead) ? NULL : q->next;
-                /* cppcheck-suppress nullPointer
-                 * (reason: possible bug in cppcheck 1.6x) */
-                if (!q) {
-                    break;
-                }
-            }
-
-            /* if q hasn't fallen off end, we have two lists to merge */
-            qsize = insize;
-
-            /* now we have two lists; merge them */
-            while (psize > 0 || (qsize > 0 && q)) {
-
-                /* decide whether next element of merge comes from p or q */
-                if (psize == 0) {
-                    /* p is empty; e must come from q. */
-                    e = q; q = q->next; qsize--;
-                    if (q == oldhead) {
-                        q = NULL;
-                    }
-                }
-                else if (qsize == 0 || !q) {
-                    /* q is empty; e must come from p. */
-                    e = p; p = p->next; psize--;
-                    if (p == oldhead) {
-                        p = NULL;
-                    }
-                }
-                else if (cmp(p, q) <= 0) {
-                    /* First element of p is lower (or same);
-                     * e must come from p. */
-                    e = p; p = p->next; psize--;
-                    if (p == oldhead) {
-                        p = NULL;
-                    }
-                }
-                else {
-                    /* First element of q is lower; e must come from q. */
-                    e = q; q = q->next; qsize--;
-                    if (q == oldhead) {
-                        q = NULL;
-                    }
-                }
-
-                /* add the next element to the merged list */
-                if (tail) {
-                    tail->next = e;
-                }
-                else {
-                    list = e;
-                }
-                tail = e;
-            }
-
-            /* now p has stepped `insize' places along, and q has too */
-            p = q;
-        }
-
-        /* cppcheck-suppress nullPointer
-         * (reason: tail cannot be NULL at this point, because list != NULL) */
-        tail->next = list;
-
-        /* If we have done only one merge, we're finished. */
-        if (nmerges <= 1) { /* allow for nmerges==0, the empty list case */
-            return tail;
-        }
-
-        /* Otherwise repeat, merging lists twice the size */
-        insize *= 2;
+    /* Special case: Only one item */
+    if (!list->next) {
+        return list;
     }
+
+    /* We break the circular list into two linear lists. The list sorted
+     * gets one element, all others go into unsorted. We then sort in one
+     * element from unsorted into sorted at a time using insertion sort.
+     * Note: Since sorted is one element long at start, it is naturally sorted,
+     *       as every one item list is inherently sorted.
+      */
+    sorted = list->next;
+    unsorted = sorted->next;
+    sorted->next = NULL;
+    list->next = NULL;
+
+sort_next_cycle:
+    while (unsorted) {
+        clist_node_t *iter = sorted;
+        clist_node_t **prev = &sorted;
+        while (iter) {
+            if (cmp(unsorted, iter) < 0) {
+                /* head of unsorted needs to be inserted before iter */
+                clist_node_t *tmp = unsorted->next;
+                *prev = unsorted;
+                unsorted->next = iter;
+                unsorted = tmp;
+                goto sort_next_cycle;
+            }
+            prev = &iter->next;
+            iter = iter->next;
+        }
+        /* head of unsorted needs to be inserted after iter */
+        clist_node_t *tmp = unsorted->next;
+        *prev = unsorted;
+        unsorted->next = NULL;
+        unsorted = tmp;
+    }
+
+    /* We now have in sorted a sorted linear list. Let's make that circular
+     * again and return the pointer to the last item */
+
+    clist_node_t *last = sorted;
+    while (last->next) {
+        last = last->next;
+    }
+    last->next = sorted;
+
+    return last;
 }

--- a/core/lib/include/clist.h
+++ b/core/lib/include/clist.h
@@ -386,18 +386,6 @@ static inline clist_node_t *clist_foreach(clist_node_t *list, int (*func)(
 typedef int (*clist_cmp_func_t)(clist_node_t *a, clist_node_t *b);
 
 /**
- * @brief   List sorting helper function
- *
- * @internal
- *
- * @param[in]   list_head   ptr to the first element inside a clist
- * @param[in]   cmp         comparison function
- *
- * @returns     ptr to *last* element in list
- */
-clist_node_t *_clist_sort(clist_node_t *list_head, clist_cmp_func_t cmp);
-
-/**
  * @brief   Sort a list
  *
  * This function will sort @p list using merge sort.
@@ -439,12 +427,7 @@ clist_node_t *_clist_sort(clist_node_t *list_head, clist_cmp_func_t cmp);
  * @param[in,out]   list    List to sort
  * @param[in]       cmp     Comparison function
  */
-static inline void clist_sort(clist_node_t *list, clist_cmp_func_t cmp)
-{
-    if (list->next) {
-        list->next = _clist_sort(list->next->next, cmp);
-    }
-}
+void clist_sort(clist_node_t *list, clist_cmp_func_t cmp);
 
 /**
  * @brief   Count the number of items in the given list

--- a/core/lib/include/clist.h
+++ b/core/lib/include/clist.h
@@ -31,7 +31,7 @@
  * clist_find()         | O(n)    | find and return node
  * clist_find_before()  | O(n)    | find node return node pointing to node
  * clist_remove()       | O(n)    | remove and return node
- * clist_sort()         | O(NlogN)| sort list (stable)
+ * clist_sort()         | O(n²)   | sort list (stable)
  * clist_count()        | O(n)    | count the number of elements in a list
  * clist_is_empty()     | O(1)    | returns true if the list contains no elements
  * clist_exactly_one()  | O(1)    | returns true if the list contains one element

--- a/sys/include/benchmark.h
+++ b/sys/include/benchmark.h
@@ -44,6 +44,10 @@ extern "C" {
 #define BENCHMARK_FUNC(name, runs, func)                        \
     do {                                                        \
         ztimer_stopwatch_t timer = { .clock = ZTIMER_USEC };    \
+        /* warm up cache, branch predictor, ... */              \
+        for (unsigned long i = 0; i < 32; i++) {                \
+            func;                                               \
+        }                                                       \
         ztimer_stopwatch_start(&timer);                         \
         for (unsigned long i = 0; i < runs; i++) {              \
             func;                                               \

--- a/tests/bench/runtime_coreapis/tests/01-run.py
+++ b/tests/bench/runtime_coreapis/tests/01-run.py
@@ -27,6 +27,9 @@ def testfunc(child):
     child.expect(BENCHMARK_REGEXP.format(func="thread flags set/wait one"), timeout=TIMEOUT)
     child.expect(BENCHMARK_REGEXP.format(func=r"msg_try_receive\(\)"), timeout=TIMEOUT)
     child.expect(BENCHMARK_REGEXP.format(func=r"msg_avail\(\)"))
+    child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort\(\) \(\d+ nodes\)", timeout=TIMEOUT))
+    child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort\(\) \(\d+ nodes\)", timeout=TIMEOUT))
+    child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort\(\) \(\d+ nodes\)", timeout=TIMEOUT))
     child.expect_exact('[SUCCESS]')
 
 

--- a/tests/bench/runtime_coreapis/tests/01-run.py
+++ b/tests/bench/runtime_coreapis/tests/01-run.py
@@ -27,9 +27,9 @@ def testfunc(child):
     child.expect(BENCHMARK_REGEXP.format(func="thread flags set/wait one"), timeout=TIMEOUT)
     child.expect(BENCHMARK_REGEXP.format(func=r"msg_try_receive\(\)"), timeout=TIMEOUT)
     child.expect(BENCHMARK_REGEXP.format(func=r"msg_avail\(\)"))
-    child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort\(\) \(\d+ nodes\)", timeout=TIMEOUT))
-    child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort\(\) \(\d+ nodes\)", timeout=TIMEOUT))
-    child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort\(\) \(\d+ nodes\)", timeout=TIMEOUT))
+    for _ in range(7):
+        child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort \(#\d+, worst\)", timeout=TIMEOUT))
+        child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort \(#\d+, avg\)", timeout=TIMEOUT))
     child.expect_exact('[SUCCESS]')
 
 

--- a/tests/bench/runtime_coreapis/tests/01-run.py
+++ b/tests/bench/runtime_coreapis/tests/01-run.py
@@ -28,8 +28,10 @@ def testfunc(child):
     child.expect(BENCHMARK_REGEXP.format(func=r"msg_try_receive\(\)"), timeout=TIMEOUT)
     child.expect(BENCHMARK_REGEXP.format(func=r"msg_avail\(\)"))
     for _ in range(7):
-        child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort \(#\d+, worst\)", timeout=TIMEOUT))
-        child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort \(#\d+, avg\)", timeout=TIMEOUT))
+        child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort \(#\d+, rev\)", timeout=TIMEOUT))
+        child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort \(#\d+, prng\)", timeout=TIMEOUT))
+        child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort \(#\d+, sort\)", timeout=TIMEOUT))
+        child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort \(#\d+, ≈sort\)", timeout=TIMEOUT))
     child.expect_exact('[SUCCESS]')
 
 

--- a/tests/unittests/tests-core/tests-core-clist.c
+++ b/tests/unittests/tests-core/tests-core-clist.c
@@ -6,19 +6,32 @@
  * directory for more details.
  */
 
+#include <assert.h>
 #include <string.h>
 #include <stdint.h>
 
 #include "embUnit.h"
 
 #include "clist.h"
+#include "container.h"
 
 #include "tests-core.h"
 
 #define TEST_CLIST_LEN    (8)
 
-static list_node_t tests_clist_buf[TEST_CLIST_LEN];
+/* Test list data structure */
+struct test_list_node {
+    list_node_t list;
+    unsigned value;
+};
+
+static struct test_list_node tests_clist_buf[TEST_CLIST_LEN];
 static list_node_t test_clist;
+
+static struct test_list_node * _get_test_list_node(list_node_t *node)
+{
+    return container_of(node, struct test_list_node, list);
+}
 
 static void set_up(void)
 {
@@ -28,7 +41,7 @@ static void set_up(void)
 
 static void test_clist_rpush(void)
 {
-    list_node_t *elem = &(tests_clist_buf[0]);
+    list_node_t *elem = &(tests_clist_buf[0].list);
     list_node_t *list = &test_clist;
 
     clist_rpush(list, elem);
@@ -41,7 +54,7 @@ static void test_clist_add_two(void)
 {
     list_node_t *list = &test_clist;
 
-    list_node_t *elem = &(tests_clist_buf[1]);
+    list_node_t *elem = &(tests_clist_buf[1].list);
 
     test_clist_rpush();
 
@@ -57,14 +70,14 @@ static void test_clist_add_three(void)
     list_node_t *list = &test_clist;
 
     for (int i = 0; i < 3; i++) {
-        clist_rpush(list, &(tests_clist_buf[i]));
+        clist_rpush(list, &(tests_clist_buf[i].list));
     }
 
     TEST_ASSERT_NOT_NULL(list->next);
-    TEST_ASSERT(list->next == &(tests_clist_buf[2]));
-    TEST_ASSERT(list->next->next == &(tests_clist_buf[0]));
-    TEST_ASSERT(list->next->next->next == &(tests_clist_buf[1]));
-    TEST_ASSERT(list->next->next->next->next == &(tests_clist_buf[2]));
+    TEST_ASSERT(list->next == &(tests_clist_buf[2].list));
+    TEST_ASSERT(list->next->next == &(tests_clist_buf[0].list));
+    TEST_ASSERT(list->next->next->next == &(tests_clist_buf[1].list));
+    TEST_ASSERT(list->next->next->next->next == &(tests_clist_buf[2].list));
 }
 
 static void test_clist_find(void)
@@ -74,10 +87,10 @@ static void test_clist_find(void)
     test_clist_add_three();
 
     for (int i = 0; i < 3; i++) {
-        TEST_ASSERT(clist_find(list, &(tests_clist_buf[i])) == &(tests_clist_buf[i]));
+        TEST_ASSERT(clist_find(list, &(tests_clist_buf[i].list)) == &(tests_clist_buf[i].list));
     }
 
-    TEST_ASSERT_NULL(clist_find(list, &(tests_clist_buf[3])));
+    TEST_ASSERT_NULL(clist_find(list, &(tests_clist_buf[3].list)));
 }
 
 static void test_clist_find_before(void)
@@ -86,13 +99,13 @@ static void test_clist_find_before(void)
 
     test_clist_add_three();
 
-    TEST_ASSERT(clist_find_before(list, &(tests_clist_buf[0])) == &(tests_clist_buf[2]));
+    TEST_ASSERT(clist_find_before(list, &(tests_clist_buf[0].list)) == &(tests_clist_buf[2].list));
 
     for (int i = 1; i < 3; i++) {
-        TEST_ASSERT(clist_find_before(list, &(tests_clist_buf[i])) == &(tests_clist_buf[i-1]));
+        TEST_ASSERT(clist_find_before(list, &(tests_clist_buf[i].list)) == &(tests_clist_buf[i-1].list));
     }
 
-    TEST_ASSERT_NULL(clist_find_before(list, &(tests_clist_buf[3])));
+    TEST_ASSERT_NULL(clist_find_before(list, &(tests_clist_buf[3].list)));
 }
 
 static void test_clist_remove(void)
@@ -102,27 +115,27 @@ static void test_clist_remove(void)
     for (int i = 0; i < 3; i++) {
         set_up();
         test_clist_add_three();
-        clist_remove(list, &(tests_clist_buf[i]));
+        clist_remove(list, &(tests_clist_buf[i].list));
 
         for (int j = 0; j < 3; j++) {
             if (i == j) {
-                TEST_ASSERT_NULL(clist_find(list, &(tests_clist_buf[j])));
+                TEST_ASSERT_NULL(clist_find(list, &(tests_clist_buf[j].list)));
             }
             else {
-                TEST_ASSERT(clist_find(list, &(tests_clist_buf[j])) == &(tests_clist_buf[j]));
+                TEST_ASSERT(clist_find(list, &(tests_clist_buf[j].list)) == &(tests_clist_buf[j].list));
             }
         }
     }
 
     /* list now contains 0, 1 */
-    TEST_ASSERT(list->next == &(tests_clist_buf[1]));
-    TEST_ASSERT(list->next->next == &(tests_clist_buf[0]));
+    TEST_ASSERT(list->next == &(tests_clist_buf[1].list));
+    TEST_ASSERT(list->next->next == &(tests_clist_buf[0].list));
 
-    clist_remove(list, &(tests_clist_buf[1]));
-    TEST_ASSERT(list->next == &(tests_clist_buf[0]));
-    TEST_ASSERT(list->next->next == &(tests_clist_buf[0]));
+    clist_remove(list, &(tests_clist_buf[1].list));
+    TEST_ASSERT(list->next == &(tests_clist_buf[0].list));
+    TEST_ASSERT(list->next->next == &(tests_clist_buf[0].list));
 
-    clist_remove(list, &(tests_clist_buf[0]));
+    clist_remove(list, &(tests_clist_buf[0].list));
     TEST_ASSERT_NULL(list->next);
 }
 
@@ -132,13 +145,13 @@ static void test_clist_lpop(void)
 
     test_clist_add_three();
 
-    TEST_ASSERT(clist_lpop(list) == &tests_clist_buf[0]);
+    TEST_ASSERT(clist_lpop(list) == &tests_clist_buf[0].list);
     TEST_ASSERT_NOT_NULL(list->next);
 
-    TEST_ASSERT(clist_lpop(list) == &tests_clist_buf[1]);
+    TEST_ASSERT(clist_lpop(list) == &tests_clist_buf[1].list);
     TEST_ASSERT_NOT_NULL(list->next);
 
-    TEST_ASSERT(clist_lpop(list) == &tests_clist_buf[2]);
+    TEST_ASSERT(clist_lpop(list) == &tests_clist_buf[2].list);
     TEST_ASSERT_NULL(list->next);
     TEST_ASSERT_NULL(clist_lpop(list));
 }
@@ -148,10 +161,10 @@ static void test_clist_lpush(void)
     list_node_t *list = &test_clist;
 
     test_clist_add_two();
-    clist_lpush(list, &tests_clist_buf[2]);
+    clist_lpush(list, &tests_clist_buf[2].list);
 
     TEST_ASSERT_NOT_NULL(list->next);
-    TEST_ASSERT(list->next->next == &tests_clist_buf[2]);
+    TEST_ASSERT(list->next->next == &tests_clist_buf[2].list);
 }
 
 static void test_clist_rpop(void)
@@ -163,7 +176,7 @@ static void test_clist_rpop(void)
     clist_rpop(list);
 
     TEST_ASSERT_NOT_NULL(list->next);
-    TEST_ASSERT(list->next->next == &tests_clist_buf[0]);
+    TEST_ASSERT(list->next->next == &tests_clist_buf[0].list);
 }
 
 static void test_clist_remove_two(void)
@@ -187,11 +200,11 @@ static void test_clist_lpoprpush(void)
 
     clist_lpoprpush(list);
 
-    TEST_ASSERT(list->next->next == &tests_clist_buf[1]);
+    TEST_ASSERT(list->next->next == &tests_clist_buf[1].list);
 
     clist_lpoprpush(list);
 
-    TEST_ASSERT(list->next->next == &tests_clist_buf[0]);
+    TEST_ASSERT(list->next->next == &tests_clist_buf[0].list);
 }
 
 static int _foreach_called;
@@ -200,10 +213,10 @@ static int _foreach_abort_after = TEST_CLIST_LEN/2;
 
 static void _foreach_test(clist_node_t *node)
 {
-    TEST_ASSERT(node == &tests_clist_buf[_foreach_called]);
+    TEST_ASSERT(node == &tests_clist_buf[_foreach_called].list);
 
     for (int i = 0; i < TEST_CLIST_LEN; i++) {
-        if (node == &tests_clist_buf[i]) {
+        if (node == &tests_clist_buf[i].list) {
             _foreach_visited[i]++;
             break;
         }
@@ -246,7 +259,7 @@ static void test_clist_foreach(void)
     TEST_ASSERT(res == NULL);
 
     for (int i = 0; i < TEST_CLIST_LEN; i++) {
-        clist_rpush(list, &tests_clist_buf[i]);
+        clist_rpush(list, &tests_clist_buf[i].list);
     }
 
     res = clist_foreach(list, _foreach_test_trampoline, NULL);
@@ -266,19 +279,60 @@ static void test_clist_foreach(void)
     TEST_ASSERT(res == NULL);
 }
 
-static int _cmp(clist_node_t *a, clist_node_t *b)
+static int _cmp(clist_node_t *_a, clist_node_t *_b)
 {
-    /* this comparison function will sort by the actual memory address of the
-     * list node (descending) */
-    return (uintptr_t)a - (uintptr_t) b;
+    struct test_list_node *a = _get_test_list_node(_a), *b = _get_test_list_node(_b);
+    return a->value - b->value;
 }
 
-static void test_clist_sort_empty(void)
+static bool _is_clist_stable_sorted(clist_node_t *list)
 {
-    clist_node_t empty = { .next=NULL };
-    clist_sort(&empty, _cmp);
+    /* empty list is always considered as sorted */
+    if (!list->next) {
+        return true;
+    }
 
-    TEST_ASSERT(empty.next == NULL);
+    clist_node_t *end_of_clist = list->next;
+    clist_node_t *prev = list->next->next;
+    clist_node_t *cur = prev->next;
+
+    while (prev != end_of_clist) {
+        struct test_list_node *a = _get_test_list_node(prev);
+        struct test_list_node *b = _get_test_list_node(cur);
+
+        if (a->value > b->value) {
+            return false;
+        }
+        if (a->value == b->value) {
+            /* stable sort requires that order is not touched when elements
+             * are equal */
+            if ((uintptr_t)a > (uintptr_t)b) {
+                return false;
+            }
+        }
+
+        prev = cur;
+        cur = cur->next;
+    }
+
+    return true;
+}
+
+static void _prepare_unsorted_clist(size_t len)
+{
+    TEST_ASSERT(len <= ARRAY_SIZE(tests_clist_buf));
+    static const unsigned values[] = {
+        7, 3, 9, 3, 2, 11, 5, 3
+    };
+    static_assert(ARRAY_SIZE(tests_clist_buf) <= ARRAY_SIZE(values),
+                  "Not enough test date for sort test");
+
+    set_up();
+    clist_node_t *list = &test_clist;
+    for (size_t i = 0; i < len; i++) {
+        tests_clist_buf[i].value = values[i];
+        clist_rpush(list, &tests_clist_buf[i].list);
+    }
 }
 
 /*
@@ -295,22 +349,10 @@ static void test_clist_sort(void)
 {
     clist_node_t *list = &test_clist;
 
-    for (int i = 0; i < TEST_CLIST_LEN; i++) {
-        clist_rpush(list, &tests_clist_buf[i]);
-    }
-
-    /* rotate the list a couple of times in order to mess up the sorting */
-    clist_lpoprpush(list);
-    clist_lpoprpush(list);
-    clist_lpoprpush(list);
-
-    /* sort list */
-    clist_sort(list, _cmp);
-
-    uintptr_t last = (uintptr_t) list->next;
-
-    for (int i = 0; i < TEST_CLIST_LEN; i++) {
-        TEST_ASSERT((uintptr_t) clist_rpop(list) <= last);
+    for (size_t cur_len = 0; cur_len < TEST_CLIST_LEN; cur_len++) {
+        _prepare_unsorted_clist(cur_len);
+        clist_sort(list, _cmp);
+        TEST_ASSERT(_is_clist_stable_sorted(list));
     }
 }
 
@@ -320,7 +362,7 @@ static void test_clist_count(void)
     TEST_ASSERT(n == 0);
 
     for (unsigned i = 1; i <= TEST_CLIST_LEN; i++) {
-        clist_rpush(&test_clist, &tests_clist_buf[i - 1]);
+        clist_rpush(&test_clist, &tests_clist_buf[i - 1].list);
         n = clist_count(&test_clist);
         TEST_ASSERT(n == i);
     }
@@ -336,7 +378,7 @@ static void test_clist_is_empty(void)
     TEST_ASSERT(clist_is_empty(&test_clist));
 
     for (unsigned i = 1; i <= TEST_CLIST_LEN; i++) {
-        clist_rpush(&test_clist, &tests_clist_buf[i - 1]);
+        clist_rpush(&test_clist, &tests_clist_buf[i - 1].list);
         TEST_ASSERT(!clist_is_empty(&test_clist));
     }
     for (unsigned i = TEST_CLIST_LEN; i > 0; i--) {
@@ -355,14 +397,14 @@ static void test_clist_special_cardinality(void)
     TEST_ASSERT(!clist_exactly_one(&test_clist));
     TEST_ASSERT(!clist_more_than_one(&test_clist));
 
-    clist_rpush(&test_clist, &tests_clist_buf[i++]);
+    clist_rpush(&test_clist, &tests_clist_buf[i++].list);
 
     TEST_ASSERT(!clist_is_empty(&test_clist));
     TEST_ASSERT(clist_exactly_one(&test_clist));
     TEST_ASSERT(!clist_more_than_one(&test_clist));
 
     while (i < TEST_CLIST_LEN) {
-        clist_rpush(&test_clist, &tests_clist_buf[i++]);
+        clist_rpush(&test_clist, &tests_clist_buf[i++].list);
 
         TEST_ASSERT(!clist_is_empty(&test_clist));
         TEST_ASSERT(!clist_exactly_one(&test_clist));
@@ -402,7 +444,6 @@ Test *tests_core_clist_tests(void)
         new_TestFixture(test_clist_remove),
         new_TestFixture(test_clist_lpoprpush),
         new_TestFixture(test_clist_foreach),
-        new_TestFixture(test_clist_sort_empty),
         new_TestFixture(test_clist_sort),
         new_TestFixture(test_clist_count),
         new_TestFixture(test_clist_is_empty),


### PR DESCRIPTION
### Contribution description

This replaces the previous clist sort implementation, which used a merge sort, with a simple insertion sort implementation.

The motivation is as follow:

1. The insertion sort is smaller (code size)
2. The performance benefit of the merge sort would only become noticeable on data sets that would be to large to comfortably handle on the MCUs RIOT targets
3. The previous implementation looked like a good candidate for the IOCCC, while the insertion sort is trivial to understand
4. Static analysis could provide for two statements an example control flow path that would trigger a `NULL` pointer dereferencation. The current code has no such defects.

### Testing procedure

1. There is a unit test that should still pass.
2. Adding `-fanalyzer` should now be happy with the code
3. The code should now be understandable without spending hours on a white board

### Issues/PRs references

None