### PR TITLE
sys/event: make debug output of `event_loop_debug` more useful

### DIFF
--- a/sys/event/callback.c
+++ b/sys/event/callback.c
@@ -13,6 +13,12 @@
 void _event_callback_handler(event_t *event)
 {
     event_callback_t *event_callback = (event_callback_t *) event;
+    if (IS_USED(MODULE_EVENT_LOOP_DEBUG)) {
+        printf("event: executing %p->%p(%p)\n",
+               (void *)event,
+               (void *)(uintptr_t)event_callback->callback,
+               event_callback->arg);
+    }
     event_callback->callback(event_callback->arg);
 }
 

--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -441,8 +441,13 @@ static inline void event_loop_multi(event_queue_t *queues, size_t n_queues)
         if (IS_USED(MODULE_EVENT_LOOP_DEBUG)) {
             uint32_t now;
             ztimer_acquire(ZTIMER_USEC);
-            printf("event: executing %p->%p\n",
-                   (void *)event, (void *)(uintptr_t)event->handler);
+
+            void _event_callback_handler(event_t *event);
+            if (!IS_USED(MODULE_EVENT_CALLBACK) ||
+                event->handler != _event_callback_handler) {
+                printf("event: executing %p->%p\n",
+                       (void *)event, (void *)(uintptr_t)event->handler);
+            }
             now = ztimer_now(ZTIMER_USEC);
 
             event->handler(event);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Callback events will always have `_event_callback_handler()` as their callback function, which is not very useful. 

Detect them and print the debut output in `_event_callback_handler()` instead to make for some more useful debug output.

### Testing procedure

Enable the `event_loop_debug` module.

```
025-04-30 14:44:05,875 # main(): This is RIOT! (Version: 2025.07-devel-97-gaf6bc9)
2025-04-30 14:44:05,876 # event: executing 0x416b20->0x402646(0x409983)
2025-04-30 14:44:05,877 # event 0
2025-04-30 14:44:05,878 # event: 0x416b20 took 7 µs
2025-04-30 14:44:05,878 # event: executing 0x416be8->0x402646(0x409993)
2025-04-30 14:44:05,879 # event A
2025-04-30 14:44:05,880 # event: 0x416be8 took 26 µs
2025-04-30 14:44:05,880 # event: executing 0x416b40->0x402646(0x40998b)
2025-04-30 14:44:05,881 # event D
2025-04-30 14:44:05,881 # event: 0x416b40 took 17 µs
2025-04-30 14:44:05,882 # event: executing 0x416c68->0x402646(0x40999b)
2025-04-30 14:44:05,883 # event B
2025-04-30 14:44:05,883 # event: 0x416c68 took 18 µs
2025-04-30 14:44:05,884 # event: executing 0x416be8->0x402646(0x409993)
2025-04-30 14:44:05,884 # event A
2025-04-30 14:44:05,885 # event: 0x416be8 took 14 µs
2025-04-30 14:44:06,371 # event: executing 0x416ce8->0x402646(0x4099a3)
2025-04-30 14:44:06,371 # event C
2025-04-30 14:44:06,372 # event: 0x416ce8 took 24 µs
2025-04-30 14:44:06,377 # event: executing 0x416be8->0x402646(0x409993)
2025-04-30 14:44:06,378 # event A
2025-04-30 14:44:06,379 # event: 0x416be8 took 23 µs
2025-04-30 14:44:06,872 # event: executing 0x416c68->0x402646(0x40999b)
2025-04-30 14:44:06,873 # event B
2025-04-30 14:44:06,873 # event: 0x416c68 took 24 µs
2025-04-30 14:44:06,878 # event: executing 0x416be8->0x402646(0x409993)
2025-04-30 14:44:06,879 # event A
2025-04-30 14:44:06,880 # event: 0x416be8 took 31 µs
2025-04-30 14:44:07,380 # event: executing 0x416be8->0x402646(0x409993)
2025-04-30 14:44:07,381 # event A
2025-04-30 14:44:07,381 # event: 0x416be8 took 24 µs
2025-04-30 14:44:07,870 # event: executing 0x416ce8->0x402646(0x4099a3)
2025-04-30 14:44:07,871 # event C
2025-04-30 14:44:07,872 # event: 0x416ce8 took 25 µs
2025-04-30 14:44:07,873 # event: executing 0x416c68->0x402646(0x40999b)
2025-04-30 14:44:07,874 # event B
2025-04-30 14:44:07,875 # event: 0x416c68 took 22 µs
2025-04-30 14:44:07,883 # event: executing 0x416be8->0x402646(0x409993)
2025-04-30 14:44:07,883 # event A
2025-04-30 14:44:07,884 # event: 0x416be8 took 30 µs

```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
