### PR TITLE
sys/shell/cmd: typo in ifconfig helptext, \'transition\' fixed as \'transmission\'

### DIFF
--- a/sys/shell/cmds/gnrc_netif.c
+++ b/sys/shell/cmds/gnrc_netif.c
@@ -211,7 +211,7 @@ static void _set_usage(char *cmd_name)
          "       * \"hop_limit\" - set hop limit\n"
          "       * \"hl\" - alias for \"hop_limit\"\n"
          "       * \"key\" - set the encryption key in hexadecimal format\n"
-         "       * \"mtu\" - IPv6 maximum transition unit\n"
+         "       * \"mtu\" - IPv6 maximum transmission unit\n"
          "       * \"nid\" - sets the network identifier (or the PAN ID)\n"
          "       * \"page\" - set the channel page (IEEE 802.15.4)\n"
          "       * \"pan\" - alias for \"nid\"\n"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The helptext of the `ifconfig` shell command has a typo; instead of "Maximum transmission unit" it was "Maximum transition unit". not a super big deal. but this PR fixes it.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

run `ifconfig help` and look at the line about "mtu" 

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
