### PR TITLE
pkg/driver_atwinc15x0: remove the compilation of the SPI Flash driver part

### DIFF
--- a/drivers/atwinc15x0/Makefile.dep
+++ b/drivers/atwinc15x0/Makefile.dep
@@ -17,10 +17,3 @@ USEPKG += driver_atwinc15x0
 FEATURES_REQUIRED += periph_gpio
 FEATURES_REQUIRED += periph_gpio_irq
 FEATURES_REQUIRED += periph_spi
-
-# esp8266 and esp32 vendor code and atwinc15x0 both define conflicting
-# spi_flash_{read, write} functions.
-# esp8266 and esp32 already have build-in WiFi, so it's unlikely to ever
-# use this driver - just blacklist the architecture.
-FEATURES_BLACKLIST += arch_esp8266
-FEATURES_BLACKLIST += arch_esp32

--- a/drivers/atwinc15x0/atwinc15x0_bus.c
+++ b/drivers/atwinc15x0/atwinc15x0_bus.c
@@ -40,8 +40,10 @@ sint8 nm_bus_init(void *arg)
     assert(atwinc15x0);
     assert(gpio_is_valid(atwinc15x0->params.ssn_pin));
 
+#if !defined(CPU_ESP32) && !defined(CPU_ESP8266)
     gpio_init(atwinc15x0->params.ssn_pin, GPIO_OUT);
     gpio_set(atwinc15x0->params.ssn_pin);
+#endif
 
     nm_bsp_reset();
     nm_bsp_sleep(1);

--- a/drivers/atwinc15x0/atwinc15x0_bus.c
+++ b/drivers/atwinc15x0/atwinc15x0_bus.c
@@ -40,10 +40,7 @@ sint8 nm_bus_init(void *arg)
     assert(atwinc15x0);
     assert(gpio_is_valid(atwinc15x0->params.ssn_pin));
 
-#if !defined(CPU_ESP32) && !defined(CPU_ESP8266)
-    gpio_init(atwinc15x0->params.ssn_pin, GPIO_OUT);
-    gpio_set(atwinc15x0->params.ssn_pin);
-#endif
+    spi_init_cs(atwinc15x0->params.spi, atwinc15x0->params.ssn_pin);
 
     nm_bsp_reset();
     nm_bsp_sleep(1);

--- a/pkg/driver_atwinc15x0/Makefile
+++ b/pkg/driver_atwinc15x0/Makefile
@@ -20,4 +20,3 @@ CFLAGS += -Wno-pedantic
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/driver/source -f $(RIOTBASE)/Makefile.base MODULE=driver_atwinc15x0
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/common/source -f $(RIOTBASE)/Makefile.base MODULE=driver_atwinc15x0_common
-	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/spi_flash/source -f $(RIOTBASE)/Makefile.base MODULE=driver_atwinc15x0_spi_flash

--- a/pkg/driver_atwinc15x0/Makefile.dep
+++ b/pkg/driver_atwinc15x0/Makefile.dep
@@ -3,4 +3,3 @@ FEATURES_REQUIRED += periph_spi
 
 USEMODULE += driver_atwinc15x0
 USEMODULE += driver_atwinc15x0_common
-USEMODULE += driver_atwinc15x0_spi_flash

--- a/pkg/driver_atwinc15x0/patches/0012-nmdrv-don-t-call-spi_enable_flash-0.patch
+++ b/pkg/driver_atwinc15x0/patches/0012-nmdrv-don-t-call-spi_enable_flash-0.patch
@@ -1,0 +1,35 @@
+From 0abb3daceea8424cc277a2c0c01570099c495c96 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Tue, 13 May 2025 18:47:45 +0200
+Subject: [PATCH 12/12] nmdrv: don't call spi_enable_flash(0)
+
+SPI Flash isn't used in RIOT. Disabling the SPI Flash with `spi_enable_flash(0)` is the only function call to the SPI Flash driver. Therefore we don't use the SPI Flash driver at all and comment out this call to prevent an undefined reference.
+---
+ src/driver/source/nmdrv.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/driver/source/nmdrv.c b/src/driver/source/nmdrv.c
+index 396ade953a2..160d84b011b 100644
+--- a/src/driver/source/nmdrv.c
++++ b/src/driver/source/nmdrv.c
+@@ -383,14 +383,14 @@ sint8 nm_drv_deinit(void * arg)
+ 		M2M_ERR("[nmi stop]: chip_deinit fail\n");
+ 		goto ERR1;
+ 	}
+-	
++#if 0 /* We don't use SPI Flash in RIOT */
+ 	/* Disable SPI flash to save power when the chip is off */
+-	ret = spi_flash_enable(0);
++    ret = spi_flash_enable(0);
+ 	if (M2M_SUCCESS != ret) {
+ 		M2M_ERR("[nmi stop]: SPI flash disable fail\n");
+ 		goto ERR1;
+ 	}
+-
++#endif
+ 	ret = nm_bus_iface_deinit();
+ 	if (M2M_SUCCESS != ret) {
+ 		M2M_ERR("[nmi stop]: fail init bus\n");
+-- 
+2.34.1
+


### PR DESCRIPTION
### Contribution description

The PR removes the compilation of the SPI Flash driver part of the package. This allows also to use the ATWINC15x0 for ESPs.

The SPI flash integrated in the ATWINC15x0 chip is not used in RIOT. It is therefore not necessary to compile the SPI flash driver part of the package. The only function of this part that is called by other parts of the driver package is `spi_enable_flash(0)` to disable the SPI flash during the driver deinitialization for power consumption reasons. Since we are not deinitializing the driver, the function is not called and can be commented out to be able to compile the package without the SPI flash driver part.

### Testing procedure

A networking application should still work for any board with a ATWINC15x0 WiFi module that uses the ATWINC15x0 driver package, for example:
```python
CFLAGS='-DWIFI_SSID=\"<ssid>\" -DWIFI_PASS=\"<pass>\"' \
BOARD=feather-m0-wifi make -C examples/networking/gnrc/gnrc_networking flash term
```
The PR has been tested with
- `feather-m0-wifi`
- `arduino-mkr1000`
- `esp32-wemos-d1-r32` with a [Adafruit WINC1500 WiFi Shield for Arduino](https://learn.adafruit.com/adafruit-winc1500-wifi-shield-for-arduino)


### Issues/PRs references