### PR TITLE
drivers/sx126x: add `shield_sx1262`

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -203,6 +203,13 @@ ifneq (,$(filter shield_llcc68,$(USEMODULE)))
   USEMODULE += llcc68
 endif
 
+ifneq (,$(filter shield_sx1262,$(USEMODULE)))
+  FEATURES_REQUIRED += arduino_pins
+  FEATURES_REQUIRED += arduino_shield_uno
+  FEATURES_REQUIRED += arduino_spi
+  USEMODULE += sx1262
+endif
+
 ifneq (,$(filter shield_w5100,$(USEMODULE)))
   FEATURES_REQUIRED += arduino_pins
   FEATURES_REQUIRED += arduino_shield_isp

--- a/drivers/doc.txt
+++ b/drivers/doc.txt
@@ -194,3 +194,31 @@
  * USEMODULE=shield_llcc68 make BOARD=arduino-zero -C examples/networking/misc/lorawan
  * ```
  */
+
+/**
+ * @defgroup    drivers_shield_sx1262   SX1262 Arduino LoRa Shield
+ * @ingroup     drivers_shield
+ * @brief       SX1262 Arduino LoRa Shield
+ *
+ * # Overview
+ *
+ * @image html https://www.semtech.com/uploads/products/SX1262MB2CAS_shield_1_fixed.png "Photo of the SX1262 Shield" width=50%
+ *
+ * | Key                    | Value                                                                 |
+ * |:---------------------- |:--------------------------------------------------------------------- |
+ * | Abstract               | LoRa Transceiver                                                      |
+ * | Product Name           | SX1262MB2CAS                                                          |
+ * | Vendor                 | Semtech                                                               |
+ * | Vendor Doc             | [Product Homepage][shield_sx1262_hp]                                  |
+ * | Attachment Standard    | Arduino UNO Shield (Side SPI used, no ISP-SPI required)               |
+ *
+ * [shield_sx1262_hp]: https://www.semtech.com/products/wireless-rf/lora-connect/sx1262mb2cas
+ *
+ * # Usage
+ *
+ * Use the `shield_sx1262` module, e.g. using
+ *
+ * ```
+ * USEMODULE=shield_sx1262 make BOARD=arduino-zero -C examples/networking/misc/lorawan
+ * ```
+ */

--- a/drivers/sx126x/include/sx126x_params.h
+++ b/drivers/sx126x/include/sx126x_params.h
@@ -23,7 +23,7 @@
 #include "sx126x.h"
 #include "sx126x_driver.h"
 
-#ifdef MODULE_SHIELD_LC68
+#if defined(MODULE_SHIELD_LLCC68)
 #  include "arduino_iomap.h"
 #endif
 

--- a/drivers/sx126x/include/sx126x_params.h
+++ b/drivers/sx126x/include/sx126x_params.h
@@ -23,7 +23,7 @@
 #include "sx126x.h"
 #include "sx126x_driver.h"
 
-#if defined(MODULE_SHIELD_LLCC68)
+#if defined(MODULE_SHIELD_LLCC68) || defined(MODULE_SHIELD_SX1262)
 #  include "arduino_iomap.h"
 #endif
 
@@ -31,7 +31,7 @@
 extern "C" {
 #endif
 
-#ifdef MODULE_SHIELD_LLCC68
+#if defined(MODULE_SHIELD_LLCC68) || defined(MODULE_SHIELD_SX1262)
 #  define SX126X_PARAM_SPI                  ARDUINO_SPI_D11D12D13
 #  define SX126X_PARAM_SPI_NSS              ARDUINO_PIN_7
 #  define SX126X_PARAM_RESET                ARDUINO_PIN_A0

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -460,6 +460,7 @@ PSEUDOMODULES += shell_cmds_default
 PSEUDOMODULES += shell_hooks
 PSEUDOMODULES += shell_lock_auto_locking
 PSEUDOMODULES += shield_llcc68
+PSEUDOMODULES += shield_sx1262
 PSEUDOMODULES += shield_w5100
 PSEUDOMODULES += slipdev_stdio
 PSEUDOMODULES += slipdev_l2addr


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Adds `shield_sx1262` analog to `shield_llcc68`.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
