### PR TITLE
doc/doxygen: Avoid Overlapping of Code Blocks with Table of Contents

### DIFF
--- a/doc/doxygen/src/css/riot.css
+++ b/doc/doxygen/src/css/riot.css
@@ -198,7 +198,6 @@ div.fragment {
   line-height: 1.42857143;
   margin: 0 0 10px;
   padding: 10px;
-  overflow: visible;
   page-break-inside: avoid;
   word-break: break-all;
   word-wrap: break-word;

--- a/doc/doxygen/src/css/riot.less
+++ b/doc/doxygen/src/css/riot.less
@@ -186,7 +186,6 @@ div.fragment {
   line-height: @line-height-base;
   margin: 0 0 10px;
   padding: 10px;
-  overflow: visible;
   page-break-inside: avoid;
   word-break: break-all;
   word-wrap: break-word;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The RIOT CSS for the Doxygen documentation explicitly enables `overflow: visible` for the code blocks, which leads to overlaps of the code blocks and the table of contents.

As Doxygen calculates the appropriate size for the code blocks beforehand, I don't really see the necessity of this explicit statement.
Even if you make a line über-long, the formatting still does not fail and it will insert line breaks:
![image](https://github.com/user-attachments/assets/7c5a2341-650b-42ff-b095-10642097314a)

<hr/>

Current master:

![image](https://github.com/user-attachments/assets/ab8d50ad-c935-49d8-bf29-f9a664a04aad)

With this PR:

![image](https://github.com/user-attachments/assets/dd07f02a-7f63-48ad-b946-fe1366d4e95f)


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Look at the documentation output.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->



<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
