### PR TITLE
core/msg: fix `msg_avail_thread()` and `msg_avail()`

### DIFF
--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -375,16 +375,21 @@ int msg_reply_int(msg_t *m, msg_t *reply);
  *
  * @param[in] pid    a PID
  *
- * @return Number of messages available in queue of @p pid on success
- * @return 0, if no caller's message queue is initialized
+ * @return  Number of messages available in queue of the thread identified by
+ *          PID @p pid
+ * @retval  0       The message queue of the thread identified by PID @p pid is
+ *                  *not* initialized or PID @p pid does not refer to a running
+ *                  thread
  */
 unsigned msg_avail_thread(kernel_pid_t pid);
 
 /**
  * @brief Check how many messages are available (waiting) in the message queue
  *
- * @return Number of messages available in our queue on success
- * @return 0, if no caller's message queue is initialized
+ * @pre     The caller is running in thread context
+ *
+ * @return  Number of messages available in our queue
+ * @retval  0       Caller's message queue is *not* initialized
  */
 unsigned msg_avail(void);
 

--- a/core/msg.c
+++ b/core/msg.c
@@ -458,12 +458,23 @@ static unsigned _msg_avail(thread_t *thread)
 
 unsigned msg_avail_thread(kernel_pid_t pid)
 {
-    return _msg_avail(thread_get(pid));
+    unsigned irq_state = irq_disable();
+    thread_t *t = thread_get(pid);
+    if (!t) {
+        irq_restore(irq_state);
+        return 0;
+    }
+    unsigned result = _msg_avail(t);
+    irq_restore(irq_state);
+    return result;
 }
 
 unsigned msg_avail(void)
 {
-    return _msg_avail(thread_get_active());
+    unsigned irq_state = irq_disable();
+    unsigned result = _msg_avail(thread_get_active());
+    irq_restore(irq_state);
+    return result;
 }
 
 unsigned msg_queue_capacity(kernel_pid_t pid)


### PR DESCRIPTION
### Contribution description

This now ensures race-free access to the CIB tracking the number of messages queued in the ringbuffer for a given thread.

In addition, `msg_avail_thread()` now checks if the provided pid refers to a thread that is currently existing.

### Testing procedure

- Tests of `msg_avail()` should still pass
- `msg_avail_thread()` and `msg_avail()` should no longer be racy

### Issues/PRs references

None