### PR TITLE
tests/gcoap_fileserver: re-enable test on CI

### DIFF
--- a/tests/net/gcoap_fileserver/Makefile
+++ b/tests/net/gcoap_fileserver/Makefile
@@ -21,12 +21,8 @@ USEMODULE += vfs_auto_format
 USEMODULE += hashes
 USEMODULE += shell_cmd_md5sum
 
-# This integration test uncovers a bug somwehere in our stack, but there
-# are currently no resources to debug it, so blacklist it to keep CI running
-TEST_ON_CI_BLACKLIST += all
-
 # automated test only works on native
-# TEST_ON_CI_WHITELIST += native32 native64
+TEST_ON_CI_WHITELIST += native32 native64
 
 # use small blocksize for test to increase chance for errors
 CFLAGS += -DCONFIG_NANOCOAP_BLOCKSIZE_DEFAULT=COAP_BLOCKSIZE_16


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The GCoAP Fileserver test is actually a large scale integration test of

 - IPv6 routing
 - 6LoWPAN
 - GCoAP server
 - nanoCoAP client
 - filesystem

So it is quite valuable to have this in CI.

Unfortunately in the past this has proved to be very flaky.
Now that the `socket_zep` fixes are in, maybe this is more stable :crossed_fingers: 


### Testing procedure

IIUC this should be executed by a normal Murdock run.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
