### PR TITLE
core/msg: handle error in msg_queue_capacity()

### DIFF
--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -393,10 +393,11 @@ unsigned msg_avail_thread(kernel_pid_t pid);
 unsigned msg_avail(void);
 
 /**
- * @brief Get maximum capacity of a thread's queue length
+ * @brief   Get maximum capacity of a thread's queue length
  *
- * @return Number of total messages that fit in the queue of @p pid on success
- * @return 0, if no caller's message queue is initialized
+ * @return  Number of total messages that fit in the queue of @p pid on success
+ * @retval  0       Either the thread identified by PID @p pid does not exist or
+ *                  has no message queue initialized (yet)
  */
 unsigned msg_queue_capacity(kernel_pid_t pid);
 

--- a/core/msg.c
+++ b/core/msg.c
@@ -484,7 +484,9 @@ unsigned msg_queue_capacity(kernel_pid_t pid)
 
     thread_t *thread = thread_get(pid);
 
-    assert(thread != NULL);
+    if (!thread) {
+        return 0;
+    }
 
     int queue_cap = 0;
 


### PR DESCRIPTION
### Contribution description

Rather than using an `assert()` on `thread_get()`, check for the thread to exist and return a capacity of `0` if it does not.

This fixes compilation with `-fanalyzer` with `NDEBUG` defined, is more consistent with other core APIs, and makes the API usable for threads with a dynamic life cycle.

> [!NOTE]
> I marked this both as API change and as minor, as the API does not change for any user that did not run into a blowing assertion (or a `NULL` dereference with `NDEBUG`) before. The API is changed in that those cases previously being forbidden are now are allowed.

### Testing procedure

Green CI

### Issues/PRs references

None