### PR TITLE
doc/doxygen: accept doc*.md files

### DIFF
--- a/cpu/esp32/doc_esp32c3.md
+++ b/cpu/esp32/doc_esp32c3.md
@@ -1,12 +1,11 @@
-/*
- * Copyright (C) 2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- */
+<!--
+Copyright (C) 2022 Gunar Schorcht
 
-/**
+This file is subject to the terms and conditions of the GNU Lesser
+General Public License v2.1. See the file LICENSE in the top level
+directory for more details.
+-->
+
 @defgroup   cpu_esp32_esp32c3 ESP32-C3 family
 @ingroup    cpu_esp32
 @brief      Specific properties of ESP32-C3 variant (family)
@@ -229,5 +228,3 @@ For more information about JTAG configuration for ESP32-C3, refer to the
 section [Configure Other JTAG Interface]
 (https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-guides/jtag-debugging/configure-other-jtag.html)
 in the ESP-IDF documentation.
-
-*/

--- a/dist/tools/doccheck/check.sh
+++ b/dist/tools/doccheck/check.sh
@@ -73,8 +73,8 @@ exclude_filter() {
 
 # Check groups are correctly defined (e.g. no undefined groups and no group
 # defined multiple times)
-ALL_RAW_DEFGROUP=$(git grep -n '@defgroup' -- '*.h' '*.hpp' '*.txt' '*/doc.md' '*.doc.md' 'makefiles/pseudomodules.inc.mk' 'sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c'| exclude_filter)
-ALL_RAW_INGROUP=$(git grep -n '@ingroup' -- '*.h' '*.hpp' '*.txt' '*/doc.md' '*.doc.md' 'makefiles/pseudomodules.inc.mk' 'sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c'| exclude_filter)
+ALL_RAW_DEFGROUP=$(git grep -n '@defgroup' -- '*.h' '*.hpp' '*.txt' '*/doc*.md' '*.doc.md' 'makefiles/pseudomodules.inc.mk' 'sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c'| exclude_filter)
+ALL_RAW_INGROUP=$(git grep -n '@ingroup' -- '*.h' '*.hpp' '*.txt' '*/doc*.md' '*.doc.md' 'makefiles/pseudomodules.inc.mk' 'sys/net/gnrc/routing/ipv6_auto_subnets/gnrc_ipv6_auto_subnets.c'| exclude_filter)
 DEFINED_GROUPS=$(echo "${ALL_RAW_DEFGROUP}" | \
                     grep -oE '@defgroup[ ]+[^ ]+' | \
                     grep -oE '[^ ]+$' | \

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -927,7 +927,7 @@ INPUT_ENCODING         = UTF-8
 # *.ucf, *.qsf and *.ice.
 
 FILE_PATTERNS          = *.txt \
-                         doc.md \
+                         doc*.md \
                          *.doc.md \
                          *.h \
                          *.h.in \


### PR DESCRIPTION
### Contribution description

This PR changes `doc.md` file pattern to `doc*.md` to allow multipart documentation in a module directory.

ESP32 doc is splitted into several parts `cpu/esp32/doc_esp32xy....txt` due to its complexity. When trying to migrate these files to `cpu/esp32/doc_esp32xy.md` files, I realized that the documentation is generated but the groups are not linked correctly so that the documentation is neither linked in the document tree nor the references between these parts work.

Instead of adding a separate `doc_*.md` file in `riot.doxyfile` and `docche.sh`, I just replaced the existing `doc.md` pattern by `doc*.md`. It seems really unlikely that a file which should not be part of the documentation is called `doc.....md` by accident.

### Testing procedure

As a test I migrated `doc_esp32c3.txt` to `doc_esp32c3.md` which has to be removed before merge.
```
make doc
```
The documentation for ESP32-C3 and the ESP32-C3 boards should still work. That is the documentation of the ESP-C3 should be found in

_RIOT OS -> Modules -> CPU -> ESP32 SoC Series -> ESP32-C3 family_

and link from a section, e.g. ADC channel, in

_RIOT OS -> Modules -> CPU -> ESP32 SoC Series

to the ESP32-C3 specific documentation should still work.

### Issues/PRs references

#21220