### PR TITLE
pkg/esp32_sdk: Fix broken `rtc_io.h` declaration and prevent `sys/uio.h` inclusion outside RIOT

### DIFF
--- a/pkg/esp32_sdk/patches/0037-driver-rtc_io-correct-declaration-of-renamed-functio.patch
+++ b/pkg/esp32_sdk/patches/0037-driver-rtc_io-correct-declaration-of-renamed-functio.patch
@@ -1,0 +1,30 @@
+From d9443415cc1e10526a265601cd98374988660101 Mon Sep 17 00:00:00 2001
+From: Jongmin Kim <jmkim@debian.org>
+Date: Mon, 14 Apr 2025 15:03:34 +0900
+Subject: [PATCH 1/2] driver/rtc_io: correct declaration of renamed function
+ rtc_gpio_force_hold_en_all
+
+The implementation of `rtc_gpio_force_hold_all()` was renamed to`rtc_gpio_force_hold_en_all()`
+in the patch `0022-driver-gpio-fix-undefined-reference-to-rtc_gpio_forc.patch`.
+
+This patch corrects the function declaration to match the renamed implementation.
+---
+ components/driver/include/driver/rtc_io.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/components/driver/include/driver/rtc_io.h b/components/driver/include/driver/rtc_io.h
+index cbf32c4f..766bde11 100644
+--- a/components/driver/include/driver/rtc_io.h
++++ b/components/driver/include/driver/rtc_io.h
+@@ -269,7 +269,7 @@ esp_err_t rtc_gpio_isolate(gpio_num_t gpio_num);
+  * Force hold signal is enabled before going into deep sleep for pins which
+  * are used for EXT1 wakeup.
+  */
+-esp_err_t rtc_gpio_force_hold_all(void);
++esp_err_t rtc_gpio_force_hold_en_all(void);
+ 
+ /**
+  * @brief Disable force hold signal for all RTC IOs
+-- 
+2.49.0
+

--- a/pkg/esp32_sdk/patches/0038-newlib-avoid-sys-uio.h-inclusion-outside-of-RIOT.patch
+++ b/pkg/esp32_sdk/patches/0038-newlib-avoid-sys-uio.h-inclusion-outside-of-RIOT.patch
@@ -1,0 +1,31 @@
+From 87cf66f13900f4609ac6e1fa4b4c8046232268bd Mon Sep 17 00:00:00 2001
+From: Jongmin Kim <jmkim@debian.org>
+Date: Mon, 14 Apr 2025 15:08:58 +0900
+Subject: [PATCH 2/2] newlib: avoid sys/uio.h inclusion outside of RIOT
+
+The RIOT header `<sys/uio.h>` is not available when using the bundled ESP-IDF
+outside of RIOT.
+
+This patch ensures that `<sys/uio.h>` is only included when `RIOT_VERSION` is
+defined.
+---
+ components/newlib/platform_include/sys/uio.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/components/newlib/platform_include/sys/uio.h b/components/newlib/platform_include/sys/uio.h
+index 388fed3d..5a8652a7 100644
+--- a/components/newlib/platform_include/sys/uio.h
++++ b/components/newlib/platform_include/sys/uio.h
+@@ -6,7 +6,9 @@
+ 
+ #pragma once
+ 
++#ifdef RIOT_VERSION
+ #include_next <sys/uio.h>
++#endif /* RIOT_VERSION */
+ 
+ #include <stdint.h>
+ #include <sys/types.h>
+-- 
+2.49.0
+


### PR DESCRIPTION
### Contribution description

This PR includes two `esp32_sdk` patches to ensure that the RIOT-bundled ESP-IDF remains compatible when used independently of the RIOT environment.

These changes are minimal and isolated, and they make the RIOT-patched ESP-IDF usable when ESP-IDF is used directly.

**1. [driver/rtc_io] Fixes an incorrect function declaration in ESP-IDF `components/driver/include/driver/rtc_io.h`.**

The implementation was renamed in [0022-driver-gpio-fix-undefined-reference-to-rtc_gpio_forc.patch](https://github.com/RIOT-OS/RIOT/blob/master/pkg/esp32_sdk/patches/0022-driver-gpio-fix-undefined-reference-to-rtc_gpio_forc.patch) as follows:

* From: `rtc_gpio_force_hold_all()`
* To: `rtc_gpio_force_hold_en_all()`

However, the declaration in the header file was not updated accordingly.

This patch corrects the function declaration to match the renamed implementation.

**2. [newlib] Prevents inclusion of `<sys/uio.h>` when RIOT is not used.**

RIOT's `sys/libc/include/sys/uio.h` header attempts to override the system header, which causes build errors when the bundled ESP-IDF is used independently.

This patch wraps the include with `#ifdef RIOT_VERSION`, so `<sys/uio.h>` is only included when building with RIOT.

### Testing procedure

1. Set `RIOTBASE`, `IDF_PATH`, and `PATH`:
    ```bash
    export RIOTBASE="$(pwd)/RIOT"                    # Replace with your actual clone path of github.com/jmkim/RIOT.git
    export IDF_PATH="$RIOTBASE/build/pkg/esp32_sdk"
    export PATH="$IDF_PATH/tools:$PATH"
    ```

2.  Download the RIOT bundled ESP-IDF:

    **esp-idf.Makefile:**
    ```make
    RIOTBASE                ?= $(CURDIR)/RIOT
    PKGDIRBASE              ?= $(RIOTBASE)/build/pkg
    PKG_DIR                 ?= $(RIOTBASE)/pkg/esp32_sdk
    PKG_SOURCE_DIR          ?= $(PKGDIRBASE)/esp32_sdk
    PKG_BUILD_OUT_OF_SOURCE ?= 1    
    include $(PKG_DIR)/Makefile
    ```

    **Run the esp-idf.Makefile:**
    ```bash
    make -f esp-idf.Makefile
    ```

3. Ensure that all the patches are applied. You should see output similar to:
    ```bash
    ...
    Applying: pkg/esp32: correct declaration of renamed function rtc_gpio_force_hold_en_all
    Applying: pkg/esp32: avoid sys/uio.h inclusion outside of RIOT
    touch .../RIOT/build/pkg/esp32_sdk/.pkg-state.git-patched
    ...
    ```

4. Build a standalone ESP-IDF example project:
    ```bash
    cd $IDF_PATH/examples/get-started/hello_world
    idf.py set-target esp32s3
    idf.py build
    ```

Without these patches:
   - A linker error occurs due to `rtc_gpio_force_hold_all()` being undefined.
   - The build fails due to `<sys/uio.h>` not being found.

With these patches applied:
   - The project builds and links successfully.

### Issues/PRs references

None
