### PR TITLE
tests/pkg/fatfs*: cleanup MTD default dependencies

### DIFF
--- a/boards/esp32-wrover-kit/Makefile.dep
+++ b/boards/esp32-wrover-kit/Makefile.dep
@@ -12,8 +12,11 @@ ifneq (,$(filter vfs_default,$(USEMODULE)))
 endif
 
 ifneq (,$(filter mtd,$(USEMODULE)))
-  ifeq (,$(filter sdcard_spi,$(USEMODULE)))
-    # use mtd_sdmmc_default if sdcard_spi isn't explicitly enabled
+  ifneq (,$(filter sdcard_spi,$(USEMODULE)))
+    # use SD Card in SPI mode if sdcard_spi is explicitly enabled
+    USEMODULE += mtd_sdcard_default
+  else
+    # use SDMMC host for the SD Card otherwise
     USEMODULE += mtd_sdmmc_default
   endif
 endif

--- a/tests/pkg/fatfs/Makefile
+++ b/tests/pkg/fatfs/Makefile
@@ -13,20 +13,17 @@ USEPKG    += fatfs
 FATFS_IMAGE_FILE_SIZE_MIB ?= 128
 
 ifneq (,$(filter native native32 native64,$(BOARD)))
-#overwrite default mtd_native-config to use fat image as flash device
-CFLAGS += -DMTD_NATIVE_FILENAME=\"./bin/riot_fatfs_disk.img\"
-CFLAGS += -DFATFS_IMAGE_FILE_SIZE_MIB=$(FATFS_IMAGE_FILE_SIZE_MIB)
-CFLAGS += -DMTD_SECTOR_NUM=\(\(\(FATFS_IMAGE_FILE_SIZE_MIB\)*1024*1024\)/MTD_SECTOR_SIZE\)
-else
-# for actual hardware use mtd_sdcard as storage device
-USEMODULE += mtd_sdcard
+  # overwrite default mtd_native-config to use fat image as flash device
+  CFLAGS += -DMTD_NATIVE_FILENAME=\"./bin/riot_fatfs_disk.img\"
+  CFLAGS += -DFATFS_IMAGE_FILE_SIZE_MIB=$(FATFS_IMAGE_FILE_SIZE_MIB)
+  CFLAGS += -DMTD_SECTOR_NUM=\(\(\(FATFS_IMAGE_FILE_SIZE_MIB\)*1024*1024\)/MTD_SECTOR_SIZE\)
 endif
 
 image:
 	${Q}mkdir -p bin
 	${Q}tar -xjf riot_fatfs_disk.tar.bz2 -C ./bin/
 
-#this generates a compressed fat image file that can be used by the fat driver on native
+# this generates a compressed fat image file that can be used by the fat driver on native
 compressed-image:
 	${Q}./create_fat_image_file.sh $(FATFS_IMAGE_FILE_SIZE_MIB)
 

--- a/tests/pkg/fatfs/Makefile.board.dep
+++ b/tests/pkg/fatfs/Makefile.board.dep
@@ -1,0 +1,13 @@
+# The dependency resolution is called multiple times, but not all the
+# dependencies are resolved in the first round, such as the board deps.
+# To make sure that the board deps are resolved before running, we
+# create a temporary variable that stores the rounds and adds a `+` to
+# the string (make does not support integer incrementation).
+TEST_FATFS_DEP_ROUND := $(TEST_FATFS_DEP_ROUND)+
+
+ifeq (++,$(TEST_FATFS_DEP_ROUND))
+  ifeq (,$(filter mtd_sdcard mtd_sdmmc,$(USEMODULE)))
+    # if no SD interface is specified, use mtd_sdcard by default
+    USEMODULE += mtd_sdcard
+  endif
+endif

--- a/tests/pkg/fatfs/README.md
+++ b/tests/pkg/fatfs/README.md
@@ -23,5 +23,8 @@ or your FS will probably get damaged.
 
 # Real Hardware
 
-Currently the test defaults to sdcard_spi on real hardware. But generally any
-device that supports the mtd-interface can be used with FatFs.
+On real hardware, an SD card is used by default either via an SD/MMC controller
+in SD mode or via an SPI interface in SPI mode using the driver module
+`sdcard_spi`. Whether the SD card is used with an SD/MMC controller in
+SD mode is determined by the board by enabling the `mtd_sdmmc_default` module.
+Generally any device that supports the mtd-interface can be used with FatFS.

--- a/tests/pkg/fatfs_vfs/Makefile
+++ b/tests/pkg/fatfs_vfs/Makefile
@@ -13,14 +13,12 @@ FATFS_IMAGE_FILE_SIZE_MIB ?= 128
 ifneq (,$(filter native native32 native64,$(BOARD)))
   USEMODULE += mtd_native
 
-  #overwrite default mtd_native-config to use fat image as flash device
+  # overwrite default mtd_native-config to use fat image as flash device
   MTD_NATIVE_FILENAME    ?= \"./bin/riot_fatfs_disk.img\"
   MTD_SECTOR_NUM  ?= \(\(\(FATFS_IMAGE_FILE_SIZE_MIB\)*1024*1024\)/MTD_SECTOR_SIZE\)
   CFLAGS += -DMTD_NATIVE_FILENAME=$(MTD_NATIVE_FILENAME)
   CFLAGS += -DFATFS_IMAGE_FILE_SIZE_MIB=$(FATFS_IMAGE_FILE_SIZE_MIB)
   CFLAGS += -DMTD_SECTOR_NUM=$(MTD_SECTOR_NUM)
-else
-  USEMODULE += mtd_sdcard
 endif
 
 TEST_DEPS += image

--- a/tests/pkg/fatfs_vfs/Makefile.board.dep
+++ b/tests/pkg/fatfs_vfs/Makefile.board.dep
@@ -1,0 +1,13 @@
+# The dependency resolution is called multiple times, but not all the
+# dependencies are resolved in the first round, such as the board deps.
+# To make sure that the board deps are resolved before running, we
+# create a temporary variable that stores the rounds and adds a `+` to
+# the string (make does not support integer incrementation).
+TEST_FATFS_DEP_ROUND := $(TEST_FATFS_DEP_ROUND)+
+
+ifeq (++,$(TEST_FATFS_DEP_ROUND))
+  ifeq (,$(filter mtd_sdcard mtd_sdmmc,$(USEMODULE)))
+    # if no SD interface is specified, use mtd_sdcard by default
+    USEMODULE += mtd_sdcard
+  endif
+endif

--- a/tests/pkg/fatfs_vfs/README.md
+++ b/tests/pkg/fatfs_vfs/README.md
@@ -25,12 +25,19 @@ or your FS will probably get damaged.
 
 # Real Hardware
 
-Currently the test defaults to sdcard_spi on real hardware. But generally any
-device that supports the mtd-interface can be used with FatFs. To use the
-automated test in pkg_fatfs_vfs you need to copy the generated image to your
-storage device (e.g. your SD-card). To copy the image onto the card you can use
-something like `make image && dd if=bin/riot_fatfs_disk.img
-of=/dev/<your_sdcard>`. After that you can connect the card to your RIOT device
+On real hardware, an SD card is used by default either via an SD/MMC controller
+in SD mode or via an SPI interface in SPI mode using the driver module
+`sdcard_spi`. Whether the SD card is used with an SD/MMC controller in
+SD mode is determined by the board by enabling the `mtd_sdmmc_default` module.
+Generally any device that supports the mtd-interface can be used with FatFS.
+
+To use the automated test in pkg_fatfs_vfs you need to copy the generated image
+to your storage device (e.g. your SD-card). To copy the image onto the card you
+can use something like
+
+    make image && dd if=bin/riot_fatfs_disk.img of=/dev/<your_sdcard>
+
+After that you can connect the card to your RIOT device
 and check the test output via terminal.
 
     make flash test-with-config


### PR DESCRIPTION
### Contribution description

To prevent `mtd_sdcard` from being used by default for boards that use a different default MTD, which can lead to module conflicts, `mtd_sdcard` is now only enabled in `tests/pkg/fatfs` and `tests/pkg/fatfs_vfat` if no other MTD is enabled by default with the corresponding `mtd_*_default` module.

With this PR, MTD dependencies for `esp32-wrover-kit` could be fixed.

### Testing procedure

Compilation in CI should succeed.

Use any board definition with SDMMC as SD Card interface und try the following command with and w/o this PR:
```
BOARD=stm32f746g-disco make -C tests/pkg/fatfs info-modules | grep mtd
```
Without the PR, the list of MTD modules is:
```
mtd
mtd_sdcard
mtd_sdmmc
mtd_sdmmc_default
```
With the PR the command should give:
```
mtd
mtd_sdmmc
mtd_sdmmc_default
```

### Issues/PRs references

Prerequisite for PR #21471 