### PR TITLE
features.yaml: add feather_shield feature

### DIFF
--- a/boards/adafruit-feather-nrf52840-express/Makefile.features
+++ b/boards/adafruit-feather-nrf52840-express/Makefile.features
@@ -8,6 +8,7 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
+FEATURES_PROVIDED += feather_shield
 FEATURES_PROVIDED += highlevel_stdio
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/adafruit-feather-nrf52840-sense/Makefile.features
+++ b/boards/adafruit-feather-nrf52840-sense/Makefile.features
@@ -8,6 +8,7 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
+FEATURES_PROVIDED += feather_shield
 FEATURES_PROVIDED += highlevel_stdio
 
 include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/feather-m0/Makefile.features
+++ b/boards/feather-m0/Makefile.features
@@ -15,4 +15,5 @@ FEATURES_PROVIDED += periph_usbdev
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += arduino_analog
 FEATURES_PROVIDED += arduino_pins
+FEATURES_PROVIDED += feather_shield
 FEATURES_PROVIDED += highlevel_stdio

--- a/doc/doxygen/src/io-mapping-and-shields.md
+++ b/doc/doxygen/src/io-mapping-and-shields.md
@@ -152,6 +152,7 @@ features. The following list of features currently exists:
 | `arduino_shield_nano` | Board has side headers compatible with the Arduino Nano       |
 | `arduino_shield_uno`  | Board has side headers compatible with the Arduino UNO        |
 | `arduino_shield_mega` | Board has side headers compatible with the Arduino MEGA       |
+| `feather_shield`      | Board has headers compatible with the Adafruit Feather boards |
 | `xiao_shield`         | Board has headers compatible with the Seeedstudio XIAO boards |
 
 @note   A board providing `arduino_shield_mega` **MUST** also provide

--- a/features.yaml
+++ b/features.yaml
@@ -409,6 +409,10 @@ groups:
             Indicates that the board is mechanically and electrically compatible
             with shields developed for the Arduino Nano. (Note: Except the
             ISP header, that requires `arduino_shield_isp` in addition.)
+    - name: feather_shield
+      help: >
+            Indicates that the board is mechanically and electrically compatible
+            with shields developed for the Adafruit Feather board family.
     - name: xiao_shield
       help: >
             Indicates that the board is mechanically and electrically compatible

--- a/makefiles/features_existing.inc.mk
+++ b/makefiles/features_existing.inc.mk
@@ -127,6 +127,7 @@ FEATURES_EXISTING := \
     esp_wifi \
     esp_wifi_ap \
     esp_wifi_enterprise \
+    feather_shield \
     gecko_sdk_librail_fpu \
     gecko_sdk_librail_nonfpu \
     highlevel_stdio \


### PR DESCRIPTION
### Contribution description

Same as `xiao_shield` for all Feather boards supported by RIOT. Not used yet as no extension boards for Feather's are currently defined (and I'm not sure how we would even model them right now in our build system).


### Testing procedure

Briefly skim over the changes, CI should be green.
