### PR TITLE
sys/embunit: fix return value on failure

### DIFF
--- a/sys/embunit/TextUIRunner.c
+++ b/sys/embunit/TextUIRunner.c
@@ -39,26 +39,28 @@
  */
 static TestResult result_;
 static OutputterRef outputterRef_ = 0;
-static int wasfailure_ = 0;
+static int testcasewasfailure_ = 0;
+static int testsuitewasfailure_ = 0;
 
 static void TextUIRunner_startTest(TestListnerRef self,TestRef test)
 {
     (void)self;
     (void)test;
-    wasfailure_ = 0;
+    testcasewasfailure_ = 0;
 }
 
 static void TextUIRunner_endTest(TestListnerRef self,TestRef test)
 {
     (void)self;
-    if (!wasfailure_)
+    if (!testcasewasfailure_)
         Outputter_printSuccessful(outputterRef_,test,result_.runCount);
 }
 
 static void TextUIRunner_addFailure(TestListnerRef self,TestRef test,char *msg,int line,char *file)
 {
     (void)self;
-    wasfailure_ = 1;
+    testcasewasfailure_ = 1;
+    testsuitewasfailure_ = 1;
     Outputter_printFailure(outputterRef_,test,msg,line,file,result_.runCount);
 }
 
@@ -89,6 +91,7 @@ void TextUIRunner_startWithOutputter(OutputterRef outputter)
 
 void TextUIRunner_start(void)
 {
+    testsuitewasfailure_ = 0;
     if (!outputterRef_)
         outputterRef_ = TextOutputter_outputter();
     TextUIRunner_startWithOutputter(outputterRef_);
@@ -104,5 +107,5 @@ void TextUIRunner_runTest(TestRef test)
 int TextUIRunner_end(void)
 {
     Outputter_printStatistics(outputterRef_,&result_);
-    return wasfailure_;
+    return testsuitewasfailure_;
 }


### PR DESCRIPTION
### Contribution description

When using `OUTPUT=COLORTEST` the return value of the unit test's `main()` on failure was `0`, while it should be `1`. As a result, running the unit tests from a script using

    $ OUTPUT=COLORTEXT make BOARD=native64 RIOT_TERMINAL=native -j32 flash term -C tests/unittests

would not catch a test failure.

This commit changes the behavior so that `0` is returned on success and `1` on failure for both regular and colored text output.

### Testing procedure

Run

```
$ TZ=Europe/Berlin OUTPUT=COLORTEXT make BOARD=native64 RIOT_TERMINAL=native -j32 flash term -C tests/unittests
```

and


```
$ TZ=UTC OUTPUT=COLORTEXT make BOARD=native64 RIOT_TERMINAL=native -j32 flash term -C tests/unittests
```

The former will fail, the latter succeed. But both will have an exit code of `0` (`echo $?`) in `master`, while ommitting the `OUTPUT=COLORTEXT` will cause the failed test to have an exit code of `1`.

With this PR, failures will have an exit code of `1` and success an exit code of `0`, regardless of output.

### Issues/PRs references

None