### PR TITLE
sys/net/sock_util: Do not depend on network stack

### DIFF
--- a/sys/include/net/sock/util.h
+++ b/sys/include/net/sock/util.h
@@ -28,19 +28,60 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "net/sock/udp.h"
-#include "net/sock/tcp.h"
 #include "net/sock/config.h"
 
+#if MODULE_GNRC_SOCK_UDP || MODULE_LWIP_SOCK_UDP || DOXYGEN
+#  include "net/sock/udp.h"
+#endif
+#if MODULE_GNRC_SOCK_TCP || MODULE_LWIP_SOCK_TCP || DOXYGEN
+#  include "net/sock/tcp.h"
+#endif
 #ifdef MODULE_SOCK_DTLS
-#include "net/credman.h"
-#include "net/sock/dtls.h"
+#  include "net/credman.h"
+#  include "net/sock/dtls.h"
+#endif
+
+#if MODULE_GNRC_SOCK_UDP || MODULE_LWIP_SOCK_UDP ||MODULE_GNRC_SOCK_TCP || MODULE_LWIP_SOCK_TCP || DOXYGEN
+#  define HAVE_SOCK_TL_EP   1 /**< Indicates presence of `struct _sock_tl_ep` */
 #endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/**
+ * @brief    Split url to host:port and url path
+ *
+ * Will split e.g., "https://host.name:1234/url/path" into
+ * "host.name:1234" and "/url/path".
+ *
+ * @note Caller has to make sure hostport and urlpath can hold the results!
+ *       Make sure to provide space for @ref CONFIG_SOCK_HOSTPORT_MAXLEN respectively
+ *       @ref CONFIG_SOCK_URLPATH_MAXLEN bytes, if pointers are not NULL.
+ *       Scheme part of the URL is limited to @ref CONFIG_SOCK_SCHEME_MAXLEN length.
+ *
+ * @pre `url != NULL`
+ *
+ * @param[in]   url         URL to split. Must not be NULL.
+ * @param[out]  hostport    where to write host:port. Can be NULL.
+ * @param[out]  urlpath     where to write url path. Can be NULL.
+ *
+ * @returns     0 on success
+ * @returns     <0 otherwise
+ */
+int sock_urlsplit(const char *url, char *hostport, char *urlpath);
+
+/**
+ * @brief   Returns a pointer to the path component in @p url
+ *
+ * @param[in]   url         URL to examine. Must not be NULL.
+ *
+ * @returns     pointer to the start of the path component in @p url
+ * @returns     NULL if @p url is invalid
+ */
+const char *sock_urlpath(const char *url);
+
+#if HAVE_SOCK_TL_EP
 /**
  * @brief   Format common IP-based transport layer endpoint to string and port
  *
@@ -85,38 +126,6 @@ static inline int sock_udp_ep_fmt(const sock_udp_ep_t *endpoint,
 {
     return sock_tl_ep_fmt(endpoint, addr_str, port);
 }
-
-/**
- * @brief    Split url to host:port and url path
- *
- * Will split e.g., "https://host.name:1234/url/path" into
- * "host.name:1234" and "/url/path".
- *
- * @note Caller has to make sure hostport and urlpath can hold the results!
- *       Make sure to provide space for @ref CONFIG_SOCK_HOSTPORT_MAXLEN respectively
- *       @ref CONFIG_SOCK_URLPATH_MAXLEN bytes, if pointers are not NULL.
- *       Scheme part of the URL is limited to @ref CONFIG_SOCK_SCHEME_MAXLEN length.
- *
- * @pre `url != NULL`
- *
- * @param[in]   url         URL to split. Must not be NULL.
- * @param[out]  hostport    where to write host:port. Can be NULL.
- * @param[out]  urlpath     where to write url path. Can be NULL.
- *
- * @returns     0 on success
- * @returns     <0 otherwise
- */
-int sock_urlsplit(const char *url, char *hostport, char *urlpath);
-
-/**
- * @brief   Returns a pointer to the path component in @p url
- *
- * @param[in]   url         URL to examine. Must not be NULL.
- *
- * @returns     pointer to the start of the path component in @p url
- * @returns     NULL if @p url is invalid
- */
-const char *sock_urlpath(const char *url);
 
 /**
  * @brief    Convert string to common IP-based transport layer endpoint
@@ -273,6 +282,7 @@ static inline bool sock_udp_ep_equal(const sock_udp_ep_t *a,
 {
     return sock_tl_ep_equal(a, b);
 }
+#endif
 
 #if defined(MODULE_SOCK_DTLS) || DOXYGEN
 /**

--- a/sys/include/net/sock/util.h
+++ b/sys/include/net/sock/util.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    net_sock_util   sock utility functions
  * @ingroup     net_sock
@@ -21,9 +23,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NET_SOCK_UTIL_H
-#define NET_SOCK_UTIL_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -310,6 +309,4 @@ int sock_dtls_establish_session(sock_udp_t *sock_udp, sock_dtls_t *sock_dtls,
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* NET_SOCK_UTIL_H */
 /** @} */


### PR DESCRIPTION
### Contribution description

This allows using and compiling the URL handling functions of `sock_util` without a network stack used.

Specifically, the URL splitting function can be useful even without having a network stack in use, e.g. for exotic CoAP transports (say, CoAP over SMS or CoAP over UART).

### Testing procedure

The generated binaries should not change. But including `sock/util.h` without a network stack should now work without compilation failures.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/21048