### PR TITLE
dist/tools/riotboot_gen_hdr: don't be pedantic, add riotboot_slot_get_current_hdr()

### DIFF
--- a/dist/tools/riotboot_gen_hdr/Makefile
+++ b/dist/tools/riotboot_gen_hdr/Makefile
@@ -18,7 +18,7 @@ GENHDR_SRC := $(COMMON_SRC) $(RIOT_HDR_SRC) \
 
 GENHDR_HDR := $(COMMON_HDR) $(RIOT_HDR_HDR)
 
-CFLAGS += -g -I. -O3 -Wall -Wextra -pedantic -std=c99
+CFLAGS += -g -I. -O3 -Wall -Wextra
 
 ifeq ($(QUIET),1)
   Q=@

--- a/sys/include/riotboot/slot.h
+++ b/sys/include/riotboot/slot.h
@@ -72,6 +72,20 @@ void riotboot_slot_jump(unsigned slot);
 const riotboot_hdr_t *riotboot_slot_get_hdr(unsigned slot);
 
 /**
+ * @brief  Get header from currently running image slot
+ *
+ * @returns header of current image
+ */
+static inline const riotboot_hdr_t *riotboot_slot_get_current_hdr(void)
+{
+    int slot = riotboot_slot_current();
+    if (slot < 0) {
+        return NULL;
+    }
+    return riotboot_slot_get_hdr(slot);
+}
+
+/**
  * @brief  Validate slot
  *
  * @param[in] slot    slot nr to work on


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

 - drop `-pedantic` from `riotboot_gen_hdr` to get rid of the warning about `#inclulde_next`
 - add `riotboot_slot_get_current_hdr()` convenience function 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
