### PR TITLE
cpu/native: use correct isr_stack for valgrind

### DIFF
--- a/cpu/native/irq.c
+++ b/cpu/native/irq.c
@@ -421,9 +421,9 @@ void native_interrupt_init(void)
     struct sigaction sa;
     DEBUG_IRQ("native_interrupt_init\n");
 
-    (void) VALGRIND_STACK_REGISTER(__isr_stack, __isr_stack + sizeof(__isr_stack));
+    (void) VALGRIND_STACK_REGISTER(_isr_stack, _isr_stack + sizeof(_isr_stack));
     VALGRIND_DEBUG("VALGRIND_STACK_REGISTER(%p, %p)\n",
-                   (void *)__isr_stack, (void*)(__isr_stack + sizeof(__isr_stack)));
+                   (void *)_isr_stack, (void*)(_isr_stack + sizeof(_isr_stack)));
 
     _native_pending_signals = 0;
     memset(_native_irq_handlers, 0, sizeof(_native_irq_handlers));


### PR DESCRIPTION
### Contribution description

In the cleanup PR for native (#21283) (90a3f3ffcc3ae25f07ba5ac9fe2d1444cf7c26ea) the ISR stack variable got renamed from __isr_stack to _isr_stack but the valgrind configuration hasn't been updated.

### Testing procedure

Build any application for native with `make all-valgrind`.

### Issues/PRs references

Fixes a leftover issue from #21283 