### PR TITLE
boards/nrf52840dongle: Support a FLOSS programmer

### DIFF
--- a/boards/nrf52840dongle/Makefile.include
+++ b/boards/nrf52840dongle/Makefile.include
@@ -3,8 +3,24 @@
 PROGRAMMER ?= nrfutil
 
 ifeq (nrfutil,$(PROGRAMMER))
+  USING_NRF_BOOTLOADER = 1
 
-  # Using nrfutil implies using the Nordic bootloader described at
+  FLASHFILE = $(HEXFILE)
+  FLASHDEPS += $(HEXFILE).zip
+  FLASHER = nrfutil
+  FFLAGS = dfu usb-serial --port=${PORT} --package=$(HEXFILE).zip
+endif
+
+ifeq (nrfdfu,$(PROGRAMMER))
+  USING_NRF_BOOTLOADER = 1
+
+  FLASHFILE = $(ELFFILE)
+  FLASHER = nrfdfu
+  FFLAGS = $(FLASHFILE)
+endif
+
+ifeq (1,$(USING_NRF_BOOTLOADER))
+  # Using an nrfutil style flasher implies using the Nordic bootloader described at
   # <https://devzone.nordicsemi.com/nordic/short-range-guides/b/getting-started/posts/nrf52840-dongle-programming-tutorial>.
   #
   # It has a static MBR at the first 4k, and an ample 128k Open USB Bootloader at
@@ -14,15 +30,10 @@ ifeq (nrfutil,$(PROGRAMMER))
   ROM_OFFSET = 0x1000
   ROM_LEN = 0xdf000
 
-  FLASHFILE = $(HEXFILE)
-  FLASHDEPS += $(HEXFILE).zip
-  FLASHER = nrfutil
-  FFLAGS = dfu usb-serial --port=${PORT} --package=$(HEXFILE).zip
-
   include $(RIOTMAKE)/tools/usb_board_reset.mk
 endif
 
-PROGRAMMERS_SUPPORTED += nrfutil
+PROGRAMMERS_SUPPORTED += nrfutil nrfdfu
 
 %.hex.zip: %.hex
 	$(call check_cmd,$(FLASHER),Flash program and preparation tool)

--- a/boards/nrf52840dongle/Makefile.include
+++ b/boards/nrf52840dongle/Makefile.include
@@ -1,6 +1,6 @@
 # This board uses the vendor's serial bootloader
 
-PROGRAMMER ?= nrfutil
+PROGRAMMER ?= nrfdfu
 
 ifeq (nrfutil,$(PROGRAMMER))
   USING_NRF_BOOTLOADER = 1

--- a/boards/nrf52840dongle/doc.md
+++ b/boards/nrf52840dongle/doc.md
@@ -48,7 +48,27 @@ reset button as well as 15 configurable external pins.
 
 ### Flash the board {#nrf52840dongle_flash}
 
-The board is flashed using its on-board boot loader; the proprietary
+The board is flashed using its on-board boot loader
+called [Open USB bootloader](https://devzone.nordicsemi.com/nordic/short-range-guides/b/getting-started/posts/nrf52840-dongle-programming-tutorial)
+using either of two tools described below.
+
+If RIOT is already running on the board, flashing the device will automatically reset the CPU and enter
+the bootloader.
+If some other firmware is running or RIOT crashed, you need to enter the bootloader
+manually by pressing the board's reset button.
+
+Readiness of the bootloader is indicated by LD2 pulsing in red.
+
+#### nrfdfu
+
+The tool [nrfdfu](https://github.com/knurling-rs/nrfdfu-rs/)
+is RIOT's default way of flashing a program by sending it to the bootloader.
+
+It needs to be installed locally using `cargo install nrfdfu`.
+
+#### nrfutil
+
+The proprietary
 [nrfutil](https://www.nordicsemi.com/Products/Development-tools/nRF-Util) program needs to
 be installed, and `nrfutil install nrf5sdk-tools` needs to be executed. Note
 that nrfutil, even when not running the "install" command, will install itself
@@ -58,12 +78,11 @@ maintained by Nordic, and has become dysfunctional on Python 3.11.
 The nrfutil can turn the binary into a suitable zip file and send it to the
 bootloader. The process is automated in the usual `make flash` target.
 
-If RIOT is already running on the board, it will automatically reset the CPU and enter
-the bootloader.
-If some other firmware is running or RIOT crashed, you need to enter the bootloader
-manually by pressing the board's reset button.
+#### Other programming methods
 
-Readiness of the bootloader is indicated by LD2 pulsing in red.
+When building a program for this board to be flashed using other methods
+(e.g. using the board's Tag-Connect footprint),
+setting `USING_NRF_BOOTLOADER=1` in the makefiles aligns the program suitable to be flashed after the bootloader.
 
 ### Accessing STDIO
 

--- a/boards/nrf52840dongle/doc.md
+++ b/boards/nrf52840dongle/doc.md
@@ -75,7 +75,7 @@ that nrfutil, even when not running the "install" command, will install itself
 into `~/.nrfutil`. The older Python based version of nrfutil is no longer
 maintained by Nordic, and has become dysfunctional on Python 3.11.
 
-The nrfutil can turn the binary into a suitable zip file and send it to the
+The nrfutil works in two steps by turning the binary into a zip file and then sending the content of that zip file to the
 bootloader. The process is automated in the usual `make flash` target.
 
 #### Other programming methods

--- a/doc/doxygen/src/flashing.md
+++ b/doc/doxygen/src/flashing.md
@@ -110,7 +110,7 @@ support multiple platforms are given in section
 ### nRF52
 
 - `adafruit-nrfutil`, `uf2conv` (requires Adafruit bootloader), see @ref boards_common_adafruit-nrf52-bootloader
-- `nrfutil` (required nRF bootloader)
+- `nrfdfu` or `nrfutil` (requires nRF bootloader)
 - `nrfjprog` (requires a separate J-Link debugger)
 
 ### RP2040


### PR DESCRIPTION
### Contribution description

The nrfutil programmer used for nrf52840dongle was never FLOSS (AFAICT it always had a 3-clause BSD license plus but-only-use-it-for-our-hardware), and installation has become way more convoluted since they abandoned the Python version.

There is a free implementation that's generally more hassle-free, too, as it works right from the .elf without going the extra detour over a programmer-specific zip file. [edit:] It is set as the new default.

### Testing procedure

**While there has not been a new release of nrfdfu**: `cargo install --git https://github.com/knurling-rs/nrfdfu-rs/` (later it should be `cargo install nrfdfu`)

* Take any test or example and run `make -C tests/periph/cpuid BOARD=nrf52840dongle all flash term`. (No need to set `PROGRAMMER=nrfdfu` -- it is the default now).

Note that unlike nrfutil, this tool discards the PORT= variable -- it doesn't deal in serial port terms, it looks at USB devices with the right uid/vid; there's a [PR](https://github.com/knurling-rs/nrfdfu-rs/pull/21) to identify the USB device through its serial number, which IMO should be the way to go for us anyway.

### Issues/PRs references

* This used to depend on https://github.com/ferrous-systems/nrfdfu-rs/pull/18 but that is merged now.