### PR TITLE
sys/arduino: define LED_BUILTIN as frequently used by Arduino sketches

### DIFF
--- a/sys/arduino/include/arduino_board.h
+++ b/sys/arduino/include/arduino_board.h
@@ -46,6 +46,18 @@ extern "C" {
 #define F_CPU CLOCK_CORECLOCK
 #endif
 
+/**
+ * @brief Arduino IDE define for the on-board LED
+ *
+ * In Arduino IDE the on-board LED pin is defined by macro `LED_BUILTIN`. It
+ * is used whenever the LED is controlled. To make it easier to use Arduino
+ * sketches as they are, `LED_BUILTIN` is defined by using @ref ARDUINO_LED as
+ * defined by the board.
+ */
+#ifndef LED_BUILTIN
+#  define LED_BUILTIN   ARDUINO_LED
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/sys/arduino_blinky/BlinkWithoutDelay.sketch
+++ b/tests/sys/arduino_blinky/BlinkWithoutDelay.sketch
@@ -1,0 +1,71 @@
+/*
+  Blink without Delay
+
+  Turns on and off a light emitting diode (LED) connected to a digital pin,
+  without using the delay() function. This means that other code can run at the
+  same time without being interrupted by the LED code.
+
+  The circuit:
+  - Use the onboard LED.
+  - Note: Most Arduinos have an on-board LED you can control. On the UNO, MEGA
+    and ZERO it is attached to digital pin 13, on MKR1000 on pin 6. LED_BUILTIN
+    is set to the correct LED pin independent of which board is used.
+    If you want to know what pin the on-board LED is connected to on your
+    Arduino model, check the Technical Specs of your board at:
+    https://www.arduino.cc/en/Main/Products
+
+  created 2005
+  by David A. Mellis
+  modified 8 Feb 2010
+  by Paul Stoffregen
+  modified 11 Nov 2013
+  by Scott Fitzgerald
+  modified 9 Jan 2017
+  by Arturo Guadalupi
+
+  This example code is in the public domain.
+
+  https://www.arduino.cc/en/Tutorial/BuiltInExamples/BlinkWithoutDelay
+*/
+
+// constants won't change. Used here to set a pin number:
+const int ledPin = LED_BUILTIN;  // the number of the LED pin
+
+// Variables will change:
+int ledState = LOW;  // ledState used to set the LED
+
+// Generally, you should use "unsigned long" for variables that hold time
+// The value will quickly become too large for an int to store
+unsigned long previousMillis = 0;  // will store last time LED was updated
+
+// constants won't change:
+const long interval = 1000;  // interval at which to blink (milliseconds)
+
+void setup() {
+  // set the digital pin as output:
+  pinMode(ledPin, OUTPUT);
+}
+
+void loop() {
+  // here is where you'd put code that needs to be running all the time.
+
+  // check to see if it's time to blink the LED; that is, if the difference
+  // between the current time and last time you blinked the LED is bigger than
+  // the interval at which you want to blink the LED.
+  unsigned long currentMillis = millis();
+
+  if (currentMillis - previousMillis >= interval) {
+    // save the last time you blinked the LED
+    previousMillis = currentMillis;
+
+    // if the LED is off turn it on and vice-versa:
+    if (ledState == LOW) {
+      ledState = HIGH;
+    } else {
+      ledState = LOW;
+    }
+
+    // set the LED with the ledState of the variable:
+    digitalWrite(ledPin, ledState);
+  }
+}

--- a/tests/sys/arduino_blinky/Makefile
+++ b/tests/sys/arduino_blinky/Makefile
@@ -1,0 +1,7 @@
+BOARD ?= arduino-zero
+
+include ../Makefile.sys_common
+
+USEMODULE += arduino
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/sys/arduino_blinky/Makefile.ci
+++ b/tests/sys/arduino_blinky/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-l011k4 \
+    #


### PR DESCRIPTION
### Contribution description

This PR defines `LED_BUILTIN` by using `ARDUINO_LED` as defined by a board for compatibility reasons with the Arduino IDE to make it easier to use Arduino sketches as they are.

While completing the Arduino I/O mapping for ESP32x in PR #21484 I was wondering why we define `ARDUINO_LED` while Arduino sketches mostly use `LED_BUILTIN`. In Arduino IDE, `LED_BUILTIN` ist usually defined for a board an is therefore frequently used to control the on-board LED. The most common example `BlinkWithoutDelay` also uses `LED_BUILTIN`.

The PR includes `tests/sys/arduino_blinky` which is just the orginal `BlinkWithoutDelay` example without any changes which works in RIOT-OS out of the box with this PR.

### Testing procedure

Use any board with enabled Arduino features and flash the test app:
```
BOARD=arduino-uno make -j4 -C tests/sys/arduino_blinky flash
```

I have tested it for a couple of boards:
`arduino-uno`
`arduino-mega2560`
`esp32-wemos-d1-r32` (PR #21479)
`nucleo-f103rb`

### Issues/PRs references
