### PR TITLE
examples/basic/subfolders: fix test

### DIFF
--- a/examples/basic/subfolders/Makefile
+++ b/examples/basic/subfolders/Makefile
@@ -11,6 +11,11 @@ RIOTBASE ?= $(CURDIR)/../../..
 EXTERNAL_MODULE_DIRS += $(CURDIR)/external_modules/
 USEMODULE += module # module name must match folder name
 
+# This is used for the test integration: The app will wait for "s" being sent
+# before starting with the output, so that the test does not fail because it
+# already finished printing when the terminal attaches.
+USEMODULE += test_utils_interactive_sync
+
 # Add source files in subfolders manually
 SRC += main.c
 SRC += folder/a.c folder/subfolder/b.c folder/subfolder/c.c


### PR DESCRIPTION
### Contribution description

At least on the samr21-xpro used for hardware in the loop testing, the terminal did not attach in time after the reset to capture all of the output.

This adds the `test_utils_interactive_sync` module to wait for an `s` to be received via `stdio` before starting to print to sync with the test scripting.

### Testing procedure

Test in the CI should pass now.

### Issues/PRs references

None