### PR TITLE
core/clist_sort: rewrite

### DIFF
--- a/core/lib/include/clist.h
+++ b/core/lib/include/clist.h
@@ -386,18 +386,6 @@ static inline clist_node_t *clist_foreach(clist_node_t *list, int (*func)(
 typedef int (*clist_cmp_func_t)(clist_node_t *a, clist_node_t *b);
 
 /**
- * @brief   List sorting helper function
- *
- * @internal
- *
- * @param[in]   list_head   ptr to the first element inside a clist
- * @param[in]   cmp         comparison function
- *
- * @returns     ptr to *last* element in list
- */
-clist_node_t *_clist_sort(clist_node_t *list_head, clist_cmp_func_t cmp);
-
-/**
  * @brief   Sort a list
  *
  * This function will sort @p list using merge sort.
@@ -439,12 +427,7 @@ clist_node_t *_clist_sort(clist_node_t *list_head, clist_cmp_func_t cmp);
  * @param[in,out]   list    List to sort
  * @param[in]       cmp     Comparison function
  */
-static inline void clist_sort(clist_node_t *list, clist_cmp_func_t cmp)
-{
-    if (list->next) {
-        list->next = _clist_sort(list->next->next, cmp);
-    }
-}
+void clist_sort(clist_node_t *list, clist_cmp_func_t cmp);
 
 /**
  * @brief   Count the number of items in the given list

--- a/sys/include/benchmark.h
+++ b/sys/include/benchmark.h
@@ -42,10 +42,24 @@ extern "C" {
  * @param[in] func      function call to benchmark
  */
 #define BENCHMARK_FUNC(name, runs, func)                        \
+    BENCHMARK_FUNC_WARMUP(name, 0, runs, func)
+
+/**
+ * @brief   Measure the runtime of a given function call
+ *
+ * Same as @ref BENCHMARK_FUNC, but do a few warmup iterations before starting
+ * the benchmark to warm up the dynamic branch predictor state and caches.
+ *
+ * @param[in] name      name for labeling the output
+ * @param[in] warmup    number of times to run @p func before the benchmark
+ * @param[in] runs      number of times to run @p func during the benchmark
+ * @param[in] func      function call to benchmark
+ */
+#define BENCHMARK_FUNC_WARMUP(name, warmup, runs, func)         \
     do {                                                        \
         ztimer_stopwatch_t timer = { .clock = ZTIMER_USEC };    \
         /* warm up cache, branch predictor, ... */              \
-        for (unsigned long i = 0; i < 32; i++) {                \
+        for (unsigned long i = 0; i < warmup; i++) {            \
             func;                                               \
         }                                                       \
         ztimer_stopwatch_start(&timer);                         \

--- a/sys/include/benchmark.h
+++ b/sys/include/benchmark.h
@@ -59,7 +59,8 @@ extern "C" {
     do {                                                        \
         ztimer_stopwatch_t timer = { .clock = ZTIMER_USEC };    \
         /* warm up cache, branch predictor, ... */              \
-        for (unsigned long i = 0; i < warmup; i++) {            \
+        unsigned long _warmup = warmup;                         \
+        while (_warmup--) {                                     \
             func;                                               \
         }                                                       \
         ztimer_stopwatch_start(&timer);                         \

--- a/sys/include/benchmark.h
+++ b/sys/include/benchmark.h
@@ -44,6 +44,10 @@ extern "C" {
 #define BENCHMARK_FUNC(name, runs, func)                        \
     do {                                                        \
         ztimer_stopwatch_t timer = { .clock = ZTIMER_USEC };    \
+        /* warm up cache, branch predictor, ... */              \
+        for (unsigned long i = 0; i < 32; i++) {                \
+            func;                                               \
+        }                                                       \
         ztimer_stopwatch_start(&timer);                         \
         for (unsigned long i = 0; i < runs; i++) {              \
             func;                                               \

--- a/tests/bench/runtime_coreapis/main.c
+++ b/tests/bench/runtime_coreapis/main.c
@@ -160,7 +160,7 @@ static void _clist_sort_test_reversed(void)
     clist_node_t *list = &clist;
 
     unsigned value = BENCH_CLIST_SORT_TEST_NODES;
-    clist_foreach(list, _insert_reserved_data, &value);
+    clist_foreach(list, _insert_reversed_data, &value);
     clist_sort(list, _cmp);
 }
 

--- a/tests/bench/runtime_coreapis/main.c
+++ b/tests/bench/runtime_coreapis/main.c
@@ -31,11 +31,7 @@
 #  define BENCH_RUNS          (1000UL * 1000UL)
 #endif
 #ifndef BENCH_CLIST_RUNS
-#  if defined(BOARD_NATIVE64) || defined(BOARD_NATIVE32)
-#    define BENCH_CLIST_RUNS BENCH_RUNS
-#  else
-#    define BENCH_CLIST_RUNS (BENCH_RUNS / 1000UL)
-#  endif
+#  define BENCH_CLIST_RUNS (BENCH_RUNS / 1000UL)
 #endif
 
 #ifndef BENCH_CLIST_SORT_TEST_NODES

--- a/tests/bench/runtime_coreapis/main.c
+++ b/tests/bench/runtime_coreapis/main.c
@@ -79,7 +79,7 @@ static void _flag_waitone(void)
 
 static clist_node_t clist;
 
-static int _insert_reserved_data(clist_node_t *item, void *arg)
+static int _insert_reversed_data(clist_node_t *item, void *arg)
 {
     unsigned *val = arg;
     struct test_node *n = container_of(item, struct test_node, list);

--- a/tests/bench/runtime_coreapis/tests/01-run.py
+++ b/tests/bench/runtime_coreapis/tests/01-run.py
@@ -27,6 +27,9 @@ def testfunc(child):
     child.expect(BENCHMARK_REGEXP.format(func="thread flags set/wait one"), timeout=TIMEOUT)
     child.expect(BENCHMARK_REGEXP.format(func=r"msg_try_receive\(\)"), timeout=TIMEOUT)
     child.expect(BENCHMARK_REGEXP.format(func=r"msg_avail\(\)"))
+    child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort\(\) \(\d+ nodes\)", timeout=TIMEOUT))
+    child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort\(\) \(\d+ nodes\)", timeout=TIMEOUT))
+    child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort\(\) \(\d+ nodes\)", timeout=TIMEOUT))
     child.expect_exact('[SUCCESS]')
 
 

--- a/tests/bench/runtime_coreapis/tests/01-run.py
+++ b/tests/bench/runtime_coreapis/tests/01-run.py
@@ -27,9 +27,9 @@ def testfunc(child):
     child.expect(BENCHMARK_REGEXP.format(func="thread flags set/wait one"), timeout=TIMEOUT)
     child.expect(BENCHMARK_REGEXP.format(func=r"msg_try_receive\(\)"), timeout=TIMEOUT)
     child.expect(BENCHMARK_REGEXP.format(func=r"msg_avail\(\)"))
-    child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort\(\) \(\d+ nodes\)", timeout=TIMEOUT))
-    child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort\(\) \(\d+ nodes\)", timeout=TIMEOUT))
-    child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort\(\) \(\d+ nodes\)", timeout=TIMEOUT))
+    for _ in range(7):
+        child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort \(#\d+, worst\)", timeout=TIMEOUT))
+        child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort \(#\d+, avg\)", timeout=TIMEOUT))
     child.expect_exact('[SUCCESS]')
 
 

--- a/tests/bench/runtime_coreapis/tests/01-run.py
+++ b/tests/bench/runtime_coreapis/tests/01-run.py
@@ -28,8 +28,10 @@ def testfunc(child):
     child.expect(BENCHMARK_REGEXP.format(func=r"msg_try_receive\(\)"), timeout=TIMEOUT)
     child.expect(BENCHMARK_REGEXP.format(func=r"msg_avail\(\)"))
     for _ in range(7):
-        child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort \(#\d+, worst\)", timeout=TIMEOUT))
-        child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort \(#\d+, avg\)", timeout=TIMEOUT))
+        child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort \(#\d+, rev\)", timeout=TIMEOUT))
+        child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort \(#\d+, prng\)", timeout=TIMEOUT))
+        child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort \(#\d+, sort\)", timeout=TIMEOUT))
+        child.expect(BENCHMARK_REGEXP.format(func=r"clist_sort \(#\d+, ≈sort\)", timeout=TIMEOUT))
     child.expect_exact('[SUCCESS]')
 
 

--- a/tests/unittests/tests-core/tests-core-clist.c
+++ b/tests/unittests/tests-core/tests-core-clist.c
@@ -345,7 +345,7 @@ static void _prepare_unsorted_clist(size_t len)
         0xcb,   0xda,   0x50,   0xad,   0xb0,   0xeb,   0xea,   0x9a,
     };
     static_assert(ARRAY_SIZE(tests_clist_buf) <= ARRAY_SIZE(values),
-                  "Not enough test date for sort test");
+                  "Not enough test data for sort test");
 
     set_up();
     clist_node_t *list = &test_clist;

--- a/tests/unittests/tests-core/tests-core-clist.c
+++ b/tests/unittests/tests-core/tests-core-clist.c
@@ -87,7 +87,8 @@ static void test_clist_find(void)
     test_clist_add_three();
 
     for (int i = 0; i < 3; i++) {
-        TEST_ASSERT(clist_find(list, &(tests_clist_buf[i].list)) == &(tests_clist_buf[i].list));
+        clist_node_t *found = clist_find(list, &(tests_clist_buf[i].list));
+        TEST_ASSERT(found == &(tests_clist_buf[i].list));
     }
 
     TEST_ASSERT_NULL(clist_find(list, &(tests_clist_buf[3].list)));
@@ -99,10 +100,12 @@ static void test_clist_find_before(void)
 
     test_clist_add_three();
 
-    TEST_ASSERT(clist_find_before(list, &(tests_clist_buf[0].list)) == &(tests_clist_buf[2].list));
+    clist_node_t *found = clist_find_before(list, &(tests_clist_buf[0].list));
+    TEST_ASSERT(found == &(tests_clist_buf[2].list));
 
     for (int i = 1; i < 3; i++) {
-        TEST_ASSERT(clist_find_before(list, &(tests_clist_buf[i].list)) == &(tests_clist_buf[i-1].list));
+        found = clist_find_before(list, &(tests_clist_buf[i].list));
+        TEST_ASSERT(found == &(tests_clist_buf[i-1].list));
     }
 
     TEST_ASSERT_NULL(clist_find_before(list, &(tests_clist_buf[3].list)));
@@ -122,7 +125,8 @@ static void test_clist_remove(void)
                 TEST_ASSERT_NULL(clist_find(list, &(tests_clist_buf[j].list)));
             }
             else {
-                TEST_ASSERT(clist_find(list, &(tests_clist_buf[j].list)) == &(tests_clist_buf[j].list));
+                clist_node_t *found = clist_find(list, &(tests_clist_buf[j].list));
+                TEST_ASSERT(found == &(tests_clist_buf[j].list));
             }
         }
     }

--- a/tests/unittests/tests-core/tests-core-clist.c
+++ b/tests/unittests/tests-core/tests-core-clist.c
@@ -6,19 +6,32 @@
  * directory for more details.
  */
 
+#include <assert.h>
 #include <string.h>
 #include <stdint.h>
 
 #include "embUnit.h"
 
 #include "clist.h"
+#include "container.h"
 
 #include "tests-core.h"
 
-#define TEST_CLIST_LEN    (8)
+#define TEST_CLIST_LEN    (64)
 
-static list_node_t tests_clist_buf[TEST_CLIST_LEN];
+/* Test list data structure */
+struct test_list_node {
+    list_node_t list;
+    unsigned value;
+};
+
+static struct test_list_node tests_clist_buf[TEST_CLIST_LEN];
 static list_node_t test_clist;
+
+static struct test_list_node * _get_test_list_node(list_node_t *node)
+{
+    return container_of(node, struct test_list_node, list);
+}
 
 static void set_up(void)
 {
@@ -28,7 +41,7 @@ static void set_up(void)
 
 static void test_clist_rpush(void)
 {
-    list_node_t *elem = &(tests_clist_buf[0]);
+    list_node_t *elem = &(tests_clist_buf[0].list);
     list_node_t *list = &test_clist;
 
     clist_rpush(list, elem);
@@ -41,7 +54,7 @@ static void test_clist_add_two(void)
 {
     list_node_t *list = &test_clist;
 
-    list_node_t *elem = &(tests_clist_buf[1]);
+    list_node_t *elem = &(tests_clist_buf[1].list);
 
     test_clist_rpush();
 
@@ -57,14 +70,14 @@ static void test_clist_add_three(void)
     list_node_t *list = &test_clist;
 
     for (int i = 0; i < 3; i++) {
-        clist_rpush(list, &(tests_clist_buf[i]));
+        clist_rpush(list, &(tests_clist_buf[i].list));
     }
 
     TEST_ASSERT_NOT_NULL(list->next);
-    TEST_ASSERT(list->next == &(tests_clist_buf[2]));
-    TEST_ASSERT(list->next->next == &(tests_clist_buf[0]));
-    TEST_ASSERT(list->next->next->next == &(tests_clist_buf[1]));
-    TEST_ASSERT(list->next->next->next->next == &(tests_clist_buf[2]));
+    TEST_ASSERT(list->next == &(tests_clist_buf[2].list));
+    TEST_ASSERT(list->next->next == &(tests_clist_buf[0].list));
+    TEST_ASSERT(list->next->next->next == &(tests_clist_buf[1].list));
+    TEST_ASSERT(list->next->next->next->next == &(tests_clist_buf[2].list));
 }
 
 static void test_clist_find(void)
@@ -74,10 +87,10 @@ static void test_clist_find(void)
     test_clist_add_three();
 
     for (int i = 0; i < 3; i++) {
-        TEST_ASSERT(clist_find(list, &(tests_clist_buf[i])) == &(tests_clist_buf[i]));
+        TEST_ASSERT(clist_find(list, &(tests_clist_buf[i].list)) == &(tests_clist_buf[i].list));
     }
 
-    TEST_ASSERT_NULL(clist_find(list, &(tests_clist_buf[3])));
+    TEST_ASSERT_NULL(clist_find(list, &(tests_clist_buf[3].list)));
 }
 
 static void test_clist_find_before(void)
@@ -86,13 +99,13 @@ static void test_clist_find_before(void)
 
     test_clist_add_three();
 
-    TEST_ASSERT(clist_find_before(list, &(tests_clist_buf[0])) == &(tests_clist_buf[2]));
+    TEST_ASSERT(clist_find_before(list, &(tests_clist_buf[0].list)) == &(tests_clist_buf[2].list));
 
     for (int i = 1; i < 3; i++) {
-        TEST_ASSERT(clist_find_before(list, &(tests_clist_buf[i])) == &(tests_clist_buf[i-1]));
+        TEST_ASSERT(clist_find_before(list, &(tests_clist_buf[i].list)) == &(tests_clist_buf[i-1].list));
     }
 
-    TEST_ASSERT_NULL(clist_find_before(list, &(tests_clist_buf[3])));
+    TEST_ASSERT_NULL(clist_find_before(list, &(tests_clist_buf[3].list)));
 }
 
 static void test_clist_remove(void)
@@ -102,27 +115,27 @@ static void test_clist_remove(void)
     for (int i = 0; i < 3; i++) {
         set_up();
         test_clist_add_three();
-        clist_remove(list, &(tests_clist_buf[i]));
+        clist_remove(list, &(tests_clist_buf[i].list));
 
         for (int j = 0; j < 3; j++) {
             if (i == j) {
-                TEST_ASSERT_NULL(clist_find(list, &(tests_clist_buf[j])));
+                TEST_ASSERT_NULL(clist_find(list, &(tests_clist_buf[j].list)));
             }
             else {
-                TEST_ASSERT(clist_find(list, &(tests_clist_buf[j])) == &(tests_clist_buf[j]));
+                TEST_ASSERT(clist_find(list, &(tests_clist_buf[j].list)) == &(tests_clist_buf[j].list));
             }
         }
     }
 
     /* list now contains 0, 1 */
-    TEST_ASSERT(list->next == &(tests_clist_buf[1]));
-    TEST_ASSERT(list->next->next == &(tests_clist_buf[0]));
+    TEST_ASSERT(list->next == &(tests_clist_buf[1].list));
+    TEST_ASSERT(list->next->next == &(tests_clist_buf[0].list));
 
-    clist_remove(list, &(tests_clist_buf[1]));
-    TEST_ASSERT(list->next == &(tests_clist_buf[0]));
-    TEST_ASSERT(list->next->next == &(tests_clist_buf[0]));
+    clist_remove(list, &(tests_clist_buf[1].list));
+    TEST_ASSERT(list->next == &(tests_clist_buf[0].list));
+    TEST_ASSERT(list->next->next == &(tests_clist_buf[0].list));
 
-    clist_remove(list, &(tests_clist_buf[0]));
+    clist_remove(list, &(tests_clist_buf[0].list));
     TEST_ASSERT_NULL(list->next);
 }
 
@@ -132,13 +145,13 @@ static void test_clist_lpop(void)
 
     test_clist_add_three();
 
-    TEST_ASSERT(clist_lpop(list) == &tests_clist_buf[0]);
+    TEST_ASSERT(clist_lpop(list) == &tests_clist_buf[0].list);
     TEST_ASSERT_NOT_NULL(list->next);
 
-    TEST_ASSERT(clist_lpop(list) == &tests_clist_buf[1]);
+    TEST_ASSERT(clist_lpop(list) == &tests_clist_buf[1].list);
     TEST_ASSERT_NOT_NULL(list->next);
 
-    TEST_ASSERT(clist_lpop(list) == &tests_clist_buf[2]);
+    TEST_ASSERT(clist_lpop(list) == &tests_clist_buf[2].list);
     TEST_ASSERT_NULL(list->next);
     TEST_ASSERT_NULL(clist_lpop(list));
 }
@@ -148,10 +161,10 @@ static void test_clist_lpush(void)
     list_node_t *list = &test_clist;
 
     test_clist_add_two();
-    clist_lpush(list, &tests_clist_buf[2]);
+    clist_lpush(list, &tests_clist_buf[2].list);
 
     TEST_ASSERT_NOT_NULL(list->next);
-    TEST_ASSERT(list->next->next == &tests_clist_buf[2]);
+    TEST_ASSERT(list->next->next == &tests_clist_buf[2].list);
 }
 
 static void test_clist_rpop(void)
@@ -163,7 +176,7 @@ static void test_clist_rpop(void)
     clist_rpop(list);
 
     TEST_ASSERT_NOT_NULL(list->next);
-    TEST_ASSERT(list->next->next == &tests_clist_buf[0]);
+    TEST_ASSERT(list->next->next == &tests_clist_buf[0].list);
 }
 
 static void test_clist_remove_two(void)
@@ -187,11 +200,11 @@ static void test_clist_lpoprpush(void)
 
     clist_lpoprpush(list);
 
-    TEST_ASSERT(list->next->next == &tests_clist_buf[1]);
+    TEST_ASSERT(list->next->next == &tests_clist_buf[1].list);
 
     clist_lpoprpush(list);
 
-    TEST_ASSERT(list->next->next == &tests_clist_buf[0]);
+    TEST_ASSERT(list->next->next == &tests_clist_buf[0].list);
 }
 
 static int _foreach_called;
@@ -200,10 +213,10 @@ static int _foreach_abort_after = TEST_CLIST_LEN/2;
 
 static void _foreach_test(clist_node_t *node)
 {
-    TEST_ASSERT(node == &tests_clist_buf[_foreach_called]);
+    TEST_ASSERT(node == &tests_clist_buf[_foreach_called].list);
 
     for (int i = 0; i < TEST_CLIST_LEN; i++) {
-        if (node == &tests_clist_buf[i]) {
+        if (node == &tests_clist_buf[i].list) {
             _foreach_visited[i]++;
             break;
         }
@@ -246,7 +259,7 @@ static void test_clist_foreach(void)
     TEST_ASSERT(res == NULL);
 
     for (int i = 0; i < TEST_CLIST_LEN; i++) {
-        clist_rpush(list, &tests_clist_buf[i]);
+        clist_rpush(list, &tests_clist_buf[i].list);
     }
 
     res = clist_foreach(list, _foreach_test_trampoline, NULL);
@@ -266,19 +279,80 @@ static void test_clist_foreach(void)
     TEST_ASSERT(res == NULL);
 }
 
-static int _cmp(clist_node_t *a, clist_node_t *b)
+static int _cmp(clist_node_t *_a, clist_node_t *_b)
 {
-    /* this comparison function will sort by the actual memory address of the
-     * list node (descending) */
-    return (uintptr_t)a - (uintptr_t) b;
+    struct test_list_node *a = _get_test_list_node(_a), *b = _get_test_list_node(_b);
+    return a->value - b->value;
 }
 
-static void test_clist_sort_empty(void)
+static bool _is_clist_stable_sorted(clist_node_t *list)
 {
-    clist_node_t empty = { .next=NULL };
-    clist_sort(&empty, _cmp);
+    /* empty list is always considered as sorted */
+    if (!list->next) {
+        return true;
+    }
 
-    TEST_ASSERT(empty.next == NULL);
+    clist_node_t *end_of_clist = list->next;
+    clist_node_t *prev = list->next->next;
+    clist_node_t *cur = prev->next;
+
+    while (prev != end_of_clist) {
+        struct test_list_node *a = _get_test_list_node(prev);
+        struct test_list_node *b = _get_test_list_node(cur);
+
+        if (a->value > b->value) {
+            return false;
+        }
+        if (a->value == b->value) {
+            /* stable sort requires that order is not touched when elements
+             * are equal */
+            if ((uintptr_t)a > (uintptr_t)b) {
+                return false;
+            }
+        }
+
+        prev = cur;
+        cur = cur->next;
+    }
+
+    return true;
+}
+
+static void _prepare_unsorted_clist(size_t len)
+{
+    TEST_ASSERT(len <= ARRAY_SIZE(tests_clist_buf));
+    /*
+     * Test data generated using following python snippet:
+     *
+     * import random
+     *
+     * random.seed(1337)
+     * for i in range(8):
+     *     result = " " * 8
+     *     for i in range(7):
+     *         result += f"0x{random.getrandbits(8):02x},   "
+     *     result += f"0x{random.getrandbits(8):02x},"
+     *     print(result)
+     */
+    static const unsigned values[] = {
+        0x9e,   0xec,   0x88,   0xb5,   0x5d,   0x92,   0x95,   0xbb,
+        0x2a,   0xc6,   0xd3,   0x55,   0x62,   0xa2,   0xca,   0x5c,
+        0xeb,   0xfe,   0x4e,   0x64,   0xfe,   0xb2,   0x34,   0xc2,
+        0xa8,   0xdd,   0xe9,   0x5d,   0x1b,   0x6c,   0xd2,   0xa2,
+        0x66,   0xe6,   0x10,   0x81,   0xb2,   0xab,   0x59,   0xe3,
+        0x67,   0x67,   0xcd,   0xbc,   0xcc,   0x4f,   0xa9,   0x04,
+        0xd5,   0x5a,   0x98,   0x1e,   0x75,   0x3f,   0xf5,   0x2b,
+        0xcb,   0xda,   0x50,   0xad,   0xb0,   0xeb,   0xea,   0x9a,
+    };
+    static_assert(ARRAY_SIZE(tests_clist_buf) <= ARRAY_SIZE(values),
+                  "Not enough test date for sort test");
+
+    set_up();
+    clist_node_t *list = &test_clist;
+    for (size_t i = 0; i < len; i++) {
+        tests_clist_buf[i].value = values[i];
+        clist_rpush(list, &tests_clist_buf[i].list);
+    }
 }
 
 /*
@@ -295,22 +369,11 @@ static void test_clist_sort(void)
 {
     clist_node_t *list = &test_clist;
 
-    for (int i = 0; i < TEST_CLIST_LEN; i++) {
-        clist_rpush(list, &tests_clist_buf[i]);
-    }
-
-    /* rotate the list a couple of times in order to mess up the sorting */
-    clist_lpoprpush(list);
-    clist_lpoprpush(list);
-    clist_lpoprpush(list);
-
-    /* sort list */
-    clist_sort(list, _cmp);
-
-    uintptr_t last = (uintptr_t) list->next;
-
-    for (int i = 0; i < TEST_CLIST_LEN; i++) {
-        TEST_ASSERT((uintptr_t) clist_rpop(list) <= last);
+    for (size_t cur_len = 0; cur_len < TEST_CLIST_LEN; cur_len++) {
+        _prepare_unsorted_clist(cur_len);
+        clist_sort(list, _cmp);
+        TEST_ASSERT(_is_clist_stable_sorted(list));
+        TEST_ASSERT_EQUAL_INT(cur_len, clist_count(list));
     }
 }
 
@@ -320,7 +383,7 @@ static void test_clist_count(void)
     TEST_ASSERT(n == 0);
 
     for (unsigned i = 1; i <= TEST_CLIST_LEN; i++) {
-        clist_rpush(&test_clist, &tests_clist_buf[i - 1]);
+        clist_rpush(&test_clist, &tests_clist_buf[i - 1].list);
         n = clist_count(&test_clist);
         TEST_ASSERT(n == i);
     }
@@ -336,7 +399,7 @@ static void test_clist_is_empty(void)
     TEST_ASSERT(clist_is_empty(&test_clist));
 
     for (unsigned i = 1; i <= TEST_CLIST_LEN; i++) {
-        clist_rpush(&test_clist, &tests_clist_buf[i - 1]);
+        clist_rpush(&test_clist, &tests_clist_buf[i - 1].list);
         TEST_ASSERT(!clist_is_empty(&test_clist));
     }
     for (unsigned i = TEST_CLIST_LEN; i > 0; i--) {
@@ -355,14 +418,14 @@ static void test_clist_special_cardinality(void)
     TEST_ASSERT(!clist_exactly_one(&test_clist));
     TEST_ASSERT(!clist_more_than_one(&test_clist));
 
-    clist_rpush(&test_clist, &tests_clist_buf[i++]);
+    clist_rpush(&test_clist, &tests_clist_buf[i++].list);
 
     TEST_ASSERT(!clist_is_empty(&test_clist));
     TEST_ASSERT(clist_exactly_one(&test_clist));
     TEST_ASSERT(!clist_more_than_one(&test_clist));
 
     while (i < TEST_CLIST_LEN) {
-        clist_rpush(&test_clist, &tests_clist_buf[i++]);
+        clist_rpush(&test_clist, &tests_clist_buf[i++].list);
 
         TEST_ASSERT(!clist_is_empty(&test_clist));
         TEST_ASSERT(!clist_exactly_one(&test_clist));
@@ -402,7 +465,6 @@ Test *tests_core_clist_tests(void)
         new_TestFixture(test_clist_remove),
         new_TestFixture(test_clist_lpoprpush),
         new_TestFixture(test_clist_foreach),
-        new_TestFixture(test_clist_sort_empty),
         new_TestFixture(test_clist_sort),
         new_TestFixture(test_clist_count),
         new_TestFixture(test_clist_is_empty),


### PR DESCRIPTION
### Contribution description

This rewrites `clist_sort()` with a different implementation of a merge sort. The goal is that the code is more readable and passes `-fanalyzer` without GCC barking, but it turns out to be a bit faster as well.

### Testing procedure

This currently includes two other PRs for better testing, namely:

- [x] https://github.com/RIOT-OS/RIOT/pull/21403
- [ ] https://github.com/RIOT-OS/RIOT/pull/21402

(This PR needs to wait for those to be merged first and rebased then.)

### Issues/PRs references

More complex but faster alternative to https://github.com/RIOT-OS/RIOT/pull/21398