### PR TITLE
sys/string_utils: make `swprintf()` appear in doc

### DIFF
--- a/sys/include/string_utils.h
+++ b/sys/include/string_utils.h
@@ -87,6 +87,7 @@ static inline const char *string_writer_str(const string_writer_t *sw)
     return sw->start;
 }
 
+#ifndef DOXYGEN
 /**
  * @brief   internal helper macro
  */
@@ -96,6 +97,8 @@ static inline const char *string_writer_str(const string_writer_t *sw)
 #define __swprintf swprintf
 __attribute__ ((format (printf, 2, 3)))
 #endif
+int __swprintf(string_writer_t *sw, FLASH_ATTR const char *restrict format, ...);
+#else
 /**
  * @brief   Write a formatted string to a buffer
  *          The string will be truncated if there is not enough space left in
@@ -106,9 +109,10 @@ __attribute__ ((format (printf, 2, 3)))
  * @param[in]   format  format string to write
  *
  * @return      number of bytes written on success
- *              -E2BIG if the string was truncated
+ * @retval      -E2BIG if the string was truncated
  */
-int __swprintf(string_writer_t *sw, FLASH_ATTR const char *restrict format, ...);
+int swprintf(string_writer_t *sw, FLASH_ATTR const char *restrict format, ...);
+#endif /* DOXYGEN */
 
 #if IS_ACTIVE(HAS_FLASH_UTILS_ARCH)
 #define swprintf(sw, fmt, ...) flash_swprintf(sw, TO_FLASH(fmt), ## __VA_ARGS__)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently the documentation only lists the [internal helper function](https://doc.riot-os.org/group__sys__string__utils.html#gadbe2d9857cb1488db63972bbd427fbce), not the actual `swprintf()` function.



### Testing procedure

Now the `swprintf` function gets properly documented:

![image](https://github.com/user-attachments/assets/54645d47-8faa-4dcf-962b-8cdb5ae68450)



### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
