### PR TITLE
makefiles/riotgen: fix colors and behavior for undefined `generate-*` targets

### DIFF
--- a/makefiles/tools/riotgen.inc.mk
+++ b/makefiles/tools/riotgen.inc.mk
@@ -1,17 +1,21 @@
-.PHONY: riotgen-installed generate-%
+.PHONY: riotgen-installed _generate-%
 
--include makefiles/color.inc.mk
+RIOTMAKE=$(RIOTBASE)/makefiles
+
+-include $(RIOTMAKE)/utils/ansi.mk
+-include $(RIOTMAKE)/color.inc.mk
 
 riotgen-installed:
 	@command -v riotgen > /dev/null 2>&1 || \
 	{ $(COLOR_ECHO) \
-	"$(COLOR_RED)'riotgen' command is not available \
-	please consider installing it from \
-	https://pypi.python.org/pypi/riotgen$(COLOR_RESET)"; \
+	"$(COLOR_RED)'riotgen' command is not available.\n\
+	Please consider installing it with 'pip install riotgen' or download \
+	it from https://pypi.python.org/pypi/riotgen.$(COLOR_RESET)"; \
 	exit 1; }
 
 GENERATORS = board driver example module pkg test
-$(addprefix generate-,$(GENERATORS)): generate-%
+.SECONDEXPANSION:
+$(addprefix generate-,$(GENERATORS)): $$(addprefix _,$$@)
 
-generate-%: riotgen-installed
+_generate-%: riotgen-installed
 	@RIOTBASE=$(CURDIR) riotgen $* -i


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Recently I noticed that when you call `make generate-Makefile.ci` from the base directory, it would try to call `riotgen Makefile.ci`, which obviously fails. Likewise with any other `generate-*` target. Also, the colors for the warnings did not work for the warning when `riotgen` is not installed:

![image](https://github.com/user-attachments/assets/55d4ab82-43c5-4d48-89a5-e4bdceb047c0)

With this PR, the unrecognized target will be called out by the `Welcome Message` and the colors work for the warning. Also I made the warning a bit nicer.

![image](https://github.com/user-attachments/assets/91488023-c1d7-470b-9564-ec12c403f8d3)




<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `make generate-bogus` and `make generate-Makefile.ci` in the base directory and observe that the correct warning is displayed.

Uninstall `riotgen` and see that the warning is colored.

Install `riotgen` again and see that `make generate-test` will still call `riotgen` and ask you for the application name.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


