### PR TITLE
shell/saul: Rename internal functions

### DIFF
--- a/sys/shell/cmds/saul_reg.c
+++ b/sys/shell/cmds/saul_reg.c
@@ -85,7 +85,7 @@ static void list(void)
     }
 }
 
-static void read(int argc, char **argv)
+static void _reg_read(int argc, char **argv)
 {
     int num;
     saul_reg_t *dev;
@@ -109,7 +109,7 @@ static void read(int argc, char **argv)
     probe(num, dev);
 }
 
-static void write(int argc, char **argv)
+static void _reg_write(int argc, char **argv)
 {
     int num, dim;
     saul_reg_t *dev;
@@ -156,10 +156,10 @@ static int _saul(int argc, char **argv)
     }
     else {
         if (flash_strcmp(argv[1], TO_FLASH("read")) == 0) {
-            read(argc, argv);
+            _reg_read(argc, argv);
         }
         else if (flash_strcmp(argv[1], TO_FLASH("write")) == 0) {
-            write(argc, argv);
+            _reg_write(argc, argv);
         }
         else {
             printf("usage: %s read|write\n", argv[0]);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hello 🐶,

this renames internal functions of the shell command module `saul_reg`.
As C does not have proper name spacing, reusing names is risky. Especially well known names such as `read` and `write`.
I am not sure how I triggered the issue for me, as the functions are static but well...


### Testing procedure

If the CI doesn't find anything and we get a regression, then there is a coverage hole in our tests :>
Otherwise: build & flash the default example and use saul I guess.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
