### PR TITLE
cpu/cc2538: Distinguish between GPIO_OD and GPIO_OD_PU

### DIFF
--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -153,7 +153,7 @@ typedef enum {
     GPIO_IN_PD      = ((uint8_t)OVERRIDE_PULLDOWN),     /**< input, pull-down */
     GPIO_IN_PU      = ((uint8_t)OVERRIDE_PULLUP),       /**< input, pull-up */
     GPIO_OUT        = ((uint8_t)OVERRIDE_ENABLE),       /**< output */
-    GPIO_OD         = (0xff),                           /**< not supported */
+    GPIO_OD         = (0xfe),                           /**< not supported */
     GPIO_OD_PU      = (0xff)                            /**< not supported */
 } gpio_mode_t;
 /** @} */

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -31,7 +31,7 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-#define MODE_NOTSUP         (0xff)
+#define MODE_NOTSUP         (0xf0)
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
 static gpio_isr_ctx_t isr_ctx[4][8];
@@ -100,7 +100,7 @@ static inline uint8_t _pp_num(gpio_t pin)
 int gpio_init(gpio_t pin, gpio_mode_t mode)
 {
     /* check if mode is valid */
-    if (mode == MODE_NOTSUP) {
+    if (mode >= MODE_NOTSUP) {
         return -1;
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The CC2538 does not support "Open Drain" or "Open Drain with Pullup" outputs. However problems can arrise from setting both macros to the same value. This commit sets them to separate values which are both invalid to avoid conflicts with other applications.

The value of `0xf0` was chosen arbitrarily, but it is still very far away from the valid values:
https://github.com/RIOT-OS/RIOT/blob/04a169867e530e0a1113540c3db321c1b8d95002/cpu/cc2538/include/cc2538_gpio.h#L304-L313

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Unfortunately I don't have the hardware to test this, but the changes should be fairly obvious.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Prerequisite for #10688.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
