### PR TITLE
build system: improve cargo/docker interaction

### DIFF
--- a/makefiles/cargo-targets.inc.mk
+++ b/makefiles/cargo-targets.inc.mk
@@ -91,11 +91,5 @@ $(APPLICATION_RUST_MODULE).module: $(CARGO_LIB) FORCE
 	$(Q)# ... and move them back if any exist, careful to err if anything is duplicate
 	$(Q)rmdir $(BINDIR)/$(APPLICATION_RUST_MODULE)/bin/ || (mv -n $(BINDIR)/$(APPLICATION_RUST_MODULE)/bin/* $(BINDIR)/$(APPLICATION_RUST_MODULE)/ && rmdir $(BINDIR)/$(APPLICATION_RUST_MODULE)/bin/)
 
-# create cargo folders
-# This prevents cargo inside docker from creating them with root permissions
-# (should they not exist), and also from re-building everything every time
-# because the .cargo inside is as ephemeral as the build container.
-$(shell mkdir -p $(HOME)/.cargo/git $(HOME)/.cargo/registry)
-
 FORCE:
 .phony: FORCE


### PR DESCRIPTION
### Contribution description

Do not create the cargo folder unconditionally, but only before running docker and only when they do not exist.

### Testing procedure

```
make BUILD_IN_DOCKER=1 BOARD=samr21-xpro -C examples/lang_support/official/rust-hello-world/
```

without `.cargo/git` and `.cargo/registry` should create those folders before running docker, so that they are not created as root.

### Issues/PRs references

None