### PR TITLE
sys/suit: don't block in suit_worker_trigger()

### DIFF
--- a/sys/include/suit/transport/worker.h
+++ b/sys/include/suit/transport/worker.h
@@ -25,6 +25,7 @@
 #ifndef SUIT_TRANSPORT_WORKER_H
 #define SUIT_TRANSPORT_WORKER_H
 
+#include <stdbool.h>
 #if MODULE_NANOCOAP
 #  include "net/nanocoap.h"
 #endif
@@ -38,8 +39,11 @@ extern "C" {
  *
  * @param[in] url       url pointer containing the full coap url to the manifest
  * @param[in] len       length of the url
+ *
+ * @retval true if the worker was triggered
+ * @retval false if the worker is already busy
  */
-void suit_worker_trigger(const char *url, size_t len);
+bool suit_worker_trigger(const char *url, size_t len);
 
 /**
  * @brief   Trigger a SUIT update via a worker thread

--- a/sys/suit/transport/worker.c
+++ b/sys/suit/transport/worker.c
@@ -207,11 +207,13 @@ static bool _worker_reap(void)
     return true;
 }
 
-void suit_worker_trigger(const char *url, size_t len)
+bool suit_worker_trigger(const char *url, size_t len)
 {
-    mutex_lock(&_worker_lock);
+    if (!mutex_trylock(&_worker_lock)) {
+        return false;
+    }
     if (!_worker_reap()) {
-        return;
+        return false;
     }
 
     assert(len != 0); /* A zero-length URI is invalid, but _url[0] == '\0' is
@@ -222,6 +224,7 @@ void suit_worker_trigger(const char *url, size_t len)
     _worker_pid = thread_create(_stack, SUIT_WORKER_STACKSIZE, SUIT_COAP_WORKER_PRIO,
                   0,
                   _suit_worker_thread, NULL, "suit worker");
+    return true;
 }
 
 void suit_worker_trigger_prepared(const uint8_t *buffer, size_t size)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`suit_worker_trigger()` might be triggered from e.g. a CoAP endpoint or an event thread were we do not want to block for an extended period of time.

Replace the `mutex_lock()` with a `mutex_trylock()` to return immediately if a worker thread is already running. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
