### PR TITLE
dist/tools/riotboot_gen_hdr: add JSON mode

### DIFF
--- a/dist/tools/riotboot_gen_hdr/genhdr.c
+++ b/dist/tools/riotboot_gen_hdr/genhdr.c
@@ -14,6 +14,7 @@
 
 #include <errno.h>
 #include <limits.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
@@ -140,7 +141,23 @@ int updatehdr(int argc, char *argv[])
     return 0;
 }
 
-int readhdr(const char *file)
+static void print_hdr(const riotboot_hdr_t *hdr)
+{
+    printf("version: %u\n", hdr->version);
+    printf("address: 0x%x\n", hdr->start_addr);
+    printf("checksum: %svalid\n", riotboot_hdr_validate(hdr) ? "in" : "");
+}
+
+static void print_hdr_json(const riotboot_hdr_t *hdr)
+{
+    printf("{\n");
+    printf("\t\"version\": %u,\n", hdr->version);
+    printf("\t\"address\": %u,\n", hdr->start_addr);
+    printf("\t\"valid\": %s\n", riotboot_hdr_validate(hdr) ? "false" : "true");
+    printf("}\n");
+}
+
+int readhdr(const char *file, bool json)
 {
     riotboot_hdr_t hdr = { 0 };
     int res = from_file(file, &hdr, sizeof(hdr));
@@ -154,9 +171,11 @@ int readhdr(const char *file)
         return -EIO;
     }
 
-    printf("version: %u\n", hdr.version);
-    printf("address: 0x%x\n", hdr.start_addr);
-    printf("checksum: %svalid\n", riotboot_hdr_validate(&hdr) ? "in" : "");
+    if (json) {
+        print_hdr_json(&hdr);
+    } else {
+        print_hdr(&hdr);
+    }
 
     return 0;
 }

--- a/dist/tools/riotboot_gen_hdr/main.c
+++ b/dist/tools/riotboot_gen_hdr/main.c
@@ -14,18 +14,19 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 
 int genhdr(int argc, char *argv[]);
 int updatehdr(int argc, char *argv[]);
-int readhdr(const char *file);
+int readhdr(const char *file, bool json);
 
 int main(int argc, char *argv[])
 {
     char *usage = "genhdr generate [args]\n\t"
-                  "genhdr update [file] [new_version]\n\t"
-                  "genhdr show [file]";
+                  "genhdr update <file> <new_version>\n\t"
+                  "genhdr show [--json] <file>";
 
     if (argc < 2) {
         goto usage;
@@ -37,7 +38,9 @@ int main(int argc, char *argv[])
         return updatehdr(argc - 1, &argv[1]);
     }
     else if (!strcmp(argv[1], "show")) {
-        return readhdr(argv[2]);
+        bool json = argc > 2
+                 && !strcmp(argv[2], "--json");
+        return readhdr(argv[2 + json], json);
     }
 
 usage:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

For parsing the output of the `genhdr` command, a JSON mode will make things easier.


### Testing procedure

#### JSON mode

```
$ genhdr show --json slot0.1748336784.bin 
{
	"version": 1748336786,
	"address": 4352,
	"valid": true
}
```

#### old mode

```
$ genhdr show slot0.1748336784.bin        
version: 1748336786
address: 0x1100
checksum: valid
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
