### PR TITLE
makefiles/defaultmodules*.mk: fix the description in comments

### DIFF
--- a/makefiles/defaultmodules_deps.inc.mk
+++ b/makefiles/defaultmodules_deps.inc.mk
@@ -1,5 +1,5 @@
 # This files contains dependencies for default modules. They are parsed at the
-# end of the dependency loop. They MAY include new modules, but this modules
+# end of the dependency loop. They MAY include new modules, but these modules
 # MUST NOT have dependencies themselves.
 
 ifneq (,$(filter auto_init%,$(USEMODULE)))

--- a/makefiles/defaultmodules_no_recursive_deps.inc.mk
+++ b/makefiles/defaultmodules_no_recursive_deps.inc.mk
@@ -1,7 +1,8 @@
-# This file declare DEFAULT_MODULEs that MAY only have as dependecies modules
-# with no dependencies themselfs. If they modules declared here have dependencies
-# they must be delcared in defaultmodules_deps.inc.mk.
-# These DEFAULT_MODULEs MAY be disabled during dependency resolution
+# This file declares DEFAULT_MODULEs, which may only have modules as
+# dependencies that themselves have no dependencies. DEFAULT_MODULEs that have
+# dependencies must be delcared in defaultmodules_deps.inc.mk.
+# DEFAULT_MODULEs declared in this file MAY be disabled during dependency
+# resolution.
 
 DEFAULT_MODULE += auto_init periph_init
 

--- a/makefiles/defaultmodules_regular.inc.mk
+++ b/makefiles/defaultmodules_regular.inc.mk
@@ -1,7 +1,7 @@
-# This file declare DEFAULT_MODULEs that MAY have dependencies themselfs
-# and where there dependencies MAY have dependencies as well.
+# This file declares DEFAULT_MODULEs that MAY have dependencies themselves
+# and whose dependencies MAY have dependencies as well.
 # These DEFAULT_MODULEs MUST only be disabled at application level or
-# in BOARD/CPU Makefile.default
+# in BOARD/CPU Makefile.default.
 
 DEFAULT_MODULE += board board_common_init \
                   cpu \


### PR DESCRIPTION
### Contribution description

This PR is a small correction of the comments in `makefiles/defaultmodules*.inc` which were a bit confusing, especially in `makefiles/defaultmodules_no_recursive_deps.inc.mk`.

### Testing procedure

Review of the comments.

### Issues/PRs references
