### PR TITLE
shell/vfs: set proper file permissions

### DIFF
--- a/sys/shell/cmds/vfs.c
+++ b/sys/shell/cmds/vfs.c
@@ -419,7 +419,7 @@ static int _write_handler(int argc, char **argv)
         return 5;
     }
 
-    int fd = vfs_open(path, flag, 0);
+    int fd = vfs_open(path, flag, 0644);
     if (fd < 0) {
         printf("Error opening file \"%s\": %s\n", path, tiny_strerror(fd));
         return 3;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Permission flags of `0` lead to a file that can't be read by anyone. 

### Testing procedure

Run `tests/sys/vfs_default`. In master a `vfs w /nvm0/test.txt ascii o data` would produce

```
---------- 1 benpicco benpicco    2 Apr 23 16:06 test.txt
```

With this patch we get

```
-rw-r--r-- 1 benpicco benpicco    4 Apr 23 16:25 test2.txt
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
