### PR TITLE
examples/suit_update: fix compilation for `native` [backport 2025.04]

### DIFF
--- a/examples/advanced/suit_update/Makefile
+++ b/examples/advanced/suit_update/Makefile
@@ -107,10 +107,11 @@ TESTRUNNER_RESET_AFTER_TERM ?= 1
 # with ed25519 support.
 TEST_ON_CI_BLACKLIST = all
 
+# Include global Makefile.include first to apply board aliasses
+include $(RIOTBASE)/Makefile.include
+
 # Add custom SUIT targets
 include $(CURDIR)/Makefile.suit.custom
-
-include $(RIOTBASE)/Makefile.include
 
 # export IFACE for test
 $(call target-export-variables,test-with-config test-with-config/check-config,IFACE)


### PR DESCRIPTION
# Backport of #21424

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

@benpicco discovered a regression introduced by #21242 that the `examples/advanced/suit_update` example does not compile when the BOARD is set to `native`. It does work with `native64` though.

See: https://github.com/RIOT-OS/RIOT/pull/21242#issuecomment-2822327207

The reason is that the Makefiles for the example use the `BOARD` variable before the alias is applied to create a path, which becomes invalid once the alias is applied by `makefiles/board_alias.inc.mk`.

This PR swaps the includes of the global `Makefile.include` with the local makefile that uses the `BOARD` variable to make sure the alias is applied before using the `BOARD` variable.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Current `master` with `native`:

```
cbuec@W11nMate:~/RIOTstuff/riot-suit/RIOT$ BOARD=native make -C examples/advanced/suit_update
make: Entering directory '/home/cbuec/RIOTstuff/riot-suit/RIOT/examples/advanced/suit_update'
using BOARD="native64" as "native" on a 64-bit system
Building application "suit_update" for "native64" with CPU "native".

make: *** No rule to make target '/home/cbuec/RIOTstuff/riot-suit/RIOT/examples/advanced/suit_update/bin/native64/suit_update/fw.1745402462.bin', needed by 'link'.  Stop.
make: Leaving directory '/home/cbuec/RIOTstuff/riot-suit/RIOT/examples/advanced/suit_update'
```

Current `master` with `native64`:
```
cbuec@W11nMate:~/RIOTstuff/riot-suit/RIOT$ BOARD=native64 make -C examples/advanced/suit_update
make: Entering directory '/home/cbuec/RIOTstuff/riot-suit/RIOT/examples/advanced/suit_update'
Building application "suit_update" for "native64" with CPU "native".

read EC key
...
"make" -C /home/cbuec/RIOTstuff/riot-suit/RIOT/sys/ztimer
   text    data     bss     dec     hex filename
 201065    9032  235376  445473   6cc21 /home/cbuec/RIOTstuff/riot-suit/RIOT/examples/advanced/suit_update/bin/native64/suit_update.elf
make: Leaving directory '/home/cbuec/RIOTstuff/riot-suit/RIOT/examples/advanced/suit_update'
```


This PR with `native`:
```
cbuec@W11nMate:~/RIOTstuff/riot-suit/RIOT$ BOARD=native make -C examples/advanced/suit_update
make: Entering directory '/home/cbuec/RIOTstuff/riot-suit/RIOT/examples/advanced/suit_update'
using BOARD="native64" as "native" on a 64-bit system
Building application "suit_update" for "native64" with CPU "native".

read EC key
...
"make" -C /home/cbuec/RIOTstuff/riot-suit/RIOT/sys/ztimer
   text    data     bss     dec     hex filename
 201097    9032  235376  445505   6cc41 /home/cbuec/RIOTstuff/riot-suit/RIOT/examples/advanced/suit_update/bin/native64/suit_update.elf
make: Leaving directory '/home/cbuec/RIOTstuff/riot-suit/RIOT/examples/advanced/suit_update'
```

This PR with `native64`:
```
cbuec@W11nMate:~/RIOTstuff/riot-suit/RIOT$ BOARD=native64 make -C examples/advanced/suit_update
make: Entering directory '/home/cbuec/RIOTstuff/riot-suit/RIOT/examples/advanced/suit_update'
Building application "suit_update" for "native64" with CPU "native".

read EC key
...
"make" -C /home/cbuec/RIOTstuff/riot-suit/RIOT/sys/ztimer
   text    data     bss     dec     hex filename
 201097    9032  235376  445505   6cc41 /home/cbuec/RIOTstuff/riot-suit/RIOT/examples/advanced/suit_update/bin/native64/suit_update.elf
make: Leaving directory '/home/cbuec/RIOTstuff/riot-suit/RIOT/examples/advanced/suit_update'
```

The resulting binary has about the same size, I would assume that the small difference is due to the different version strings.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes a regression introduced in #21242.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
