### PR TITLE
core/thread: fix thread_has_msg_queue()

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -284,8 +284,9 @@ kernel_pid_t thread_create(char *stack,
 /**
  * @brief       Retrieve a thread control block by PID.
  * @pre         @p pid is valid
- * @param[in]   pid   Thread to retrieve.
- * @return      `NULL` if the PID is invalid or there is no such thread.
+ * @param[in]   pid         Thread to retrieve.
+ * @return      The thread identified by @p pid
+ * @retval      `NULL`      no thread at the given valid PID is active.
  */
 static inline thread_t *thread_get_unchecked(kernel_pid_t pid)
 {

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -118,8 +118,11 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#include "clist.h"
+#include <stdbool.h>
+
 #include "cib.h"
+#include "clist.h"
+#include "compiler_hints.h"
 #include "msg.h"
 #include "sched.h"
 #include "thread_config.h"
@@ -507,11 +510,15 @@ void thread_print_stack(void);
  *
  * @param[in] thread    The thread to check for
  *
- * @return  `== 0`, if @p thread has no initialized message queue
- * @return  `!= 0`, if @p thread has its message queue initialized
+ * @pre     @p thread is not `NULL` and the thread corresponding to the thread
+ *          control block @p thread points to (still) exists
+ *
+ * @retval  false    @p thread has no initialized message queue
+ * @retval  true     @p thread has its message queue initialized
  */
-static inline int thread_has_msg_queue(const volatile struct _thread *thread)
+static inline bool thread_has_msg_queue(const thread_t *thread)
 {
+    assume(thread != NULL);
 #if defined(MODULE_CORE_MSG) || defined(DOXYGEN)
     return (thread->msg_array != NULL);
 #else

--- a/tests/net/gnrc_netif/main.c
+++ b/tests/net/gnrc_netif/main.c
@@ -148,7 +148,7 @@ static void test_creation(void)
 #ifdef DEVELHELP
     TEST_ASSERT_EQUAL_STRING("eth", sched_threads[ethernet_netif.pid]->name);
 #endif
-    TEST_ASSERT(thread_has_msg_queue(sched_threads[ethernet_netif.pid]));
+    TEST_ASSERT(msg_queue_capacity(ethernet_netif.pid) > 0);
 
     TEST_ASSERT_EQUAL_INT((gnrc_netif_ieee802154_create(&ieee802154_netif,
             ieee802154_netif_stack, IEEE802154_STACKSIZE, GNRC_NETIF_PRIO,
@@ -170,7 +170,7 @@ static void test_creation(void)
 #ifdef DEVELHELP
     TEST_ASSERT_EQUAL_STRING("wpan", sched_threads[ieee802154_netif.pid]->name);
 #endif
-    TEST_ASSERT(thread_has_msg_queue(sched_threads[ieee802154_netif.pid]));
+    TEST_ASSERT(msg_queue_capacity(ieee802154_netif.pid) > 0);
 
     for (unsigned i = 0; i < DEFAULT_DEVS_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT((gnrc_netif_create(&netifs[i],
@@ -182,7 +182,7 @@ static void test_creation(void)
         TEST_ASSERT_EQUAL_INT(CONFIG_GNRC_NETIF_DEFAULT_HL, netifs[i].cur_hl);
         TEST_ASSERT_EQUAL_INT(NETDEV_TYPE_TEST, netifs[i].device_type);
         TEST_ASSERT(netifs[i].pid > KERNEL_PID_UNDEF);
-        TEST_ASSERT(thread_has_msg_queue(sched_threads[netifs[i].pid]));
+        TEST_ASSERT(msg_queue_capacity(netifs[i].pid) > 0);
         TEST_ASSERT_EQUAL_INT(i + SPECIAL_DEVS + 1, gnrc_netif_numof());
         for (unsigned j = 0; j < (i + SPECIAL_DEVS + 1); j++) {
             TEST_ASSERT_NOT_NULL((ptr = gnrc_netif_iter(ptr)));


### PR DESCRIPTION
### Contribution description

This fixes compilation with `-fanalyzer`. We use `assume()` to signal GCC that `thread` must not be null in `NDEBUG` mode, and `assert()` it in with enabled assertions.

This also drops the `volatile` qualifier from the function argument and changes the return value to `bool`.

> [!NOTE]
> I've marked this as an API change because it technically is. But calling sides from C that did use the API correctly will just continue to compile and work as before.

### Testing procedure

- Calling sides from C code should not be affect. If rust code uses this, the CI will spot it
- Compiling with `-fanalyzer` of `tests/sys/entropy_source` should now almost work

### Issues/PRs references

None