### PR TITLE
doc/creating-an-application: Add Section about Makefile.board.dep

### DIFF
--- a/doc/doxygen/src/creating-an-application.md
+++ b/doc/doxygen/src/creating-an-application.md
@@ -106,6 +106,28 @@ Makefile wildcards.
 
 Both approaches are illustrated and explained in `examples/basic/subfolders`.
 
+## Setting Board-specific Dependencies
+
+Required dependencies of applications may change depending on the
+target board or architecture. This is especially
+relevant for networking applications where multiple hardware implementations
+exist and the appropriate one has to be chosen for the given board
+or architecture.
+To achieve this task elegantly, a `Makefile.board.dep` file can be
+created in the application folder, which is automatically included and
+evaluated by RIOT build system during the dependency resolution phase.
+This ensures that all the relevant variables such as `FEATURES_USED` or the
+`USEMODULE` list are fully populated.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
+ifneq (,$(filter arch_esp,$(FEATURES_USED)))
+  USEMODULE += esp_wifi
+endif
+
+ifneq (,$(filter native native32 native64,$(BOARD)))
+  USEMODULE += netdev_default
+endif
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # Helper tools
 


### PR DESCRIPTION
The existance of the `Makefile.board.dep` files in application directories was previously undocumented, but used throughout the RIOT example applications.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The possibility to create a board-specific `Makefile.dep` in the application folder was introduced in #12755, but no further documentation about it was added.

This is unfortunate, because it's used throughout RIOT already and a very useful feature, since that file (unlike the application Makefile) will be called throughout the dependency resolution phase and therefore have the latest and updated `FEATURES_USED`, `USEMODULE`, ... variables.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Look at the generated Doxygen documentation.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

The feature was introduced in #12755.
The lack of documentation came up in #21442.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
