### PR TITLE
sys/benchmark: warm up cache

### DIFF
--- a/sys/include/benchmark.h
+++ b/sys/include/benchmark.h
@@ -42,8 +42,27 @@ extern "C" {
  * @param[in] func      function call to benchmark
  */
 #define BENCHMARK_FUNC(name, runs, func)                        \
+    BENCHMARK_FUNC_WARMUP(name, 0, runs, func)
+
+/**
+ * @brief   Measure the runtime of a given function call
+ *
+ * Same as @ref BENCHMARK_FUNC, but do a few warmup iterations before starting
+ * the benchmark to warm up the dynamic branch predictor state and caches.
+ *
+ * @param[in] name      name for labeling the output
+ * @param[in] warmup    number of times to run @p func before the benchmark
+ * @param[in] runs      number of times to run @p func during the benchmark
+ * @param[in] func      function call to benchmark
+ */
+#define BENCHMARK_FUNC_WARMUP(name, warmup, runs, func)         \
     do {                                                        \
         ztimer_stopwatch_t timer = { .clock = ZTIMER_USEC };    \
+        /* warm up cache, branch predictor, ... */              \
+        unsigned long _warmup = warmup;                         \
+        while (_warmup--) {                                     \
+            func;                                               \
+        }                                                       \
         ztimer_stopwatch_start(&timer);                         \
         for (unsigned long i = 0; i < runs; i++) {              \
             func;                                               \


### PR DESCRIPTION
### Contribution description

Add a few cycles before starting the stopwatch for fancy CPUs that do have a cache and branch predictor that may warm up (e.g. Cortex M7).

### Testing procedure

...

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/21403