### PR TITLE
buildsystem: include Makefile.{dep,include} for application modules

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -31,6 +31,9 @@ include $(RIOTBASE)/boards/Makefile.dep
 # pull dependencies from packages
 -include $(PKG_PATHS:%=%Makefile.dep)
 
+# pull application module Makefile.dep if they exist
+-include $(sort $(USEMODULE:%=$(APPDIR)/%/Makefile.dep))
+
 ifneq (,$(filter mpu_stack_guard,$(USEMODULE)))
   FEATURES_REQUIRED += cortexm_mpu
 endif

--- a/Makefile.include
+++ b/Makefile.include
@@ -581,6 +581,9 @@ include $(RIOTBASE)/sys/Makefile.include
 # include external modules configuration
 -include $(EXTERNAL_MODULE_PATHS:%=%Makefile.include)
 
+# include application module Makefile.include if they exist
+-include $(USEMODULE:%=$(APPDIR)/%/Makefile.include)
+
 # Deduplicate includes without sorting them
 # see https://stackoverflow.com/questions/16144115/makefile-remove-duplicate-words-without-sorting
 define uniq


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Since #20024 you might be having modules in a subfolder in you application folder.
If it has a Mekefile.include and Makefile.dep, they must be pulled by RIOT to handle dependency resolution.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
