### PR TITLE
dist/tools: Improve Headerguard Check

### DIFF
--- a/dist/tools/headerguards/headerguards.py
+++ b/dist/tools/headerguards/headerguards.py
@@ -54,11 +54,17 @@ def fix_headerguard(filename):
             # check for lines that have leading whitespaces and add a correction
             pragma_once_found += 1
             line = "#pragma once\n"
-        if guard_found == 0 and pragma_once_found == 0:
-            if line.startswith("#ifndef"):
+        if guard_found == 0:
+            if pragma_once_found == 0 and line.startswith("#ifndef"):
                 guard_found += 1
                 guard_name = line[8:].rstrip()
                 line = "#ifndef %s\n" % (supposed)
+            elif pragma_once_found != 0 and line.startswith("#ifndef %s" % supposed):
+                # check if there is pragma once *and* headerguards, but avoid false
+                # positives by narrowing in on the to-be-expected guard
+                guard_found += 1
+                guard_name = line[8:].rstrip()
+                line = ""
         elif guard_found == 1:
             if line.startswith("#define") and line[8:].rstrip() == guard_name:
                 line = "#define %s\n" % (supposed)
@@ -82,12 +88,22 @@ def fix_headerguard(filename):
     tmp.seek(0)
     if (pragma_once_found == 0 and guard_found == 3) or \
        (pragma_once_found == 1 and guard_found == 0):
+        # Valid cases:
+        #  - no #pragma once, classic headerguards (#ifndef, #define, #endif)
+        #  - one #pragma once, no classic headerguards
         if include_next_found == 0:
             for line in difflib.unified_diff(inlines, tmp.readlines(),
                                              "%s" % filename, "%s" % filename):
                 sys.stdout.write(line)
+    elif (pragma_once_found == 0 and guard_found == 0):
+        print("%s: no header guards found" % filename, file=sys.stderr)
+        return False
+    elif (pragma_once_found == 1 and guard_found != 0):
+        print("%s: #pragma once and classic header guards used in the same file" %
+              filename, file=sys.stderr)
+        return False
     else:
-        print("%s: no / broken header guard" % filename, file=sys.stderr)
+        print("%s: broken header guard" % filename, file=sys.stderr)
         return False
 
 

--- a/dist/tools/headerguards/headerguards.py
+++ b/dist/tools/headerguards/headerguards.py
@@ -44,7 +44,6 @@ def fix_headerguard(filename):
 
     guard_found = 0
     pragma_once_found = 0
-    include_next_found = 0
     guard_name = ""
     ifstack = 0
     for line in inlines:
@@ -80,8 +79,6 @@ def fix_headerguard(filename):
                 else:
                     guard_found += 1
                     line = "#endif /* %s */\n" % supposed
-            elif line.startswith("#include_next"):
-                include_next_found = 1
 
         tmp.write(line)
 
@@ -91,10 +88,9 @@ def fix_headerguard(filename):
         # Valid cases:
         #  - no #pragma once, classic headerguards (#ifndef, #define, #endif)
         #  - one #pragma once, no classic headerguards
-        if include_next_found == 0:
-            for line in difflib.unified_diff(inlines, tmp.readlines(),
-                                             "%s" % filename, "%s" % filename):
-                sys.stdout.write(line)
+        for line in difflib.unified_diff(inlines, tmp.readlines(),
+                                         "%s" % filename, "%s" % filename):
+            sys.stdout.write(line)
     elif (pragma_once_found == 0 and guard_found == 0):
         print("%s: no header guards found" % filename, file=sys.stderr)
         return False


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The headerguard check did not catch the case when a `#pragma once` is present in the file followed by classic header guards.
Apparently I did not anticipate this corner case in #21367...

This commit also improves the error messages to give a better reason why the test failed.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

#### Improved Error Messages: Missing Header Guards

Remove the header guards from a header of your liking, for example `boards/feather-m0/include/board.h`

Current Master:
```
cbuec@W11nMate:~/RIOTstuff/riot-gettingstarted/RIOT$ ./dist/tools/headerguards/check.sh
boards/feather-m0/include/board.h: no / broken header guard
```

This PR:
```
cbuec@W11nMate:~/RIOTstuff/riot-gettingstarted/RIOT$ git diff boards/feather-m0/include/board.h
diff --git a/boards/feather-m0/include/board.h b/boards/feather-m0/include/board.h
index bd410fdfb2..2ff00cf26b 100644
--- a/boards/feather-m0/include/board.h
+++ b/boards/feather-m0/include/board.h
@@ -17,9 +17,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */

-#ifndef BOARD_H
-#define BOARD_H
-
 #include "cpu.h"
 #include "periph_conf.h"
 #include "periph_cpu.h"
cbuec@W11nMate:~/RIOTstuff/riot-gettingstarted/RIOT$ ./dist/tools/headerguards/check.sh
boards/feather-m0/include/board.h: no header guards found
```

#### Corner Case: Pragma Once *and* Headerguards

Add a ´#pragma once´ to a header of your liking that still has the old format, for example `boards/feather-m0/include/board.h`

Current Master (PASS, but should not pass):
```
cbuec@W11nMate:~/RIOTstuff/riot-gettingstarted/RIOT$ git diff boards/feather-m0/include/board.h
diff --git a/boards/feather-m0/include/board.h b/boards/feather-m0/include/board.h
index bd410fdfb2..c0ce0440b4 100644
--- a/boards/feather-m0/include/board.h
+++ b/boards/feather-m0/include/board.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */

+#pragma once
+
 /**
  * @ingroup     boards_feather-m0
  *
cbuec@W11nMate:~/RIOTstuff/riot-gettingstarted/RIOT$ ./dist/tools/headerguards/check.sh
cbuec@W11nMate:~/RIOTstuff/riot-gettingstarted/RIOT$
```

With this PR:
```
cbuec@W11nMate:~/RIOTstuff/riot-gettingstarted/RIOT$ ./dist/tools/headerguards/check.sh
boards/feather-m0/include/board.h: #pragma once and classic header guards used in the same file
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

`#pragma once` check introduced in #21367.

Discovered in https://github.com/RIOT-OS/RIOT/pull/21479#discussion_r2084905034

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
