### PR TITLE
buildsystem: clean `dist/tools` with `(dist)clean` as well, parallel cleaning!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ docclean:
 
 clean:
 	@echo "Cleaning all build products for the current board"
-	@for dir in $(APPLICATION_DIRS); do "$(MAKE)" -C$$dir clean; done
+	@for dir in $(APPLICATION_DIRS) $(TOOLS_DIRS); do "$(MAKE)" -C$$dir clean; done
 
 pkg-clean:
 	@echo "Cleaning all package sources"
@@ -25,7 +25,7 @@ pkg-clean:
 
 distclean: docclean pkg-clean
 	@echo "Cleaning all build products"
-	@for dir in $(APPLICATION_DIRS); do "$(MAKE)" -C$$dir distclean; done
+	@for dir in $(APPLICATION_DIRS) $(TOOLS_DIRS); do "$(MAKE)" -C$$dir distclean; done
 
 print-versions:
 	@./dist/tools/ci/print_toolchain_versions.sh

--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,9 @@ doc doc-man doc-latex doc-ci:
 docclean:
 	"$(MAKE)" -BC doc/doxygen clean
 
-clean:
-	@echo "Cleaning all build products for the current board"
-	@for dir in $(APPLICATION_DIRS) $(TOOLS_DIRS); do "$(MAKE)" -C$$dir clean; done
-
 pkg-clean:
 	@echo "Cleaning all package sources"
 	rm -rf build/pkg
-
-distclean: docclean pkg-clean
-	@echo "Cleaning all build products"
-	@for dir in $(APPLICATION_DIRS) $(TOOLS_DIRS); do "$(MAKE)" -C$$dir distclean; done
 
 print-versions:
 	@./dist/tools/ci/print_toolchain_versions.sh
@@ -42,6 +34,21 @@ include makefiles/tools/riotgen.inc.mk
 -include makefiles/tests.inc.mk
 
 include makefiles/color.inc.mk
+
+CLEAN_DIRS := $(APPLICATION_DIRS) $(TOOLS_DIRS)
+
+.PHONY: clean distclean $(CLEAN_DIRS:%=CLEAN--%) $(CLEAN_DIRS:%=DISTCLEAN--%)
+clean: $(CLEAN_DIRS:%=CLEAN--%)
+	@echo "Cleaned all build products."
+
+distclean: docclean pkg-clean $(CLEAN_DIRS:%=DISTCLEAN--%)
+	@echo "Cleaned everything."
+
+$(CLEAN_DIRS:%=CLEAN--%):
+	-"$(MAKE)" -C $(@:CLEAN--%=%) clean
+
+$(CLEAN_DIRS:%=DISTCLEAN--%):
+	-"$(MAKE)" -C $(@:DISTCLEAN--%=%) distclean
 
 # Prints a welcome message
 define welcome_message

--- a/dist/tools/benchmark_udp/Makefile
+++ b/dist/tools/benchmark_udp/Makefile
@@ -17,3 +17,5 @@ $(BINARY): $(SRCS)
 
 clean:
 	rm -f $(BINARY)
+
+distclean: clean

--- a/dist/tools/cc2538-bsl/Makefile
+++ b/dist/tools/cc2538-bsl/Makefile
@@ -3,6 +3,8 @@ PKG_URL=https://github.com/JelmerT/cc2538-bsl.git
 PKG_VERSION=11de8cb2933d23ce001a1af14225ff4f5cd1983c
 PKG_LICENSE=BSD-3-Clause
 
+RIOTBASE ?= $(CURDIR)/../../..
+
 include $(RIOTBASE)/pkg/pkg.mk
 
 all: $(CURDIR)/cc2538-bsl.py

--- a/dist/tools/cosy/Makefile
+++ b/dist/tools/cosy/Makefile
@@ -3,6 +3,8 @@ PKG_URL=https://github.com/RIOT-OS/cosy/
 PKG_VERSION=087fb2d1f2e4d82c7df985e770011f703998aefa
 PKG_LICENSE=GPL-3
 
+RIOTBASE ?= $(CURDIR)/../../..
+
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:

--- a/dist/tools/dose/Makefile
+++ b/dist/tools/dose/Makefile
@@ -5,3 +5,5 @@ dose: dose.c
 
 clean:
 	rm -f dose
+
+distclean: clean

--- a/dist/tools/ethos/Makefile
+++ b/dist/tools/ethos/Makefile
@@ -5,3 +5,5 @@ ethos: ethos.c
 
 clean:
 	rm -f ethos
+
+distclean: clean

--- a/dist/tools/fixdep/Makefile
+++ b/dist/tools/fixdep/Makefile
@@ -9,3 +9,5 @@ fixdep: fixdep_patched.c
 clean:
 	$(RM) fixdep_patched.c
 	$(RM) fixdep
+
+distclean: clean

--- a/dist/tools/kconfiglib/Makefile
+++ b/dist/tools/kconfiglib/Makefile
@@ -3,6 +3,8 @@ PKG_URL=https://github.com/RIOT-OS/Kconfiglib
 PKG_VERSION=110688d78edba9fa7eb09cbe001c62fbbee86abf
 PKG_LICENSE=ISC
 
+RIOTBASE ?= $(CURDIR)/../../..
+
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:

--- a/dist/tools/lpc2k_pgm/Makefile
+++ b/dist/tools/lpc2k_pgm/Makefile
@@ -42,6 +42,8 @@ boot_23xx.c boot_23xx.h: src/boot_23xx.armasm mkbootc
 clean:
 	rm -f bin/lpc2k_pgm cksum_test obj/*.o obj/*.d core core.* obj/*.armobj bin/pseudoterm
 
+distclean: clean
+
 install:
 	install -m 0755 bin/lpc2k_pgm $(prefix)/bin
 

--- a/dist/tools/pioasm/Makefile
+++ b/dist/tools/pioasm/Makefile
@@ -3,6 +3,10 @@ PKG_URL=https://github.com/raspberrypi/pico-sdk.git
 # release SDK 1.5.0
 PKG_VERSION=2ccab115de0d42d31d6611cca19ef0cd0d2ccaa7
 PKG_LICENSE=BSD-3-Clause
+
+RIOTBASE ?= $(CURDIR)/../../..
+RIOTTOOLS ?= $(RIOTBASE)/dist/tools
+
 PKG_PATCH_DIR=$(RIOTTOOLS)/pioasm/patches
 PKG_BUILD_DIR=$(PKG_SOURCE_DIR)/tools/pioasm
 

--- a/dist/tools/riotboot_gen_hdr/Makefile
+++ b/dist/tools/riotboot_gen_hdr/Makefile
@@ -37,3 +37,5 @@ bin/genhdr: $(GENHDR_HDR) $(GENHDR_SRC) Makefile | bin/
 
 clean:
 	$(Q)rm -rf bin/
+
+distclean: clean

--- a/dist/tools/riotboot_serial/Makefile
+++ b/dist/tools/riotboot_serial/Makefile
@@ -12,3 +12,5 @@ riotboot_serial: $(OBJS)
 clean:
 	@rm -fr $(OBJS)
 	@rm -fr riotboot_serial
+
+distclean: clean

--- a/dist/tools/sliptty/Makefile
+++ b/dist/tools/sliptty/Makefile
@@ -11,3 +11,5 @@ $(BIN): $(wildcard *.c)
 
 clean:
 	$(RM) $(BIN)
+
+distclean: clean

--- a/dist/tools/teensy-loader-cli/Makefile
+++ b/dist/tools/teensy-loader-cli/Makefile
@@ -11,6 +11,8 @@ else
   PKG_VERSION=76921edbdd81ae99b869b104404c16c06b0a266f
 endif
 
+RIOTBASE ?= $(CURDIR)/../../..
+
 PKG_SOURCE_DIR = $(CURDIR)/bin
 PKG_BUILD_OUT_OF_SOURCE = 0
 include $(RIOTBASE)/pkg/pkg.mk

--- a/dist/tools/tunslip/Makefile
+++ b/dist/tools/tunslip/Makefile
@@ -12,4 +12,6 @@ uninstall:
 clean:
 	rm -f $(BIN)
 
+distclean: clean
+
 CFLAGS += -Wall -Wextra -pedantic -std=c99

--- a/dist/tools/uf2/Makefile
+++ b/dist/tools/uf2/Makefile
@@ -3,6 +3,8 @@ PKG_URL=https://github.com/microsoft/uf2.git
 PKG_VERSION=27e322fcdcc6eee0642242638d4f2557efb32559
 PKG_LICENSE=MIT
 
+RIOTBASE ?= $(CURDIR)/../../..
+
 include $(RIOTBASE)/pkg/pkg.mk
 
 all: $(CURDIR)/uf2conv.py $(CURDIR)/uf2families.json

--- a/dist/tools/uhcpd/Makefile
+++ b/dist/tools/uhcpd/Makefile
@@ -15,3 +15,5 @@ bin/uhcpd: $(SRCS) $(HDRS)
 
 clean:
 	rm -f bin/uhcpd
+
+distclean: clean

--- a/dist/tools/zep_dispatch/Makefile
+++ b/dist/tools/zep_dispatch/Makefile
@@ -31,9 +31,11 @@ $(DISPATCH): $(SRCS) bin
 $(TOPOGEN): topogen.c bin
 	$(CC) $(CFLAGS) $< -o $@ -lm
 
-.PHONY: clean run graph help
+.PHONY: clean distclean run graph help
 clean:
 	rm -fr bin
+
+distclean: clean
 
 run: $(DISPATCH) $(TOPOLOGY)
 	$(DISPATCH) -t $(TOPOLOGY) -g $(GV_OUT) ::1 $(ZEP_PORT_BASE)

--- a/makefiles/app_dirs.inc.mk
+++ b/makefiles/app_dirs.inc.mk
@@ -4,6 +4,7 @@
 RIOTBASE ?= .
 
 APPS_BASE_DIRS = bootloaders examples fuzzing tests
+TOOLS_BASE_DIRS = dist/tools
 
 # 1. recursively find Makefiles
 # 2. take parent folders
@@ -13,6 +14,12 @@ APPS_BASE_DIRS = bootloaders examples fuzzing tests
 APPLICATION_DIRS := $(shell find $(APPS_BASE_DIRS) -name Makefile -type f | \
     xargs dirname | \
     grep -vF "/bin/" | \
+    grep -vFf $(RIOTBASE)/makefiles/app_dirs.blacklist | \
+    sort | uniq)
+
+# used for `make claen` and `make distclean`
+TOOLS_DIRS := $(shell find $(TOOLS_BASE_DIRS) -mindepth 2 -maxdepth 2 -name Makefile -type f | \
+    xargs dirname | \
     grep -vFf $(RIOTBASE)/makefiles/app_dirs.blacklist | \
     sort | uniq)
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

@mguetschow noticed that `make distclean` does not clean `dist/tools`. The cause is described in #21409.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Make sure that the `clean` and `distclean` actually enter the `dist/tools` subdirectory. This can take quite a while.

```
cbuec@W11nMate:~/RIOTstuff/riot-canfix/RIOT$ time make clean --print-directory 2>/dev/null | grep -i dist/to
ols
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/benchmark_udp'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/benchmark_udp'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bootterm'
rm -f /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bootterm/bt
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bootterm'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-1.8'
rm -f /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-1.8/bossac
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-1.8'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-1.9'
rm -f /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-1.9/bossac
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-1.9'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-nrf52'
rm -f /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-nrf52/bossac
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-nrf52'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/cc2538-bsl'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/cc2538-bsl'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/cosy'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/cosy'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/dose'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/dose'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/doxygen'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/doxygen'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/edbg'
rm -f /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/edbg/edbg
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/edbg'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/elf2uf2'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/elf2uf2'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/ethos'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/ethos'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/fixdep'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/fixdep'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/flatc'
rm -rf /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/flatc/bin/build
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/flatc'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/kconfiglib'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/kconfiglib'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/lpc2k_pgm'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/lpc2k_pgm'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/mosquitto_rsmb'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/mosquitto_rsmb'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/mspdebug'
rm -f /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/mspdebug/mspdebug
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/mspdebug'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/nrf52_resetpin_cfg'
rm -rf /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/nrf52_resetpin_cfg/bin/nrf52dk/pkg-build/cmsis
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/nrf52_resetpin_cfg'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/pioasm'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/pioasm'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/riotboot_gen_hdr'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/riotboot_gen_hdr'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/riotboot_serial'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/riotboot_serial'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/setsid'
rm -f /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/setsid/setsid
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/setsid'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/sliptty'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/sliptty'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/teensy-loader-cli'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/teensy-loader-cli'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/tunslip'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/tunslip'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/uf2'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/uf2'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/uhcpd'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/uhcpd'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/zep_dispatch'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/zep_dispatch'

real    4m31.670s
user    1m9.512s
sys     0m18.344s
```

```
cbuec@W11nMate:~/RIOTstuff/riot-canfix/RIOT$ time make distclean --print-directory 2>/dev/null | grep -i dist/tools
make[2]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/doxygen'
make[2]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/doxygen'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/benchmark_udp'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/benchmark_udp'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bootterm'
rm -f /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bootterm/bt
rm -rf /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bootterm/bin
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bootterm'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-1.8'
rm -f /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-1.8/bossac
rm -rf /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-1.8/bin
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-1.8'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-1.9'
rm -f /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-1.9/bossac
rm -rf /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-1.9/bin
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-1.9'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-nrf52'
rm -f /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-nrf52/bossac
rm -rf /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-nrf52/bin
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/bossa-nrf52'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/cc2538-bsl'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/cc2538-bsl'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/cosy'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/cosy'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/dose'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/dose'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/doxygen'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/doxygen'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/edbg'
rm -f /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/edbg/edbg
rm -rf /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/edbg/bin
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/edbg'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/elf2uf2'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/elf2uf2'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/ethos'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/ethos'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/fixdep'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/fixdep'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/flatc'
rm -rf /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/flatc/bin/build
rm -rf /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/flatc/bin
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/flatc'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/kconfiglib'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/kconfiglib'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/lpc2k_pgm'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/lpc2k_pgm'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/mosquitto_rsmb'
rm -rf /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/mosquitto_rsmb/bin
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/mosquitto_rsmb'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/mspdebug'
rm -f /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/mspdebug/mspdebug
rm -rf /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/mspdebug/bin
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/mspdebug'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/nrf52_resetpin_cfg'
rm -rf /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/nrf52_resetpin_cfg/bin/nrf52dk/pkg-build/cmsis
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/nrf52_resetpin_cfg'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/pioasm'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/pioasm'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/riotboot_gen_hdr'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/riotboot_gen_hdr'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/riotboot_serial'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/riotboot_serial'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/setsid'
rm -f /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/setsid/setsid
rm -rf /home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/setsid/bin
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/setsid'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/sliptty'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/sliptty'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/teensy-loader-cli'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/teensy-loader-cli'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/tunslip'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/tunslip'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/uf2'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/uf2'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/uhcpd'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/uhcpd'
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/zep_dispatch'
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-canfix/RIOT/dist/tools/zep_dispatch'

real    3m43.434s
user    1m5.344s
sys     0m15.711s
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #21409.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
