### PR TITLE
drivers/slipmux: Add to RIOT

### DIFF
--- a/drivers/include/slipdev.h
+++ b/drivers/include/slipdev.h
@@ -12,6 +12,10 @@
  * @defgroup    drivers_slipdev_stdio   STDIO via SLIP
  * @ingroup     sys_stdio
  * @brief       Standard input/output backend multiplexed via SLIP
+ * @see         [draft-bormann-t2trg-slipmux-03](https://datatracker.ietf.org/doc/html/draft-bormann-t2trg-slipmux-03)
+ *
+ * This extension is part of the [Slipmux draft](https://datatracker.ietf.org/doc/html/draft-bormann-t2trg-slipmux-03).
+ * @warning This module is under development for optimizations and module names might change!
  *
  * This will multiplex STDIO via the Serial Line Internet Protocol.
  * The shell can be accessed via the `sliptty` tool.
@@ -24,10 +28,31 @@
  */
 
 /**
+ * @defgroup    drivers_slipdev_configuration CoAP via SLIP
+ * @ingroup     drivers_slipdev
+ * @brief       Exchange CoAP requests and responses via SLIP
+ * @see         [draft-bormann-t2trg-slipmux-03](https://datatracker.ietf.org/doc/html/draft-bormann-t2trg-slipmux-03)
+ *
+ * This extension is part of the [Slipmux draft](https://datatracker.ietf.org/doc/html/draft-bormann-t2trg-slipmux-03).
+ * @warning This module is under development for optimizations and module names might change!
+ *
+ * This will multiplex CoAP messages via the Serial Line Internet Protocol.
+ * It spawns an extra thread as a CoAP server. The incoming requests are handled with `nanocoap`
+ * according to any `NANOCOAP_RESOURCE`s present in the binary. See @ref net_nanocoap for more.
+ *
+ * To enable this implementation, select
+ *
+ *     USEMODULE += slipdev_config
+ *
+ * @see         drivers_slipdev
+ */
+
+/**
  * @defgroup    drivers_slipdev SLIP network device
  * @ingroup     drivers_netdev
  * @brief       SLIP network device over @ref drivers_periph_uart
- * @see         [RFC 1055](https://github.com/RIOT-OS/RIOT/pull/6487)
+ * @see         [RFC 1055](https://datatracker.ietf.org/doc/html/rfc1055)
+ *
  * @{
  *
  * @file
@@ -42,6 +67,7 @@
 #include "net/netdev.h"
 #include "periph/uart.h"
 #include "chunked_ringbuffer.h"
+#include "sched.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -94,6 +120,14 @@ enum {
      */
     SLIPDEV_STATE_STDIN_ESC,
     /**
+     * @brief   Device writes received data as CoAP message
+     */
+    SLIPDEV_STATE_CONFIG,
+    /**
+     * @brief   Device writes received data as CoAP message, next byte is escaped
+     */
+    SLIPDEV_STATE_CONFIG_ESC,
+    /**
      * @brief   Device is in standby, will wake up when sending data
      */
     SLIPDEV_STATE_STANDBY,
@@ -120,13 +154,19 @@ typedef struct {
 typedef struct {
     netdev_t netdev;                        /**< parent class */
     slipdev_params_t config;                /**< configuration parameters */
-    chunk_ringbuf_t rb;                     /**< Ringbuffer to store received frames.       */
+    chunk_ringbuf_t rb;                     /**< Ringbuffer to store received networking frames.*/
                                             /* Written to from interrupts (with irq_disable */
                                             /* to prevent any simultaneous writes),         */
                                             /* consumed exclusively in the network stack's  */
                                             /* loop at _isr.                                */
 
     uint8_t rxmem[CONFIG_SLIPDEV_BUFSIZE];  /**< memory used by RX buffer */
+
+#if IS_USED(MODULE_SLIPDEV_CONFIG)
+    chunk_ringbuf_t rb_config;              /**< Ringbuffer stores received configuration frames */
+    uint8_t rxmem_config[CONFIG_SLIPDEV_BUFSIZE]; /**< memory used by RX buffer */
+    kernel_pid_t coap_server_pid;           /**< The PID of the CoAP server */
+#endif
     /**
      * @brief   Device state
      * @see     [Device state definitions](@ref drivers_slipdev_states)

--- a/drivers/slipdev/Makefile.dep
+++ b/drivers/slipdev/Makefile.dep
@@ -7,3 +7,10 @@ FEATURES_REQUIRED += periph_uart
 ifneq (,$(filter slipdev_stdio,$(USEMODULE)))
   USEMODULE += isrpipe
 endif
+ifneq (,$(filter slipdev_config,$(USEMODULE)))
+  USEMODULE += checksum
+  USEMODULE += sock_udp
+  USEMODULE += gnrc_ipv6
+  USEMODULE += nanocoap_sock
+  USEMODULE += nanocoap_resources
+endif

--- a/drivers/slipdev/include/slipdev_internal.h
+++ b/drivers/slipdev/include/slipdev_internal.h
@@ -43,9 +43,16 @@ extern "C" {
 /**
  * @brief   Marker byte for beginning of stdio
  * @see     taken from diagnostic transfer from
- *          [SLIPMUX](https://tools.ietf.org/html/draft-bormann-t2trg-slipmux-02#section-4)
+ *          [SLIPMUX](https://tools.ietf.org/html/draft-bormann-t2trg-slipmux-03#section-4)
  */
 #define SLIPDEV_STDIO_START (0x0aU)
+
+/**
+ * @brief   Marker byte for beginning of configuration/CoAP
+ * @see     taken from configuration from
+ *          [SLIPMUX](https://tools.ietf.org/html/draft-bormann-t2trg-slipmux-03#section-5)
+ */
+#define SLIPDEV_CONFIG_START (0xa9U)
 /** @} */
 
 /**

--- a/drivers/slipdev/stdio.c
+++ b/drivers/slipdev/stdio.c
@@ -24,8 +24,6 @@
 #include "stdio_base.h"
 #include "stdio_uart.h"
 
-mutex_t slipdev_mutex = MUTEX_INIT;
-
 static void _isrpipe_write(void *arg, uint8_t data)
 {
     isrpipe_write_one(arg, (char)data);
@@ -34,9 +32,11 @@ static void _isrpipe_write(void *arg, uint8_t data)
 static void _init(void)
 {
     /* intentionally overwritten in netdev init so we have stdio before
-     * the network device is initialized is initialized */
+     * the network device is initialized */
     uart_init(slipdev_params[0].uart, slipdev_params[0].baudrate,
               _isrpipe_write, &stdin_isrpipe);
+
+    slipdev_write_byte(slipdev_params[0].uart, SLIPDEV_END);
 }
 
 static ssize_t _write(const void *buffer, size_t len)

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -464,6 +464,7 @@ PSEUDOMODULES += shield_llcc68
 PSEUDOMODULES += shield_sx1262
 PSEUDOMODULES += shield_w5100
 PSEUDOMODULES += slipdev_stdio
+PSEUDOMODULES += slipdev_config
 PSEUDOMODULES += slipdev_l2addr
 PSEUDOMODULES += sock
 PSEUDOMODULES += sock_async

--- a/tests/unittests/tests-checksum/tests-checksum-crc16-ccitt-fcs.c
+++ b/tests/unittests/tests-checksum/tests-checksum-crc16-ccitt-fcs.c
@@ -5,7 +5,6 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
-#include <stdio.h>
 #include <stdint.h>
 
 #include "embUnit/embUnit.h"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hey 🪼,

this adds an (incomplete) implementation of [Slipmux](https://tools.ietf.org/html/draft-bormann-t2trg-slipmux-03) to RIOT. It extends the current slip driver and is backwards compatible.

The second commit adds an usage example, where the shell commands are exposed to coap and through it to slipmux. That commit will be dropped prio merging. 

It is incomplete as frame abort is missing. 

### Testing procedure

Grab your favorite slipmux tool and connect RIOTs stdio to it. Make sure to build RIOT with `USEMODULE += slipdev_stdio` and optionally set `CFLAGS += "-DCONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX=10"` to be able to handle coap packets that are longer than 64 bytes. See the changes I made to the default example. 


### Feedback wanted: coap server

My current approach spawns a new thread with a nanocoap server to handle the incoming and outgoing configuration frames. This might cause issues when another coap server is in use (one that is connected to the network instead of just the uart). For example, the `NANOCOAP_RESOURCE(..)`s will be shared between them.

I also experimented with sending the coap messages with a fake ip6+udp header into gnrc. One can then only run one single coap server (and it is no longer bound to nanocoap) who listens for such packets. The outgoing way is a bit more annoying, here a new dummy interface must be created, to which gnrc can direct those fake ip6+udp headers. Very similar to how it is already done with the current slip implementation.

What alternative approaches do you see? Any idea is appreciated. 
