### PR TITLE
boards: add Wemos D1 R32 (aka ESPDuino-32) board definition

### DIFF
--- a/boards/esp32-wemos-d1-r32/Kconfig
+++ b/boards/esp32-wemos-d1-r32/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (C) 2025 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp32-wemos-d1-r2" if BOARD_ESP32_WEMOS_D1_R32
+
+config BOARD_ESP32_WEMOS_D1_R32
+    bool
+    default y
+    select BOARD_COMMON_ESP32
+    select CPU_MODEL_ESP32_WROOM_32
+
+source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-wemos-d1-r32/Makefile
+++ b/boards/esp32-wemos-d1-r32/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/esp32
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/esp32-wemos-d1-r32/Makefile.dep
+++ b/boards/esp32-wemos-d1-r32/Makefile.dep
@@ -1,0 +1,5 @@
+include $(RIOTBOARD)/common/esp32/Makefile.dep
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/esp32-wemos-d1-r32/Makefile.features
+++ b/boards/esp32-wemos-d1-r32/Makefile.features
@@ -1,0 +1,21 @@
+CPU_MODEL = esp32-wroom_32
+
+# common board and CPU features
+include $(RIOTBOARD)/common/esp32/Makefile.features
+
+# additional features provided by the board
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+
+FEATURES_PROVIDED += arduino_pins
+FEATURES_PROVIDED += arduino_analog
+FEATURES_PROVIDED += arduino_dac
+FEATURES_PROVIDED += arduino_i2c
+FEATURES_PROVIDED += arduino_pins
+FEATURES_PROVIDED += arduino_pwm
+FEATURES_PROVIDED += arduino_shield_uno
+FEATURES_PROVIDED += arduino_spi
+FEATURES_PROVIDED += arduino_uart

--- a/boards/esp32-wemos-d1-r32/Makefile.include
+++ b/boards/esp32-wemos-d1-r32/Makefile.include
@@ -1,0 +1,5 @@
+include $(RIOTBOARD)/common/esp32/Makefile.include
+
+# Only consider TTYs matching the following filter when auto-selecting the TTY
+# with `MOST_RECENT_PORT=1`.
+TTY_BOARD_FILTER := --driver 'cp210x' --vendor 'Silicon Labs' --model 'CP2102 USB to UART Bridge Controller'

--- a/boards/esp32-wemos-d1-r32/doc.md
+++ b/boards/esp32-wemos-d1-r32/doc.md
@@ -1,0 +1,126 @@
+@defgroup    boards_esp32_wemos_d1_r32 Wemos D1 R32 (ESPDuino-32)
+@ingroup     boards_esp32
+@brief       Support for the Wemos D1 R32 (ESPDuino-32) board
+@author      Gunar Schorcht <gunar@schorcht.net>
+
+\section esp32_wemos_d1_r32 Wemos D1 R32 board (ESPDuino-32)
+
+## Table of Contents {#esp32_wemos_d1_r32_toc}
+
+-# [Overview](#esp32_wemos_d1_r32_overview)
+-# [Hardware](#esp32_wemos_d1_r32_hardware)
+    -# [MCU](#esp32_wemos_d1_r32_mcu)
+    -# [Board Configuration](#esp32_wemos_d1_r32_board_configuration)
+    -# [Board Pinout](#esp32_wemos_d1_r32_pinout)
+-# [Flashing the Device](#esp32_wemos_d1_r32_flashing)
+
+## Overview {#esp32_wemos_d1_r32_overview}
+
+The Wemos D1 R32 board is an ESP32 board in the Arduino Uno format that uses the
+ESP32-WROOM-32 module. It is exactly the same board that is also known as
+ESPDuino-32 on the market. The board is pin compatible with the Arduino Uno
+board. The peripheral configuration corresponds to the Arduino Uno pinout and
+guaranties the compatibility with Arduino Uno Shields.
+
+\image html "https://makerselectronics.com/wp-content/uploads/2022/09/wemos-d1-r32-w-esp32-uno-r3-pinout-1-800x800.jpg.webp" "WeMos D1 R32 ESPDuino32" width=400px
+
+[Back to table of contents](#esp32_wemos_d1_r32_toc)
+
+## Hardware {#esp32_wemos_d1_r32_hardware}
+
+This section describes
+
+- the [MCU](#esp32_wemos_d1_r32_mcu),
+- the [board configuration](#esp32_wemos_d1_r32_board_configuration),
+- the [board pinout](#esp32_wemos_d1_r32_pinout).
+
+[Back to table of contents](#esp32_wemos_d1_r32_toc)
+
+### MCU {#esp32_wemos_d1_r32_mcu}
+
+Most features of the board are provided by the ESP32 SoC. For detailed
+information about the ESP32, see section \ref esp32_mcu_esp32 "MCU ESP32".
+
+[Back to table of contents](#esp32_wemos_d1_r32_toc)
+
+### Board Configuration {#esp32_wemos_d1_r32_board_configuration}
+
+The board configuration guarantees that the board is compatible with Arduino
+Uno Shield. The board configuration provides:
+
+- 6 x ADC channels
+- 2 x DAC channels
+- 2 x PWM devices with a total of 7 channels
+- 1 x SPI device
+- 1 x I2C device
+- 2 x UART devices
+
+The following table shows the default board configuration, which is sorted
+according to the defined functionality of GPIOs.
+
+<center>
+Function        | GPIOs  | Arduino Pin |Configuration
+:---------------|:-------|:------------|:----------------------------------
+ADC_LINE(0)     | GPIO2  | A0          | \ref esp32_adc_channels "ADC Channels"
+ADC_LINE(1)     | GPIO4  | A1          | \ref esp32_adc_channels "ADC Channels"
+ADC_LINE(2)     | GPIO35 | A2          | \ref esp32_adc_channels "ADC Channels"
+ADC_LINE(3)     | GPIO34 | A3          | \ref esp32_adc_channels "ADC Channels"
+ADC_LINE(4)     | GPIO36 | A4          | \ref esp32_adc_channels "ADC Channels"
+ADC_LINE(5)     | GPIO39 | A5          | \ref esp32_adc_channels "ADC Channels"
+DAC_LINE(0)     | GPIO25 | D3          | \ref esp32_pwm_channels "DAC Channels"
+DAC_LINE(1)     | GPIO26 | D2          | \ref esp32_pwm_channels "DAC Channels"
+I2C_DEV(0):SDA  | GPIO21 | SDA         | \ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(0):SCL  | GPIO22 | SCL         | \ref esp32_i2c_interfaces "I2C Interfaces"
+LED             | GPIO2  | A0          | -
+PWM_DEV(0):0    | GPIO25 | D3          | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(0):1    | GPIO16 | D5          | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(0):2    | GPIO27 | D6          | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(0):3    | GPIO13 | D9          | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(0):4    | GPIO2  | A0          | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(1):0    | GPIO5  | D10         | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(1):1    | GPIO23 | D11         | \ref esp32_pwm_channels "PWM Channels"
+SPI_DEV(0):CLK  | GPIO18 | D13         | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MISO | GPIO19 | D12         | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MOSI | GPIO23 | D11         | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):CS0  | GPIO5  | D10         | \ref esp32_spi_interfaces "SPI Interfaces"
+UART_DEV(0):TxD | GPIO1  | D1          | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(0):RxD | GPIO3  | D0          | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(1):TxD | GPIO10 | D4          | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(1):RxD | GPIO9  | D5          | \ref esp32_uart_interfaces "UART interfaces"
+</center>
+\n
+
+For detailed information about the configuration of ESP32 boards, see
+section \ref esp32_peripherals "Common Peripherals".
+
+[Back to table of contents](#esp32_wemos_d1_r32_toc)
+
+### Board Pinout {#esp32_wemos_d1_r32_pinout}
+
+The following figure shows the pinout of the Wemos D1 R32 board. It is exactly
+the same as for the ESPDuino-32 board. The corresponding board schematics can
+be found
+[here](https://gitlab.com/gschorcht/RIOT.wiki-Images/raw/master/esp32/Wemos-D1-R32_Schematic.pdf).
+
+@image html "https://makerselectronics.com/wp-content/uploads/2022/09/2_Pinout_D1_R32.png.webp" "Wemos D1 R32 ESPDuino Pinout"
+
+@warning The pinout contains the following errors.
+         Analog Arduino pin A2 with white label `IO36` is actually ADC1 Channel7
+         that is connected to GPIO35 and analog Arduino pin A4 with white label
+         `IO38` is actually ADC1 Channel0 that is connected to GPIO36. That is
+         the colored labels are correct in the pinout.
+
+[Back to table of contents](#esp32_wemos_d1_r32_toc)
+
+## Flashing the Device {#esp32_wemos_d1_r32_flashing}
+
+Flashing RIOT is quite easy. The board has a Micro-USB connector with
+reset/boot/flash logic. Just connect the board to your host computer
+and type using the programming port:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+make flash BOARD=esp32-wemos-d1-r32 ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For detailed information about ESP32 as well as configuring and compiling
+RIOT for ESP32 boards, see \ref esp32_riot.
+
+[Back to table of contents](#esp32_wemos_d1_r32_toc)

--- a/boards/esp32-wemos-d1-r32/include/arduino_iomap.h
+++ b/boards/esp32-wemos-d1-r32/include/arduino_iomap.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C)  2025 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_esp32_wemos_d1_r32
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ARDUINO_UART_D0D1       UART_DEV(0) /**< Arduino UART interface */
+#define ARDUINO_SPI_D11D12D13   SPI_DEV(0)  /**< Arduino SPI bus */
+#define ARDUINO_I2C_UNO         I2C_DEV(0)  /**< Arduino I2C bus */
+#define ARDUINO_LED             14          /**< LED is connected to Arduino pin 14 */
+
+/**
+ * @name   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0   GPIO3       /**< Arduino pin 0 (RxD) */
+#define ARDUINO_PIN_1   GPIO1       /**< Arduino pin 1 (TxD) */
+
+#define ARDUINO_PIN_2   GPIO26      /**< Arduino pin 2 (DAC1) */
+#define ARDUINO_PIN_3   GPIO25      /**< Arduino pin 3 (PWM / DAC0) */
+#define ARDUINO_PIN_4   GPIO17      /**< Arduino pin 4 */
+#define ARDUINO_PIN_5   GPIO16      /**< Arduino pin 5 (PWM) */
+#define ARDUINO_PIN_6   GPIO27      /**< Arduino pin 6 (PWM) */
+#define ARDUINO_PIN_7   GPIO14      /**< Arduino pin 7 */
+#define ARDUINO_PIN_8   GPIO12      /**< Arduino pin 8 */
+#define ARDUINO_PIN_9   GPIO13      /**< Arduino pin 9 (PWM) */
+
+#define ARDUINO_PIN_10  GPIO5       /**< Arduino pin 10 (CS0 / PWM)  */
+#define ARDUINO_PIN_11  GPIO23      /**< Arduino pin 11 (MOSI / PWM) */
+#define ARDUINO_PIN_12  GPIO19      /**< Arduino pin 12 (MISO) */
+#define ARDUINO_PIN_13  GPIO18      /**< Arduino pin 13 (SCK)  */
+
+/* analog pins as digital pin: */
+#define ARDUINO_PIN_14  GPIO2       /**< Arduino pin 14 (A0 / LED) */
+#define ARDUINO_PIN_15  GPIO4       /**< Arduino pin 15 (A1) */
+#define ARDUINO_PIN_16  GPIO35      /**< Arduino pin 16 (A2), input only! */
+#define ARDUINO_PIN_17  GPIO34      /**< Arduino pin 17 (A3), input only! */
+#define ARDUINO_PIN_18  GPIO36      /**< Arduino pin 18 (A4), input only! */
+#define ARDUINO_PIN_19  GPIO39      /**< Arduino pin 19 (A5), input only! */
+
+/* I2C pins as digital pins */
+#define ARDUINO_PIN_20  GPIO21      /**< Arduino pin 20 (SDA) */
+#define ARDUINO_PIN_21  GPIO22      /**< Arduino pin 21 (SCL) */
+
+#define ARDUINO_PIN_LAST    21      /**< Last Arduino pin index */
+/** @} */
+
+/**
+ * @name    Aliases for analog pins
+ * @{
+ */
+#define ARDUINO_PIN_A0      ARDUINO_PIN_14   /**< Arduino pin A0 */
+#define ARDUINO_PIN_A1      ARDUINO_PIN_15   /**< Arduino pin A1 */
+#define ARDUINO_PIN_A2      ARDUINO_PIN_16   /**< Arduino pin A2 */
+#define ARDUINO_PIN_A3      ARDUINO_PIN_17   /**< Arduino pin A3 */
+#define ARDUINO_PIN_A4      ARDUINO_PIN_18   /**< Arduino pin A4 */
+#define ARDUINO_PIN_A5      ARDUINO_PIN_19   /**< Arduino pin A5 */
+
+#define ARDUINO_PIN_DAC0    ARDUINO_PIN_3    /**< Arduino pin D3 */
+#define ARDUINO_PIN_DAC1    ARDUINO_PIN_2    /**< Arduino pin D2 */
+/** @} */
+
+/**
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
+ * @{
+ */
+#define ARDUINO_A0          ADC_LINE(0)     /**< ADC line for Arduino pin A0 */
+#define ARDUINO_A1          ADC_LINE(1)     /**< ADC line for Arduino pin A1 */
+#define ARDUINO_A2          ADC_LINE(2)     /**< ADC line for Arduino pin A2 */
+#define ARDUINO_A3          ADC_LINE(3)     /**< ADC line for Arduino pin A3 */
+#define ARDUINO_A4          ADC_LINE(4)     /**< ADC line for Arduino pin A4 */
+#define ARDUINO_A5          ADC_LINE(5)     /**< ADC line for Arduino pin A5 */
+
+#define ARDUINO_ANALOG_PIN_LAST 5           /**< Last Arduino analog pin index */
+/** @} */
+
+/**
+ * @name    Mapping of Arduino DAC pins to RIOT DAC lines
+ * @{
+ */
+#define ARDUINO_DAC0        DAC_LINE(0)     /**< DAC line for Arduino DAC0 pin */
+#define ARDUINO_DAC1        DAC_LINE(1)     /**< DAC line for Arduino DAC1 pin */
+
+#define ARDUINO_DAC_PIN_LAST    1           /**< Last Arduino DAC pin index */
+/** @} */
+
+/**
+ * @name    Mapping of Arduino pins to RIOT PWM dev and channel pairs
+ * @{
+ */
+#define ARDUINO_PIN_3_PWM_DEV   PWM_DEV(0)  /**< PWM device for Arduino pin 3 */
+#define ARDUINO_PIN_3_PWM_CHAN  0           /**< PWM channel for Arduino pin 3 */
+
+#define ARDUINO_PIN_5_PWM_DEV   PWM_DEV(0)  /**< PWM device for Arduino pin 5 */
+#define ARDUINO_PIN_5_PWM_CHAN  1           /**< PWM channel for Arduino pin 5 */
+
+#define ARDUINO_PIN_6_PWM_DEV   PWM_DEV(0)  /**< PWM device for Arduino pin 6 */
+#define ARDUINO_PIN_6_PWM_CHAN  2           /**< PWM channel for Arduino pin 6 */
+
+#define ARDUINO_PIN_9_PWM_DEV   PWM_DEV(0)  /**< PWM device for Arduino pin 9 */
+#define ARDUINO_PIN_9_PWM_CHAN  3           /**< PWM channel for Arduino pin 9 */
+
+#define ARDUINO_PIN_10_PWM_DEV  PWM_DEV(1)  /**< PWM device for Arduino pin 10 */
+#define ARDUINO_PIN_10_PWM_CHAN 0           /**< PWM channel for Arduino pin 10 */
+
+#define ARDUINO_PIN_11_PWM_DEV  PWM_DEV(1)  /**< PWM device for Arduino pin 11 */
+#define ARDUINO_PIN_11_PWM_CHAN 1           /**< PWM channel for Arduino pin 11 */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+/** @} */

--- a/boards/esp32-wemos-d1-r32/include/board.h
+++ b/boards/esp32-wemos-d1-r32/include/board.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_esp32_wemos_d1_r32
+ * @brief       Board specific definitions for Wemos D1 R32 (ESPDuino-32) board
+ * @{
+ *
+ * For detailed information about the configuration of ESP32 boards, see
+ * section \ref esp32_peripherals "Common Peripherals".
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include <stdint.h>
+
+/**
+ * @name    LED (on-board) configuration
+ * @{
+ */
+#define LED0_PIN        GPIO2   /**< LED is connected to GPIO2 */
+#define LED0_ACTIVE     1       /**< LED is HIGH active */
+/** @} */
+
+/* include common board definitions as last step */
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/** @} */

--- a/boards/esp32-wemos-d1-r32/include/gpio_params.h
+++ b/boards/esp32-wemos-d1-r32/include/gpio_params.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_esp32_wemos_d1_r32
+ * @brief       Board specific configuration of direct mapped GPIOs
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @{
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   LED configuration
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/esp32-wemos-d1-r32/include/periph_conf.h
+++ b/boards/esp32-wemos-d1-r32/include/periph_conf.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2025 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_esp32_wemos_d1_r32
+ * @brief       Peripheral MCU configuration for Wemos D1 R32 (ESPDuino-32) board
+ * @{
+ *
+ * The peripheral configuration corresponds to the Arduino Uno pinout and
+ * guarantees the compatibility with Arduino Uno Shields.
+ *
+ * For detailed information about the configuration of ESP32 boards, see
+ * section \ref esp32_peripherals "Common Peripherals".
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    ADC and DAC channel configuration
+ * @{
+ */
+
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ */
+#define ADC_GPIOS   { GPIO2, GPIO4, GPIO35, GPIO34, GPIO36, GPIO39 }
+
+/**
+ * @brief   Declaration of GPIOs that can be used as DAC channels
+ */
+#define DAC_GPIOS   { GPIO25, GPIO26 }
+/** @} */
+
+/**
+ * @name   I2C configuration
+ * @{
+ */
+#ifndef I2C0_SPEED
+#  define I2C0_SPEED  I2C_SPEED_FAST    /**< I2C bus speed of I2C_DEV(0) */
+#endif
+
+#define I2C0_SCL    GPIO22              /**< SCL signal of I2C_DEV(0) */
+#define I2C0_SDA    GPIO21              /**< SDA signal of I2C_DEV(0) */
+/** @} */
+
+/**
+ * @name   PWM channel configuration
+ * @{
+ */
+
+/**
+ * @brief Declaration of PWM_DEV(0) channels, at maximum six channels.
+ */
+#define PWM0_GPIOS  { GPIO25, GPIO16, GPIO27, GPIO13, GPIO2 }
+
+/**
+ * @brief Declaration of PWM_DEV(1) channels, at maximum six channels.
+ *
+ * GPIO5 and GPIO23 are also used for SPI_DEV(0) an can only be used as
+ * PWM channels if SPI_DEV(0) is not used an vice versa.
+ */
+#define PWM1_GPIOS  { GPIO5, GPIO23 }
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * @note The GPIOs listed in the configuration are first initialized as SPI
+ * signals when the corresponding SPI interface is used for the first time
+ * by either calling the `spi_init_cs` function or the `spi_acquire`
+ * function. That is, they are not allocated as SPI signals before and can
+ * be used for other purposes as long as the SPI interface is not used.
+ * @{
+ */
+#define SPI0_CTRL   VSPI    /**< VSPI is used as SPI_DEV(0) */
+#define SPI0_SCK    GPIO18  /**< VSPI SCK */
+#define SPI0_MISO   GPIO19  /**< VSPI MISO */
+#define SPI0_MOSI   GPIO23  /**< VSPI MOSI */
+#define SPI0_CS0    GPIO5   /**< VSPI CS0 */
+/** @} */
+
+/**
+ * @name   UART configuration
+ *
+ * UART_DEV(0) uses fixed standard configuration.<br>
+ * UART_DEV(1) is defined here.<br>
+ *
+ * @{
+ */
+#define UART0_TXD   GPIO1  /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO3  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+
+#define UART1_TXD   GPIO17  /**< direct I/O pin for UART_DEV(1) TxD */
+#define UART1_RXD   GPIO16  /**< direct I/O pin for UART_DEV(1) RxD */
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/* include common peripheral definitions as last step */
+#include "periph_conf_common.h"
+
+/** @} */

--- a/boards/esp32-wroom-32/doc.txt
+++ b/boards/esp32-wroom-32/doc.txt
@@ -96,8 +96,8 @@ Function        | GPIOs  | Remarks |Configuration
 :---------------|:-------|:--------|:----------------------------------
 BUTTON0         | GPIO0  | | |
 ADC             | GPIO0, GPIO2, GPIO4, GPIO12, GPIO13,\n GPIO14, GPIO15, GPIO25, GPIO26, GPIO27,\n GPIO32, GPIO33, GPIO34, GPIO35, GPIO36,\n GPIO39 | | see \ref esp32_adc_channels "ADC Channels"
-DAC             | GPIO25, GPIO26 | | \ref esp32_dac_channels "refer"
-PWM_DEV(0)      | GPIO0, GPIO2, GPIO4, GPIO16, GPIO17 | - | \ref esp32_pwm_channels "DAC Channels"
+DAC             | GPIO25, GPIO26 | | \ref esp32_dac_channels "DAC Channels"
+PWM_DEV(0)      | GPIO0, GPIO2, GPIO4, GPIO16, GPIO17 | - | \ref esp32_pwm_channels "PWM Channels"
 PWM_DEV(1)      | GPIO27, GPIO32, GPIO33 | - | \ref esp32_pwm_channels "PWM Channels"
 I2C_DEV(0):SDA  | GPIO21 | | \ref esp32_i2c_interfaces "I2C Interfaces"
 I2C_DEV(0):SCL  | GPIO22 | | \ref esp32_i2c_interfaces "I2C Interfaces"


### PR DESCRIPTION
### Contribution description

This PR adds the board definition for the Wemos D1 R32 also known as ESPDuino-32, the only  only Arduino-sized ESP32 board with Arduino Uno compatible headers.

<img src="https://makerselectronics.com/wp-content/uploads/2022/09/wemos-d1-r32-w-esp32-uno-r3-pinout-1-800x800.jpg.webp" alt="WeMos D1 R32" width="400"/>

### Testing procedure

Compilation in CI should succeed.

### Issues/PRs references