### PR TITLE
tools/uf2/nrf52_softdevice_check: abort when several bootloaders present

### DIFF
--- a/dist/tools/uf2/nrf52_softdevice_check.sh
+++ b/dist/tools/uf2/nrf52_softdevice_check.sh
@@ -24,10 +24,17 @@ if [ -z "${MOUNTPOINT}" ]; then
     exit 1
 fi
 
+if [ ! "$(echo "${MOUNTPOINT}" | wc -l)" -eq 1 ]; then
+    echo "More than one device with UF2 bootloader found!"
+    echo "RIOT cannot distinguish the correct device."\
+    "Please connect no more than one device at a time."
+    exit 1
+fi
+
 INFO_FILE="${MOUNTPOINT}/INFO_UF2.TXT"
 
 if [ ! -f "${INFO_FILE}" ]; then
-    echo "No INFO_FILE.TXT found in UF2 Mass Storage Device!"
+    echo "No INFO_UF2.TXT found in UF2 Mass Storage Device!"
     exit 1
 fi
 


### PR DESCRIPTION
### Contribution description

The current tooling cannot distinguish which one is the correct one to flash.

### Testing procedure

1. Connect two or more boards with Adafruit nrf52 bootloaders to your host.
2. Switch both of them to bootloader mode.
3. Try flashing one of them with `make -C examples/basic/hello-world BOARD=adafruit-feather-nrf52840-sense flash`

On `master`, this will actually give the bogus error message "No INFO_FILE.TXT found in UF2 Mass Storage Device!". Now, it should fail with a clearer error message.


### Issues/PRs references

Fixup for f8c9df35add38292b7705f7b7e678f17cb381bf5