### PR TITLE
sys/shell: rename shell_readline()

### DIFF
--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -293,7 +293,7 @@ int shell_parse_file(const shell_command_t *commands,
  * @return  EOF, if the end of the input stream was reached.
  * @return  -ENOBUFS if the buffer size was exceeded.
  */
-int readline(char *buf, size_t size);
+int shell_readline(char *buf, size_t size);
 
 #ifndef __cplusplus
 /**

--- a/sys/shell/cmds/udptty.c
+++ b/sys/shell/cmds/udptty.c
@@ -32,8 +32,6 @@
 #define EOT 0x4
 #endif
 
-extern int readline(char *buf, size_t size);
-
 static void _sock_cb(sock_udp_t *sock, sock_async_flags_t flags, void *arg)
 {
     (void)arg;
@@ -90,7 +88,7 @@ static int _udptty_cmd(int argc, char **argv)
 
     do {
         char buf[64];
-        res = readline(buf, sizeof(buf));
+        res = shell_readline(buf, sizeof(buf));
 
         if (res > 0) {
             buf[res] = '\n';

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -439,7 +439,7 @@ static inline void new_line(void)
     }
 }
 
-int readline(char *buf, size_t size)
+int shell_readline(char *buf, size_t size)
 {
     int curr_pos = 0;
     bool length_exceeded = false;
@@ -513,7 +513,7 @@ void shell_run_once(const shell_command_t *shell_commands,
     print_prompt();
 
     while (1) {
-        int res = readline(line_buf, len);
+        int res = shell_readline(line_buf, len);
 
         if (IS_USED(MODULE_SHELL_LOCK)) {
             if (shell_lock_is_locked()) {

--- a/sys/shell_lock/shell_lock.c
+++ b/sys/shell_lock/shell_lock.c
@@ -105,7 +105,7 @@ static bool _login(char *line_buf, size_t buf_size)
 
     while (1) {
         memset(line_buf, 0, buf_size);
-        while (readline(line_buf, buf_size) > 0) {
+        while (shell_readline(line_buf, buf_size) > 0) {
             return _safe_strcmp(line_buf, CONFIG_SHELL_LOCK_PASSWORD);
         }
     }


### PR DESCRIPTION
Hello 🦫,

the recent PR #21505 exposed the shell readline function. This PR adjust its name as proposed by @mguetschow 