### PR TITLE
cpu: replace header guards with #pragma once

### DIFF
--- a/cpu/arm7_common/include/VIC.h
+++ b/cpu/arm7_common/include/VIC.h
@@ -5,8 +5,7 @@
  *
  */
 
-#ifndef VIC_H
-#define VIC_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -86,4 +85,3 @@ bool cpu_install_irq(int IntNumber, void *HandlerAddr, int Priority);
 #endif
 
 /** @} */
-#endif /* VIC_H */

--- a/cpu/arm7_common/include/architecture_arch.h
+++ b/cpu/arm7_common/include/architecture_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_arm7_common
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef ARCHITECTURE_ARCH_H
-#define ARCHITECTURE_ARCH_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,4 +34,3 @@ extern "C" {
 #endif
 
 /** @} */
-#endif /* ARCHITECTURE_ARCH_H */

--- a/cpu/arm7_common/include/arm7_common.h
+++ b/cpu/arm7_common/include/arm7_common.h
@@ -6,8 +6,7 @@
  * more details.
  */
 
-#ifndef ARM7_COMMON_H
-#define ARM7_COMMON_H
+#pragma once
 
 /**
  * @defgroup    cpu_arm7_common ARM7 CPU common
@@ -101,4 +100,3 @@ extern "C" {
 #endif
 
 /** @} */
-#endif /* ARM7_COMMON_H */

--- a/cpu/arm7_common/include/arm_cpu.h
+++ b/cpu/arm7_common/include/arm_cpu.h
@@ -6,8 +6,7 @@
  * directory for more details.
  */
 
-#ifndef ARM_CPU_H
-#define ARM_CPU_H
+#pragma once
 
 #include <stdint.h>
 #include "VIC.h"
@@ -60,5 +59,3 @@ static inline uintptr_t cpu_get_caller_pc(void)
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* ARM_CPU_H */

--- a/cpu/arm7_common/include/atomic_utils_arch.h
+++ b/cpu/arm7_common/include/atomic_utils_arch.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_arm7_common
  *
@@ -16,8 +18,6 @@
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
 
-#ifndef ATOMIC_UTILS_ARCH_H
-#define ATOMIC_UTILS_ARCH_H
 #ifndef DOXYGEN
 
 #include "periph_cpu.h"
@@ -72,5 +72,4 @@ static inline void atomic_store_u32(volatile uint32_t *dest, uint32_t val)
 #endif
 
 #endif /* DOXYGEN */
-#endif /* ATOMIC_UTILS_ARCH_H */
 /** @} */

--- a/cpu/arm7_common/include/iap.h
+++ b/cpu/arm7_common/include/iap.h
@@ -6,8 +6,7 @@
  * directory for more details.
  */
 
-#ifndef IAP_H
-#define IAP_H
+#pragma once
 
 #include <stdint.h>
 
@@ -62,5 +61,3 @@ uint8_t iap_get_sector(uint32_t addr);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* IAP_H */

--- a/cpu/arm7_common/include/irq_arch.h
+++ b/cpu/arm7_common/include/irq_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_arm7_common
  * @{
@@ -16,8 +18,6 @@
  * @author          Heiko Will <hwill@inf.fu-berlin.de>
  */
 
-#ifndef IRQ_ARCH_H
-#define IRQ_ARCH_H
 
 #include "VIC.h"
 #include <stdbool.h>
@@ -79,5 +79,4 @@ static inline __attribute__((always_inline)) bool irq_is_enabled(void)
 }
 #endif
 
-#endif /* IRQ_ARCH_H */
 /** @} */

--- a/cpu/arm7_common/include/thread_arch.h
+++ b/cpu/arm7_common/include/thread_arch.h
@@ -7,6 +7,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_arm7_common
  * @{
@@ -17,8 +19,6 @@
  * @author Kaspar Schleiser <kaspar@schleiser.de>
  * @author Heiko Will <heiko.will@fu-berlin.de>
  */
-#ifndef THREAD_ARCH_H
-#define THREAD_ARCH_H
 
 #include "irq.h"
 
@@ -46,5 +46,4 @@ static inline __attribute__((always_inline)) void thread_yield_higher(void)
 }
 #endif
 
-#endif /* THREAD_ARCH_H */
 /** @} */

--- a/cpu/arm7tdmi_gba/include/cpu.h
+++ b/cpu/arm7tdmi_gba/include/cpu.h
@@ -6,8 +6,7 @@
  * directory for more details.
  */
 
-#ifndef CPU_H
-#define CPU_H
+#pragma once
 
 /**
  * @ingroup     cpu_arm7tdmi_gba
@@ -27,4 +26,3 @@ extern uintptr_t __stack_start;     /**< end of user stack memory space */
 #endif
 
 /** @} */
-#endif /* CPU_H */

--- a/cpu/arm7tdmi_gba/include/cpu_conf.h
+++ b/cpu/arm7tdmi_gba/include/cpu_conf.h
@@ -6,8 +6,7 @@
  * directory for more details.
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
+#pragma once
 
 #ifdef __cplusplus
 extern "C"
@@ -90,5 +89,3 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* CPU_CONF_H */

--- a/cpu/arm7tdmi_gba/include/periph_cpu.h
+++ b/cpu/arm7tdmi_gba/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_arm7tdmi_gba
  * @{
@@ -16,8 +18,6 @@
  * @author
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -34,5 +34,4 @@ extern "C"
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/arm7tdmi_gba/include/periph_gba.h
+++ b/cpu/arm7tdmi_gba/include/periph_gba.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_arm7tdmi_gba
  * @{
@@ -16,8 +18,6 @@
  * @author      Bennet Blischke
  */
 
-#ifndef PERIPH_GBA_H
-#define PERIPH_GBA_H
 
 #include <stdint.h>
 
@@ -102,5 +102,4 @@ extern "C"
 }
 #endif
 
-#endif /* PERIPH_GBA_H */
 /** @} */

--- a/cpu/arm7tdmi_gba/stdio_fb/font_terminal.h
+++ b/cpu/arm7tdmi_gba/stdio_fb/font_terminal.h
@@ -1,5 +1,5 @@
-#ifndef FONT_TERMINAL_H
-#define FONT_TERMINAL_H
+#pragma once
+
 
 #ifdef __cplusplus
 extern "C"
@@ -282,5 +282,3 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* FONT_TERMINAL_H */

--- a/cpu/atmega1281/include/atmega_pcint.h
+++ b/cpu/atmega1281/include/atmega_pcint.h
@@ -1,5 +1,5 @@
-#ifndef ATMEGA_PCINT_H
-#define ATMEGA_PCINT_H
+#pragma once
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,5 +11,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* ATMEGA_PCINT_H */

--- a/cpu/atmega1281/include/default_timer_config.h
+++ b/cpu/atmega1281/include/default_timer_config.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega1281
  * @{
@@ -20,8 +22,6 @@
  * @author          Francisco Acosta <francisco.acosta@inria.fr>
  */
 
-#ifndef DEFAULT_TIMER_CONFIG_H
-#define DEFAULT_TIMER_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,5 +50,4 @@ extern "C" {
 }
 #endif
 
-#endif /* DEFAULT_TIMER_CONFIG_H */
 /** @} */

--- a/cpu/atmega1281/include/periph_cpu.h
+++ b/cpu/atmega1281/include/periph_cpu.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega1281
  * @{
@@ -20,8 +22,6 @@
  * @author          Francisco Acosta <francisco.acosta@inria.fr>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -110,5 +110,4 @@ static inline bool atmega_has_pin_exti(uint8_t port_num, uint8_t pin_num)
 #include "periph_conf.h"
 #include "default_timer_config.h"
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/atmega1284p/include/atmega_pcint.h
+++ b/cpu/atmega1284p/include/atmega_pcint.h
@@ -1,5 +1,5 @@
-#ifndef ATMEGA_PCINT_H
-#define ATMEGA_PCINT_H
+#pragma once
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,5 +13,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* ATMEGA_PCINT_H */

--- a/cpu/atmega1284p/include/default_timer_config.h
+++ b/cpu/atmega1284p/include/default_timer_config.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega1284p
  * @{
@@ -16,8 +18,6 @@
  * @author          Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
 
-#ifndef DEFAULT_TIMER_CONFIG_H
-#define DEFAULT_TIMER_CONFIG_H
 
 #include "periph_cpu_common.h"
 #include "periph_conf.h" /* <- Allow overwriting timer config from board */
@@ -47,5 +47,4 @@ extern "C" {
 }
 #endif
 
-#endif /* DEFAULT_TIMER_CONFIG_H */
 /** @} */

--- a/cpu/atmega1284p/include/periph_cpu.h
+++ b/cpu/atmega1284p/include/periph_cpu.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega1284p
  * @{
@@ -20,8 +22,6 @@
  * @author          Matthew Blue <matthew.blue.neuro@gmail.com>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include "periph_cpu_common.h"
 
@@ -113,5 +113,4 @@ static inline bool atmega_has_pin_exti(uint8_t port_num, uint8_t pin_num)
 #include "periph_conf.h"
 #include "default_timer_config.h"
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/atmega128rfa1/include/atmega_pcint.h
+++ b/cpu/atmega128rfa1/include/atmega_pcint.h
@@ -1,5 +1,5 @@
-#ifndef ATMEGA_PCINT_H
-#define ATMEGA_PCINT_H
+#pragma once
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,5 +11,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* ATMEGA_PCINT_H */

--- a/cpu/atmega128rfa1/include/default_timer_config.h
+++ b/cpu/atmega128rfa1/include/default_timer_config.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega128rfa1
  * @{
@@ -17,8 +19,6 @@
  * @author          Steffen Robertz <steffen.robertz@rwth-aachen.de>
  */
 
-#ifndef DEFAULT_TIMER_CONFIG_H
-#define DEFAULT_TIMER_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -54,5 +54,4 @@ extern "C" {
 }
 #endif
 
-#endif /* DEFAULT_TIMER_CONFIG_H */
 /** @} */

--- a/cpu/atmega128rfa1/include/periph_cpu.h
+++ b/cpu/atmega128rfa1/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega128rfa1
  * @{
@@ -17,8 +19,6 @@
  * @author          Steffen Robertz <steffen.robertz@rwth-aachen.de>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include "periph_cpu_common.h"
 #include "atmega_regs_common.h"
@@ -107,5 +107,4 @@ static inline bool atmega_has_pin_exti(uint8_t port_num, uint8_t pin_num)
 #include "periph_conf.h"
 #include "default_timer_config.h"
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/atmega2560/include/atmega_pcint.h
+++ b/cpu/atmega2560/include/atmega_pcint.h
@@ -1,5 +1,5 @@
-#ifndef ATMEGA_PCINT_H
-#define ATMEGA_PCINT_H
+#pragma once
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,5 +12,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* ATMEGA_PCINT_H */

--- a/cpu/atmega2560/include/default_timer_config.h
+++ b/cpu/atmega2560/include/default_timer_config.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega2560
  * @{
@@ -20,8 +22,6 @@
  * @author          Francisco Acosta <francisco.acosta@inria.fr>
  */
 
-#ifndef DEFAULT_TIMER_CONFIG_H
-#define DEFAULT_TIMER_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,5 +50,4 @@ extern "C" {
 }
 #endif
 
-#endif /* DEFAULT_TIMER_CONFIG_H */
 /** @} */

--- a/cpu/atmega2560/include/periph_cpu.h
+++ b/cpu/atmega2560/include/periph_cpu.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega2560
  * @{
@@ -18,8 +20,6 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include "periph_cpu_common.h"
 
@@ -112,5 +112,4 @@ static inline bool atmega_has_pin_exti(uint8_t port_num, uint8_t pin_num)
 #include "periph_conf.h"
 #include "default_timer_config.h"
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/atmega256rfr2/include/atmega_pcint.h
+++ b/cpu/atmega256rfr2/include/atmega_pcint.h
@@ -1,5 +1,5 @@
-#ifndef ATMEGA_PCINT_H
-#define ATMEGA_PCINT_H
+#pragma once
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,5 +11,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* ATMEGA_PCINT_H */

--- a/cpu/atmega256rfr2/include/default_timer_config.h
+++ b/cpu/atmega256rfr2/include/default_timer_config.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega256rfr2
  * @{
@@ -17,8 +19,6 @@
  * @author          Steffen Robertz <steffen.robertz@rwth-aachen.de>
  */
 
-#ifndef DEFAULT_TIMER_CONFIG_H
-#define DEFAULT_TIMER_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -54,5 +54,4 @@ extern "C" {
 }
 #endif
 
-#endif /* DEFAULT_TIMER_CONFIG_H */
 /** @} */

--- a/cpu/atmega256rfr2/include/periph_cpu.h
+++ b/cpu/atmega256rfr2/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega256rfr2
  * @{
@@ -17,8 +19,6 @@
  * @author          Steffen Robertz <steffen.robertz@rwth-aachen.de>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include "periph_cpu_common.h"
 #include "atmega_regs_common.h"
@@ -108,5 +108,4 @@ static inline bool atmega_has_pin_exti(uint8_t port_num, uint8_t pin_num)
 #include "periph_conf.h"
 #include "default_timer_config.h"
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/atmega328p/include/atmega_pcint.h
+++ b/cpu/atmega328p/include/atmega_pcint.h
@@ -1,5 +1,5 @@
-#ifndef ATMEGA_PCINT_H
-#define ATMEGA_PCINT_H
+#pragma once
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,5 +12,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* ATMEGA_PCINT_H */

--- a/cpu/atmega328p/include/default_timer_config.h
+++ b/cpu/atmega328p/include/default_timer_config.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega328p
  * @{
@@ -18,8 +20,6 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef DEFAULT_TIMER_CONFIG_H
-#define DEFAULT_TIMER_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,5 +40,4 @@ extern "C" {
 }
 #endif
 
-#endif /* DEFAULT_TIMER_CONFIG_H */
 /** @} */

--- a/cpu/atmega328p/include/periph_cpu.h
+++ b/cpu/atmega328p/include/periph_cpu.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega328p
  * @{
@@ -18,8 +20,6 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include "periph_cpu_common.h"
 
@@ -103,5 +103,4 @@ static inline bool atmega_has_pin_exti(uint8_t port_num, uint8_t pin_num)
 #include "periph_conf.h"
 #include "default_timer_config.h"
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/atmega32u4/include/atmega_pcint.h
+++ b/cpu/atmega32u4/include/atmega_pcint.h
@@ -1,5 +1,5 @@
-#ifndef ATMEGA_PCINT_H
-#define ATMEGA_PCINT_H
+#pragma once
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -10,5 +10,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* ATMEGA_PCINT_H */

--- a/cpu/atmega32u4/include/default_timer_config.h
+++ b/cpu/atmega32u4/include/default_timer_config.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega32u4
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef DEFAULT_TIMER_CONFIG_H
-#define DEFAULT_TIMER_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,5 +47,4 @@ extern "C" {
 }
 #endif
 
-#endif /* DEFAULT_TIMER_CONFIG_H */
 /** @} */

--- a/cpu/atmega32u4/include/periph_cpu.h
+++ b/cpu/atmega32u4/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega32u4
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include "periph_cpu_common.h"
 
@@ -97,5 +97,4 @@ static inline bool atmega_has_pin_exti(uint8_t port_num, uint8_t pin_num)
 #include "periph_conf.h"
 #include "default_timer_config.h"
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/atmega8/include/cpu_conf.h
+++ b/cpu/atmega8/include/cpu_conf.h
@@ -9,6 +9,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega_common
  * @{
@@ -24,8 +26,6 @@
  * @author          Hugues Larrive <hugues.larrive@pm.me>
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #include "atmega_regs_common.h"
 
@@ -89,5 +89,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/atmega8/include/default_timer_config.h
+++ b/cpu/atmega8/include/default_timer_config.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega8
  * @{
@@ -20,8 +22,6 @@
  * @author          Hugues Larrive <hugues.larrive@pm.me>
  */
 
-#ifndef DEFAULT_TIMER_CONFIG_H
-#define DEFAULT_TIMER_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,5 +42,4 @@ extern "C" {
 }
 #endif
 
-#endif /* DEFAULT_TIMER_CONFIG_H */
 /** @} */

--- a/cpu/atmega8/include/periph_cpu.h
+++ b/cpu/atmega8/include/periph_cpu.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega8
  * @{
@@ -20,8 +22,6 @@
  * @author          Hugues Larrive <hugues.larrive@pm.me>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include "periph_cpu_common.h"
 
@@ -105,5 +105,4 @@ static inline bool atmega_has_pin_exti(uint8_t port_num, uint8_t pin_num)
 #include "periph_conf.h"
 #include "default_timer_config.h"
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/atmega_common/include/atmega_gpio.h
+++ b/cpu/atmega_common/include/atmega_gpio.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_atmega_common
  * @ingroup     drivers_periph_gpio
@@ -22,8 +24,6 @@
  * @author      Laurent Navet <laurent.navet@gmail.com>
  */
 
-#ifndef ATMEGA_GPIO_H
-#define ATMEGA_GPIO_H
 #include <stddef.h>
 #include <stdio.h>
 
@@ -83,5 +83,4 @@ static inline uint16_t atmega_port_addr(gpio_t pin)
 }
 #endif
 
-#endif /* ATMEGA_GPIO_H */
 /** @} */

--- a/cpu/atmega_common/include/atmega_regs_common.h
+++ b/cpu/atmega_common/include/atmega_regs_common.h
@@ -9,6 +9,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_atmega_common
  * @{
@@ -23,8 +25,6 @@
  *
  */
 
-#ifndef ATMEGA_REGS_COMMON_H
-#define ATMEGA_REGS_COMMON_H
 
 #include <avr/io.h>
 #include <avr/power.h>
@@ -182,5 +182,4 @@ typedef struct {
 }
 #endif
 
-#endif /* ATMEGA_REGS_COMMON_H */
 /** @} */

--- a/cpu/atmega_common/include/cpu_clock.h
+++ b/cpu/atmega_common/include/cpu_clock.h
@@ -9,6 +9,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_atmega_common
  * @brief       Common clock support for ATmega family based micro-controllers
@@ -29,8 +31,6 @@
  *
  */
 
-#ifndef CPU_CLOCK_H
-#define CPU_CLOCK_H
 
 #include <stdint.h>
 
@@ -78,5 +78,4 @@ static inline void atmega_set_prescaler(uint8_t clk_scale)
 }
 #endif
 
-#endif /* CPU_CLOCK_H */
 /** @} */

--- a/cpu/atmega_common/include/cpu_conf.h
+++ b/cpu/atmega_common/include/cpu_conf.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega_common
  * @{
@@ -22,8 +24,6 @@
  * @author          Matthew Blue <matthew.blue.neuro@gmail.com>
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #include "atmega_regs_common.h"
 
@@ -87,5 +87,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/atmega_common/include/gpio_ll_arch.h
+++ b/cpu/atmega_common/include/gpio_ll_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_atmega_common
  * @ingroup     drivers_periph_gpio_ll
@@ -20,8 +22,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef GPIO_LL_ARCH_H
-#define GPIO_LL_ARCH_H
 
 #include <assert.h>
 
@@ -372,5 +372,4 @@ static inline bool is_gpio_port_num_valid(uint_fast8_t num)
 }
 #endif
 
-#endif /* GPIO_LL_ARCH_H */
 /** @} */

--- a/cpu/atmega_common/include/periph_cpu_common.h
+++ b/cpu/atmega_common/include/periph_cpu_common.h
@@ -9,6 +9,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atmega_common
  * @{
@@ -22,8 +24,6 @@
  * @author          Hugues Larrive <hugues.larrive@pm.me>
  */
 
-#ifndef PERIPH_CPU_COMMON_H
-#define PERIPH_CPU_COMMON_H
 
 #include "cpu.h"
 
@@ -384,5 +384,4 @@ typedef struct {
 }
 #endif
 
-#endif /* PERIPH_CPU_COMMON_H */
 /** @} */

--- a/cpu/atxmega/include/cpu_clock.h
+++ b/cpu/atxmega/include/cpu_clock.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_atxmega
  * @brief       Common implementations and headers for ATxmega family based micro-controllers
@@ -21,8 +23,6 @@
  *
  */
 
-#ifndef CPU_CLOCK_H
-#define CPU_CLOCK_H
 
 #include <stdint.h>
 
@@ -71,5 +71,4 @@ static inline void atxmega_set_prescaler(uint8_t clk_scale, uint8_t bus_scale)
 }
 #endif
 
-#endif /* CPU_CLOCK_H */
 /** @} */

--- a/cpu/atxmega/include/cpu_conf.h
+++ b/cpu/atxmega/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atxmega
  * @{
@@ -16,8 +18,6 @@
  * @author          Gerson Fernando Budke <nandojve@gmail.com>
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -72,5 +72,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/atxmega/include/cpu_ebi.h
+++ b/cpu/atxmega/include/cpu_ebi.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atxmega
  * @{
@@ -18,8 +20,6 @@
 
 #include "periph_cpu.h"
 
-#ifndef CPU_EBI_H
-#define CPU_EBI_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -150,5 +150,4 @@ void hugemem_write_block(hugemem_ptr_t to, const void *from, size_t size);
 }
 #endif
 
-#endif /* CPU_EBI_H */
 /** @} */

--- a/cpu/atxmega/include/cpu_nvm.h
+++ b/cpu/atxmega/include/cpu_nvm.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_atxmega
  * @brief       Non Volatile Memory (NVM) internal API
@@ -15,8 +17,6 @@
  *
  */
 
-#ifndef CPU_NVM_H
-#define CPU_NVM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -61,5 +61,4 @@ uint8_t nvm_read_production_signature_row(uint8_t address);
 }
 #endif
 
-#endif /* CPU_NVM_H */
 /** @} */

--- a/cpu/atxmega/include/cpu_pm.h
+++ b/cpu/atxmega/include/cpu_pm.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atxmega
  * @{
@@ -22,8 +24,6 @@
 
 #include "periph_cpu.h"
 
-#ifndef CPU_PM_H
-#define CPU_PM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,5 +37,4 @@ void pm_periph_power_off(void);
 }
 #endif
 
-#endif /* CPU_PM_H */
 /** @} */

--- a/cpu/atxmega/include/periph_cpu.h
+++ b/cpu/atxmega/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_atxmega
  * @{
@@ -16,8 +18,6 @@
  * @author          Gerson Fernando Budke <nandojve@gmail.com>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include <avr/io.h>
 
@@ -612,5 +612,4 @@ typedef struct {
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/avr8_common/avr_libc_extra/include/errno.h
+++ b/cpu/avr8_common/avr_libc_extra/include/errno.h
@@ -28,8 +28,7 @@
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE. */
 
-#ifndef ERRNO_H
-#define ERRNO_H
+#pragma once
 
 /**
  *  @addtogroup cpu_atmega_common
@@ -154,5 +153,3 @@ extern int errno;
 /** @} */
 
 /** @} */
-
-#endif /* ERRNO_H */

--- a/cpu/avr8_common/avr_libc_extra/include/inttypes.h
+++ b/cpu/avr8_common/avr_libc_extra/include/inttypes.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup  cpu_atmega_common
  * @{
@@ -15,8 +17,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef INTTYPES_H
-#define INTTYPES_H
 
 #include_next <inttypes.h>
 
@@ -33,5 +33,4 @@ extern "C" {
 }
 #endif
 
-#endif /* INTTYPES_H */
 /** @} */

--- a/cpu/avr8_common/avr_libc_extra/include/strings.h
+++ b/cpu/avr8_common/avr_libc_extra/include/strings.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @addtogroup cpu_atmega_common
  *
@@ -22,8 +24,6 @@
 
 #include <string.h>
 
-#ifndef STRINGS_H
-#define STRINGS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -78,5 +78,4 @@ static inline void bcopy(const void *src, void *dest, size_t n)
 }
 #endif
 
-#endif /* STRINGS_H */
 /** @} */

--- a/cpu/avr8_common/avr_libc_extra/include/sys/time.h
+++ b/cpu/avr8_common/avr_libc_extra/include/sys/time.h
@@ -6,8 +6,7 @@
  * directory for more details.
  */
 
-#ifndef SYS_TIME_H
-#define SYS_TIME_H
+#pragma once
 
 #include <sys/types.h>
 #include <time.h>
@@ -28,5 +27,3 @@ struct timeval {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* SYS_TIME_H */

--- a/cpu/avr8_common/avr_libc_extra/include/sys/types.h
+++ b/cpu/avr8_common/avr_libc_extra/include/sys/types.h
@@ -7,8 +7,7 @@
  * directory for more details.
  */
 
-#ifndef SYS_TYPES_H
-#define SYS_TYPES_H
+#pragma once
 
 #include <stdint.h>
 #include <stddef.h>
@@ -43,5 +42,3 @@ typedef     uint32_t useconds_t;  /**< Used for time in microseconds */
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* SYS_TYPES_H */

--- a/cpu/avr8_common/avr_libc_extra/include/unistd.h
+++ b/cpu/avr8_common/avr_libc_extra/include/unistd.h
@@ -7,8 +7,7 @@
  * directory for more details.
  */
 
-#ifndef UNISTD_H
-#define UNISTD_H
+#pragma once
 
 #include <stddef.h>
 #include <stdint.h>
@@ -106,5 +105,3 @@ ssize_t      write(int, const void *, size_t);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* UNISTD_H */

--- a/cpu/avr8_common/include/architecture_arch.h
+++ b/cpu/avr8_common/include/architecture_arch.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_avr8_common
  * @{
@@ -19,8 +21,6 @@
  *
  */
 
-#ifndef ARCHITECTURE_ARCH_H
-#define ARCHITECTURE_ARCH_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,4 +40,3 @@ typedef uint32_t   uinttxtptr_t;
 #endif
 
 /** @} */
-#endif /* ARCHITECTURE_ARCH_H */

--- a/cpu/avr8_common/include/atomic_utils_arch.h
+++ b/cpu/avr8_common/include/atomic_utils_arch.h
@@ -7,6 +7,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_avr8_common
  *
@@ -18,8 +20,6 @@
  * @author      Gerson Fernando Budke <nandojve@gmail.com>
  */
 
-#ifndef ATOMIC_UTILS_ARCH_H
-#define ATOMIC_UTILS_ARCH_H
 #ifndef DOXYGEN
 
 #include "periph_cpu.h"
@@ -50,5 +50,4 @@ static inline void atomic_store_u8(volatile uint8_t *dest, uint8_t val)
 #endif
 
 #endif /* DOXYGEN */
-#endif /* ATOMIC_UTILS_ARCH_H */
 /** @} */

--- a/cpu/avr8_common/include/cpu.h
+++ b/cpu/avr8_common/include/cpu.h
@@ -9,6 +9,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_avr8_common
  * @brief       Common implementations and headers for AVR-8 family based micro-controllers
@@ -29,8 +31,6 @@
  *
  */
 
-#ifndef CPU_H
-#define CPU_H
 
 #include <stdio.h>
 #include <stdint.h>
@@ -181,5 +181,4 @@ void avr8_reset_cause(void);
 }
 #endif
 
-#endif /* CPU_H */
 /** @} */

--- a/cpu/avr8_common/include/flash_utils_arch.h
+++ b/cpu/avr8_common/include/flash_utils_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_avr8_common
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef FLASH_UTILS_ARCH_H
-#define FLASH_UTILS_ARCH_H
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -105,4 +105,3 @@ int flash_snprintf(char *buf, size_t buf_len, FLASH_ATTR const char *flash, ...)
 #endif
 
 /** @} */
-#endif /* FLASH_UTILS_ARCH_H */

--- a/cpu/avr8_common/include/irq_arch.h
+++ b/cpu/avr8_common/include/irq_arch.h
@@ -9,6 +9,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_avr8_common
  * @{
@@ -24,8 +26,6 @@
  *
  */
 
-#ifndef IRQ_ARCH_H
-#define IRQ_ARCH_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -158,4 +158,3 @@ __attribute__((always_inline)) static inline bool irq_is_enabled(void)
 #endif
 
 /** @} */
-#endif /* IRQ_ARCH_H */

--- a/cpu/avr8_common/include/states_internal.h
+++ b/cpu/avr8_common/include/states_internal.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_avr8_common
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef STATES_INTERNAL_H
-#define STATES_INTERNAL_H
 
 #include <avr/io.h>
 
@@ -109,5 +109,4 @@ extern uint8_t avr8_state_irq_count_sram;               /**< IRQ state variable.
 }
 #endif
 
-#endif /* STATES_INTERNAL_H */
 /** @} */

--- a/cpu/avr8_common/include/stdio.h
+++ b/cpu/avr8_common/include/stdio.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @defgroup    cpu_avr8_common_stdio_wrapper   stdio wrapper for AVR8
  * @ingroup     cpu_avr8_common
@@ -21,8 +23,6 @@
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
 
-#ifndef STDIO_H
-#define STDIO_H
 #include_next "stdio.h"
 
 /* C++ does not support __flash. Hence, only wrap printf() and friends for
@@ -141,5 +141,4 @@ extern "C" {
 
 #endif
 
-#endif /* STDIO_H */
 /** @} */

--- a/cpu/avr8_common/include/thread_arch.h
+++ b/cpu/avr8_common/include/thread_arch.h
@@ -7,6 +7,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_avr8_common
  * @{
@@ -17,8 +19,6 @@
  * @author      Koen Zandberg <koen@bergzand.net>
  */
 
-#ifndef THREAD_ARCH_H
-#define THREAD_ARCH_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,5 +28,4 @@ extern "C" {
 }
 #endif
 
-#endif /* THREAD_ARCH_H */
 /** @} */

--- a/cpu/cc2538/include/cc2538.h
+++ b/cpu/cc2538/include/cc2538.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc2538_regs
  * @{
@@ -16,8 +18,6 @@
  * @author          Ian Martin <ian@locicontrols.com>
  */
 
-#ifndef CC2538_H
-#define CC2538_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -809,5 +809,4 @@ typedef volatile uint32_t cc2538_reg_t; /**< Least-significant 32 bits of the IE
 }
 #endif
 
-#endif /* CC2538_H */
 /** @} */

--- a/cpu/cc2538/include/cc2538_eui_primary.h
+++ b/cpu/cc2538/include/cc2538_eui_primary.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc2538
  * @{
@@ -16,8 +18,6 @@
  * @author          Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
 
-#ifndef CC2538_EUI_PRIMARY_H
-#define CC2538_EUI_PRIMARY_H
 
 #include "net/eui64.h"
 
@@ -71,5 +71,4 @@ static inline int cc2538_get_eui64_primary(uint8_t index, eui64_t *addr)
 } /* end extern "C" */
 #endif
 
-#endif /* CC2538_EUI_PRIMARY_H */
 /** @} */

--- a/cpu/cc2538/include/cc2538_gpio.h
+++ b/cpu/cc2538/include/cc2538_gpio.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup        cpu_cc2538_gpio CC2538 General-Purpose I/O
  * @ingroup         cpu_cc2538_regs
@@ -21,8 +23,6 @@
  * @{
  */
 
-#ifndef CC2538_GPIO_H
-#define CC2538_GPIO_H
 
 #include <stdint.h>
 
@@ -344,7 +344,6 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC2538_GPIO_H */
 
 /** @} */
 /** @} */

--- a/cpu/cc2538/include/cc2538_gptimer.h
+++ b/cpu/cc2538/include/cc2538_gptimer.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup        cpu_cc2538_gptimer CC2538 General Purpose Timer
  * @ingroup         cpu_cc2538_regs
@@ -19,8 +21,6 @@
  * @author          Sebastian Meiling <s@mlng.net>
  */
 
-#ifndef CC2538_GPTIMER_H
-#define CC2538_GPTIMER_H
 
 #include <stdint.h>
 
@@ -88,5 +88,4 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC2538_GPTIMER_H */
 /** @} */

--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -8,6 +8,8 @@
  *
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_cc2538
  * @{
@@ -19,8 +21,6 @@
  * @author      Ian Martin <ian@locicontrols.com>
  */
 
-#ifndef CC2538_RF_H
-#define CC2538_RF_H
 
 #include <stdbool.h>
 
@@ -468,5 +468,4 @@ void cc2538_set_tx_power(int dBm);
 }
 #endif
 
-#endif /* CC2538_RF_H */
 /** @} */

--- a/cpu/cc2538/include/cc2538_rf_internal.h
+++ b/cpu/cc2538/include/cc2538_rf_internal.h
@@ -7,6 +7,8 @@
  *
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_cc2538
  * @{
@@ -17,8 +19,6 @@
  * @author      Aaron Sowry <aaron@mutex.nz>
  */
 
-#ifndef CC2538_RF_INTERNAL_H
-#define CC2538_RF_INTERNAL_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -100,5 +100,4 @@ bool RFCORE_ASSERT_failure(const char *expr, const char *func, int line);
 }
 #endif
 
-#endif /* CC2538_RF_INTERNAL_H */
 /** @} */

--- a/cpu/cc2538/include/cc2538_rfcore.h
+++ b/cpu/cc2538/include/cc2538_rfcore.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup        cpu_cc2538_rfcore CC2538 RF core interface
  * @ingroup         cpu_cc2538_regs
@@ -18,8 +20,6 @@
  *
  */
 
-#ifndef CC2538_RFCORE_H
-#define CC2538_RFCORE_H
 
 #include "cc2538.h"
 
@@ -275,5 +275,4 @@ enum {
 } /* extern "C" */
 #endif
 
-#endif /* CC2538_RFCORE_H */
 /** @} */

--- a/cpu/cc2538/include/cc2538_soc_adc.h
+++ b/cpu/cc2538/include/cc2538_soc_adc.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup        cpu_cc2538_adc CC2538 ADC
  * @ingroup         cpu_cc2538_regs
@@ -19,8 +21,6 @@
  * @author          Sebastian Meiling <s@mlng.net>
  */
 
-#ifndef CC2538_SOC_ADC_H
-#define CC2538_SOC_ADC_H
 
 #include "cc2538.h"
 
@@ -47,6 +47,5 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC2538_SOC_ADC_H */
 
 /** @} */

--- a/cpu/cc2538/include/cc2538_ssi.h
+++ b/cpu/cc2538/include/cc2538_ssi.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup      cpu_cc2538
  * @{
@@ -17,8 +19,6 @@
  * @author          Sebastian Meiling <s@mlng.net>
  */
 
-#ifndef CC2538_SSI_H
-#define CC2538_SSI_H
 
 #include "cc2538.h"
 
@@ -61,5 +61,4 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC2538_SSI_H */
 /** @} */

--- a/cpu/cc2538/include/cc2538_sys_ctrl.h
+++ b/cpu/cc2538/include/cc2538_sys_ctrl.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup        cpu_cc2538_sysctrl CC2538 System Control
  * @ingroup         cpu_cc2538_regs
@@ -17,8 +19,6 @@
  * @author          Ian Martin <ian@locicontrols.com>
  */
 
-#ifndef CC2538_SYS_CTRL_H
-#define CC2538_SYS_CTRL_H
 
 #include "cc2538.h"
 
@@ -160,6 +160,5 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC2538_SYS_CTRL_H */
 
 /** @} */

--- a/cpu/cc2538/include/cc2538_uart.h
+++ b/cpu/cc2538/include/cc2538_uart.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup        cpu_cc2538_uart CC2538 UART
  * @ingroup         cpu_cc2538_regs
@@ -17,8 +19,6 @@
  * @author          Ian Martin <ian@locicontrols.com>
  */
 
-#ifndef CC2538_UART_H
-#define CC2538_UART_H
 
 #include "cc2538.h"
 
@@ -187,5 +187,4 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC2538_UART_H */
 /** @} */

--- a/cpu/cc2538/include/cpu_conf.h
+++ b/cpu/cc2538/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup      cpu_cc2538
  * @{
@@ -16,8 +18,6 @@
  * @author          Ian Martin <ian@locicontrols.com>
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #include "kernel_defines.h"
 #include "cpu_conf_common.h"
@@ -74,5 +74,4 @@ extern "C" {
 } /* end extern "C" */
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/cc2538/include/openwsn_defs.h
+++ b/cpu/cc2538/include/openwsn_defs.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu
  * @{
@@ -16,8 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  */
 
-#ifndef OPENWSN_DEFS_H
-#define OPENWSN_DEFS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,5 +39,4 @@ extern "C" {
 }
 #endif
 
-#endif /* OPENWSN_DEFS_H */
 /** @} */

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_cc2538
  * @{
@@ -18,8 +20,6 @@
  * @author      Sebastian Meiling <s@mlng.net>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include <stdint.h>
 #include <stdio.h>
@@ -386,5 +386,4 @@ typedef gpio_t adc_conf_t;
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/cc26x0_cc13x0/include/cc26x0_cc13x0_aux.h
+++ b/cpu/cc26x0_cc13x0/include/cc26x0_cc13x0_aux.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26x0_cc13x0_definitions
  * @{
@@ -14,8 +16,6 @@
  * @brief           CC26x0/CC13x0 AUX register definitions
  */
 
-#ifndef CC26X0_CC13X0_AUX_H
-#define CC26X0_CC13X0_AUX_H
 
 #include <stdbool.h>
 
@@ -253,5 +253,4 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC26X0_CC13X0_AUX_H */
 /** @} */

--- a/cpu/cc26x0_cc13x0/include/cc26x0_cc13x0_fcfg.h
+++ b/cpu/cc26x0_cc13x0/include/cc26x0_cc13x0_fcfg.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26x0_cc13x0_definitions
  * @{
@@ -14,8 +16,6 @@
  * @brief           CC26x0/CC13x0 FCFG register definitions
  */
 
-#ifndef CC26X0_CC13X0_FCFG_H
-#define CC26X0_CC13X0_FCFG_H
 
 #include <cc26xx_cc13xx.h>
 
@@ -142,5 +142,4 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC26X0_CC13X0_FCFG_H */
 /** @} */

--- a/cpu/cc26x0_cc13x0/include/cc26x0_cc13x0_prcm.h
+++ b/cpu/cc26x0_cc13x0/include/cc26x0_cc13x0_prcm.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26x0_cc13x0_definitions
  * @{
@@ -14,8 +16,6 @@
  * @brief           CC26x0/CC13x0 PRCM register definitions
  */
 
-#ifndef CC26X0_CC13X0_PRCM_H
-#define CC26X0_CC13X0_PRCM_H
 
 #include <cc26xx_cc13xx.h>
 
@@ -359,5 +359,4 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC26X0_CC13X0_PRCM_H */
 /** @} */

--- a/cpu/cc26x0_cc13x0/include/cpu_conf.h
+++ b/cpu/cc26x0_cc13x0/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup      cpu_cc26x0_cc13x0
  * @{
@@ -18,8 +20,6 @@
  *
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #ifndef SET_MODE_CONF_1_ALT_DCDC_IPEAK
 #define SET_MODE_CONF_1_ALT_DCDC_IPEAK 0x2 /**< 32 mA */
@@ -50,5 +50,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/cc26x0_cc13x0/include/periph_cpu.h
+++ b/cpu/cc26x0_cc13x0/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26x0_cc13x0
  * @{
@@ -16,8 +18,6 @@
  * @author          Leon M. George <leon@georgemail.de>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include "periph_cpu_common.h"
 
@@ -31,5 +31,4 @@ extern "C" {
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_aux.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_aux.h
@@ -6,6 +6,9 @@
  * Public License v2.1. See the file LICENSE in the top level directory for more
  * details.
  */
+
+#pragma once
+
 /**
  * @ingroup         cpu_cc26x2_cc13x2_definitions
  * @{
@@ -14,8 +17,6 @@
  * @brief           CC26x2, CC13x2 AUX register definitions
  */
 
-#ifndef CC26X2_CC13X2_AUX_H
-#define CC26X2_CC13X2_AUX_H
 
 #include <stdbool.h>
 
@@ -476,6 +477,5 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC26X2_CC13X2_AUX_H */
 
 /** @}*/

--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_fcfg.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_fcfg.h
@@ -5,6 +5,9 @@
  * Public License v2.1. See the file LICENSE in the top level directory for more
  * details.
  */
+
+#pragma once
+
 /**
  * @ingroup         cpu_cc26x2_cc13x2_definitions
  * @{
@@ -13,8 +16,6 @@
  * @brief           CC26x2, CC13x2 FCFG register definitions
  */
 
-#ifndef CC26X2_CC13X2_FCFG_H
-#define CC26X2_CC13X2_FCFG_H
 
 #include <cc26xx_cc13xx.h>
 
@@ -156,6 +157,5 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC26X2_CC13X2_FCFG_H */
 
 /** @} */

--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26x2_cc13x2_definitions
  * @{
@@ -14,8 +16,6 @@
  * @brief           CC26x2, CC13x2 PRCM register definitions
  */
 
-#ifndef CC26X2_CC13X2_PRCM_H
-#define CC26X2_CC13X2_PRCM_H
 
 #include <cc26xx_cc13xx.h>
 
@@ -385,5 +385,4 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC26X2_CC13X2_PRCM_H */
 /** @} */

--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_setup.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_setup.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26x2_cc13x2
  * @{
@@ -14,8 +16,6 @@
  * @brief           CC26x2/CC13x2 Device setup functions
  */
 
-#ifndef CC26X2_CC13X2_SETUP_H
-#define CC26X2_CC13X2_SETUP_H
 
 #include <cc26xx_cc13xx.h>
 
@@ -117,5 +117,4 @@ void setup_trim_device(void);
 } /* end extern "C" */
 #endif
 
-#endif /* CC26X2_CC13X2_SETUP_H */
 /** @} */

--- a/cpu/cc26x2_cc13x2/include/cpu_conf.h
+++ b/cpu/cc26x2_cc13x2/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup      cpu_cc26x2_cc13x2
  * @{
@@ -18,8 +20,6 @@
  *
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #ifndef SET_MODE_CONF_1_ALT_DCDC_IPEAK
 #define SET_MODE_CONF_1_ALT_DCDC_IPEAK 0x2 /**< 12 mA */
@@ -50,5 +50,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/cc26x2_cc13x2/include/periph_cpu.h
+++ b/cpu/cc26x2_cc13x2/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26x2_cc13x2
  * @{
@@ -16,8 +18,6 @@
  * @author          Leon M. George <leon@georgemail.de>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include "periph_cpu_common.h"
 
@@ -31,5 +31,4 @@ extern "C" {
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26xx_cc13xx_definitions
  * @{
@@ -17,8 +19,6 @@
  * @author          Anton Gerasimov <tossel@gmail.com>
  */
 
-#ifndef CC26XX_CC13XX_H
-#define CC26XX_CC13XX_H
 
 #include <stdint.h>
 
@@ -177,5 +177,4 @@ typedef enum IRQn {
 }
 #endif
 
-#endif /* CC26XX_CC13XX_H */
 /** @} */

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_adi.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_adi.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26xx_cc13xx_definitions
  * @{
@@ -16,8 +18,6 @@
  * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
  */
 
-#ifndef CC26XX_CC13XX_ADI_H
-#define CC26XX_CC13XX_ADI_H
 
 #include "cc26xx_cc13xx.h"
 
@@ -122,5 +122,4 @@ typedef struct {
 }
 #endif
 
-#endif /* CC26XX_CC13XX_ADI_H */
 /** @} */

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_ccfg.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_ccfg.h
@@ -5,6 +5,9 @@
  * Public License v2.1. See the file LICENSE in the top level directory for more
  * details.
  */
+
+#pragma once
+
 /**
  * @ingroup         cpu_cc26xx_cc13xx_definitions
  * @{
@@ -13,8 +16,6 @@
  * @brief           CC26xx/CC13xx CCFG register definitions
  */
 
-#ifndef CC26XX_CC13XX_CCFG_H
-#define CC26XX_CC13XX_CCFG_H
 
 #include <cc26xx_cc13xx.h>
 
@@ -163,6 +164,5 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC26XX_CC13XX_CCFG_H */
 
 /** @} */

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_gpio.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_gpio.h
@@ -5,6 +5,9 @@
  * Public License v2.1. See the file LICENSE in the top level directory for more
  * details.
  */
+
+#pragma once
+
 /**
  * @ingroup         cpu_cc26xx_cc13xx_definitions
  * @{
@@ -16,8 +19,6 @@
  *
  */
 
-#ifndef CC26XX_CC13XX_GPIO_H
-#define CC26XX_CC13XX_GPIO_H
 
 #include "cc26xx_cc13xx.h"
 
@@ -58,6 +59,5 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC26XX_CC13XX_GPIO_H */
 
 /** @} */

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_gpt.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_gpt.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26xx_cc13xx_definitions
  * @{
@@ -16,8 +18,6 @@
  * @author          Leon George <leon@georgemail.eu>
  */
 
-#ifndef CC26XX_CC13XX_GPT_H
-#define CC26XX_CC13XX_GPT_H
 
 #include "cc26xx_cc13xx.h"
 
@@ -207,5 +207,4 @@ typedef struct {
 }
 #endif
 
-#endif /* CC26XX_CC13XX_GPT_H */
 /** @} */

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_hard_api.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_hard_api.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26xx_cc13xx_definitions
  * @{
@@ -16,8 +18,6 @@
  * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
  */
 
-#ifndef CC26XX_CC13XX_HARD_API_H
-#define CC26XX_CC13XX_HARD_API_H
 
 #include "cc26xx_cc13xx.h"
 
@@ -93,5 +93,4 @@ typedef struct {
 }
 #endif
 
-#endif /* CC26XX_CC13XX_HARD_API_H */
 /** @} */

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_i2c.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_i2c.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26xx_cc13xx_definitions
  * @{
@@ -16,8 +18,6 @@
  * @author          Leon George <leon@georgemail.eu>
  */
 
-#ifndef CC26XX_CC13XX_I2C_H
-#define CC26XX_CC13XX_I2C_H
 
 #include "cc26xx_cc13xx.h"
 
@@ -198,5 +198,4 @@ cycle or continues on to a repeated START condition
 }
 #endif
 
-#endif /* CC26XX_CC13XX_I2C_H */
 /** @} */

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_ioc.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_ioc.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26xx_cc13xx_definitions
  * @{
@@ -16,8 +18,6 @@
  * @author          Leon George <leon@georgemail.eu>
  */
 
-#ifndef CC26XX_CC13XX_IOC_H
-#define CC26XX_CC13XX_IOC_H
 
 #include "cc26xx_cc13xx.h"
 
@@ -182,5 +182,4 @@ typedef struct {
 }
 #endif
 
-#endif /* CC26XX_CC13XX_IOC_H */
 /** @} */

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_power.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_power.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26xx_cc13xx
  * @{
@@ -16,8 +18,6 @@
  * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
  */
 
-#ifndef CC26XX_CC13XX_POWER_H
-#define CC26XX_CC13XX_POWER_H
 
 #include <cc26xx_cc13xx.h>
 #include <stdbool.h>
@@ -91,5 +91,4 @@ void power_clock_disable_uart(uart_t uart);
 } /* end extern "C" */
 #endif
 
-#endif /* CC26XX_CC13XX_POWER_H */
 /** @} */

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_rfc.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_rfc.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26xx_cc13xx_definitions
  * @{
@@ -16,8 +18,6 @@
  * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
  */
 
-#ifndef CC26XX_CC13XX_RFC_H
-#define CC26XX_CC13XX_RFC_H
 
 #include "cc26xx_cc13xx.h"
 
@@ -167,5 +167,4 @@ typedef struct {
 }
 #endif
 
-#endif /* CC26XX_CC13XX_RFC_H */
 /** @} */

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_uart.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_uart.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup      cpu_cc26xx_cc13xx_definitions
  * @{
@@ -15,8 +17,6 @@
  *
  */
 
-#ifndef CC26XX_CC13XX_UART_H
-#define CC26XX_CC13XX_UART_H
 
 #include "cc26xx_cc13xx.h"
 
@@ -141,5 +141,4 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC26XX_CC13XX_UART_H */
 /** @} */

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_vims.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_vims.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26xx_cc13xx_definitions
  * @{
@@ -14,8 +16,6 @@
  * @brief           CC26xx/CC13xx VIMS register definitions
  */
 
-#ifndef CC26XX_CC13XX_VIMS_H
-#define CC26XX_CC13XX_VIMS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -258,5 +258,4 @@ typedef struct {
 }
 #endif
 
-#endif /* CC26XX_CC13XX_VIMS_H */
 /** @} */

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_wdt.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_wdt.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26xx_cc13xx_definitions
  * @{
@@ -14,8 +16,6 @@
  * @brief           CC26xx/CC13xx WDT register definitions
  */
 
-#ifndef CC26XX_CC13XX_WDT_H
-#define CC26XX_CC13XX_WDT_H
 
 #include <cc26xx_cc13xx.h>
 
@@ -53,5 +53,4 @@ typedef struct {
 } /* end extern "C" */
 #endif
 
-#endif /* CC26XX_CC13XX_WDT_H */
 /** @} */

--- a/cpu/cc26xx_cc13xx/include/cpu_conf_cc26xx_cc13xx.h
+++ b/cpu/cc26xx_cc13xx/include/cpu_conf_cc26xx_cc13xx.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup      cpu_cc26xx_cc13xx
  * @{
@@ -18,8 +20,6 @@
  * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
  */
 
-#ifndef CPU_CONF_CC26XX_CC13XX_H
-#define CPU_CONF_CC26XX_CC13XX_H
 
 #include "kernel_defines.h"
 
@@ -534,5 +534,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_CC26XX_CC13XX_H */
 /** @} */

--- a/cpu/cc26xx_cc13xx/include/periph_cpu_common.h
+++ b/cpu/cc26xx_cc13xx/include/periph_cpu_common.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_cc26xx_cc13xx
  * @{
@@ -16,8 +18,6 @@
  * @author          Leon M. George <leon@georgemail.de>
  */
 
-#ifndef PERIPH_CPU_COMMON_H
-#define PERIPH_CPU_COMMON_H
 
 #include "cpu.h"
 
@@ -166,5 +166,4 @@ typedef struct {
 }
 #endif
 
-#endif /* PERIPH_CPU_COMMON_H */
 /** @} */

--- a/cpu/cortexm_common/include/architecture_arch.h
+++ b/cpu/cortexm_common/include/architecture_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_cortexm_common
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef ARCHITECTURE_ARCH_H
-#define ARCHITECTURE_ARCH_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,4 +35,3 @@ extern "C" {
 #endif
 
 /** @} */
-#endif /* ARCHITECTURE_ARCH_H */

--- a/cpu/cortexm_common/include/atomic_utils_arch.h
+++ b/cpu/cortexm_common/include/atomic_utils_arch.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_cortexm_common
  *
@@ -16,8 +18,6 @@
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
 
-#ifndef ATOMIC_UTILS_ARCH_H
-#define ATOMIC_UTILS_ARCH_H
 #ifndef DOXYGEN
 
 #include "bit.h"
@@ -188,5 +188,4 @@ static inline void atomic_clear_bit_u64(atomic_bit_u64_t bit)
 #endif
 
 #endif /* DOXYGEN */
-#endif /* ATOMIC_UTILS_ARCH_H */
 /** @} */

--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    cpu_cortexm_common ARM Cortex-M common
  * @ingroup     cpu
@@ -27,8 +29,6 @@
  * @todo        remove include irq.h once core was adjusted
  */
 
-#ifndef CPU_H
-#define CPU_H
 
 #include "irq.h"
 #include "sched.h"
@@ -250,5 +250,4 @@ bool cpu_check_address(volatile const char *address);
 }
 #endif
 
-#endif /* CPU_H */
 /** @} */

--- a/cpu/cortexm_common/include/cpu_conf_common.h
+++ b/cpu/cortexm_common/include/cpu_conf_common.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_cortexm_common
  * @{
@@ -16,8 +18,6 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef CPU_CONF_COMMON_H
-#define CPU_CONF_COMMON_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -182,5 +182,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_COMMON_H */
 /** @} */

--- a/cpu/cortexm_common/include/irq_arch.h
+++ b/cpu/cortexm_common/include/irq_arch.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_cortexm_common
  * @{
@@ -16,8 +18,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef IRQ_ARCH_H
-#define IRQ_ARCH_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -129,5 +129,4 @@ bool irq_is_in(void)
 }
 #endif
 
-#endif /* IRQ_ARCH_H */
 /** @} */

--- a/cpu/cortexm_common/include/mpu.h
+++ b/cpu/cortexm_common/include/mpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_cortexm_common
  * @{
@@ -18,8 +20,6 @@
  * @}
  */
 
-#ifndef MPU_H
-#define MPU_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -159,5 +159,3 @@ int mpu_configure(uint_fast8_t region, uintptr_t base, uint_fast32_t attr);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* MPU_H */

--- a/cpu/cortexm_common/include/thread_arch.h
+++ b/cpu/cortexm_common/include/thread_arch.h
@@ -7,6 +7,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_cortexm_common
  * @{
@@ -17,8 +19,6 @@
  * @author      Koen Zandberg <koen@bergzand.net>
  */
 
-#ifndef THREAD_ARCH_H
-#define THREAD_ARCH_H
 
 #include "cpu_conf.h"
 
@@ -46,5 +46,4 @@ static inline __attribute__((always_inline)) void thread_yield_higher(void)
 }
 #endif
 
-#endif /* THREAD_ARCH_H */
 /** @} */

--- a/cpu/cortexm_common/include/vectors_cortexm.h
+++ b/cpu/cortexm_common/include/vectors_cortexm.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_cortexm_common
  * @{
@@ -16,8 +18,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef VECTORS_CORTEXM_H
-#define VECTORS_CORTEXM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -141,5 +141,4 @@ void dummy_handler_default(void);
 }
 #endif
 
-#endif /* VECTORS_CORTEXM_H */
 /** @} */

--- a/cpu/efm32/include/cpu_conf.h
+++ b/cpu/efm32/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_efm32
  * @{
@@ -17,8 +19,6 @@
  * @author      Bas Stottelaar <basstottelaar@gmail.com>
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #include "cpu_conf_common.h"
 
@@ -64,5 +64,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/efm32/include/drivers/coretemp.h
+++ b/cpu/efm32/include/drivers/coretemp.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    cpu_efm32_drivers_coretemp EFM32 internal temperature sensor
  * @ingroup     cpu_efm32_drivers
@@ -30,8 +32,6 @@
  * @author      Bas Stottelaar <basstottelaar@gmail.com>
  */
 
-#ifndef DRIVERS_CORETEMP_H
-#define DRIVERS_CORETEMP_H
 
 #include <stdint.h>
 
@@ -64,5 +64,4 @@ int16_t coretemp_read(void);
 }
 #endif
 
-#endif /* DRIVERS_CORETEMP_H */
 /** @} */

--- a/cpu/efm32/include/gpio_ll_arch.h
+++ b/cpu/efm32/include/gpio_ll_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_efm32
  * @ingroup     drivers_periph_gpio_ll
@@ -34,8 +36,6 @@
  * @author      Christian Amsüss <chrysn@fsfe.org>
  */
 
-#ifndef GPIO_LL_ARCH_H
-#define GPIO_LL_ARCH_H
 
 #include "cpu.h"
 #include "periph_cpu.h"
@@ -203,5 +203,4 @@ static inline void * gpio_port_unpack_addr(gpio_port_t port)
 }
 #endif
 
-#endif /* GPIO_LL_ARCH_H */
 /** @} */

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_efm32
  * @{
@@ -17,8 +19,6 @@
  * @author      Bas Stottelaar <basstottelaar@gmail.com>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include "kernel_defines.h"
 #include "mutex.h"
@@ -745,5 +745,4 @@ typedef enum {
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/esp32/bootloader/sdkconfig.h
+++ b/cpu/esp32/bootloader/sdkconfig.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_esp32_sdk
  * @{
@@ -24,8 +26,6 @@
  * @author      iosabi <iosabi@protonmail.com>
  */
 
-#ifndef SDKCONFIG_H
-#define SDKCONFIG_H
 
 #ifndef DOXYGEN
 
@@ -111,5 +111,3 @@ extern "C" {
 
 #endif /* DOXYGEN */
 /** @} */
-
-#endif /* SDKCONFIG_H */

--- a/cpu/esp32/bootloader/sdkconfig_default_common.h
+++ b/cpu/esp32/bootloader/sdkconfig_default_common.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef SDKCONFIG_DEFAULT_COMMON_H
-#define SDKCONFIG_DEFAULT_COMMON_H
 
 #ifndef DOXYGEN
 
@@ -47,5 +47,4 @@ extern "C" {
 #endif
 
 #endif /* DOXYGEN */
-#endif /* SDKCONFIG_DEFAULT_COMMON_H */
 /** @} */

--- a/cpu/esp32/bootloader/sdkconfig_default_esp32.h
+++ b/cpu/esp32/bootloader/sdkconfig_default_esp32.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef SDKCONFIG_DEFAULT_ESP32_H
-#define SDKCONFIG_DEFAULT_ESP32_H
 
 #ifndef DOXYGEN
 
@@ -42,5 +42,4 @@ extern "C" {
 #endif
 
 #endif /* DOXYGEN */
-#endif /* SDKCONFIG_DEFAULT_ESP32_H */
 /** @} */

--- a/cpu/esp32/bootloader/sdkconfig_default_esp32c3.h
+++ b/cpu/esp32/bootloader/sdkconfig_default_esp32c3.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef SDKCONFIG_DEFAULT_ESP32C3_H
-#define SDKCONFIG_DEFAULT_ESP32C3_H
 
 #ifndef DOXYGEN
 
@@ -43,5 +43,4 @@ extern "C" {
 #endif
 
 #endif /* DOXYGEN */
-#endif /* SDKCONFIG_DEFAULT_ESP32C3_H */
 /** @} */

--- a/cpu/esp32/bootloader/sdkconfig_default_esp32s2.h
+++ b/cpu/esp32/bootloader/sdkconfig_default_esp32s2.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef SDKCONFIG_DEFAULT_ESP32S2_H
-#define SDKCONFIG_DEFAULT_ESP32S2_H
 
 #ifndef DOXYGEN
 
@@ -40,5 +40,4 @@ extern "C" {
 #endif
 
 #endif /* DOXYGEN */
-#endif /* SDKCONFIG_DEFAULT_ESP32S2_H */
 /** @} */

--- a/cpu/esp32/bootloader/sdkconfig_default_esp32s3.h
+++ b/cpu/esp32/bootloader/sdkconfig_default_esp32s3.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef SDKCONFIG_DEFAULT_ESP32S3_H
-#define SDKCONFIG_DEFAULT_ESP32S3_H
 
 #ifndef DOXYGEN
 
@@ -42,5 +42,4 @@ extern "C" {
 #endif
 
 #endif /* DOXYGEN */
-#endif /* SDKCONFIG_DEFAULT_ESP32S3_H */
 /** @} */

--- a/cpu/esp32/esp-eth/esp_eth_netdev.h
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32_esp_eth
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef ESP_ETH_NETDEV_H
-#define ESP_ETH_NETDEV_H
 
 #include <stdbool.h>
 
@@ -59,5 +59,4 @@ typedef struct {
 }
 #endif
 
-#endif /* ESP_ETH_NETDEV_H */
 /** @} */

--- a/cpu/esp32/esp-eth/esp_eth_params.h
+++ b/cpu/esp32/esp-eth/esp_eth_params.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32_esp_eth
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef ESP_ETH_PARAMS_H
-#define ESP_ETH_PARAMS_H
 
 #if defined(MODULE_ESP_ETH) || defined(DOXYGEN)
 
@@ -46,5 +46,4 @@ extern "C" {
 
 #endif /* MODULE_ESP_ETH || DOXYGEN */
 
-#endif /* ESP_ETH_PARAMS_H */
 /** @} */

--- a/cpu/esp32/esp-idf/include/driver/gpio.h
+++ b/cpu/esp32/esp-idf/include/driver/gpio.h
@@ -1,5 +1,5 @@
-#ifndef DRIVER_GPIO_H
-#define DRIVER_GPIO_H
+#pragma once
+
 
 #ifdef ESP_IDF_CODE
 
@@ -20,5 +20,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DRIVER_GPIO_H */

--- a/cpu/esp32/esp-idf/include/log/esp_log.h
+++ b/cpu/esp32/esp-idf/include/log/esp_log.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -17,8 +19,6 @@
  * @}
  */
 
-#ifndef LOG_ESP_LOG_H
-#define LOG_ESP_LOG_H
 
 #ifndef DOXYGEN     /* Hide implementation details from doxygen */
 
@@ -98,4 +98,3 @@ extern "C" {
 #endif
 
 #endif /* DOXYGEN */
-#endif /* LOG_ESP_LOG_H */

--- a/cpu/esp32/include/adc_arch.h
+++ b/cpu/esp32/include/adc_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -24,8 +26,6 @@
  * @}
  */
 
-#ifndef ADC_ARCH_H
-#define ADC_ARCH_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -120,5 +120,3 @@ static inline int adc_vref_to_gpio25(void)
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* ADC_ARCH_H */

--- a/cpu/esp32/include/adc_arch_private.h
+++ b/cpu/esp32/include/adc_arch_private.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -17,8 +19,6 @@
  * @}
  */
 
-#ifndef ADC_ARCH_PRIVATE_H
-#define ADC_ARCH_PRIVATE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -61,5 +61,3 @@ extern const gpio_t _gpio_rtcio_map[];
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* ADC_ARCH_PRIVATE_H */

--- a/cpu/esp32/include/can_esp.h
+++ b/cpu/esp32/include/can_esp.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    cpu_esp32_esp_can ESP32 CAN controller
  * @ingroup     cpu_esp32
@@ -42,8 +44,6 @@
  * @file
  */
 
-#ifndef CAN_ESP_H
-#define CAN_ESP_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -104,5 +104,4 @@ typedef struct {
 }
 #endif
 
-#endif /* CAN_ESP_H */
 /** @} */

--- a/cpu/esp32/include/can_params.h
+++ b/cpu/esp32/include/can_params.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32_esp_can
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef CAN_PARAMS_H
-#define CAN_PARAMS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -69,5 +69,4 @@ static const can_conf_t candev_conf[] = {
 }
 #endif
 
-#endif /* CAN_PARAMS_H */
 /** @} */

--- a/cpu/esp32/include/cpu_conf.h
+++ b/cpu/esp32/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    cpu_esp32_conf ESP32 compile configurations
  * @ingroup     cpu_esp32
@@ -19,8 +21,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #if !defined(__ASSEMBLER__)
 #include <stdint.h>
@@ -120,5 +120,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/esp32/include/cpu_conf_esp32.h
+++ b/cpu/esp32/include/cpu_conf_esp32.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @ingroup     config
@@ -18,8 +20,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef CPU_CONF_ESP32_H
-#define CPU_CONF_ESP32_H
 
 /** Number of DRAM sections that can be used as heap. */
 #define NUM_HEAPS (4)
@@ -32,5 +32,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_ESP32_H */
 /** @} */

--- a/cpu/esp32/include/cpu_conf_esp32c3.h
+++ b/cpu/esp32/include/cpu_conf_esp32c3.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @ingroup     config
@@ -18,8 +20,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef CPU_CONF_ESP32C3_H
-#define CPU_CONF_ESP32C3_H
 
 #ifndef ESP_ISR_STACKSIZE
 /** Stack size used in interrupt context */
@@ -37,5 +37,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_ESP32C3_H */
 /** @} */

--- a/cpu/esp32/include/cpu_conf_esp32s2.h
+++ b/cpu/esp32/include/cpu_conf_esp32s2.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @ingroup     config
@@ -18,8 +20,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef CPU_CONF_ESP32S2_H
-#define CPU_CONF_ESP32S2_H
 
 #ifndef ESP_ISR_STACKSIZE
 /** Stack size used in interrupt context */
@@ -37,5 +37,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_ESP32S2_H */
 /** @} */

--- a/cpu/esp32/include/cpu_conf_esp32s3.h
+++ b/cpu/esp32/include/cpu_conf_esp32s3.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @ingroup     config
@@ -18,8 +20,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef CPU_CONF_ESP32S3_H
-#define CPU_CONF_ESP32S3_H
 
 #ifndef ESP_ISR_STACKSIZE
 /** Stack size used in interrupt context */
@@ -37,5 +37,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_ESP32S3_H */
 /** @} */

--- a/cpu/esp32/include/esp_ble_nimble/syscfg/syscfg.h
+++ b/cpu/esp32/include/esp_ble_nimble/syscfg/syscfg.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32_esp_ble_nimble
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef ESP_BLE_NIMBLE_SYSCFG_SYSCFG_H
-#define ESP_BLE_NIMBLE_SYSCFG_SYSCFG_H
 
 #if !DOXYGEN
 
@@ -36,5 +36,4 @@ extern "C" {
 #endif
 
 #endif /* !DOXYGEN */
-#endif /* ESP_BLE_NIMBLE_SYSCFG_SYSCFG_H */
 /** @} */

--- a/cpu/esp32/include/esp_idf_api/gpio.h
+++ b/cpu/esp32/include/esp_idf_api/gpio.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32_esp_idf_api
  * @{
@@ -17,8 +19,6 @@
  * @}
  */
 
-#ifndef ESP_IDF_API_GPIO_H
-#define ESP_IDF_API_GPIO_H
 
 #include "esp_err.h"
 #include "hal/gpio_types.h"
@@ -63,4 +63,3 @@ esp_err_t esp_idf_rtc_gpio_pulldown_dis(gpio_num_t gpio_num);
 #endif
 
 #endif /* DOXYGEN */
-#endif /* ESP_IDF_API_GPIO_H */

--- a/cpu/esp32/include/esp_idf_api/uart.h
+++ b/cpu/esp32/include/esp_idf_api/uart.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32_esp_idf_api
  * @{
@@ -17,8 +19,6 @@
  * @}
  */
 
-#ifndef ESP_IDF_API_UART_H
-#define ESP_IDF_API_UART_H
 
 #ifndef DOXYGEN     /* Hide implementation details from doxygen */
 
@@ -33,4 +33,3 @@ void esp_idf_uart_set_wakeup_threshold(unsigned uart_num, uint32_t threshold);
 #endif
 
 #endif /* DOXYGEN */
-#endif /* ESP_IDF_API_UART_H */

--- a/cpu/esp32/include/freertos/FreeRTOSConfig.h
+++ b/cpu/esp32/include/freertos/FreeRTOSConfig.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -19,8 +21,6 @@
 
 #include "sdkconfig.h"
 
-#ifndef FREERTOS_FREERTOSCONFIG_H
-#define FREERTOS_FREERTOSCONFIG_H
 
 #ifndef DOXYGEN
 
@@ -33,4 +33,3 @@ extern "C" {
 #endif
 
 #endif /* DOXYGEN */
-#endif /* FREERTOS_FREERTOSCONFIG_H */

--- a/cpu/esp32/include/gpio_arch.h
+++ b/cpu/esp32/include/gpio_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -17,8 +19,6 @@
  * @}
  */
 
-#ifndef GPIO_ARCH_H
-#define GPIO_ARCH_H
 
 #include <stdbool.h>
 
@@ -44,5 +44,3 @@ void gpio_pm_sleep_exit(uint32_t cause);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* GPIO_ARCH_H */

--- a/cpu/esp32/include/gpio_ll_arch.h
+++ b/cpu/esp32/include/gpio_ll_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @ingroup     drivers_periph_gpio_ll
@@ -18,8 +20,6 @@
  * @}
  */
 
-#ifndef GPIO_LL_ARCH_H
-#define GPIO_LL_ARCH_H
 
 #include "gpio_arch.h"
 #include "irq.h"
@@ -159,5 +159,3 @@ static inline bool is_gpio_port_num_valid(uint_fast8_t num)
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* GPIO_LL_ARCH_H */

--- a/cpu/esp32/include/irq_arch.h
+++ b/cpu/esp32/include/irq_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -18,8 +20,6 @@
  * @}
  */
 
-#ifndef IRQ_ARCH_H
-#define IRQ_ARCH_H
 
 #include "irq_arch_common.h"
 
@@ -64,5 +64,3 @@ void esp_irq_init(void);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* IRQ_ARCH_H */

--- a/cpu/esp32/include/newlib.h
+++ b/cpu/esp32/include/newlib.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -20,8 +22,6 @@
  * toolchains, ESP32x toolchains don't use different `newlib.h` versions.
  */
 
-#ifndef NEWLIB_H
-#define NEWLIB_H
 
 #include "kernel_defines.h"
 
@@ -43,5 +43,4 @@ extern "C" {
 #endif
 
 #endif /* DOXYGEN */
-#endif /* NEWLIB_H */
 /** @} */

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -1022,5 +1022,4 @@ typedef struct {
 #include "can_esp.h"
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/esp32/include/periph_cpu_esp32.h
+++ b/cpu/esp32/include/periph_cpu_esp32.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef PERIPH_CPU_ESP32_H
-#define PERIPH_CPU_ESP32_H
 
 #include "sdkconfig.h"
 
@@ -249,5 +249,4 @@ extern "C" {
 }
 #endif
 
-#endif /* PERIPH_CPU_ESP32_H */
 /** @} */

--- a/cpu/esp32/include/periph_cpu_esp32c3.h
+++ b/cpu/esp32/include/periph_cpu_esp32c3.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef PERIPH_CPU_ESP32C3_H
-#define PERIPH_CPU_ESP32C3_H
 
 #include "sdkconfig.h"
 
@@ -176,5 +176,4 @@ extern "C" {
 }
 #endif
 
-#endif /* PERIPH_CPU_ESP32C3_H */
 /** @} */

--- a/cpu/esp32/include/periph_cpu_esp32s2.h
+++ b/cpu/esp32/include/periph_cpu_esp32s2.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef PERIPH_CPU_ESP32S2_H
-#define PERIPH_CPU_ESP32S2_H
 
 #include "sdkconfig.h"
 
@@ -275,5 +275,4 @@ extern "C" {
 }
 #endif
 
-#endif /* PERIPH_CPU_ESP32S2_H */
 /** @} */

--- a/cpu/esp32/include/periph_cpu_esp32s3.h
+++ b/cpu/esp32/include/periph_cpu_esp32s3.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef PERIPH_CPU_ESP32S3_H
-#define PERIPH_CPU_ESP32S3_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -275,5 +275,4 @@ extern "C" {
 }
 #endif
 
-#endif /* PERIPH_CPU_ESP32S3_H */
 /** @} */

--- a/cpu/esp32/include/rtt_arch.h
+++ b/cpu/esp32/include/rtt_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -37,8 +39,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef RTT_ARCH_H
-#define RTT_ARCH_H
 
 #include "periph/rtt.h"
 
@@ -120,5 +120,4 @@ void rtt_pm_sleep_exit(uint32_t cause);
 }
 #endif
 
-#endif /* RTT_ARCH_H */
 /** @} */

--- a/cpu/esp32/include/sdkconfig.h
+++ b/cpu/esp32/include/sdkconfig.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -19,8 +21,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef SDKCONFIG_H
-#define SDKCONFIG_H
 
 /*
  * Some files in ESP-IDF use functions from `stdlib.h` without including the
@@ -269,5 +269,4 @@ extern "C" {
 }
 #endif
 
-#endif /* SDKCONFIG_H */
 /** @} */

--- a/cpu/esp32/include/sdkconfig_esp32.h
+++ b/cpu/esp32/include/sdkconfig_esp32.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -19,8 +21,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef SDKCONFIG_ESP32_H
-#define SDKCONFIG_ESP32_H
 
 #ifndef DOXYGEN
 
@@ -216,5 +216,4 @@ extern "C" {
 #endif
 
 #endif /* DOXYGEN */
-#endif /* SDKCONFIG_ESP32_H */
 /** @} */

--- a/cpu/esp32/include/sdkconfig_esp32c3.h
+++ b/cpu/esp32/include/sdkconfig_esp32c3.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -19,8 +21,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef SDKCONFIG_ESP32C3_H
-#define SDKCONFIG_ESP32C3_H
 
 #ifndef DOXYGEN
 
@@ -142,5 +142,4 @@ extern "C" {
 #endif
 
 #endif /* DOXYGEN */
-#endif /* SDKCONFIG_ESP32C3_H */
 /** @} */

--- a/cpu/esp32/include/sdkconfig_esp32s2.h
+++ b/cpu/esp32/include/sdkconfig_esp32s2.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -19,8 +21,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef SDKCONFIG_ESP32S2_H
-#define SDKCONFIG_ESP32S2_H
 
 #ifndef DOXYGEN
 
@@ -145,5 +145,4 @@ extern "C" {
 #endif
 
 #endif /* DOXYGEN */
-#endif /* SDKCONFIG_ESP32S2_H */
 /** @} */

--- a/cpu/esp32/include/sdkconfig_esp32s3.h
+++ b/cpu/esp32/include/sdkconfig_esp32s3.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -19,8 +21,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef SDKCONFIG_ESP32S3_H
-#define SDKCONFIG_ESP32S3_H
 
 #ifndef DOXYGEN
 
@@ -190,5 +190,4 @@ extern "C" {
 #endif
 
 #endif /* DOXYGEN */
-#endif /* SDKCONFIG_ESP32S3_H */
 /** @} */

--- a/cpu/esp32/include/sys/features.h
+++ b/cpu/esp32/include/sys/features.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -19,8 +21,6 @@
  * lead to compilation problems with newer GCC/newlib versions, see below.
  */
 
-#ifndef SYS_FEATURES_H
-#define SYS_FEATURES_H
 
 #ifndef DOXYGEN
 
@@ -53,5 +53,4 @@ extern "C" {
 #endif
 
 #endif /* DOXYGEN */
-#endif /* SYS_FEATURES_H */
 /** @} */

--- a/cpu/esp32/include/sys/lock.h
+++ b/cpu/esp32/include/sys/lock.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -19,8 +21,6 @@
  * even if retargetable locking is enabled in newlib.
  */
 
-#ifndef SYS_LOCK_H
-#define SYS_LOCK_H
 
 #ifndef DOXYGEN
 
@@ -59,5 +59,4 @@ void _lock_release_recursive(_lock_t *lock);
 #endif
 
 #endif /* DOXYGEN */
-#endif /* SYS_LOCK_H */
 /** @} */

--- a/cpu/esp32/include/syscalls.h
+++ b/cpu/esp32/include/syscalls.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp32
  * @{
@@ -18,8 +20,6 @@
  * @}
  */
 
-#ifndef SYSCALLS_H
-#define SYSCALLS_H
 
 #include "syscalls_common.h"
 
@@ -45,5 +45,3 @@ void system_wdt_feed (void);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* SYSCALLS_H */

--- a/cpu/esp8266/include/cpu_conf.h
+++ b/cpu/esp8266/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    cpu_esp8266_conf ESP8266 compile configurations
  * @ingroup     cpu_esp8266
@@ -19,8 +21,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #include "cpu_conf_common.h"
 #include "xtensa_conf.h"
@@ -117,5 +117,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/esp8266/include/gpio_arch.h
+++ b/cpu/esp8266/include/gpio_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp8266
  * @{
@@ -17,8 +19,6 @@
  * @}
  */
 
-#ifndef GPIO_ARCH_H
-#define GPIO_ARCH_H
 
 #include "gpio_arch_common.h"
 
@@ -38,4 +38,3 @@ extern const uint8_t _iomux_to_gpio[];
 #endif
 
 #endif /* DOXYGEN */
-#endif /* GPIO_ARCH_H */

--- a/cpu/esp8266/include/irq_arch.h
+++ b/cpu/esp8266/include/irq_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp8266
  * @{
@@ -18,8 +20,6 @@
  * @}
  */
 
-#ifndef IRQ_ARCH_H
-#define IRQ_ARCH_H
 
 #include "irq_arch_common.h"
 
@@ -40,5 +40,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* IRQ_ARCH_H */

--- a/cpu/esp8266/include/periph_cpu.h
+++ b/cpu/esp8266/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp8266
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include <stdint.h>
 #include <limits.h>
@@ -333,5 +333,4 @@ typedef struct {
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/esp8266/include/sdk_conf.h
+++ b/cpu/esp8266/include/sdk_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp8266
  * @{
@@ -21,8 +23,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef SDK_CONF_H
-#define SDK_CONF_H
 
 #ifndef DOXYGEN
 
@@ -85,5 +85,4 @@ extern "C" {
 #endif
 
 #endif /* DOXYGEN */
-#endif /* SDK_CONF_H */
 /** @} */

--- a/cpu/esp8266/include/sys/types.h
+++ b/cpu/esp8266/include/sys/types.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common
  * @{
@@ -37,8 +39,6 @@
    doesn't have a stat, and the necv70 doesn't matter.) -- eichin
  */
 
-#ifndef SYS_TYPES_H
-#define SYS_TYPES_H
 
 #ifndef DOXYGEN
 
@@ -325,7 +325,6 @@ typedef long suseconds_t;
 
 #undef __need_inttypes
 
-#endif /* _SYS_TYPES_H */
 
 #ifdef __cplusplus
 }

--- a/cpu/esp8266/include/syscalls.h
+++ b/cpu/esp8266/include/syscalls.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp8266
  * @{
@@ -18,8 +20,6 @@
  * @}
  */
 
-#ifndef SYSCALLS_H
-#define SYSCALLS_H
 
 #include "syscalls_common.h"
 
@@ -36,5 +36,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* SYSCALLS_H */

--- a/cpu/esp8266/sdk/ets.h
+++ b/cpu/esp8266/sdk/ets.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp8266_sdk
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  * @}
  */
-#ifndef ETS_H
-#define ETS_H
 
 #ifndef DOXYGEN
 
@@ -71,4 +71,3 @@ extern void ets_wdt_enable (void);
 #endif
 
 #endif /* DOXYGEN */
-#endif /* ETS_H */

--- a/cpu/esp8266/sdk/phy.h
+++ b/cpu/esp8266/sdk/phy.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp8266_sdk
  * @{
@@ -17,8 +19,6 @@
  * @}
  */
 
-#ifndef PHY_H
-#define PHY_H
 
 #ifndef DOXYGEN
 
@@ -36,4 +36,3 @@ extern uint32_t phy_get_mactime(void);
 #endif
 
 #endif /* DOXYGEN */
-#endif /* PHY_H */

--- a/cpu/esp8266/sdk/sdk.h
+++ b/cpu/esp8266/sdk/sdk.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp8266_sdk
  * @{
@@ -17,8 +19,6 @@
  * @}
  */
 
-#ifndef SDK_H
-#define SDK_H
 
 #include <stdint.h>
 
@@ -33,5 +33,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* SDK_H */

--- a/cpu/esp8266/sdk/system.h
+++ b/cpu/esp8266/sdk/system.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp8266_sdk
  * @{
@@ -17,8 +19,6 @@
  * @}
  */
 
-#ifndef SYSTEM_H
-#define SYSTEM_H
 
 #ifndef DOXYGEN
 
@@ -55,4 +55,3 @@ extern void system_restart(void);
 #endif
 
 #endif /* DOXYGEN */
-#endif /* SYSTEM_H */

--- a/cpu/esp_common/esp-now/esp_now_gnrc.h
+++ b/cpu/esp_common/esp-now/esp_now_gnrc.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common_esp_now
  * @{
@@ -15,8 +17,6 @@
  *
  * @author      Timo Rothenpieler <timo.rothenpieler@uni-bremen.de>
  */
-#ifndef ESP_NOW_GNRC_H
-#define ESP_NOW_GNRC_H
 
 #include "net/gnrc/netif.h"
 
@@ -44,5 +44,4 @@ int gnrc_netif_esp_now_create(gnrc_netif_t *netif, char *stack, int stacksize, c
 }
 #endif
 
-#endif /* ESP_NOW_GNRC_H */
 /** @} */

--- a/cpu/esp_common/esp-now/esp_now_netdev.h
+++ b/cpu/esp_common/esp-now/esp_now_netdev.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common_esp_now
  * @{
@@ -17,8 +19,6 @@
  * @author      Timo Rothenpieler <timo.rothenpieler@uni-bremen.de>
  */
 
-#ifndef ESP_NOW_NETDEV_H
-#define ESP_NOW_NETDEV_H
 
 #include "net/netdev.h"
 #include "mutex.h"
@@ -122,5 +122,4 @@ int esp_now_set_channel(uint8_t channel);
 }
 #endif
 
-#endif /* ESP_NOW_NETDEV_H */
 /** @} */

--- a/cpu/esp_common/esp-now/esp_now_params.h
+++ b/cpu/esp_common/esp-now/esp_now_params.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common_esp_now
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef ESP_NOW_PARAMS_H
-#define ESP_NOW_PARAMS_H
 
 #if defined(MODULE_ESP_NOW) || defined(DOXYGEN)
 
@@ -125,5 +125,4 @@ static const esp_now_params_t esp_now_params = ESP_NOW_PARAMS;
 
 #endif /* MODULE_ESP_NOW || DOXYGEN */
 
-#endif /* ESP_NOW_PARAMS_H */
 /**@}*/

--- a/cpu/esp_common/esp-wifi/esp_wifi_netdev.h
+++ b/cpu/esp_common/esp-wifi/esp_wifi_netdev.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common_esp_wifi
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef ESP_WIFI_NETDEV_H
-#define ESP_WIFI_NETDEV_H
 
 #include <stdbool.h>
 
@@ -73,5 +73,4 @@ typedef struct
 }
 #endif
 
-#endif /* ESP_WIFI_NETDEV_H */
 /** @} */

--- a/cpu/esp_common/esp-wifi/esp_wifi_params.h
+++ b/cpu/esp_common/esp-wifi/esp_wifi_params.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common_esp_wifi
  * @ingroup     cpu_esp_common_conf
@@ -17,8 +19,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef ESP_WIFI_PARAMS_H
-#define ESP_WIFI_PARAMS_H
 
 #if defined(MODULE_ESP_WIFI) || defined(DOXYGEN)
 
@@ -111,5 +111,4 @@ extern "C" {
 
 #endif /* MODULE_ESP_WIFI || DOXYGEN */
 
-#endif /* ESP_WIFI_PARAMS_H */
 /**@}*/

--- a/cpu/esp_common/include/architecture_arch.h
+++ b/cpu/esp_common/include/architecture_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef ARCHITECTURE_ARCH_H
-#define ARCHITECTURE_ARCH_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,4 +34,3 @@ extern "C" {
 #endif
 
 /** @} */
-#endif /* ARCHITECTURE_ARCH_H */

--- a/cpu/esp_common/include/atomic_utils_arch.h
+++ b/cpu/esp_common/include/atomic_utils_arch.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common
  *
@@ -16,8 +18,6 @@
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
 
-#ifndef ATOMIC_UTILS_ARCH_H
-#define ATOMIC_UTILS_ARCH_H
 #ifndef DOXYGEN
 
 #include "periph_cpu.h"
@@ -72,5 +72,4 @@ static inline void atomic_store_u32(volatile uint32_t *dest, uint32_t val)
 #endif
 
 #endif /* DOXYGEN */
-#endif /* ATOMIC_UTILS_ARCH_H */
 /** @} */

--- a/cpu/esp_common/include/cpu.h
+++ b/cpu/esp_common/include/cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef CPU_H
-#define CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -44,5 +44,4 @@ static inline uintptr_t cpu_get_caller_pc(void)
 }
 #endif
 
-#endif /* CPU_H */
 /** @} */

--- a/cpu/esp_common/include/cpu_conf_common.h
+++ b/cpu/esp_common/include/cpu_conf_common.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    cpu_esp_common_conf ESP common compile configurations
  * @ingroup     cpu_esp_common
@@ -19,8 +21,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef CPU_CONF_COMMON_H
-#define CPU_CONF_COMMON_H
 
 /**
  * @brief   Declare the heap_stats function as available
@@ -52,5 +52,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_COMMON_H */
 /** @} */

--- a/cpu/esp_common/include/esp_common.h
+++ b/cpu/esp_common/include/esp_common.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef ESP_COMMON_H
-#define ESP_COMMON_H
 
 #ifndef DOXYGEN
 
@@ -121,5 +121,4 @@ extern "C" {
 
 #endif /* DOXYGEN */
 
-#endif /* ESP_COMMON_H */
 /** @} */

--- a/cpu/esp_common/include/esp_common_log.h
+++ b/cpu/esp_common/include/esp_common_log.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef ESP_COMMON_LOG_H
-#define ESP_COMMON_LOG_H
 
 #ifndef DOXYGEN
 
@@ -140,5 +140,4 @@ extern int ets_printf(const char *fmt, ...);
 
 #endif /* DOXYGEN */
 
-#endif /* ESP_COMMON_LOG_H */
 /** @} */

--- a/cpu/esp_common/include/exceptions.h
+++ b/cpu/esp_common/include/exceptions.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common
  * @{
@@ -17,8 +19,6 @@
  * @}
  */
 
-#ifndef EXCEPTIONS_H
-#define EXCEPTIONS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,5 +30,3 @@ extern void init_exceptions(void);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* EXCEPTIONS_H */

--- a/cpu/esp_common/include/freertos/FreeRTOS.h
+++ b/cpu/esp_common/include/freertos/FreeRTOS.h
@@ -8,8 +8,7 @@
  * FreeRTOS to RIOT-OS adaption module for source code compatibility
  */
 
-#ifndef FREERTOS_FREERTOS_H
-#define FREERTOS_FREERTOS_H
+#pragma once
 
 #ifndef DOXYGEN
 
@@ -76,4 +75,3 @@ void vPortClearInterruptMaskFromISR(UBaseType_t state);
 #include "freertos/queue.h"
 
 #endif /* DOXYGEN */
-#endif /* FREERTOS_FREERTOS_H */

--- a/cpu/esp_common/include/freertos/event_groups.h
+++ b/cpu/esp_common/include/freertos/event_groups.h
@@ -8,8 +8,7 @@
  * FreeRTOS to RIOT-OS adaption module for source code compatibility
  */
 
-#ifndef FREERTOS_EVENT_GROUPS_H
-#define FREERTOS_EVENT_GROUPS_H
+#pragma once
 
 #ifndef DOXYGEN
 
@@ -43,4 +42,3 @@ EventBits_t xEventGroupWaitBits (const EventGroupHandle_t xEventGroup,
 #endif
 
 #endif /* DOXYGEN */
-#endif /* FREERTOS_EVENT_GROUPS_H */

--- a/cpu/esp_common/include/freertos/portable.h
+++ b/cpu/esp_common/include/freertos/portable.h
@@ -8,10 +8,10 @@
  * FreeRTOS to RIOT-OS adaption module for source code compatibility
  */
 
+#pragma once
+
 /* Empty file, only required for source code compatibility */
 
-#ifndef FREERTOS_PORTABLE_H
-#define FREERTOS_PORTABLE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,5 +20,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* FREERTOS_PORTABLE_H */

--- a/cpu/esp_common/include/freertos/portmacro.h
+++ b/cpu/esp_common/include/freertos/portmacro.h
@@ -8,8 +8,7 @@
  * FreeRTOS to RIOT-OS adaption module for source code compatibility
  */
 
-#ifndef FREERTOS_PORTMACRO_H
-#define FREERTOS_PORTMACRO_H
+#pragma once
 
 #ifndef DOXYGEN
 
@@ -80,4 +79,3 @@ bool xPortCanYield(void);
 #endif
 
 #endif /* DOXYGEN */
-#endif /* FREERTOS_PORTMACRO_H */

--- a/cpu/esp_common/include/freertos/queue.h
+++ b/cpu/esp_common/include/freertos/queue.h
@@ -8,8 +8,7 @@
  * FreeRTOS to RIOT-OS adaption module for source code compatibility
  */
 
-#ifndef FREERTOS_QUEUE_H
-#define FREERTOS_QUEUE_H
+#pragma once
 
 #ifndef DOXYGEN
 
@@ -123,4 +122,3 @@ UBaseType_t uxQueueMessagesWaiting( QueueHandle_t xQueue );
 #endif
 
 #endif /* DOXYGEN */
-#endif /* FREERTOS_QUEUE_H */

--- a/cpu/esp_common/include/freertos/ringbuf.h
+++ b/cpu/esp_common/include/freertos/ringbuf.h
@@ -12,8 +12,7 @@
  * such as `uart.h` even if they do not need definitions from `ringbuf.h`.
  */
 
-#ifndef FREERTOS_RINGBUF_H
-#define FREERTOS_RINGBUF_H
+#pragma once
 
 #ifndef DOXYGEN
 
@@ -54,4 +53,3 @@ void vRingbufferReturnItemFromISR(RingbufHandle_t xRingbuffer, void *pvItem,
 #endif
 
 #endif /* DOXYGEN */
-#endif /* FREERTOS_RINGBUF_H */

--- a/cpu/esp_common/include/freertos/semphr.h
+++ b/cpu/esp_common/include/freertos/semphr.h
@@ -8,8 +8,7 @@
  * FreeRTOS to RIOT-OS adaption module for source code compatibility
  */
 
-#ifndef FREERTOS_SEMPHR_H
-#define FREERTOS_SEMPHR_H
+#pragma once
 
 #ifndef DOXYGEN
 
@@ -81,4 +80,3 @@ void vPortCPUReleaseMutex (portMUX_TYPE *mux);
 #endif
 
 #endif /* DOXYGEN */
-#endif /* FREERTOS_SEMPHR_H */

--- a/cpu/esp_common/include/freertos/task.h
+++ b/cpu/esp_common/include/freertos/task.h
@@ -8,8 +8,7 @@
  * FreeRTOS to RIOT-OS adaption module for source code compatibility
  */
 
-#ifndef FREERTOS_TASK_H
-#define FREERTOS_TASK_H
+#pragma once
 
 #ifndef DOXYGEN
 
@@ -104,4 +103,3 @@ uint32_t ulTaskNotifyTake(BaseType_t xClearCountOnExit,
 #endif
 
 #endif /* DOXYGEN */
-#endif /* FREERTOS_TASK_H */

--- a/cpu/esp_common/include/freertos/timers.h
+++ b/cpu/esp_common/include/freertos/timers.h
@@ -8,8 +8,7 @@
  * FreeRTOS to RIOT-OS adaption module for source code compatibility
  */
 
-#ifndef FREERTOS_TIMERS_H
-#define FREERTOS_TIMERS_H
+#pragma once
 
 #ifndef DOXYGEN
 
@@ -40,4 +39,3 @@ void *pvTimerGetTimerID(const TimerHandle_t xTimer);
 #endif
 
 #endif /* DOXYGEN */
-#endif /* FREERTOS_TIMERS_H */

--- a/cpu/esp_common/include/freertos/xtensa_api.h
+++ b/cpu/esp_common/include/freertos/xtensa_api.h
@@ -8,8 +8,7 @@
  * FreeRTOS to RIOT-OS adaption module for source code compatibility
  */
 
-#ifndef FREERTOS_XTENSA_API_H
-#define FREERTOS_XTENSA_API_H
+#pragma once
 
 #include "xtensa/xtensa_api.h"
 
@@ -20,5 +19,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* FREERTOS_XTENSA_API_H */

--- a/cpu/esp_common/include/gpio_arch_common.h
+++ b/cpu/esp_common/include/gpio_arch_common.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common
  * @{
@@ -17,8 +19,6 @@
  * @}
  */
 
-#ifndef GPIO_ARCH_COMMON_H
-#define GPIO_ARCH_COMMON_H
 
 #include "periph/gpio.h"
 
@@ -82,4 +82,3 @@ const char* gpio_get_pin_usage_str(gpio_t pin);
 #endif
 
 #endif /* DOXYGEN */
-#endif /* GPIO_ARCH_COMMON_H */

--- a/cpu/esp_common/include/irq_arch_common.h
+++ b/cpu/esp_common/include/irq_arch_common.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common
  * @{
@@ -18,8 +20,6 @@
  * @}
  */
 
-#ifndef IRQ_ARCH_COMMON_H
-#define IRQ_ARCH_COMMON_H
 
 #include "irq.h"
 #include "sched.h"
@@ -70,5 +70,3 @@ extern volatile uint32_t irq_interrupt_nesting;
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* IRQ_ARCH_COMMON_H */

--- a/cpu/esp_common/include/log_module.h
+++ b/cpu/esp_common/include/log_module.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef LOG_MODULE_H
-#define LOG_MODULE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -57,4 +57,3 @@ static inline void log_write(unsigned level, const char *format, ...) {
 }
 #endif
 /**@}*/
-#endif /* LOG_MODULE_H */

--- a/cpu/esp_common/include/syscalls_common.h
+++ b/cpu/esp_common/include/syscalls_common.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common
  * @{
@@ -18,8 +20,6 @@
  * @}
  */
 
-#ifndef SYSCALLS_COMMON_H
-#define SYSCALLS_COMMON_H
 
 #include <stdarg.h>
 #include <stdbool.h>
@@ -50,5 +50,3 @@ void *system_secure_memset(void *s, int c, size_t n);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* SYSCALLS_COMMON_H */

--- a/cpu/esp_common/include/thread_arch.h
+++ b/cpu/esp_common/include/thread_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common
  * @{
@@ -19,8 +21,6 @@
  * @}
  */
 
-#ifndef THREAD_ARCH_H
-#define THREAD_ARCH_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,5 +36,3 @@ extern void thread_isr_stack_init(void);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* THREAD_ARCH_H */

--- a/cpu/esp_common/include/tools.h
+++ b/cpu/esp_common/include/tools.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common
  * @{
@@ -18,8 +20,6 @@
  * @}
  */
 
-#ifndef TOOLS_H
-#define TOOLS_H
 
 #include <stdint.h>
 #include <inttypes.h>
@@ -40,5 +40,3 @@ void esp_hexdump (const void* addr, uint32_t num, char width, uint8_t per_line);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* TOOLS_H */

--- a/cpu/esp_common/include/xtensa_conf.h
+++ b/cpu/esp_common/include/xtensa_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_esp_common
  * @{
@@ -16,8 +18,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef XTENSA_CONF_H
-#define XTENSA_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,5 +33,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* XTENSA_CONF_H */
 /** @} */

--- a/cpu/fe310/include/clk_conf.h
+++ b/cpu/fe310/include/clk_conf.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_fe310
  * @{
@@ -16,8 +18,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef CLK_CONF_H
-#define CLK_CONF_H
 
 #include "macros/units.h"
 #include "kernel_defines.h"
@@ -131,5 +131,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CLK_CONF_H */
 /** @} */

--- a/cpu/fe310/include/cpu.h
+++ b/cpu/fe310/include/cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_fe310
  * @{
@@ -14,8 +16,6 @@
  * @brief       CPU specific definitions
  */
 
-#ifndef CPU_H
-#define CPU_H
 
 #include "cpu_common.h"
 
@@ -27,5 +27,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_H */
 /** @} */

--- a/cpu/fe310/include/cpu_conf.h
+++ b/cpu/fe310/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_fe310
  * @{
@@ -16,8 +18,6 @@
  * @author          Ken Rabold
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #include "cpu_conf_common.h"
 #include "vendor/platform.h"
@@ -46,5 +46,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/fe310/include/periph_cpu.h
+++ b/cpu/fe310/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_fe310
  * @{
@@ -16,8 +18,6 @@
  * @author          Ken Rabold
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include <inttypes.h>
 
@@ -181,5 +181,4 @@ void fe310_clock_init(void);
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/gd32v/include/cpu.h
+++ b/cpu/gd32v/include/cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_gd32v
  * @{
@@ -14,8 +16,6 @@
  * @brief       CPU specific definitions
  */
 
-#ifndef CPU_H
-#define CPU_H
 
 #include "cpu_conf.h"
 #include "cpu_common.h"
@@ -45,5 +45,4 @@ static inline void cpu_jump_to_image(uint32_t addr)
 }
 #endif
 
-#endif /* CPU_H */
 /** @} */

--- a/cpu/gd32v/include/cpu_conf.h
+++ b/cpu/gd32v/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_gd32v
  * @{
@@ -19,8 +21,6 @@
 #include "vendor/gd32vf103_core.h"
 #include "cpu_conf_common.h"
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -78,5 +78,4 @@ typedef enum {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/gd32v/include/gpio_ll_arch.h
+++ b/cpu/gd32v/include/gpio_ll_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_gd32v
  * @ingroup     drivers_periph_gpio_ll
@@ -17,8 +19,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef GPIO_LL_ARCH_H
-#define GPIO_LL_ARCH_H
 
 #include "architecture.h"
 #include "periph_cpu.h"
@@ -165,5 +165,4 @@ static inline bool is_gpio_port_num_valid(uint_fast8_t num)
 }
 #endif
 
-#endif /* GPIO_LL_ARCH_H */
 /** @} */

--- a/cpu/gd32v/include/periph_cpu.h
+++ b/cpu/gd32v/include/periph_cpu.h
@@ -7,6 +7,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_gd32v
  * @{
@@ -18,8 +20,6 @@
  * @author          Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include <inttypes.h>
 
@@ -570,5 +570,4 @@ void gd32v_disable_irc8(void);
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/kinetis/include/bme.h
+++ b/cpu/kinetis/include/bme.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @defgroup    cpu_kinetis_bme Kinetis Bit Manipulation Engine (BME)
  * @ingroup     cpu_kinetis
@@ -19,8 +21,6 @@
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef BME_H
-#define BME_H
 
 #include <stdint.h>
 
@@ -251,6 +251,5 @@ static inline void bit_clear8(volatile uint8_t *ptr, uint8_t bit)
 }
 #endif
 
-#endif /* BME_H */
 
 /** @} */

--- a/cpu/kinetis/include/cpu_conf.h
+++ b/cpu/kinetis/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_kinetis
  * @{
@@ -16,8 +18,6 @@
  * @author          Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 /* This is needed to homogenize the symbolic IRQ names across different versions
  * of the vendor headers. These must be defined before any vendor headers are
@@ -72,5 +72,4 @@ extern "C"
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/kinetis/include/cpu_conf_kinetis.h
+++ b/cpu/kinetis/include/cpu_conf_kinetis.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_kinetis
  * @{
@@ -16,8 +18,6 @@
  * @author          Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef CPU_CONF_KINETIS_H
-#define CPU_CONF_KINETIS_H
 
 #include "cpu_conf_common.h"
 
@@ -187,5 +187,4 @@ extern "C"
 }
 #endif
 
-#endif /* CPU_CONF_KINETIS_H */
 /** @} */

--- a/cpu/kinetis/include/cpu_conf_kinetis_ea.h
+++ b/cpu/kinetis/include/cpu_conf_kinetis_ea.h
@@ -7,6 +7,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_kinetis
  * @brief           CPU specific implementations for the NXP Kinetis EA series of
@@ -20,8 +22,6 @@
  * @author          Anton Gerasimov <anton.gerasimov@here.com>
  */
 
-#ifndef CPU_CONF_KINETIS_EA_H
-#define CPU_CONF_KINETIS_EA_H
 
 #if defined(KINETIS_CORE_Z)
 #if (KINETIS_ROMSIZE == 128)
@@ -41,5 +41,4 @@ extern "C"
 }
 #endif
 
-#endif /* CPU_CONF_KINETIS_EA_H */
 /** @} */

--- a/cpu/kinetis/include/cpu_conf_kinetis_k.h
+++ b/cpu/kinetis/include/cpu_conf_kinetis_k.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_kinetis
  * @brief           CPU specific implementations for the NXP Kinetis K series of
@@ -18,8 +20,6 @@
  * @author          Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef CPU_CONF_KINETIS_K_H
-#define CPU_CONF_KINETIS_K_H
 
 #if (KINETIS_FAMILY == 2)
 #if (KINETIS_SUBFAMILY == 2)
@@ -163,5 +163,4 @@ extern "C"
 }
 #endif
 
-#endif /* CPU_CONF_KINETIS_K_H */
 /** @} */

--- a/cpu/kinetis/include/cpu_conf_kinetis_l.h
+++ b/cpu/kinetis/include/cpu_conf_kinetis_l.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_kinetis
  * @brief           CPU specific implementations for the NXP Kinetis L series of
@@ -18,8 +20,6 @@
  * @author          Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef CPU_CONF_KINETIS_L_H
-#define CPU_CONF_KINETIS_L_H
 
 #if (KINETIS_FAMILY == 4)
 #if (KINETIS_SUBFAMILY == 3)
@@ -41,5 +41,4 @@ extern "C"
 }
 #endif
 
-#endif /* CPU_CONF_KINETIS_L_H */
 /** @} */

--- a/cpu/kinetis/include/cpu_conf_kinetis_m.h
+++ b/cpu/kinetis/include/cpu_conf_kinetis_m.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_kinetis
  * @brief           CPU specific implementations for the NXP Kinetis M series of
@@ -18,8 +20,6 @@
  * @author          Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef CPU_CONF_KINETIS_M_H
-#define CPU_CONF_KINETIS_M_H
 
 #if (KINETIS_FAMILY == 2)
 #if (KINETIS_SUBFAMILY == 2)
@@ -36,5 +36,4 @@ extern "C"
 }
 #endif
 
-#endif /* CPU_CONF_KINETIS_M_H */
 /** @} */

--- a/cpu/kinetis/include/cpu_conf_kinetis_v.h
+++ b/cpu/kinetis/include/cpu_conf_kinetis_v.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_kinetis
  * @brief           CPU specific implementations for the NXP Kinetis V series of
@@ -18,8 +20,6 @@
  * @author          Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef CPU_CONF_KINETIS_V_H
-#define CPU_CONF_KINETIS_V_H
 
 #if (KINETIS_FAMILY == 2)
 #if (KINETIS_SUBFAMILY == 2)
@@ -36,5 +36,4 @@ extern "C"
 }
 #endif
 
-#endif /* CPU_CONF_KINETIS_V_H */
 /** @} */

--- a/cpu/kinetis/include/cpu_conf_kinetis_w.h
+++ b/cpu/kinetis/include/cpu_conf_kinetis_w.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_kinetis
  * @brief           CPU specific implementations for the NXP Kinetis K series of
@@ -18,8 +20,6 @@
  * @author          Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef CPU_CONF_KINETIS_W_H
-#define CPU_CONF_KINETIS_W_H
 
 #if defined(KINETIS_CORE_D)
 /* Kinetis KW2xD */
@@ -103,5 +103,4 @@ extern "C"
 }
 #endif
 
-#endif /* CPU_CONF_KINETIS_W_H */
 /** @} */

--- a/cpu/kinetis/include/mcg.h
+++ b/cpu/kinetis/include/mcg.h
@@ -7,6 +7,8 @@
  * details.
  */
 
+#pragma once
+
 /* please doxygen by hiding dangling references */
 #if defined(MODULE_PERIPH_MCG) || defined(MODULE_PERIPH_MCG_LITE) || defined(DOXYGEN)
 /**
@@ -120,8 +122,6 @@
  */
 #endif /* MODULE_PERIPH_MCG */
 
-#ifndef MCG_H
-#define MCG_H
 
 #include "periph_conf.h"
 
@@ -171,5 +171,4 @@ void kinetis_mcg_init(void);
 }
 #endif
 
-#endif /* MCG_H */
 /** @} */

--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_kinetis
  * @{
@@ -18,8 +20,6 @@
  * @author          Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -881,5 +881,4 @@ void gpio_init_port(gpio_t pin, uint32_t pcr);
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/kinetis/include/vectors_kinetis.h
+++ b/cpu/kinetis/include/vectors_kinetis.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_kinetis
  * @{
@@ -18,8 +20,6 @@
  * @}
  */
 
-#ifndef VECTORS_KINETIS_H
-#define VECTORS_KINETIS_H
 
 #include <stdint.h>
 #include "vectors_cortexm.h"
@@ -178,5 +178,3 @@ void isr_wdog_ewm(void);     /**< WDOG interrupt handler */
 #ifdef __cplusplus
 } /* extern "C" */
 #endif
-
-#endif /* VECTORS_KINETIS_H */

--- a/cpu/kinetis/include/wdog.h
+++ b/cpu/kinetis/include/wdog.h
@@ -7,6 +7,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @defgroup    cpu_kinetis_wdog Kinetis WDOG
  * @ingroup     cpu_kinetis
@@ -36,8 +38,6 @@
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
-#ifndef WDOG_H
-#define WDOG_H
 
 #ifdef __cplusplus
 extern "C"
@@ -53,5 +53,4 @@ void wdog_disable(void);
 }
 #endif
 
-#endif /* WDOG_H */
 /** @} */

--- a/cpu/lm4f120/include/cpu_conf.h
+++ b/cpu/lm4f120/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @defgroup        cpu_lm4f120 LM4F
  * @ingroup         cpu
@@ -18,8 +20,6 @@
  * @author          Rakendra Thapa <rakendrathapa@gmail.com>
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #include "cpu_conf_common.h"
 
@@ -71,5 +71,4 @@ extern void cpu_clock_init(int);
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/lm4f120/include/periph_cpu.h
+++ b/cpu/lm4f120/include/periph_cpu.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_lm4f120
  * @{
@@ -18,8 +20,6 @@
  * @author          Marc Poulhiès <dkm@kataplop.net>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include "cpu.h"
 
@@ -187,5 +187,4 @@ typedef enum {
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/lpc1768/include/cpu_conf.h
+++ b/cpu/lpc1768/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @defgroup        cpu_lpc1768 NXP LPC1768
  * @ingroup         cpu
@@ -18,8 +20,6 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #include "cpu_conf_common.h"
 
@@ -50,5 +50,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/lpc1768/include/periph_cpu.h
+++ b/cpu/lpc1768/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_lpc1768
  * @{
@@ -17,8 +19,6 @@
  * @author          Bas Stottelaar <basstottelaar@gmail.com>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include <stdint.h>
 
@@ -91,5 +91,4 @@ typedef struct {
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/lpc23xx/include/cpu.h
+++ b/cpu/lpc23xx/include/cpu.h
@@ -6,8 +6,7 @@
  * directory for more details.
  */
 
-#ifndef CPU_H
-#define CPU_H
+#pragma once
 
 /**
  * @defgroup    cpu_lpc23xx     NXP LPC23XX
@@ -79,4 +78,3 @@ bool cpu_backup_ram_is_initialized(void);
 #endif
 
 /** @} */
-#endif /* CPU_H */

--- a/cpu/lpc23xx/include/cpu_conf.h
+++ b/cpu/lpc23xx/include/cpu_conf.h
@@ -6,8 +6,7 @@
  * directory for more details.
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -170,4 +169,3 @@ extern "C" {
 #endif
 
 /** @} */
-#endif /* CPU_CONF_H */

--- a/cpu/lpc23xx/include/lpc23xx.h
+++ b/cpu/lpc23xx/include/lpc23xx.h
@@ -8,8 +8,7 @@
  * Parts taken from FeuerWhere-Project, lpc2387.h.
  */
 
-#ifndef LPC23XX_H
-#define LPC23XX_H
+#pragma once
 
 #include "vendor/lpc23xx.h"
 #include "arm7_common.h"
@@ -152,5 +151,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* LPC23XX_H */

--- a/cpu/lpc23xx/include/periph_cpu.h
+++ b/cpu/lpc23xx/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_lpc23xx
  * @{
@@ -16,8 +18,6 @@
  * @author          Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -252,5 +252,4 @@ typedef struct {
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/msp430/include/architecture_arch.h
+++ b/cpu/msp430/include/architecture_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_msp430
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef ARCHITECTURE_ARCH_H
-#define ARCHITECTURE_ARCH_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,4 +34,3 @@ extern "C" {
 #endif
 
 /** @} */
-#endif /* ARCHITECTURE_ARCH_H */

--- a/cpu/msp430/include/atomic_utils_arch.h
+++ b/cpu/msp430/include/atomic_utils_arch.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_msp430
  *
@@ -16,8 +18,6 @@
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
 
-#ifndef ATOMIC_UTILS_ARCH_H
-#define ATOMIC_UTILS_ARCH_H
 #ifndef DOXYGEN
 
 #include "periph_cpu.h"
@@ -60,5 +60,4 @@ static inline void atomic_store_u16(volatile uint16_t *dest, uint16_t val)
 #endif
 
 #endif /* DOXYGEN */
-#endif /* ATOMIC_UTILS_ARCH_H */
 /** @} */

--- a/cpu/msp430/include/cpu.h
+++ b/cpu/msp430/include/cpu.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_msp430
  * @brief       Texas Instruments MSP430 specific code
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef CPU_H
-#define CPU_H
 
 #include <stdint.h>
 
@@ -140,5 +140,4 @@ static inline uintptr_t cpu_get_caller_pc(void)
 }
 #endif
 
-#endif /* CPU_H */
 /** @} */

--- a/cpu/msp430/include/cpu_conf.h
+++ b/cpu/msp430/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_msp430
  * @{
@@ -15,8 +17,6 @@
  *
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -96,5 +96,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/msp430/include/f2xx_g2xx/msp430_regs.h
+++ b/cpu/msp430/include/f2xx_g2xx/msp430_regs.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_msp430_f2xx_g2xx
  * @{
@@ -20,8 +22,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef F2XX_G2XX_MSP430_REGS_H
-#define F2XX_G2XX_MSP430_REGS_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -207,5 +207,4 @@ extern msp430_usci_b_t USCI_B1;
 }
 #endif
 
-#endif /* F2XX_G2XX_MSP430_REGS_H */
 /** @} */

--- a/cpu/msp430/include/f2xx_g2xx/periph_cpu.h
+++ b/cpu/msp430/include/f2xx_g2xx/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_msp430_f2xx_g2xx
  * @{
@@ -16,8 +18,6 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef F2XX_G2XX_PERIPH_CPU_H
-#define F2XX_G2XX_PERIPH_CPU_H
 
 #include <stdbool.h>
 
@@ -268,5 +268,4 @@ extern const msp430_usci_spi_params_t usci_b1_as_spi;
 }
 #endif
 
-#endif /* F2XX_G2XX_PERIPH_CPU_H */
 /** @} */

--- a/cpu/msp430/include/gpio_ll_arch.h
+++ b/cpu/msp430/include/gpio_ll_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_msp430
  * @ingroup     drivers_periph_gpio_ll
@@ -17,8 +19,6 @@
  * @author      Marian Buschsieweke <marian.buschsieweke@posteo.net>
  */
 
-#ifndef GPIO_LL_ARCH_H
-#define GPIO_LL_ARCH_H
 
 #include "cpu.h"
 #include "periph_cpu.h"
@@ -204,5 +204,4 @@ uword_t gpio_port_num(gpio_port_t port);
 }
 #endif
 
-#endif /* GPIO_LL_ARCH_H */
 /** @} */

--- a/cpu/msp430/include/irq_arch.h
+++ b/cpu/msp430/include/irq_arch.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_msp430
 * @{
@@ -20,8 +22,6 @@
  *
  */
 
-#ifndef IRQ_ARCH_H
-#define IRQ_ARCH_H
 
 #include <stdbool.h>
 #include <msp430.h>
@@ -107,4 +107,3 @@ __attribute__((always_inline)) static inline bool irq_is_enabled(void)
 #endif
 
 /** @} */
-#endif /* IRQ_ARCH_H */

--- a/cpu/msp430/include/msp430_regs_common.h
+++ b/cpu/msp430/include/msp430_regs_common.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_msp430
  * @{
@@ -20,8 +22,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef MSP430_REGS_COMMON_H
-#define MSP430_REGS_COMMON_H
 
 #include <stdint.h>
 
@@ -117,5 +117,4 @@ typedef struct {
 }
 #endif
 
-#endif /* MSP430_REGS_COMMON_H */
 /** @} */

--- a/cpu/msp430/include/periph_cpu_common.h
+++ b/cpu/msp430/include/periph_cpu_common.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_msp430_x1xx
  * @{
@@ -16,8 +18,6 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef PERIPH_CPU_COMMON_H
-#define PERIPH_CPU_COMMON_H
 
 #include <stdbool.h>
 
@@ -507,5 +507,4 @@ void msp430_clock_release(msp430_clock_t clock);
 }
 #endif
 
-#endif /* PERIPH_CPU_COMMON_H */
 /** @} */

--- a/cpu/msp430/include/thread_arch.h
+++ b/cpu/msp430/include/thread_arch.h
@@ -7,6 +7,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_msp430
  * @{
@@ -16,8 +18,6 @@
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-#ifndef THREAD_ARCH_H
-#define THREAD_ARCH_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -27,5 +27,4 @@ extern "C" {
 }
 #endif
 
-#endif /* THREAD_ARCH_H */
 /** @} */

--- a/cpu/msp430/include/x1xx/msp430_regs.h
+++ b/cpu/msp430/include/x1xx/msp430_regs.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_msp430_x1xx
  * @{
@@ -20,8 +22,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef X1XX_MSP430_REGS_H
-#define X1XX_MSP430_REGS_H
 
 #include <stdint.h>
 
@@ -120,5 +120,4 @@ extern msp430_usart_t USART_1;
 }
 #endif
 
-#endif /* X1XX_MSP430_REGS_H */
 /** @} */

--- a/cpu/msp430/include/x1xx/periph_cpu.h
+++ b/cpu/msp430/include/x1xx/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_msp430_x1xx
  * @{
@@ -16,8 +18,6 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef X1XX_PERIPH_CPU_H
-#define X1XX_PERIPH_CPU_H
 
 #include <stdbool.h>
 
@@ -388,5 +388,4 @@ msp430_usart_prescaler_t msp430_usart_prescale(uint32_t clock, uint16_t min_br);
 }
 #endif
 
-#endif /* X1XX_PERIPH_CPU_H */
 /** @} */

--- a/cpu/native/include/architecture_arch.h
+++ b/cpu/native/include/architecture_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup cpu_native
  * @{
@@ -16,8 +18,6 @@
  * @brief Architecture details
  * @author Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
-#ifndef ARCHITECTURE_ARCH_H
-#define ARCHITECTURE_ARCH_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -44,5 +44,4 @@ void native_breakpoint(void);
 }
 #endif
 
-#endif /* ARCHITECTURE_ARCH_H */
 /** @} */

--- a/cpu/native/include/async_read.h
+++ b/cpu/native/include/async_read.h
@@ -6,6 +6,8 @@
  * more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup cpu_native
  * @{
@@ -16,8 +18,6 @@
  * @brief  Multiple asynchronous read on file descriptors
  * @author Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
  */
-#ifndef ASYNC_READ_H
-#define ASYNC_READ_H
 
 #include <sys/types.h>
 #include <poll.h>
@@ -102,5 +102,4 @@ void native_async_read_add_int_handler(int fd, void *arg, native_async_read_call
 }
 #endif
 
-#endif /* ASYNC_READ_H */
 /** @} */

--- a/cpu/native/include/atomic_utils_arch.h
+++ b/cpu/native/include/atomic_utils_arch.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @addtogroup cpu_native
  * @{
@@ -16,8 +18,6 @@
  * @brief  Implementation of fast atomic utility functions
  * @author Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
-#ifndef ATOMIC_UTILS_ARCH_H
-#define ATOMIC_UTILS_ARCH_H
 
 #include "periph_cpu.h"
 
@@ -73,5 +73,4 @@ static inline void atomic_store_u32(volatile uint32_t *dest, uint32_t val)
 }
 #endif
 
-#endif /* ATOMIC_UTILS_ARCH_H */
 /** @} */

--- a/cpu/native/include/backtrace.h
+++ b/cpu/native/include/backtrace.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup backtrace       Stack backtrace (only under native)
  * @ingroup  core_util
@@ -21,8 +23,6 @@
  * @brief Backtrace functionalitry
  * @author Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef BACKTRACE_H
-#define BACKTRACE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -57,5 +57,4 @@ int backtrace_len(void);
 }
 #endif
 
-#endif /* BACKTRACE_H */
 /** @} */

--- a/cpu/native/include/can_params.h
+++ b/cpu/native/include/can_params.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup drivers_candev_linux
  * @{
@@ -16,8 +18,6 @@
  * @brief  Default linux can config
  * @author Vincent Dupont <vincent@otakeys.com>
  */
-#ifndef CAN_PARAMS_H
-#define CAN_PARAMS_H
 
 #include "candev_linux.h"
 #include "can/device.h"
@@ -42,5 +42,4 @@ static const candev_params_t candev_params[] = {
 }
 #endif
 
-#endif /* CAN_PARAMS_H */
 /** @} */

--- a/cpu/native/include/candev_linux.h
+++ b/cpu/native/include/candev_linux.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup drivers_candev_linux SocketCAN driver
  * @ingroup  drivers_can
@@ -20,8 +22,6 @@
  * @author Aurelien Gonce <aurelien.gonce@altran.com>
  * @author Vincent Dupont <vincent@otakeys.com>
  */
-#ifndef CANDEV_LINUX_H
-#define CANDEV_LINUX_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -91,5 +91,4 @@ extern can_conf_t candev_conf[CAN_DLL_NUMOF];
 }
 #endif
 
-#endif /* CANDEV_LINUX_H */
 /** @} */

--- a/cpu/native/include/cpu.h
+++ b/cpu/native/include/cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup cpu_native  Native CPU
  * @ingroup  cpu
@@ -22,8 +24,6 @@
  * @brief Native CPU header
  * @author Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
  */
-#ifndef CPU_H
-#define CPU_H
 
 #include <stdint.h>
 #include <stdio.h>
@@ -60,5 +60,4 @@ __attribute__((always_inline)) static inline uintptr_t cpu_get_caller_pc(void)
 }
 #endif
 
-#endif /* CPU_H */
 /** @} */

--- a/cpu/native/include/cpu_conf.h
+++ b/cpu/native/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup cpu_native
  * @{
@@ -16,8 +18,6 @@
  * @brief  Native CPU configuration
  * @author Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
  */
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -154,5 +154,4 @@ extern char _native_flash[FLASHPAGE_SIZE * FLASHPAGE_NUMOF];
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/native/include/eeprom_native.h
+++ b/cpu/native/include/eeprom_native.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup drivers_eeprom_native Native extra API for EEPROM
  * @ingroup  cpu_native
@@ -17,8 +19,6 @@
  * @file
  * @author Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-#ifndef EEPROM_NATIVE_H
-#define EEPROM_NATIVE_H
 
 #include "cpu.h"
 
@@ -46,5 +46,4 @@ void eeprom_native_read(void);
 }
 #endif
 
-#endif /* EEPROM_NATIVE_H */
 /** @} */

--- a/cpu/native/include/gpiodev_linux.h
+++ b/cpu/native/include/gpiodev_linux.h
@@ -6,6 +6,8 @@
  * more details.
  */
 
+#pragma once
+
 /**
  * @defgroup drivers_gpio_linux Linux User Mode GPIO Driver
  * @ingroup  cpu_native
@@ -42,8 +44,6 @@
  * @brief  Implementation of GPIO access from Linux User Space
  * @author Benjamin Valentin <benpicco@googlemail.com>
  */
-#ifndef GPIODEV_LINUX_H
-#define GPIODEV_LINUX_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -69,5 +69,4 @@ void gpio_linux_teardown(void);
 }
 #endif
 
-#endif /* GPIODEV_LINUX_H */
 /** @} */

--- a/cpu/native/include/mtd_native.h
+++ b/cpu/native/include/mtd_native.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup drivers_mtd
  * @defgroup   drivers_mtd_native Native MTD
@@ -17,8 +19,6 @@
  * @file
  * @author Vincent Dupont <vincent@otakeys.com>
  */
-#ifndef MTD_NATIVE_H
-#define MTD_NATIVE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,5 +41,4 @@ extern const mtd_desc_t native_flash_driver;
 }
 #endif
 
-#endif /* MTD_NATIVE_H */
 /** @} */

--- a/cpu/native/include/native_cli_eui_provider.h
+++ b/cpu/native/include/native_cli_eui_provider.h
@@ -6,6 +6,8 @@
  * more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup cpu_native
  * @{
@@ -16,8 +18,6 @@
  * @brief  Command-line EUI provider for native
  * @author Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-#ifndef NATIVE_CLI_EUI_PROVIDER_H
-#define NATIVE_CLI_EUI_PROVIDER_H
 
 #include "net/eui64.h"
 
@@ -46,5 +46,4 @@ int native_cli_get_eui64(uint8_t index, eui64_t *addr);
 }
 #endif
 
-#endif /* NATIVE_CLI_EUI_PROVIDER_H */
 /** @} */

--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup cpu_native_stdio  STDIO for native
  * @ingroup  sys_stdio
@@ -32,8 +34,6 @@
  * @author Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
  * @author carl-tud
  */
-#ifndef NATIVE_INTERNAL_H
-#define NATIVE_INTERNAL_H
 
 #include "util/ucontext.h"
 #include <stdio.h>
@@ -332,5 +332,4 @@ ssize_t _native_writev(int fildes, const struct iovec *iov, int iovcnt);
 }
 #endif
 
-#endif /* NATIVE_INTERNAL_H */
 /** @} */

--- a/cpu/native/include/netdev_tap.h
+++ b/cpu/native/include/netdev_tap.h
@@ -6,6 +6,8 @@
  * more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup drivers_netdev
  * @{
@@ -17,8 +19,6 @@
  *         TAP interfaces
  * @author Kaspar Schleiser <kaspar@schleiser.de>
  */
-#ifndef NETDEV_TAP_H
-#define NETDEV_TAP_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -74,5 +74,4 @@ void netdev_tap_setup(netdev_tap_t *dev, const netdev_tap_params_t *params, int 
 }
 #endif
 
-#endif /* NETDEV_TAP_H */
 /** @} */

--- a/cpu/native/include/netdev_tap_params.h
+++ b/cpu/native/include/netdev_tap_params.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup drivers_netdev
  * @{
@@ -16,8 +18,6 @@
  * @brief  Default configuration for the netdev_tap driver
  * @author Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef NETDEV_TAP_PARAMS_H
-#define NETDEV_TAP_PARAMS_H
 
 #include "netdev_tap.h"
 
@@ -46,5 +46,4 @@ extern netdev_tap_params_t netdev_tap_params[NETDEV_TAP_MAX];
 }
 #endif
 
-#endif /* NETDEV_TAP_PARAMS_H */
 /** @} */

--- a/cpu/native/include/periph_conf.h
+++ b/cpu/native/include/periph_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup cpu_native
  * @{
@@ -16,8 +18,6 @@
  * @brief  Native CPU peripheral configuration
  * @author Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
  */
-#ifndef PERIPH_CONF_H
-#define PERIPH_CONF_H
 
 #include "macros/units.h"
 
@@ -130,5 +130,4 @@ extern "C" {
 }
 #endif
 
-#endif /* PERIPH_CONF_H */
 /** @} */

--- a/cpu/native/include/periph_cpu.h
+++ b/cpu/native/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup cpu_native
  * @{
@@ -16,8 +18,6 @@
  * @brief  CPU specific definitions for internal peripheral handling
  * @author Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include "periph_conf.h"
 
@@ -234,5 +234,4 @@ typedef enum {
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/native/include/socket_zep.h
+++ b/cpu/native/include/socket_zep.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup drivers_socket_zep  Socket-based ZEP
  * @ingroup  drivers_netdev
@@ -54,8 +56,6 @@
  * @brief  Socket ZEP definitions
  * @author Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef SOCKET_ZEP_H
-#define SOCKET_ZEP_H
 
 #include "net/netdev.h"
 #include "net/netdev/ieee802154.h"
@@ -150,5 +150,4 @@ void socket_zep_hal_setup(socket_zep_t *dev, ieee802154_dev_t *hal);
 }
 #endif
 
-#endif /* SOCKET_ZEP_H */
 /** @} */

--- a/cpu/native/include/socket_zep_params.h
+++ b/cpu/native/include/socket_zep_params.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup drivers_socket_zep
  * @{
@@ -16,8 +18,6 @@
  * @brief  Configuration parameters for the @ref drivers_socket_zep driver
  * @author Martine Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef SOCKET_ZEP_PARAMS_H
-#define SOCKET_ZEP_PARAMS_H
 
 #include "socket_zep.h"
 
@@ -44,5 +44,4 @@ extern socket_zep_params_t socket_zep_params[SOCKET_ZEP_MAX];
 }
 #endif
 
-#endif /* SOCKET_ZEP_PARAMS_H */
 /** @} */

--- a/cpu/native/include/spidev_linux.h
+++ b/cpu/native/include/spidev_linux.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup drivers_spidev_linux Linux User Mode SPI Driver
  * @ingroup  cpu_native
@@ -58,8 +60,6 @@
  * @brief  Implementation of SPI access from Linux User Space
  * @author Frank Hessel <frank@fhessel.de>
  */
-#ifndef SPIDEV_LINUX_H
-#define SPIDEV_LINUX_H
 
 #if defined(__linux__) || defined(DOXYGEN) /* Linux-only */
 
@@ -129,5 +129,4 @@ void spidev_linux_teardown(void);
 #endif
 #endif /* defined(__linux__) || defined(DOXYGEN) */
 
-#endif /* SPIDEV_LINUX_H */
 /** @} */

--- a/cpu/native/include/syscalls.h
+++ b/cpu/native/include/syscalls.h
@@ -6,8 +6,7 @@
  * directory for more details.
  */
 
-#ifndef SYSCALLS_H
-#define SYSCALLS_H
+#pragma once
 
 #include <sys/time.h>
 #include <stdint.h>
@@ -114,5 +113,3 @@ __SPECIFIER int (*real_statvfs)(const char *restrict path, struct statvfs *restr
 #endif
 
 /** @} */
-
-#endif /* SYSCALLS_H */

--- a/cpu/native/include/thread_arch.h
+++ b/cpu/native/include/thread_arch.h
@@ -7,6 +7,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @addtogroup cpu_native
  * @{
@@ -17,8 +19,6 @@
  * @brief  Implementation of the kernels thread interface
  * @author Koen Zandberg <koen@bergzand.net>
  */
-#ifndef THREAD_ARCH_H
-#define THREAD_ARCH_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,5 +28,4 @@ extern "C" {
 }
 #endif
 
-#endif /* THREAD_ARCH_H */
 /** @} */

--- a/cpu/native/include/tty_uart.h
+++ b/cpu/native/include/tty_uart.h
@@ -6,6 +6,8 @@
  * more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup cpu_native
  * @{
@@ -16,8 +18,6 @@
  * @brief  UART implementation based on /dev/tty devices on host
  * @author Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
  */
-#ifndef TTY_UART_H
-#define TTY_UART_H
 
 #include "periph/uart.h"
 
@@ -37,5 +37,4 @@ void tty_uart_setup(uart_t uart, const char *name);
 }
 #endif
 
-#endif /* TTY_UART_H */
 /** @} */

--- a/cpu/native/include/util/ucontext.h
+++ b/cpu/native/include/util/ucontext.h
@@ -7,8 +7,7 @@
  * directory for more details.
  */
 
-#ifndef UTIL_UCONTEXT_H
-#define UTIL_UCONTEXT_H
+#pragma once
 
 #if USE_LIBUCONTEXT
 #  include <libucontext/libucontext.h>
@@ -132,5 +131,3 @@ static inline void makecontext64(ucontext_t *context, void (*func)(void), void* 
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* UTIL_UCONTEXT_H */

--- a/cpu/native/include/util/valgrind.h
+++ b/cpu/native/include/util/valgrind.h
@@ -6,8 +6,7 @@
  * directory for more details.
  */
 
-#ifndef UTIL_VALGRIND_H
-#define UTIL_VALGRIND_H
+#pragma once
 
 #ifdef HAVE_VALGRIND_H
 #  include <valgrind.h>
@@ -23,5 +22,3 @@
 #ifdef __cplusplus
 extern "C" {}
 #endif
-
-#endif /* UTIL_VALGRIND_H */

--- a/cpu/nrf51/include/cpu_conf.h
+++ b/cpu/nrf51/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @defgroup        cpu_nrf51 Nordic nRF51 MCU
  * @ingroup         cpu
@@ -18,8 +20,6 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #include "cpu_conf_common.h"
 #include "vendor/nrf51.h"
@@ -81,5 +81,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/nrf51/include/periph_cpu.h
+++ b/cpu/nrf51/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_nrf51
  * @{
@@ -16,8 +18,6 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include "periph_cpu_common.h"
 
@@ -112,5 +112,4 @@ typedef struct {
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/nrf52/include/cpu_conf.h
+++ b/cpu/nrf52/include/cpu_conf.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup        cpu_nrf52 Nordic nRF52 MCU
  * @ingroup         cpu
@@ -21,8 +23,6 @@
  *
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #include "cpu_conf_common.h"
 
@@ -143,5 +143,4 @@ static inline void nrf52_sleep(void)
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/nrf52/include/nrf802154.h
+++ b/cpu/nrf52/include/nrf802154.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    drivers_nrf52_802154 IEEE802.15.4 Driver for nRF52840 SoCs
  * @ingroup     drivers_netdev
@@ -33,8 +35,6 @@
  * @author      Semjon Kerner <semjon.kerner@fu-berlin.de>
  */
 
-#ifndef NRF802154_H
-#define NRF802154_H
 
 #include "net/ieee802154/radio.h"
 
@@ -102,5 +102,4 @@ void nrf802154_setup(nrf802154_t *dev);
 }
 #endif
 
-#endif /* NRF802154_H */
 /** @} */

--- a/cpu/nrf52/include/openwsn_defs.h
+++ b/cpu/nrf52/include/openwsn_defs.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu
  * @{
@@ -16,8 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  */
 
-#ifndef OPENWSN_DEFS_H
-#define OPENWSN_DEFS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -44,5 +44,4 @@ extern "C" {
 }
 #endif
 
-#endif /* OPENWSN_DEFS_H */
 /** @} */

--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_nrf52
  * @{
@@ -18,8 +20,6 @@
  * @author          Philipp-Alexander Blum <philipp-blum@jakiku.de>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include "periph_cpu_common.h"
 
@@ -151,5 +151,4 @@ void nrf5x_spi_release(NRF_SPIM_Type *bus);
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/nrf53/include/cpu_conf.h
+++ b/cpu/nrf53/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup        cpu_nrf53 Nordic nRF53 MCU
  * @ingroup         cpu
@@ -19,8 +21,6 @@
  *
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #ifdef CPU_MODEL_NRF5340_APP
 #include "vendor/nrf5340_application.h"
@@ -71,5 +71,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/nrf53/include/periph_cpu.h
+++ b/cpu/nrf53/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_nrf53
  * @{
@@ -16,8 +18,6 @@
  * @author          Dylan Laduranty <dylan.laduranty@mesotic.com>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include "periph_cpu_common.h"
 #include "macros/units.h"
@@ -63,5 +63,4 @@ extern "C" {
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/nrf5x_common/include/gpio_ll_arch.h
+++ b/cpu/nrf5x_common/include/gpio_ll_arch.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_nrf5x_common
  * @ingroup     drivers_periph_gpio_ll
@@ -26,8 +28,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef GPIO_LL_ARCH_H
-#define GPIO_LL_ARCH_H
 
 #include <assert.h>
 
@@ -174,5 +174,4 @@ static inline bool is_gpio_port_num_valid(uint_fast8_t num)
 }
 #endif
 
-#endif /* GPIO_LL_ARCH_H */
 /** @} */

--- a/cpu/nrf5x_common/include/nrf_clock.h
+++ b/cpu/nrf5x_common/include/nrf_clock.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_nrf5x_common
  * @{
@@ -16,8 +18,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef NRF_CLOCK_H
-#define NRF_CLOCK_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -69,5 +69,4 @@ void clock_stop_lf(void);
 }
 #endif
 
-#endif /* NRF_CLOCK_H */
 /** @} */

--- a/cpu/nrf5x_common/include/nrfble.h
+++ b/cpu/nrf5x_common/include/nrfble.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    drivers_nrf5x_nrfble NRF BLE radio driver
  * @ingroup     drivers_netdev
@@ -18,8 +20,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef NRFBLE_H
-#define NRFBLE_H
 
 #include "net/netdev.h"
 
@@ -51,5 +51,4 @@ netdev_t *nrfble_setup(void);
 }
 #endif
 
-#endif /* NRFBLE_H */
 /** @} */

--- a/cpu/nrf5x_common/include/nrfmin.h
+++ b/cpu/nrf5x_common/include/nrfmin.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    drivers_nrf5x_nrfmin NRF minimal radio driver
  * @ingroup     drivers_netdev
@@ -69,8 +71,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef NRFMIN_H
-#define NRFMIN_H
 
 #include "net/netdev.h"
 
@@ -221,5 +221,4 @@ void nrfmin_set_txpower(int16_t power);
 }
 #endif
 
-#endif /* NRFMIN_H */
 /** @} */

--- a/cpu/nrf5x_common/include/nrfmin_gnrc.h
+++ b/cpu/nrf5x_common/include/nrfmin_gnrc.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    drivers_nrf5x_nrfmin_gnrc GNRC adapter for nrfmin
  * @ingroup     drivers_nrf5x_nrfmin
@@ -19,8 +21,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef NRFMIN_GNRC_H
-#define NRFMIN_GNRC_H
 
 #include "nrfmin.h"
 
@@ -44,5 +44,4 @@ void gnrc_netdev_nrfmin_init(void);
 }
 #endif
 
-#endif /* NRFMIN_GNRC_H */
 /** @} */

--- a/cpu/nrf5x_common/include/nrfusb.h
+++ b/cpu/nrf5x_common/include/nrfusb.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    cpu_nrf52_nrfusb NRF usb peripheral implementation
  * @ingroup     cpu_nrf52
@@ -19,8 +21,6 @@
  * @author      Koen Zandberg <koen@bergzand.net>
  */
 
-#ifndef NRFUSB_H
-#define NRFUSB_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -66,5 +66,4 @@ typedef struct {
 #ifdef __cplusplus
 }
 #endif
-#endif /* NRFUSB_H */
 /** @} */

--- a/cpu/nrf5x_common/include/nrfx_riot.h
+++ b/cpu/nrf5x_common/include/nrfx_riot.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_nrf5x_common
  * @{
@@ -19,8 +21,6 @@
  * @author          Koen Zandberg <koen@bergzand.net>
  */
 
-#ifndef NRFX_RIOT_H
-#define NRFX_RIOT_H
 
 #include "kernel_defines.h"
 #include "cpu_conf.h"
@@ -63,5 +63,4 @@ static inline void nrfx_dcdc_init(void)
 }
 #endif
 
-#endif /* NRFX_RIOT_H */
 /** @} */

--- a/cpu/nrf5x_common/include/periph_cpu_common.h
+++ b/cpu/nrf5x_common/include/periph_cpu_common.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_nrf5x_common
  * @{
@@ -16,8 +18,6 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef PERIPH_CPU_COMMON_H
-#define PERIPH_CPU_COMMON_H
 
 #include "cpu.h"
 
@@ -622,5 +622,4 @@ typedef struct {
 }
 #endif
 
-#endif /* PERIPH_CPU_COMMON_H */
 /** @} */

--- a/cpu/nrf5x_common/include/timer_arch.h
+++ b/cpu/nrf5x_common/include/timer_arch.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_nrf5x_common
  * @ingroup     drivers_periph_timer
@@ -19,8 +21,6 @@
  * @author      Christian Amsüss <chrysn@fsfe.org>
  */
 
-#ifndef TIMER_ARCH_H
-#define TIMER_ARCH_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,5 +38,4 @@ static inline bool timer_poll_channel(tim_t tim, int channel)
 }
 #endif
 
-#endif /* TIMER_ARCH_H */
 /** @} */

--- a/cpu/nrf9160/include/cpu_conf.h
+++ b/cpu/nrf9160/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup        cpu_nrf9160 Nordic nRF9160 MCU
  * @ingroup         cpu
@@ -19,8 +21,6 @@
  *
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #include "vendor/nrf9160.h"
 #include "vendor/nrf9160_bitfields.h"
@@ -61,5 +61,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/nrf9160/include/periph_cpu.h
+++ b/cpu/nrf9160/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_nrf9160
  * @{
@@ -16,8 +18,6 @@
  * @author          Dylan Laduranty <dylan.laduranty@mesotic.com>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include "periph_cpu_common.h"
 #include "macros/units.h"
@@ -40,5 +40,4 @@ extern "C" {
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/qn908x/include/cpu_conf.h
+++ b/cpu/qn908x/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_qn908x
  * @{
@@ -16,8 +18,6 @@
  * @author      iosabi <iosabi@protonmail.com>
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #include "cpu_conf_common.h"
 
@@ -328,5 +328,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/qn908x/include/flexcomm.h
+++ b/cpu/qn908x/include/flexcomm.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_qn908x
  *
@@ -22,8 +24,6 @@
  * @author      iosabi <iosabi@protonmail.com>
  */
 
-#ifndef FLEXCOMM_H
-#define FLEXCOMM_H
 
 #include <stdint.h>
 #include "periph_cpu.h"
@@ -63,5 +63,4 @@ int flexcomm_instance_from_addr(const FLEXCOMM_Type *dev);
 }
 #endif
 
-#endif /* FLEXCOMM_H */
 /** @} */

--- a/cpu/qn908x/include/gpio_mux.h
+++ b/cpu/qn908x/include/gpio_mux.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_qn908x
  *
@@ -20,8 +22,6 @@
  * @author      iosabi <iosabi@protonmail.com>
  */
 
-#ifndef GPIO_MUX_H
-#define GPIO_MUX_H
 
 #include <stdint.h>
 #include "periph_cpu.h"
@@ -77,5 +77,4 @@ void gpio_init_mux(gpio_t pin, uint32_t func);
 }
 #endif
 
-#endif /* GPIO_MUX_H */
 /** @} */

--- a/cpu/qn908x/include/periph_cpu.h
+++ b/cpu/qn908x/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_qn908x
  * @{
@@ -16,8 +18,6 @@
  * @author          iosabi <iosabi@protonmail.com>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -542,5 +542,4 @@ typedef enum {
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/qn908x/include/vectors_qn908x.h
+++ b/cpu/qn908x/include/vectors_qn908x.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_qn908x
  * @{
@@ -18,8 +20,6 @@
  * @}
  */
 
-#ifndef VECTORS_QN908X_H
-#define VECTORS_QN908X_H
 
 #include <stdint.h>
 #include "vectors_cortexm.h"
@@ -114,5 +114,3 @@ extern const uint32_t isp_configuration;
 #ifdef __cplusplus
 } /* extern "C" */
 #endif
-
-#endif /* VECTORS_QN908X_H */

--- a/cpu/riscv_common/include/architecture_arch.h
+++ b/cpu/riscv_common/include/architecture_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_fe310
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef ARCHITECTURE_ARCH_H
-#define ARCHITECTURE_ARCH_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,4 +34,3 @@ extern "C" {
 #endif
 
 /** @} */
-#endif /* ARCHITECTURE_ARCH_H */

--- a/cpu/riscv_common/include/atomic_utils_arch.h
+++ b/cpu/riscv_common/include/atomic_utils_arch.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_fe310
  *
@@ -16,8 +18,6 @@
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
 
-#ifndef ATOMIC_UTILS_ARCH_H
-#define ATOMIC_UTILS_ARCH_H
 
 #include "periph_cpu.h"
 
@@ -74,5 +74,4 @@ static inline void atomic_store_u32(volatile uint32_t *dest, uint32_t val)
 }
 #endif
 
-#endif /* ATOMIC_UTILS_ARCH_H */
 /** @} */

--- a/cpu/riscv_common/include/clic.h
+++ b/cpu/riscv_common/include/clic.h
@@ -5,6 +5,9 @@
  * Public License v2.1. See the file LICENSE in the top level directory for more
  * details.
  */
+
+#pragma once
+
 /**
  * @ingroup         cpu_riscv_common
  * @{
@@ -18,8 +21,6 @@
  *
  * @author          Koen Zandberg <koen@bergzand.net>
  */
-#ifndef CLIC_H
-#define CLIC_H
 
 #include "cpu_conf.h"
 
@@ -93,5 +94,4 @@ void clic_isr_handler(uint32_t irq);
 }
 #endif
 
-#endif /* CLIC_H */
 /** @} */

--- a/cpu/riscv_common/include/context_frame.h
+++ b/cpu/riscv_common/include/context_frame.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_riscv_common
  * @{
@@ -16,8 +18,6 @@
  * @author      JP Bonn
  */
 
-#ifndef CONTEXT_FRAME_H
-#define CONTEXT_FRAME_H
 
 #if !defined(__ASSEMBLER__)
 #include <stdint.h>
@@ -126,5 +126,4 @@ struct context_switch_frame {
 }
 #endif
 
-#endif /* CONTEXT_FRAME_H */
 /** @} */

--- a/cpu/riscv_common/include/cpu_common.h
+++ b/cpu/riscv_common/include/cpu_common.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    cpu_riscv_common RISC-V common
  * @ingroup     cpu
@@ -22,8 +24,6 @@
 
 #include "irq_arch.h"
 
-#ifndef CPU_COMMON_H
-#define CPU_COMMON_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -85,5 +85,4 @@ void cpu_reg_disable_bits(volatile uint32_t *reg, uint32_t mask)
 }
 #endif
 
-#endif /* CPU_COMMON_H */
 /** @} */

--- a/cpu/riscv_common/include/cpu_conf_common.h
+++ b/cpu/riscv_common/include/cpu_conf_common.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_riscv_common
  * @{
@@ -16,8 +18,6 @@
  * @author          Koen Zandberg
  */
 
-#ifndef CPU_CONF_COMMON_H
-#define CPU_CONF_COMMON_H
 
 #include "vendor/riscv_csr.h"
 #include "cpu_conf_common.h"
@@ -60,5 +60,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_COMMON_H */
 /** @} */

--- a/cpu/riscv_common/include/cpucycle.h
+++ b/cpu/riscv_common/include/cpucycle.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_riscv_common
  * @{
@@ -16,8 +18,6 @@
  * @author          JP Bonn
  */
 
-#ifndef CPUCYCLE_H
-#define CPUCYCLE_H
 
 #include <stdint.h>
 
@@ -36,5 +36,4 @@ uint64_t get_cycle_count(void);
 }
 #endif
 
-#endif /* CPUCYCLE_H */
 /** @} */

--- a/cpu/riscv_common/include/irq_arch.h
+++ b/cpu/riscv_common/include/irq_arch.h
@@ -8,6 +8,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_riscv_common
  * @{
@@ -20,8 +22,6 @@
  * @author          Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
 
-#ifndef IRQ_ARCH_H
-#define IRQ_ARCH_H
 
 #include <stdint.h>
 
@@ -114,5 +114,4 @@ static inline __attribute__((always_inline)) bool irq_is_enabled(void)
 }
 #endif
 
-#endif /* IRQ_ARCH_H */
 /** @} */

--- a/cpu/riscv_common/include/periph_cpu_common.h
+++ b/cpu/riscv_common/include/periph_cpu_common.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_riscv_common
  * @{
@@ -16,8 +18,6 @@
  * @author          Koen Zandberg <koen@bergzand.net>
  */
 
-#ifndef PERIPH_CPU_COMMON_H
-#define PERIPH_CPU_COMMON_H
 
 #include <inttypes.h>
 
@@ -43,5 +43,4 @@ typedef unsigned irqn_t;
 }
 #endif
 
-#endif /* PERIPH_CPU_COMMON_H */
 /** @} */

--- a/cpu/riscv_common/include/plic.h
+++ b/cpu/riscv_common/include/plic.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_riscv_common
  * @{
@@ -16,8 +18,6 @@
  * @author      Koen Zandberg <koen@bergzand.net>
  */
 
-#ifndef PLIC_H
-#define PLIC_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -81,5 +81,4 @@ void plic_isr_handler(void);
 }
 #endif
 
-#endif /* PLIC_H */
 /** @} */

--- a/cpu/riscv_common/include/pmp.h
+++ b/cpu/riscv_common/include/pmp.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_riscv_common
  * @{
@@ -19,8 +21,6 @@
  * @author          Bennet Blischke
  */
 
-#ifndef PMP_H
-#define PMP_H
 
 #include <assert.h>
 #include <stdint.h>
@@ -121,5 +121,4 @@ void print_pmpcfg(uint8_t entry);
 }
 #endif
 
-#endif /* PMP_H */
 /** @} */

--- a/cpu/riscv_common/include/thread_arch.h
+++ b/cpu/riscv_common/include/thread_arch.h
@@ -7,6 +7,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_fe310
  * @{
@@ -17,8 +19,6 @@
  * @author      Koen Zandberg <koen@bergzand.net>
  */
 
-#ifndef THREAD_ARCH_H
-#define THREAD_ARCH_H
 
 #include "irq.h"
 
@@ -59,5 +59,4 @@ static inline __attribute__((always_inline)) void thread_yield_higher(void)
 }
 #endif
 
-#endif /* THREAD_ARCH_H */
 /** @} */

--- a/cpu/rpx0xx/include/cpu_conf.h
+++ b/cpu/rpx0xx/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_rpx0xx
  * @{
@@ -16,8 +18,6 @@
  * @author          Fabian Hüßler <fabian.huessler@ovgu.de>
 */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #include <stdint.h>
 
@@ -42,5 +42,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/rpx0xx/include/io_reg.h
+++ b/cpu/rpx0xx/include/io_reg.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_rpx0xx
  * @{
@@ -24,8 +26,6 @@
  * @author          Fabian Hüßler <fabian.huessler@ovgu.de>
  */
 
-#ifndef IO_REG_H
-#define IO_REG_H
 
 #include <stdint.h>
 
@@ -134,5 +134,4 @@ static inline void io_reg_write_dont_corrupt(volatile uint32_t *reg, uint32_t va
 }
 #endif
 
-#endif /* IO_REG_H */
 /** @} */

--- a/cpu/rpx0xx/include/periph_cpu.h
+++ b/cpu/rpx0xx/include/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_rpx0xx
  * @{
@@ -17,8 +19,6 @@
  * @author          Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include "cpu.h"
 #include "vendor/RP2040.h"
@@ -816,5 +816,4 @@ typedef struct {
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/rpx0xx/include/pio/pio.h
+++ b/cpu/rpx0xx/include/pio/pio.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_rpx0xx
  * @{
@@ -16,8 +18,6 @@
  * @author          Fabian Hüßler <fabian.huessler@ovgu.de>
 */
 
-#ifndef PIO_PIO_H
-#define PIO_PIO_H
 
 #include "periph_conf.h"
 #include "periph/gpio.h"
@@ -1332,5 +1332,4 @@ static inline bool pio_sm_rx_fifo_full(pio_t pio, pio_sm_t sm)
 }
 #endif
 
-#endif /* PIO_PIO_H */
 /** @} */

--- a/cpu/sam0_common/sam0_eth/sam0_eth_netdev.h
+++ b/cpu/sam0_common/sam0_eth/sam0_eth_netdev.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup     cpu_sam0_common_eth sam0 Ethernet peripheral
  * @ingroup      cpu_sam0_common
@@ -17,8 +19,6 @@
  * @author      Dylan Laduranty <dylanladuranty@gmail.com>
  */
 
-#ifndef SAM0_ETH_NETDEV_H
-#define SAM0_ETH_NETDEV_H
 
 #include <stdbool.h>
 
@@ -53,5 +53,4 @@ void sam0_eth_setup(netdev_t* dev);
 }
 #endif
 
-#endif /* SAM0_ETH_NETDEV_H */
 /** @} */

--- a/cpu/sam_common/include/cpu_conf.h
+++ b/cpu/sam_common/include/cpu_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_sam_common
  * @brief           Implementation specific CPU configuration options
@@ -17,8 +19,6 @@
  * @author          Sebastian Meiling <s@mlng.net>
  */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #include "cpu_conf_common.h"
 #include "vendor/sam.h"
@@ -41,5 +41,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/sam_common/include/periph_cpu_common.h
+++ b/cpu/sam_common/include/periph_cpu_common.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_sam_common
  * @brief           Common CPU specific definitions for all SAM3/SAM4x based CPUs
@@ -17,8 +19,6 @@
  * @author          Dylan Laduranty <dylan.laduranty@mesotic.com>
  */
 
-#ifndef PERIPH_CPU_COMMON_H
-#define PERIPH_CPU_COMMON_H
 
 #include "cpu.h"
 
@@ -130,5 +130,4 @@ typedef struct {
 }
 #endif
 
-#endif /* PERIPH_CPU_COMMON_H */
 /** @} */

--- a/cpu/stm32/dist/clk_conf/clk_conf.h
+++ b/cpu/stm32/dist/clk_conf/clk_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @brief       Compute clock constants for STM32F[2|4|7] CPUs
  *
@@ -14,8 +16,6 @@
  * @{
  */
 
-#ifndef CLK_CONF_H
-#define CLK_CONF_H
 
 #include <stdbool.h>
 
@@ -655,5 +655,4 @@ static const clk_cfg_t stm32_mp_clk_cfg[] = {
 }
 #endif
 
-#endif /* CLK_CONF_H */
 /** @} */

--- a/cpu/stm32/include/can_params.h
+++ b/cpu/stm32/include/can_params.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     candev_stm32
  * @{
@@ -17,8 +19,6 @@
  * @}
  */
 
-#ifndef CAN_PARAMS_H
-#define CAN_PARAMS_H
 
 #include "can/device.h"
 #include "periph/can.h"
@@ -162,5 +162,3 @@ static const candev_params_t candev_params[] = {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* CAN_PARAMS_H */

--- a/cpu/stm32/include/candev_stm32.h
+++ b/cpu/stm32/include/candev_stm32.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_stm32
  * @ingroup     drivers_can
@@ -28,8 +30,6 @@
  * @}
  */
 
-#ifndef CANDEV_STM32_H
-#define CANDEV_STM32_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -199,5 +199,3 @@ void candev_stm32_set_pins(can_t *dev, gpio_t tx_pin, gpio_t rx_pin);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* CANDEV_STM32_H */

--- a/cpu/stm32/include/clk/c0/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/c0/cfg_clock_default.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_stm32
  * @{
@@ -16,8 +18,6 @@
  * @author      Jason Parker <Jason.Parker@bissell.com>
  */
 
-#ifndef CLK_C0_CFG_CLOCK_DEFAULT_H
-#define CLK_C0_CFG_CLOCK_DEFAULT_H
 
 #include "cfg_clock_common_fx_gx_mp1_c0.h"
 #include "kernel_defines.h"
@@ -66,5 +66,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CLK_C0_CFG_CLOCK_DEFAULT_H */
 /** @} */

--- a/cpu/stm32/include/clk/cfg_clock_common_fx_gx_mp1_c0.h
+++ b/cpu/stm32/include/clk/cfg_clock_common_fx_gx_mp1_c0.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_stm32
  * @{
@@ -20,8 +22,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef CLK_CFG_CLOCK_COMMON_FX_GX_MP1_C0_H
-#define CLK_CFG_CLOCK_COMMON_FX_GX_MP1_C0_H
 
 #include "kernel_defines.h"
 
@@ -89,5 +89,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CLK_CFG_CLOCK_COMMON_FX_GX_MP1_C0_H */
 /** @} */

--- a/cpu/stm32/include/clk/cfg_clock_common_lx_u5_wx.h
+++ b/cpu/stm32/include/clk/cfg_clock_common_lx_u5_wx.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_stm32
  * @{
@@ -20,8 +22,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef CLK_CFG_CLOCK_COMMON_LX_U5_WX_H
-#define CLK_CFG_CLOCK_COMMON_LX_U5_WX_H
 
 #include "kernel_defines.h"
 
@@ -92,5 +92,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CLK_CFG_CLOCK_COMMON_LX_U5_WX_H */
 /** @} */

--- a/cpu/stm32/include/clk/clk_conf.h
+++ b/cpu/stm32/include/clk/clk_conf.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -16,8 +18,6 @@
  * @author          Alexandre Abadie <alexandre.abadie@inria.fr>
 */
 
-#ifndef CLK_CLK_CONF_H
-#define CLK_CLK_CONF_H
 
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F1) || \
     defined(CPU_FAM_STM32F3)
@@ -50,5 +50,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CLK_CLK_CONF_H */
 /** @} */

--- a/cpu/stm32/include/clk/f0f1f3/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/f0f1f3/cfg_clock_default.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_stm32
  * @{
@@ -23,8 +25,6 @@
  *
  */
 
-#ifndef CLK_F0F1F3_CFG_CLOCK_DEFAULT_H
-#define CLK_F0F1F3_CFG_CLOCK_DEFAULT_H
 
 #include "cfg_clock_common_fx_gx_mp1_c0.h"
 #include "kernel_defines.h"
@@ -145,5 +145,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CLK_F0F1F3_CFG_CLOCK_DEFAULT_H */
 /** @} */

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -16,8 +18,6 @@
  * @author          Alexandre Abadie <alexandre.abadie@inria.fr>
 */
 
-#ifndef CLK_F2F4F7_CFG_CLOCK_DEFAULT_H
-#define CLK_F2F4F7_CFG_CLOCK_DEFAULT_H
 
 #include "cfg_clock_common_fx_gx_mp1_c0.h"
 #include "kernel_defines.h"
@@ -87,5 +87,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CLK_F2F4F7_CFG_CLOCK_DEFAULT_H */
 /** @} */

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_100.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_100.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_stm32
  * @{
@@ -20,8 +22,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef CLK_F2F4F7_CFG_CLOCK_DEFAULT_100_H
-#define CLK_F2F4F7_CFG_CLOCK_DEFAULT_100_H
 
 #include "kernel_defines.h"
 #include "macros/units.h"
@@ -97,5 +97,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CLK_F2F4F7_CFG_CLOCK_DEFAULT_100_H */
 /** @} */

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_120.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_120.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_stm32
  * @{
@@ -20,8 +22,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef CLK_F2F4F7_CFG_CLOCK_DEFAULT_120_H
-#define CLK_F2F4F7_CFG_CLOCK_DEFAULT_120_H
 
 #include "kernel_defines.h"
 #include "macros/units.h"
@@ -74,5 +74,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CLK_F2F4F7_CFG_CLOCK_DEFAULT_120_H */
 /** @} */

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_180.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_180.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_stm32
  * @{
@@ -20,8 +22,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef CLK_F2F4F7_CFG_CLOCK_DEFAULT_180_H
-#define CLK_F2F4F7_CFG_CLOCK_DEFAULT_180_H
 
 #include "kernel_defines.h"
 #include "macros/units.h"
@@ -112,5 +112,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CLK_F2F4F7_CFG_CLOCK_DEFAULT_180_H */
 /** @} */

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_216.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_216.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_stm32
  * @{
@@ -20,8 +22,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef CLK_F2F4F7_CFG_CLOCK_DEFAULT_216_H
-#define CLK_F2F4F7_CFG_CLOCK_DEFAULT_216_H
 
 #include "kernel_defines.h"
 #include "macros/units.h"
@@ -83,5 +83,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CLK_F2F4F7_CFG_CLOCK_DEFAULT_216_H */
 /** @} */

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_84.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_84.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_stm32
  * @{
@@ -20,8 +22,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef CLK_F2F4F7_CFG_CLOCK_DEFAULT_84_H
-#define CLK_F2F4F7_CFG_CLOCK_DEFAULT_84_H
 
 #include "kernel_defines.h"
 #include "macros/units.h"
@@ -83,5 +83,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CLK_F2F4F7_CFG_CLOCK_DEFAULT_84_H */
 /** @} */

--- a/cpu/stm32/include/clk/g0g4/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/g0g4/cfg_clock_default.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_stm32
  * @{
@@ -20,8 +22,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef CLK_G0G4_CFG_CLOCK_DEFAULT_H
-#define CLK_G0G4_CFG_CLOCK_DEFAULT_H
 
 #include "cfg_clock_common_fx_gx_mp1_c0.h"
 #include "kernel_defines.h"
@@ -120,5 +120,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CLK_G0G4_CFG_CLOCK_DEFAULT_H */
 /** @} */

--- a/cpu/stm32/include/clk/l0l1/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/l0l1/cfg_clock_default.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_stm32
  * @{
@@ -16,8 +18,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef CLK_L0L1_CFG_CLOCK_DEFAULT_H
-#define CLK_L0L1_CFG_CLOCK_DEFAULT_H
 
 #include "cfg_clock_common_lx_u5_wx.h"
 #include "kernel_defines.h"
@@ -96,5 +96,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CLK_L0L1_CFG_CLOCK_DEFAULT_H */
 /** @} */

--- a/cpu/stm32/include/clk/l4l5wx/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/l4l5wx/cfg_clock_default.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_stm32
  * @{
@@ -18,8 +20,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef CLK_L4L5WX_CFG_CLOCK_DEFAULT_H
-#define CLK_L4L5WX_CFG_CLOCK_DEFAULT_H
 
 #include "cfg_clock_common_lx_u5_wx.h"
 #include "kernel_defines.h"
@@ -185,5 +185,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CLK_L4L5WX_CFG_CLOCK_DEFAULT_H */
 /** @} */

--- a/cpu/stm32/include/clk/mp1/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/mp1/cfg_clock_default.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -16,8 +18,6 @@
  * @author          Gilles DOFFE <gilles.doffe@savoirfairelinux.com>
 */
 
-#ifndef CLK_MP1_CFG_CLOCK_DEFAULT_H
-#define CLK_MP1_CFG_CLOCK_DEFAULT_H
 
 #include "cfg_clock_common_fx_gx_mp1_c0.h"
 #include "kernel_defines.h"
@@ -115,5 +115,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CLK_MP1_CFG_CLOCK_DEFAULT_H */
 /** @} */

--- a/cpu/stm32/include/clk/u5/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/u5/cfg_clock_default.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_stm32
  * @{
@@ -16,8 +18,6 @@
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef CLK_U5_CFG_CLOCK_DEFAULT_H
-#define CLK_U5_CFG_CLOCK_DEFAULT_H
 
 #include "cfg_clock_common_lx_u5_wx.h"
 #include "kernel_defines.h"
@@ -130,5 +130,4 @@ extern "C" {
 }
 #endif
 
-#endif /* CLK_U5_CFG_CLOCK_DEFAULT_H */
 /** @} */

--- a/cpu/stm32/include/cpu_conf.h
+++ b/cpu/stm32/include/cpu_conf.h
@@ -7,6 +7,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -18,8 +20,6 @@
  * @author          Alexandre Abadie <alexandre.abadie@inria.fr>
 */
 
-#ifndef CPU_CONF_H
-#define CPU_CONF_H
 
 #include <stdint.h>
 #include "cpu_conf_common.h"
@@ -259,5 +259,4 @@ typedef uint16_t stm32_flashpage_block_t;
 }
 #endif
 
-#endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/stm32/include/fdcandev_stm32.h
+++ b/cpu/stm32/include/fdcandev_stm32.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     cpu_stm32
  * @ingroup     drivers_can
@@ -28,8 +30,6 @@
  * @}
  */
 
-#ifndef FDCANDEV_STM32_H
-#define FDCANDEV_STM32_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -423,5 +423,3 @@ void candev_stm32_set_pins(can_t *dev, gpio_t tx_pin, gpio_t rx_pin,
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* FDCANDEV_STM32_H */

--- a/cpu/stm32/include/gpio_ll_arch.h
+++ b/cpu/stm32/include/gpio_ll_arch.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @ingroup         drivers_periph_gpio_ll
@@ -19,8 +21,6 @@
  * @author          Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef GPIO_LL_ARCH_H
-#define GPIO_LL_ARCH_H
 
 #include "architecture.h"
 #include "periph_cpu.h"
@@ -283,5 +283,4 @@ static inline bool is_gpio_port_num_valid(uint_fast8_t num)
 }
 #endif
 
-#endif /* GPIO_LL_ARCH_H */
 /** @} */

--- a/cpu/stm32/include/lcd_fmc.h
+++ b/cpu/stm32/include/lcd_fmc.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    cpu_stm32_lcd_fmc STM32 FMC/FSMC LCD low-level parallel interface driver
  * @ingroup     cpu_stm32
@@ -13,8 +15,6 @@
  * @{
  */
 
-#ifndef LCD_FMC_H
-#define LCD_FMC_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,5 +56,4 @@ typedef struct {
 }
 #endif
 
-#endif /* LCD_FMC_H */
 /** @} */

--- a/cpu/stm32/include/periph/c0/periph_cpu.h
+++ b/cpu/stm32/include/periph/c0/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -16,8 +18,6 @@
  * @author      Jason Parker <Jason.Parker@bissell.com>
  */
 
-#ifndef PERIPH_C0_PERIPH_CPU_H
-#define PERIPH_C0_PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,5 +60,4 @@ typedef enum {
 }
 #endif
 
-#endif /* PERIPH_C0_PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_backup_ram.h
+++ b/cpu/stm32/include/periph/cpu_backup_ram.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -16,8 +18,6 @@
  * @author          Fabian Hüßler <fabian.huessler@ovgu.de>
  */
 
-#ifndef PERIPH_CPU_BACKUP_RAM_H
-#define PERIPH_CPU_BACKUP_RAM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,5 +42,4 @@ bool cpu_woke_from_backup(void);
 }
 #endif
 
-#endif /* PERIPH_CPU_BACKUP_RAM_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_common.h
+++ b/cpu/stm32/include/periph/cpu_common.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -18,8 +20,6 @@
  * @author          Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef PERIPH_CPU_COMMON_H
-#define PERIPH_CPU_COMMON_H
 
 #include <stdint.h>
 
@@ -268,5 +268,4 @@ void periph_lpclk_dis(bus_t bus, uint32_t mask);
 }
 #endif
 
-#endif /* PERIPH_CPU_COMMON_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_dma.h
+++ b/cpu/stm32/include/periph/cpu_dma.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -19,8 +21,6 @@
  * @author          Joshua DeWeese <jdeweese@primecontrols.com>
  */
 
-#ifndef PERIPH_CPU_DMA_H
-#define PERIPH_CPU_DMA_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -270,5 +270,4 @@ void dma_prepare(dma_t dma, void *mem, size_t len, bool incr_mem);
 }
 #endif
 
-#endif /* PERIPH_CPU_DMA_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_eth.h
+++ b/cpu/stm32/include/periph/cpu_eth.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -18,8 +20,6 @@
  * @author          Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef PERIPH_CPU_ETH_H
-#define PERIPH_CPU_ETH_H
 
 #include <stdint.h>
 
@@ -165,5 +165,4 @@ void stm32_eth_common_init(void);
 }
 #endif
 
-#endif /* PERIPH_CPU_ETH_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_fmc.h
+++ b/cpu/stm32/include/periph/cpu_fmc.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    cpu_stm32_periph_fmc STM32 FMC/FSMC peripheral driver
  * @ingroup     cpu_stm32
@@ -52,8 +54,6 @@
  * @author          Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef PERIPH_CPU_FMC_H
-#define PERIPH_CPU_FMC_H
 
 #include <stdint.h>
 
@@ -376,5 +376,4 @@ typedef uint8_t fmc_bank_id_t;  /**< FMC bank identifier */
 }
 #endif
 
-#endif /* PERIPH_CPU_FMC_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_gpio.h
+++ b/cpu/stm32/include/periph/cpu_gpio.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -18,8 +20,6 @@
  * @author          Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef PERIPH_CPU_GPIO_H
-#define PERIPH_CPU_GPIO_H
 
 #include <stdint.h>
 #include "cpu.h"
@@ -226,5 +226,4 @@ void gpio_init_analog(gpio_t pin);
 }
 #endif
 
-#endif /* PERIPH_CPU_GPIO_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_gpio_ll.h
+++ b/cpu/stm32/include/periph/cpu_gpio_ll.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -16,8 +18,6 @@
  * @author          Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
 
-#ifndef PERIPH_CPU_GPIO_LL_H
-#define PERIPH_CPU_GPIO_LL_H
 
 #include <stdalign.h>
 #include <stdint.h>
@@ -195,5 +195,4 @@ union gpio_conf_stm32 {
 }
 #endif
 
-#endif /* PERIPH_CPU_GPIO_LL_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_i2c.h
+++ b/cpu/stm32/include/periph/cpu_i2c.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -18,8 +20,6 @@
  * @author          Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef PERIPH_CPU_I2C_H
-#define PERIPH_CPU_I2C_H
 
 #include <stdint.h>
 
@@ -179,5 +179,4 @@ static const i2c_timing_param_t timing_params[] = {
 }
 #endif
 
-#endif /* PERIPH_CPU_I2C_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_ltdc.h
+++ b/cpu/stm32/include/periph/cpu_ltdc.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -16,8 +18,6 @@
  * @author          Alexandre Abadie <alexandre.abadie@inria.fr>
  */
 
-#ifndef PERIPH_CPU_LTDC_H
-#define PERIPH_CPU_LTDC_H
 
 #include <stdint.h>
 
@@ -92,5 +92,4 @@ void ltdc_fill(uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2, const uint16_
 }
 #endif
 
-#endif /* PERIPH_CPU_LTDC_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_pm.h
+++ b/cpu/stm32/include/periph/cpu_pm.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -18,8 +20,6 @@
  * @author          Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef PERIPH_CPU_PM_H
-#define PERIPH_CPU_PM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -71,5 +71,4 @@ void pm_backup_regulator_off(void);
 }
 #endif
 
-#endif /* PERIPH_CPU_PM_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_pwm.h
+++ b/cpu/stm32/include/periph/cpu_pwm.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -18,8 +20,6 @@
  * @author          Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef PERIPH_CPU_PWM_H
-#define PERIPH_CPU_PWM_H
 
 #include <stdint.h>
 
@@ -71,5 +71,4 @@ typedef struct {
 }
 #endif
 
-#endif /* PERIPH_CPU_PWM_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_qdec.h
+++ b/cpu/stm32/include/periph/cpu_qdec.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -18,8 +20,6 @@
  * @author          Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef PERIPH_CPU_QDEC_H
-#define PERIPH_CPU_QDEC_H
 
 #include <stdint.h>
 
@@ -66,5 +66,4 @@ typedef struct {
 }
 #endif
 
-#endif /* PERIPH_CPU_QDEC_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_sdmmc.h
+++ b/cpu/stm32/include/periph/cpu_sdmmc.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -16,8 +18,6 @@
  * @author          Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef PERIPH_CPU_SDMMC_H
-#define PERIPH_CPU_SDMMC_H
 
 #include <stdint.h>
 
@@ -96,5 +96,4 @@ typedef struct {
 }
 #endif
 
-#endif /* PERIPH_CPU_SDMMC_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_spi.h
+++ b/cpu/stm32/include/periph/cpu_spi.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -18,8 +20,6 @@
  * @author          Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef PERIPH_CPU_SPI_H
-#define PERIPH_CPU_SPI_H
 
 #include <stdint.h>
 
@@ -135,5 +135,4 @@ gpio_t spi_pin_clk(spi_t bus);
 }
 #endif
 
-#endif /* PERIPH_CPU_SPI_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_timer.h
+++ b/cpu/stm32/include/periph/cpu_timer.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -18,8 +20,6 @@
  * @author          Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef PERIPH_CPU_TIMER_H
-#define PERIPH_CPU_TIMER_H
 
 #include <stdint.h>
 
@@ -61,5 +61,4 @@ typedef struct {
 }
 #endif
 
-#endif /* PERIPH_CPU_TIMER_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_uart.h
+++ b/cpu/stm32/include/periph/cpu_uart.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -18,8 +20,6 @@
  * @author          Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef PERIPH_CPU_UART_H
-#define PERIPH_CPU_UART_H
 
 #include <stdint.h>
 
@@ -138,5 +138,4 @@ typedef struct {
 }
 #endif
 
-#endif /* PERIPH_CPU_UART_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_usbdev.h
+++ b/cpu/stm32/include/periph/cpu_usbdev.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -18,8 +20,6 @@
  * @author          Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef PERIPH_CPU_USBDEV_H
-#define PERIPH_CPU_USBDEV_H
 
 #include <stdint.h>
 
@@ -57,5 +57,4 @@ typedef struct {
 }
 #endif
 
-#endif /* PERIPH_CPU_USBDEV_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_vbat.h
+++ b/cpu/stm32/include/periph/cpu_vbat.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -16,8 +18,6 @@
  * @author          Fabian Hüßler <fabian.huessler@ovgu.de>
  */
 
-#ifndef PERIPH_CPU_VBAT_H
-#define PERIPH_CPU_VBAT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,5 +37,4 @@ void vbat_disable(void);
 }
 #endif
 
-#endif /* PERIPH_CPU_VBAT_H */
 /** @} */

--- a/cpu/stm32/include/periph/cpu_wdt.h
+++ b/cpu/stm32/include/periph/cpu_wdt.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -18,8 +20,6 @@
  * @author          Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef PERIPH_CPU_WDT_H
-#define PERIPH_CPU_WDT_H
 
 #include "timex.h"
 #include "periph/cpu_common.h"
@@ -53,5 +53,4 @@ extern "C" {
 }
 #endif
 
-#endif /* PERIPH_CPU_WDT_H */
 /** @} */

--- a/cpu/stm32/include/periph/f0/periph_cpu.h
+++ b/cpu/stm32/include/periph/f0/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -16,8 +18,6 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef PERIPH_F0_PERIPH_CPU_H
-#define PERIPH_F0_PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -76,5 +76,4 @@ typedef enum {
 }
 #endif
 
-#endif /* PERIPH_F0_PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32/include/periph/f1/periph_cpu.h
+++ b/cpu/stm32/include/periph/f1/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -16,8 +18,6 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef PERIPH_F1_PERIPH_CPU_H
-#define PERIPH_F1_PERIPH_CPU_H
 
 #include "cpu_conf.h"
 
@@ -172,5 +172,4 @@ static inline void afio_mapr_write(uint32_t new_value)
 }
 #endif
 
-#endif /* PERIPH_F1_PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32/include/periph/f2/periph_cpu.h
+++ b/cpu/stm32/include/periph/f2/periph_cpu.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -18,8 +20,6 @@
  * @author          Aurelien Gonce <aurelien.gonce@altran.fr>
  */
 
-#ifndef PERIPH_F2_PERIPH_CPU_H
-#define PERIPH_F2_PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -77,5 +77,4 @@ typedef enum {
 }
 #endif
 
-#endif /* PERIPH_F2_PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32/include/periph/f3/periph_cpu.h
+++ b/cpu/stm32/include/periph/f3/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -16,8 +18,6 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef PERIPH_F3_PERIPH_CPU_H
-#define PERIPH_F3_PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -84,5 +84,4 @@ typedef enum {
 }
 #endif
 
-#endif /* PERIPH_F3_PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32/include/periph/f4/periph_cpu.h
+++ b/cpu/stm32/include/periph/f4/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -16,8 +18,6 @@
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
-#ifndef PERIPH_F4_PERIPH_CPU_H
-#define PERIPH_F4_PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -84,5 +84,4 @@ typedef enum {
 }
 #endif
 
-#endif /* PERIPH_F4_PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32/include/periph/f7/periph_cpu.h
+++ b/cpu/stm32/include/periph/f7/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef PERIPH_F7_PERIPH_CPU_H
-#define PERIPH_F7_PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -72,5 +72,4 @@ typedef enum {
 }
 #endif
 
-#endif /* PERIPH_F7_PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32/include/periph/g0/periph_cpu.h
+++ b/cpu/stm32/include/periph/g0/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef PERIPH_G0_PERIPH_CPU_H
-#define PERIPH_G0_PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -69,5 +69,4 @@ typedef enum {
 }
 #endif
 
-#endif /* PERIPH_G0_PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32/include/periph/g4/periph_cpu.h
+++ b/cpu/stm32/include/periph/g4/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef PERIPH_G4_PERIPH_CPU_H
-#define PERIPH_G4_PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,5 +46,4 @@ extern "C" {
 }
 #endif
 
-#endif /* PERIPH_G4_PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32/include/periph/l0/periph_cpu.h
+++ b/cpu/stm32/include/periph/l0/periph_cpu.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -19,8 +21,6 @@
  *
  */
 
-#ifndef PERIPH_L0_PERIPH_CPU_H
-#define PERIPH_L0_PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -77,5 +77,4 @@ typedef enum {
 }
 #endif
 
-#endif /* PERIPH_L0_PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32/include/periph/l1/periph_cpu.h
+++ b/cpu/stm32/include/periph/l1/periph_cpu.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -18,8 +20,6 @@
  * @author          Katja Kirstein <katja.kirstein@haw-hamburg.de>
  */
 
-#ifndef PERIPH_L1_PERIPH_CPU_H
-#define PERIPH_L1_PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -73,5 +73,4 @@ typedef enum {
 }
 #endif
 
-#endif /* PERIPH_L1_PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32/include/periph/l4/periph_cpu.h
+++ b/cpu/stm32/include/periph/l4/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef PERIPH_L4_PERIPH_CPU_H
-#define PERIPH_L4_PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -84,5 +84,4 @@ typedef enum {
 }
 #endif
 
-#endif /* PERIPH_L4_PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32/include/periph/l5/periph_cpu.h
+++ b/cpu/stm32/include/periph/l5/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef PERIPH_L5_PERIPH_CPU_H
-#define PERIPH_L5_PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,5 +46,4 @@ extern "C" {
 }
 #endif
 
-#endif /* PERIPH_L5_PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32/include/periph/u5/periph_cpu.h
+++ b/cpu/stm32/include/periph/u5/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef PERIPH_U5_PERIPH_CPU_H
-#define PERIPH_U5_PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,5 +46,4 @@ extern "C" {
 }
 #endif
 
-#endif /* PERIPH_U5_PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32/include/periph/wb/periph_cpu.h
+++ b/cpu/stm32/include/periph/wb/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef PERIPH_WB_PERIPH_CPU_H
-#define PERIPH_WB_PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -81,5 +81,4 @@ typedef enum {
 }
 #endif
 
-#endif /* PERIPH_WB_PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32/include/periph/wl/periph_cpu.h
+++ b/cpu/stm32/include/periph/wl/periph_cpu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -17,8 +19,6 @@
  *
  */
 
-#ifndef PERIPH_WL_PERIPH_CPU_H
-#define PERIPH_WL_PERIPH_CPU_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -160,5 +160,4 @@ typedef enum {
 }
 #endif
 
-#endif /* PERIPH_WL_PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -18,8 +20,6 @@
  * @author          Vincent Dupont <vincent@otakeys.com>
  */
 
-#ifndef PERIPH_CPU_H
-#define PERIPH_CPU_H
 
 #include <limits.h>
 
@@ -213,5 +213,4 @@ typedef enum {
 }
 #endif
 
-#endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/stm32/include/stmclk.h
+++ b/cpu/stm32/include/stmclk.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup         cpu_stm32
  * @{
@@ -19,8 +21,6 @@
  * @author          Hauke Petersen <hauke.pertersen@fu-berlin.de>
 */
 
-#ifndef STMCLK_H
-#define STMCLK_H
 
 #include <stdbool.h>
 
@@ -98,5 +98,4 @@ bool stmclk_dbp_is_locked(void);
 }
 #endif
 
-#endif /* STMCLK_H */
 /** @} */

--- a/cpu/stm32/include/tinyusb_hw_defaults.h
+++ b/cpu/stm32/include/tinyusb_hw_defaults.h
@@ -20,6 +20,8 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_tinyusb
  * @ingroup     cpu_stm32
@@ -31,8 +33,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef TINYUSB_HW_DEFAULTS_H
-#define TINYUSB_HW_DEFAULTS_H
 
 #include "periph_conf.h"
 
@@ -137,5 +137,4 @@ extern "C" {
 #endif
 
 #endif /* !DOXYGEN */
-#endif /* TINYUSB_HW_DEFAULTS_H */
 /** @} */

--- a/cpu/stm32/include/usbdev_stm32.h
+++ b/cpu/stm32/include/usbdev_stm32.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    cpu_stm32_usbdev stm32 USB OTG FS/HS peripheral
  * @ingroup     cpu_stm32
@@ -35,8 +37,6 @@
  * @author      Koen Zandberg <koen@bergzand.net>
  */
 
-#ifndef USBDEV_STM32_H
-#define USBDEV_STM32_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -128,5 +128,4 @@ typedef struct {
 #ifdef __cplusplus
 }
 #endif
-#endif /* USBDEV_STM32_H */
 /** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is part of a greater effort to replace all header guards in RIOT with `#pragma once`. This PR only affects all headers under `cpu/`, excluding those that have a path that contains `/vendor/`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Tracking issue #21335

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
