### PR TITLE
boards/seeedstudio-xiao-esp32c3: fix pin conflict

### DIFF
--- a/boards/seeedstudio-xiao-esp32c3/Makefile.dep
+++ b/boards/seeedstudio-xiao-esp32c3/Makefile.dep
@@ -1,9 +1,17 @@
-ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
-  USEMODULE += stdio_usb_serial_jtag
+ifneq (,$(filter periph_spi, $(USEMODULE)))
+  ifeq (,$(filter periph_init_buttons, $(DISABLE_MODULE)))
+    DISABLE_MODULE += periph_init_buttons
+
+    MSG="Warning: Using periph_spi on Seeed Studio Xiao ESP32C3 board will disable BUTTON0 due to pin conflict."
+    $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)$(MSG)$(COLOR_RESET)" 1>&2)
+  endif
+else ifneq (,$(filter saul_default,$(USEMODULE)))
+  # The button is the only SAUL device. Enable it only when SPI is not enabled.
+  USEMODULE += saul_gpio
 endif
 
-ifneq (,$(filter saul_default,$(USEMODULE)))
-  USEMODULE += saul_gpio
+ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+  USEMODULE += stdio_usb_serial_jtag
 endif
 
 include $(RIOTBOARD)/common/esp32c3/Makefile.dep

--- a/boards/seeedstudio-xiao-esp32c3/Makefile.features
+++ b/boards/seeedstudio-xiao-esp32c3/Makefile.features
@@ -14,4 +14,7 @@ FEATURES_PROVIDED += esp_jtag
 
 # Various other features (if any)
 FEATURES_PROVIDED += arduino_pins
+FEATURES_PROVIDED += arduino_analog
+FEATURES_PROVIDED += arduino_i2c
+FEATURES_PROVIDED += arduino_spi
 FEATURES_PROVIDED += xiao_shield

--- a/boards/seeedstudio-xiao-esp32c3/doc.md
+++ b/boards/seeedstudio-xiao-esp32c3/doc.md
@@ -74,7 +74,7 @@ GPIO overview:
 - 1 x SPI
 - 1 x I2C
 - 1 x UART
-- 11 x PWM channels (only 4 defined by default)
+- 11 x PWM channels (only 3 defined by default)
 
 The purpose for which a GPIO is used depends on which module
 or function is used first. For example, if module `periph_spi` is not used,
@@ -91,7 +91,7 @@ BUTTON0         | GPIO9                 | GPIO9 is a [strapping pin](https://doc
 ADC             | GPIO2, GPIO3, GPIO4   | \ref esp32_adc_channels "ADC Channels"
 I2C_DEV(0):SCL  | GPIO7                 | \ref esp32_i2c_interfaces "I2C Interfaces"
 I2C_DEV(0):SDA  | GPIO6                 | \ref esp32_i2c_interfaces "I2C Interfaces"
-PWM_DEV(0)      | GPIO2, GPIO3, GPIO4, GPIO5 | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(0)      | GPIO2, GPIO3, GPIO4   | \ref esp32_pwm_channels "PWM Channels"
 SPI_DEV(0):SCK  | GPIO8                 | \ref esp32_spi_interfaces "SPI Interfaces"
 SPI_DEV(0):MISO | GPIO9                 | \ref esp32_spi_interfaces "SPI Interfaces"
 SPI_DEV(0):MOSI | GPIO10                | \ref esp32_spi_interfaces "SPI Interfaces"

--- a/boards/seeedstudio-xiao-esp32c3/doc.md
+++ b/boards/seeedstudio-xiao-esp32c3/doc.md
@@ -103,6 +103,9 @@ UART_DEV(0):RxD | GPIO20                | \ref esp32_uart_interfaces "UART inter
 @note The configuration of ADC channels contains all ESP32-C3 GPIOs that could
       be used as ADC channels.
 
+@note BUTTON0 conflicts with the SPI MISO line. If the SPI
+      module is enabled, the button will be automatically disabled.
+
 For detailed information about the peripheral configurations of ESP32-C3
 boards, see section \ref esp32_peripherals "Common Peripherals".
 

--- a/boards/seeedstudio-xiao-esp32c3/include/arduino_iomap.h
+++ b/boards/seeedstudio-xiao-esp32c3/include/arduino_iomap.h
@@ -42,16 +42,18 @@ extern "C" {
 #define ARDUINO_PIN_9       GPIO9       /**< Arduino pin 0 (SPI MISO)*/
 #define ARDUINO_PIN_10      GPIO10      /**< Arduino pin 0 (SPI MOSI) */
 
-#define ARDUINO_PIN_LAST    10
+#define ARDUINO_PIN_LAST    10          /**< Last Arduino pin index. */
 /** @} */
 
 /**
  * @name    Aliases for analog pins
  * @{
  */
-#define ARDUINO_PIN_A0          ARDUINO_PIN_0
-#define ARDUINO_PIN_A1          ARDUINO_PIN_1
-#define ARDUINO_PIN_A2          ARDUINO_PIN_2
+#define ARDUINO_A0          ADC_LINE(0)     /**< ADC line for Arduino pin A0 */
+#define ARDUINO_A1          ADC_LINE(1)     /**< ADC line for Arduino pin A1 */
+#define ARDUINO_A2          ADC_LINE(2)     /**< ADC line for Arduino pin A2 */
+
+#define ARDUINO_ANALOG_PIN_LAST 2           /**< Last Arduino analog pin index */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/seeedstudio-xiao-esp32c3/include/board.h
+++ b/boards/seeedstudio-xiao-esp32c3/include/board.h
@@ -20,6 +20,7 @@
 
 #include <stdint.h>
 
+#if MODULE_PERIPH_INIT_BUTTONS || DOXYGEN
 /**
  * @name    Button pin definitions
  * @{
@@ -31,8 +32,11 @@
  * Pressing the button will give a low signal.
  *
  * @note GPIO9 is a strapping pin that must be pulled up a boot time
- * in order to boot the user application.
- * After boot, it can be used as user button.
+ *       in order to boot the user application.
+ *       After boot, it can be used as user button.
+ *
+ * @note \c BTN0_PIN conflicts with the SPI MISO line. If the SPI
+ *       module is enabled, the button will be automatically disabled.
  */
 #define BTN0_PIN        GPIO9
 
@@ -59,6 +63,7 @@
 #define BUTTON0_PIN     BTN0_PIN
 
 /** @} */
+#endif
 
 /* include common board definitions as last step */
 #include "board_common.h"

--- a/boards/seeedstudio-xiao-esp32c3/include/gpio_params.h
+++ b/boards/seeedstudio-xiao-esp32c3/include/gpio_params.h
@@ -25,15 +25,17 @@ extern "C" {
 #endif
 
 /**
- * @brief   LED and Button configuration
+ * @brief   Button configuration
  */
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
+#ifdef MODULE_PERIPH_INIT_BUTTONS
         .name = "BOOT",
         .pin = BTN0_PIN,
         .mode = BTN0_MODE,
         .flags = SAUL_GPIO_INVERTED
+#endif
     },
 };
 

--- a/boards/seeedstudio-xiao-esp32c3/include/periph_conf.h
+++ b/boards/seeedstudio-xiao-esp32c3/include/periph_conf.h
@@ -98,7 +98,7 @@ extern "C" {
  *        at maximum PWM_CHANNEL_NUM_DEV_MAX.
  */
 #ifndef PWM0_GPIOS
-#define PWM0_GPIOS  { GPIO2, GPIO3, GPIO4, GPIO5 }
+#define PWM0_GPIOS  { GPIO2, GPIO3, GPIO4 }
 #endif
 
 /** @} */

--- a/makefiles/defaultmodules_no_recursive_deps.inc.mk
+++ b/makefiles/defaultmodules_no_recursive_deps.inc.mk
@@ -14,3 +14,4 @@ DEFAULT_MODULE += periph_init_led4
 DEFAULT_MODULE += periph_init_led5
 DEFAULT_MODULE += periph_init_led6
 DEFAULT_MODULE += periph_init_led7
+DEFAULT_MODULE += periph_init_buttons


### PR DESCRIPTION
Add guard around macro definition to allow the user to redefine it to use the SPI module

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
- Disable BUTTON0 if SPI is used because this pin conflicts with the SPI MISO line.
- Don't define GPIO5 as a PWM line any more since it is used as chip select in the default SPI configuration.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes #21462 