### PR TITLE
boards/esp32s3-usb-otg: enable SDMMC peripheral

### DIFF
--- a/boards/esp32s3-usb-otg/Makefile.dep
+++ b/boards/esp32s3-usb-otg/Makefile.dep
@@ -8,7 +8,13 @@ ifneq (,$(filter vfs_default,$(USEMODULE)))
 endif
 
 ifneq (,$(filter mtd,$(USEMODULE)))
-  USEMODULE += mtd_sdcard_default
+  ifneq (,$(filter sdcard_spi,$(USEMODULE)))
+    # use SD Card in SPI mode if sdcard_spi is explicitly enabled
+    USEMODULE += mtd_sdcard_default
+  else
+    # use SDMMC host for the SD Card otherwise
+    USEMODULE += mtd_sdmmc_default
+  endif
 endif
 
 ifneq (,$(filter disp_dev,$(USEMODULE)))

--- a/boards/esp32s3-usb-otg/Makefile.features
+++ b/boards/esp32s3-usb-otg/Makefile.features
@@ -6,6 +6,7 @@ include $(RIOTBOARD)/common/esp32s3/Makefile.features
 # additional features provided by the board
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_sdmmc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev

--- a/boards/esp32s3-usb-otg/doc.txt
+++ b/boards/esp32s3-usb-otg/doc.txt
@@ -47,7 +47,7 @@ The main features of the board are:
 | 8 MByte Flash                  | yes            |
 | USB Type-A Host Interface      | no             |
 | USB Type-A Device Interface    | yes            |
-| SD Card Slot                   | yes (SPI mode) |
+| SD Card Slot                   | yes            |
 | LCD Color Display 240 x 240    | yes            |
 
 ## Hardware {#esp32s3_usb_otg_hardware}
@@ -107,6 +107,12 @@ UART_DEV(0):TxD   | GPIO43 | USB-to-UART bridge | \ref esp32_uart_interfaces "UA
 UART_DEV(0):RxD   | GPIO44 | USB-to-UART bridge | \ref esp32_uart_interfaces "UART interfaces"
 </center>
 \n
+
+@note
+SPI_DEV(1) is only configured if the `sdcard_spi` module is explicitly added to
+the `USEMODULE` in the application's Makefile to access the SD card in SPI mode.
+By default, the SDMMC host is configured and used by the `periph_sdmmc`
+module to access the SD card.
 
 For detailed information about the peripheral configurations of ESP32-S3
 boards, see section \ref esp32_peripherals "Common Peripherals".

--- a/boards/esp32s3-usb-otg/include/periph_conf.h
+++ b/boards/esp32s3-usb-otg/include/periph_conf.h
@@ -65,6 +65,30 @@ extern "C" {
 /** @} */
 
 /**
+ * @name   SD/MMC host controller configuration
+ * @{
+ */
+
+/** SDMMC devices */
+static const sdmmc_conf_t sdmmc_config[] = {
+    {
+        .slot = SDMMC_SLOT_1,
+        .cd = GPIO_UNDEF,
+        .wp = GPIO_UNDEF,
+        .clk = GPIO36,
+        .cmd = GPIO35,
+        .dat0 = GPIO37,
+        .dat1 = GPIO38,
+        .dat2 = GPIO33,
+        .dat3 = GPIO34,
+    },
+};
+
+/** Number of configured SDMMC devices */
+#define SDMMC_CONFIG_NUMOF  1
+/** @} */
+
+/**
  * @name    SPI configuration
  *
  * SPI_DEV(0) is used for LCD display


### PR DESCRIPTION
### Contribution description

This PR enables the `periph_sdmmc` feature for the `esp32s3-usb-otg` board to use the SDMMC Host to access the SD Card instead of using the SD Card in SPI mode.

### Testing procedure

```python
BOARD=esp32s3-usb-otg make -j4 -C tests/sys/vfs_default/ flash term
```
should still work.

### Issues/PRs references

Depends on PR #21478 