### PR TITLE
boards/feather-m0: Correct ADC Settings

### DIFF
--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -186,8 +186,8 @@ static const pwm_conf_t pwm_config[] = {
 #define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV512
 
 #define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG_GND
-#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_1X
-#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INT1V
+#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_DIV2
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INTVCC1
 
 static const adc_conf_chan_t adc_channels[] = {
     /* port, pin, muxpos */
@@ -196,7 +196,7 @@ static const adc_conf_chan_t adc_channels[] = {
     { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB09 },     /* A2 */
     { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA04 },     /* A3 */
     { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA05 },     /* A4 */
-    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB02 },    /* A5 */
+    { .inputctrl = ADC_INPUTCTRL_MUXPOS_PB02 },     /* A5 */
     { .inputctrl = ADC_INPUTCTRL_MUXPOS_PA07 },     /* A7 */
 };
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The current ADC settings set the reference to the internal 1V reference with a x1 gain. This means that the maximum voltage that can be measured with any analog input is 1V, which is usually not sufficient for most applications.
Therefore the default value is changed to use the external VDDA input, which is 3.3V (internally divided by 2) and the gain to x1/2. This allows to measure voltages up to VDDA on any analog input.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

You can run the `tests/periph/adc` example with an external voltage source connected. You should see that with `master`, the ADC values max out at about 1V (or 2V for the battery input).

I connected a 0.8V voltage to the BAT input, which has a 1/2 resistor divider.

`master` : The values should be 0.8/1.0 * 0.5 * {256, 1024, 4096, 65536} = {102, 410, 1638, 26214} on ADC_LINE(6)):

```
2025-05-24 11:49:20,768 # ADC_LINE(0): -1 255 1023 4095    -1 65520
2025-05-24 11:49:20,771 # ADC_LINE(1): -1 255 1023 4095    -1 65520
2025-05-24 11:49:20,773 # ADC_LINE(2): -1 255 1023 4095    -1 65520
2025-05-24 11:49:20,775 # ADC_LINE(3): -1 255 1023 4095    -1 65520
2025-05-24 11:49:20,777 # ADC_LINE(4): -1 255 1023 4095    -1 65520
2025-05-24 11:49:20,779 # ADC_LINE(5): -1 255 1023 4095    -1 65520
2025-05-24 11:49:20,781 # ADC_LINE(6): -1 103  415 1664    -1 26630
```

This PR: The values should be: 0.8/3.3 * 0.5 * {256, 1024, 4096, 65536} = {31, 124, 496, 7944} on ADC_LINE(6)):
```
2025-05-24 11:45:03,555 #
2025-05-24 11:45:03,655 # ADC_LINE(0): -1  91  373 1496    -1 24508
2025-05-24 11:45:03,657 # ADC_LINE(1): -1  81  361 1504    -1 25126
2025-05-24 11:45:03,659 # ADC_LINE(2): -1  86  379 1534    -1 25398
2025-05-24 11:45:03,661 # ADC_LINE(3): -1  68  317 1373    -1 22436
2025-05-24 11:45:03,663 # ADC_LINE(4): -1  90  390 1621    -1 25188
2025-05-24 11:45:03,666 # ADC_LINE(5): -1  91  379 1549    -1 23639
2025-05-24 11:45:03,668 # ADC_LINE(6): -1  31  125  505    -1  8115
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found in #21022.

The ADC configuration was set when the Feather-M0 was introduced in #7510 and never changed since.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
