### PR TITLE
pkg/micropython: bump version

### DIFF
--- a/pkg/micropython/Makefile
+++ b/pkg/micropython/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=micropython
 PKG_URL=https://github.com/kaspar030/micropython
-PKG_VERSION=4ff7897215b9f8d65e147935949e88cb7cc28652
+PKG_VERSION=c7e947df88cf5b05f9e20dbeb10d5b4a9eae65a6
 PKG_LICENSE=MIT
 
 CFLAGS += -Wno-implicit-fallthrough -Wno-unused-parameter -Wno-error


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Fix the MicroPyhton pkg by casting an unused parameter.
The bug is revealed when using the MicroPython pkg and a header using pystack.h (E.g. `#include ‘py/runtime.h’`).

MicroPython code:
```c
#define m_renew(type, ptr, old_num, new_num) ((type*)(m_realloc((ptr), sizeof(type) * (new_num))))

static inline void *mp_nonlocal_realloc(void *ptr, size_t old_n_bytes, size_t new_n_bytes) {
    return m_renew(uint8_t, ptr, old_n_bytes, new_n_bytes);
}
```

Error:
```bash
/home/test/RIOT/examples/micropython/bin/arduino-nano-33-ble/pkg/micropython/py/pystack.h:88:59: error: unused parameter 'old_n_bytes' [-Werror=unused-parameter]
/home/test/RIOT/examples/micropython/bin/arduino-nano-33-ble/pkg/micropython/py/pystack.h: In function 'mp_nonlocal_realloc':
   88 | static inline void *mp_nonlocal_realloc(void *ptr, size_t old_n_bytes, size_t new_n_bytes) {
      |                                                    ~~~~~~~^~~~~~~~~~~
cc1: all warnings being treated as errors
```

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

You can include in the `RIOT/examples/lang_support/community/micropython/man.c` this header `py/runtime.h`.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
