### PR TITLE
sys/psa_crypto: Adding ecc p256r1 pub key derivation

### DIFF
--- a/pkg/driver_cryptocell_310/include/psa_cryptocell_310_ecc_common.h
+++ b/pkg/driver_cryptocell_310/include/psa_cryptocell_310_ecc_common.h
@@ -76,6 +76,22 @@ psa_status_t cryptocell_310_common_ecc_generate_key_pair(uint8_t *priv_key_buffe
                                                  CRYS_ECPKI_DomainID_t domain);
 
 /**
+ * @brief   Common ECC public key derivation function (not supported)
+ *
+ * @param   priv_key_buffer         Input buffer to read ECC private key
+ * @param   pub_key_buffer          Output buffer to write ECC public key
+ * @param   priv_key_buffer_length  Length of private key
+ * @param   pub_key_buffer_length   Output pointer to write public key length
+ * @param   domain                  ECC domain of type @c CRYS_ECPKI_DomainID_t
+ * @return  psa_status_t
+ */
+psa_status_t cryptocell_310_common_ecc_derive_pub_key(const uint8_t *priv_key_buffer,
+                                                 uint8_t *pub_key_buffer,
+                                                 uint32_t priv_key_buffer_length,
+                                                 uint32_t *pub_key_buffer_length,
+                                                 CRYS_ECPKI_DomainID_t domain);
+
+/**
  * @brief   Common ECC signature function
  *
  * @param   priv_key            Pointer to ECC private key

--- a/pkg/driver_cryptocell_310/psa_cryptocell_310/ecc_common.c
+++ b/pkg/driver_cryptocell_310/psa_cryptocell_310/ecc_common.c
@@ -72,6 +72,21 @@ psa_status_t cryptocell_310_common_ecc_generate_key_pair(uint8_t *priv_key_buffe
     return PSA_SUCCESS;
 }
 
+psa_status_t cryptocell_310_common_ecc_derive_pub_key(const uint8_t *priv_key_buffer,
+                                                 uint8_t *pub_key_buffer,
+                                                 uint32_t priv_key_buffer_length,
+                                                 uint32_t *pub_key_buffer_length,
+                                                 CRYS_ECPKI_DomainID_t domain)
+{
+    (void) priv_key_buffer;
+    (void) pub_key_buffer;
+    (void) priv_key_buffer_length;
+    (void) pub_key_buffer_length;
+    (void) domain;
+    DEBUG("cryptocell_310 does not support key derivation.\n");
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
 psa_status_t cryptocell_310_common_ecc_sign(const uint8_t *priv_key,
                                          uint32_t priv_key_size,
                                          const uint8_t *input,

--- a/pkg/driver_cryptocell_310/psa_cryptocell_310/ecc_p256.c
+++ b/pkg/driver_cryptocell_310/psa_cryptocell_310/ecc_p256.c
@@ -35,6 +35,16 @@ psa_status_t psa_generate_ecc_p256r1_key_pair(  const psa_key_attributes_t *attr
                                                CRYS_ECPKI_DomainID_secp256r1);
 }
 
+psa_status_t psa_derive_ecc_p256r1_public_key(  const uint8_t *priv_key_buffer, uint8_t *pub_key_buffer,
+                                                size_t priv_key_buffer_length,
+                                                size_t *pub_key_buffer_length)
+{
+    return cryptocell_310_common_ecc_derive_pub_key(priv_key_buffer, pub_key_buffer,
+                                                (uint32_t)priv_key_buffer_length,
+                                                (uint32_t *)pub_key_buffer_length,
+                                                CRYS_ECPKI_DomainID_secp256r1);
+}
+
 psa_status_t psa_ecc_p256r1_sign_hash(  const psa_key_attributes_t *attributes,
                                         psa_algorithm_t alg,
                                         const uint8_t *key_buffer,

--- a/pkg/micro-ecc/psa_uecc/p256.c
+++ b/pkg/micro-ecc/psa_uecc/p256.c
@@ -48,6 +48,26 @@ psa_status_t psa_generate_ecc_p256r1_key_pair(  const psa_key_attributes_t *attr
     return PSA_SUCCESS;
 }
 
+psa_status_t psa_derive_ecc_p256r1_public_key(const uint8_t *priv_key_buffer, uint8_t *pub_key_buffer,
+                                        size_t priv_key_buffer_length,
+                                        size_t *pub_key_buffer_length)
+{
+    int ret = 0;
+
+    const struct uECC_Curve_t *curve = uECC_secp256r1();
+
+    *pub_key_buffer_length = uECC_curve_public_key_size(curve) + 1;
+
+    pub_key_buffer[0] = 0x04;
+    ret = uECC_compute_public_key(priv_key_buffer, pub_key_buffer+1, curve);
+    if (!ret) {
+        return PSA_ERROR_GENERIC_ERROR;
+    }
+
+    (void)priv_key_buffer_length;
+    return PSA_SUCCESS;
+}
+
 psa_status_t psa_ecc_p256r1_sign_hash(  const psa_key_attributes_t *attributes,
                                         psa_algorithm_t alg, const uint8_t *key_buffer,
                                         size_t key_buffer_size, const uint8_t *hash,

--- a/sys/psa_crypto/doc.md
+++ b/sys/psa_crypto/doc.md
@@ -257,9 +257,12 @@ names in uppercase and add the prefix `CONFIG_MODULE_` to all of them.
 - psa_asymmetric_ecc_p192r1_custom_backend
 - psa_asymmetric_ecc_p192r1_backend_microecc
 
-#### NIST ECC P192
+#### NIST ECC P256
 - psa_asymmetric_ecc_p256r1
 - psa_asymmetric_ecc_p256r1_backend_periph
+
+@warning Cryptocell 310 does not support public key derivation from a private key.
+
 - psa_asymmetric_ecc_p256r1_custom_backend
 - psa_asymmetric_ecc_p256r1_backend_microecc
 

--- a/sys/psa_crypto/include/psa_ecc.h
+++ b/sys/psa_crypto/include/psa_ecc.h
@@ -94,6 +94,19 @@ psa_status_t psa_generate_ecc_p256r1_key_pair(  const psa_key_attributes_t *attr
                                                 size_t *pub_key_buffer_length);
 
 /**
+ * @brief   Low level wrapper function to call a driver for deriving an P256R1 public key from the private key.
+ *
+ * @param[in]       priv_key_buffer
+ * @param[out]      pub_key_buffer
+ * @param[in]       priv_key_buffer_length
+ * @param[inout]    pub_key_buffer_length
+ * @return          @ref psa_status_t
+ */
+psa_status_t psa_derive_ecc_p256r1_public_key(  const uint8_t *priv_key_buffer, uint8_t *pub_key_buffer,
+                                                size_t priv_key_buffer_length,
+                                                size_t *pub_key_buffer_length);
+
+/**
  * @brief   Low level wrapper function to call a driver for an ECC hash signature
  *          with a SECP 256 R1 key.
  *          See @ref psa_sign_hash()

--- a/sys/psa_crypto/psa_crypto.c
+++ b/sys/psa_crypto/psa_crypto.c
@@ -1306,8 +1306,9 @@ psa_status_t psa_export_key(psa_key_id_t key,
     }
 
     if (!PSA_KEY_TYPE_IS_ECC(slot->attr.type) ||
-            PSA_KEY_TYPE_ECC_GET_FAMILY(slot->attr.type) != PSA_ECC_FAMILY_TWISTED_EDWARDS) {
-        /* key export is currently only supported for ed25519 keys */
+           (PSA_KEY_TYPE_ECC_GET_FAMILY(slot->attr.type) != PSA_ECC_FAMILY_TWISTED_EDWARDS &&
+            PSA_KEY_TYPE_ECC_GET_FAMILY(slot->attr.type) != PSA_ECC_FAMILY_SECP_R1)) {
+        /* key export is currently only supported for ed25519 and secp_r1 keys */
         status = PSA_ERROR_NOT_SUPPORTED;
         unlock_status = psa_unlock_key_slot(slot);
         if (unlock_status != PSA_SUCCESS) {
@@ -1925,7 +1926,7 @@ psa_status_t psa_sign_hash(psa_key_id_t key,
         return PSA_ERROR_NOT_SUPPORTED;
     }
 
-    if (!PSA_ALG_IS_SIGN_HASH(alg) || hash_length != PSA_HASH_LENGTH(alg)) {
+    if (!PSA_ALG_IS_SIGN_HASH(alg) || (hash_length != PSA_HASH_LENGTH(alg) && PSA_ALG_IS_HASH(alg))) {
         return PSA_ERROR_INVALID_ARGUMENT;
     }
 
@@ -2029,7 +2030,7 @@ psa_status_t psa_verify_hash(psa_key_id_t key,
         return PSA_ERROR_NOT_SUPPORTED;
     }
 
-    if (!PSA_ALG_IS_SIGN_HASH(alg) || hash_length != PSA_HASH_LENGTH(alg)) {
+    if (!PSA_ALG_IS_SIGN_HASH(alg) || (hash_length != PSA_HASH_LENGTH(alg) && PSA_ALG_IS_HASH(alg))) {
         return PSA_ERROR_INVALID_ARGUMENT;
     }
 

--- a/sys/psa_crypto/psa_crypto_algorithm_dispatch.c
+++ b/sys/psa_crypto/psa_crypto_algorithm_dispatch.c
@@ -576,9 +576,7 @@ psa_status_t psa_algorithm_dispatch_import_key(const psa_key_attributes_t *attri
 #endif
 #if IS_USED(MODULE_PSA_ASYMMETRIC_ECC_P256R1)
         case PSA_ECC_P256_R1:
-            // todo: support for Weierstrass curves
-            (void)slot;
-            ret = PSA_ERROR_NOT_SUPPORTED;
+            ret = psa_derive_ecc_p256r1_public_key(data, pubkey_data, data_length, pubkey_data_len);
             break;
 #endif
 #if IS_USED(MODULE_PSA_ASYMMETRIC_ECC_ED25519)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR adds public key derivation for P256R1 curves using the micro-ecc backend. Unfortunately the Cryptocell 310 does not support this operation.



### Testing procedure
 The existing test at `tests/sys/psa_crypto_ecdsa` has been extended to verify the key derivation.



### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
