### PR TITLE
dist/tools: add a leading whitespace check for `#pragma once` in the `headerguards` static test

### DIFF
--- a/dist/tools/headerguards/headerguards.py
+++ b/dist/tools/headerguards/headerguards.py
@@ -50,6 +50,10 @@ def fix_headerguard(filename):
     for line in inlines:
         if line.startswith("#pragma once"):
             pragma_once_found += 1
+        elif line.lstrip().startswith("#pragma once"):
+            # check for lines that have leading whitespaces and add a correction
+            pragma_once_found += 1
+            line = "#pragma once\n"
         if guard_found == 0 and pragma_once_found == 0:
             if line.startswith("#ifndef"):
                 guard_found += 1


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When adding the #pragma once after a comment block, many editors will remain at the previous indentation level, adding a leading whitespace to the #pragma once. This is invalid, but causes the headerguards check to fail. Since it is a common issue, it warrants a separate check with a proposed solution, just like for other headerguard issues that are checked.

This came up in #21429 (here: https://github.com/RIOT-OS/RIOT/pull/21429#discussion_r2056845089 ) and previous Pull Requests while working on #21335.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Add a leading whitespace to the `#pragma once` of a header file of your liking (in this case I chose `core/include/msg.h`) and run the static test.

Current `master` (not very helpful):
```
cbuec@W11nMate:~/RIOTstuff/riot-suit/RIOT$ ./dist/tools/headerguards/check.sh
core/include/msg.h: no / broken header guard
```

With this PR (prints a suggestion to fix the issue):
```
cbuec@W11nMate:~/RIOTstuff/riot-suit/RIOT$ ./dist/tools/headerguards/check.sh
--- core/include/msg.h
+++ core/include/msg.h
@@ -6,7 +6,7 @@
  * directory for more details.
  */

- #pragma once
+#pragma once

 /**
  * @defgroup    core_msg  Messaging / IPC
```


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Useful for #21335.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
