### PR TITLE
sys/embUnit: add IWYU pragmas

### DIFF
--- a/sys/include/embUnit.h
+++ b/sys/include/embUnit.h
@@ -22,7 +22,7 @@
 #ifndef EMBUNIT_H
 #define EMBUNIT_H
 
-#include "embUnit/embUnit.h"
+#include "embUnit/embUnit.h" /* IWYU pragma: export */
 
 #ifdef OUTPUT
 #   define OUTPUT_XML       (1)

--- a/sys/include/embUnit/embUnit.h
+++ b/sys/include/embUnit/embUnit.h
@@ -35,17 +35,17 @@
 #ifndef EMBUNIT_EMBUNIT_H
 #define EMBUNIT_EMBUNIT_H
 
-#include <embUnit/Test.h>
-#include <embUnit/TestCase.h>
-#include <embUnit/TestListener.h>
-#include <embUnit/TestResult.h>
-#include <embUnit/TestSuite.h>
-#include <embUnit/TestRunner.h>
-#include <embUnit/TestCaller.h>
-#include <embUnit/RepeatedTest.h>
-#include <embUnit/stdImpl.h>
-#include <embUnit/AssertImpl.h>
-#include <embUnit/HelperMacro.h>
+#include <embUnit/Test.h>           /* IWYU pragma: export */
+#include <embUnit/TestCase.h>       /* IWYU pragma: export */
+#include <embUnit/TestListener.h>   /* IWYU pragma: export */
+#include <embUnit/TestResult.h>     /* IWYU pragma: export */
+#include <embUnit/TestSuite.h>      /* IWYU pragma: export */
+#include <embUnit/TestRunner.h>     /* IWYU pragma: export */
+#include <embUnit/TestCaller.h>     /* IWYU pragma: export */
+#include <embUnit/RepeatedTest.h>   /* IWYU pragma: export */
+#include <embUnit/stdImpl.h>        /* IWYU pragma: export */
+#include <embUnit/AssertImpl.h>     /* IWYU pragma: export */
+#include <embUnit/HelperMacro.h>    /* IWYU pragma: export */
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
### Contribution description

This will fix false positives for unused includes in the unit tests with clangd.

### Testing procedure

Run

```
make -C tests/unittests compile-commands
```

Then open a unit test such as `tests/unittests/tests-core/tests-core-clist.c` in an editor that uses `clangd` as language server. In `master`, this will complain about `#include "embUnit.h"` in line 12 being unused, with this PR it will not.

This is adds comments only, it will not affect any machine code.

### Issues/PRs references

None