### PR TITLE
treewide: migrate to XFA SHELL_COMMAND

### DIFF
--- a/examples/networking/coap/gcoap_dtls/client.c
+++ b/examples/networking/coap/gcoap_dtls/client.c
@@ -31,6 +31,7 @@
 #include "net/sock/udp.h"
 #include "net/sock/util.h"
 #include "od.h"
+#include "shell.h"
 #include "uri_parser.h"
 
 #include "gcoap_example.h"
@@ -229,7 +230,13 @@ static int _uristr2remote(const char *uri, sock_udp_ep_t *remote, const char **p
     return 0;
 }
 
-int gcoap_cli_cmd(int argc, char **argv)
+/**
+ * @brief   Shell interface exposing the client side features of gcoap
+ * @param   argc    Number of shell arguments (including shell command name)
+ * @param   argv    Shell argument values (including shell command name)
+ * @return  Exit status of the shell command
+ */
+static int _cli_cmd(int argc, char **argv)
 {
     /* Ordered like the RFC method code numbers, but off by 1. GET is code 0. */
     char *method_codes[] = {"ping", "get", "post", "put"};
@@ -397,3 +404,5 @@ int gcoap_cli_cmd(int argc, char **argv)
 help:
     return _print_usage(argv);
 }
+
+SHELL_COMMAND(coap, "CoAP example", _cli_cmd);

--- a/examples/networking/coap/gcoap_dtls/gcoap_example.h
+++ b/examples/networking/coap/gcoap_dtls/gcoap_example.h
@@ -36,14 +36,6 @@ extern "C" {
 extern uint16_t req_count;  /**< Counts requests sent by CLI. */
 
 /**
- * @brief   Shell interface exposing the client side features of gcoap
- * @param   argc    Number of shell arguments (including shell command name)
- * @param   argv    Shell argument values (including shell command name)
- * @return  Exit status of the shell command
- */
-int gcoap_cli_cmd(int argc, char **argv);
-
-/**
  * @brief   Registers the CoAP resources exposed in the example app
  *
  * Run this exactly one during startup.

--- a/examples/networking/coap/gcoap_dtls/main.c
+++ b/examples/networking/coap/gcoap_dtls/main.c
@@ -29,11 +29,6 @@
 #define MAIN_QUEUE_SIZE (4)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
-static const shell_command_t shell_commands[] = {
-    { "coap", "CoAP example", gcoap_cli_cmd },
-    { NULL, NULL, NULL }
-};
-
 int main(void)
 {
     /* for the thread running the shell */
@@ -44,7 +39,7 @@ int main(void)
     /* start shell */
     puts("All up, running the shell now");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* should never be reached */
     return 0;

--- a/tests/build_system/test_tools/main.c
+++ b/tests/build_system/test_tools/main.c
@@ -45,6 +45,8 @@ static int cmd_true(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(true, "do nothing, successfully", cmd_true);
+
 /**
  * @brief shellping, replies shellpong
  *
@@ -63,6 +65,8 @@ static int cmd_shellping(int argc, char **argv)
     puts("shellpong");
     return 0;
 }
+
+SHELL_COMMAND(shellping, "Just print 'shellpong'", cmd_shellping);
 
 /**
  * @brief Uppercase the first word
@@ -95,6 +99,8 @@ static int cmd_toupper(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(toupper, "uppercase first argument", cmd_toupper);
+
 /**
  * @brief getchar, read one character
  *
@@ -114,20 +120,14 @@ static int cmd_getchar(int argc, char **argv)
     return 0;
 }
 
-static const shell_command_t shell_commands[] = {
-    { "shellping", "Just print 'shellpong'", cmd_shellping },
-    { "true", "do nothing, successfully", cmd_true },
-    { "toupper", "uppercase first argument", cmd_toupper },
-    { "getchar", "Get one character and print the hex value", cmd_getchar },
-    { NULL, NULL, NULL }
-};
+SHELL_COMMAND(getchar, "Get one character and print the hex value", cmd_getchar);
 
 int main(void)
 {
     puts("Running 'tests_tools' application");
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/cpu/cortexm_address_check/main.c
+++ b/tests/cpu/cortexm_address_check/main.c
@@ -47,10 +47,7 @@ static int cmd_check(int argc, char **argv)
     return 0;
 }
 
-static const shell_command_t shell_commands[] = {
-    { "check", "Check address", cmd_check},
-    { NULL, NULL, NULL }
-};
+SHELL_COMMAND(check, "Check address", cmd_check);
 
 int main(void)
 {
@@ -61,6 +58,6 @@ int main(void)
 
     /* run the shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
     return 0;
 }

--- a/tests/sys/atomic_utils/main.c
+++ b/tests/sys/atomic_utils/main.c
@@ -812,20 +812,6 @@ static uint64_t stats_ops;
 static uint64_t stats_tests;
 static uint64_t stats_failures;
 
-static int sc_tearing_test(int argc, char **argv);
-static int sc_lost_update_test(int argc, char **argv);
-static int sc_stats(int argc, char **argv);
-static int sc_stop(int argc, char **argv);
-static int sc_list(int argc, char **argv);
-static const shell_command_t shell_commands[] = {
-    { "tearing_test", "Run a store/load tearing test", sc_tearing_test },
-    { "lost_update_test", "Run a lost update test", sc_lost_update_test },
-    { "stats", "Show stats of current test", sc_stats },
-    { "stop", "Stop running test", sc_stop },
-    { "list", "List functions that can be tested", sc_list },
-    { NULL, NULL, NULL }
-};
-
 static void tearing_test_worker(test_state_t *state)
 {
     switch (state->conf.width) {
@@ -1100,6 +1086,8 @@ static void *thread_checker_func(void *arg)
     return NULL;
 }
 
+static int sc_stop(int argc, char **argv);
+
 static void *thread_timeout_func(void *arg)
 {
     (void)arg;
@@ -1226,6 +1214,8 @@ static int sc_tearing_test(int argc, char **argv)
     return select_func_and_start_test(argv[1], timeout);
 }
 
+SHELL_COMMAND(tearing_test, "Run a store/load tearing test", sc_tearing_test );
+
 static int sc_lost_update_test(int argc, char **argv)
 {
     if ((argc != 2) && (argc != 3)) {
@@ -1253,6 +1243,8 @@ static int sc_lost_update_test(int argc, char **argv)
     return select_func_and_start_test(argv[1], timeout);
 }
 
+SHELL_COMMAND(lost_update_test, "Run a lost update test", sc_lost_update_test );
+
 static int sc_stats(int argc, char **argv)
 {
     (void)argc;
@@ -1272,6 +1264,8 @@ static int sc_stats(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(stats, "Show stats of current test", sc_stats );
+
 static int sc_stop(int argc, char **argv)
 {
     (void)argc;
@@ -1290,6 +1284,8 @@ static int sc_stop(int argc, char **argv)
     }
     return 0;
 }
+
+SHELL_COMMAND(stop, "Stop running test", sc_stop );
 
 static int sc_list(int argc, char **argv)
 {
@@ -1318,6 +1314,8 @@ static int sc_list(int argc, char **argv)
 
     return 0;
 }
+
+SHELL_COMMAND(list, "List functions that can be tested", sc_list );
 
 int main(void)
 {
@@ -1356,7 +1354,7 @@ int main(void)
         "test is working as expected.\n"
     );
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/sys/congure_abe/main.c
+++ b/tests/sys/congure_abe/main.c
@@ -24,28 +24,12 @@
 
 #include "congure_impl.h"
 
-static int _json_statham(int argc, char **argv);
-static int _set_cwnd(int argc, char **argv);
-static int _get_fr_calls(int argc, char **argv);
-static int _set_same_wnd_adv_res(int argc, char **argv);
-
 static congure_abe_snd_t _congure_state;
-static const shell_command_t shell_commands[] = {
-    { "state", "Prints current CongURE state object as JSON", _json_statham },
-    { "set_cwnd", "Set cwnd member for CongURE state object", _set_cwnd },
-    { "get_ff_calls",
-      "Get the number of calls to fast_retransmit callback of CongURE state "
-      "object", _get_fr_calls },
-    { "set_same_wnd_adv",
-      "Set the result for the same_window_advertised callback of CongURE state "
-      "object", _set_same_wnd_adv_res },
-    { NULL, NULL, NULL }
-};
 
 int main(void)
 {
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
     return 0;
 }
 
@@ -109,6 +93,8 @@ static int _json_statham(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(state, "Prints current CongURE state object as JSON", _json_statham );
+
 static int _set_cwnd(int argc, char **argv)
 {
     uint32_t tmp;
@@ -125,6 +111,8 @@ static int _set_cwnd(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(set_cwnd, "Set cwnd member for CongURE state object", _set_cwnd );
+
 static int _get_fr_calls(int argc, char **argv)
 {
     (void)argc;
@@ -135,6 +123,9 @@ static int _get_fr_calls(int argc, char **argv)
     print_str("}\n");
     return 0;
 }
+
+SHELL_COMMAND(get_ff_calls, "Get the number of calls to fast_retransmit"
+    "callback of CongURE state object", _get_fr_calls);
 
 static int _set_same_wnd_adv_res(int argc, char **argv)
 {
@@ -147,5 +138,8 @@ static int _set_same_wnd_adv_res(int argc, char **argv)
     );
     return 0;
 }
+
+SHELL_COMMAND(set_same_wnd_adv, "Set the result for the same_window_advertised"
+    "callback of CongURE state object", _set_same_wnd_adv_res);
 
 /** @} */

--- a/tests/sys/congure_quic/main.c
+++ b/tests/sys/congure_quic/main.c
@@ -205,7 +205,7 @@ static int _get_event_cb(int argc, char **argv)
     return 0;
 }
 
-SHELL_COMMAND(get_event_cb,#
+SHELL_COMMAND(get_event_cb,
     "Get state of cong_event_cb mock of CongURE state object", _get_event_cb);
 
 /** @} */

--- a/tests/sys/congure_quic/main.c
+++ b/tests/sys/congure_quic/main.c
@@ -24,36 +24,12 @@
 
 #include "congure_impl.h"
 
-static int _json_statham(int argc, char **argv);
-static int _set_cwnd(int argc, char **argv);
-static int _set_ssthresh(int argc, char **argv);
-static int _set_limited(int argc, char **argv);
-static int _set_max_ack_delay(int argc, char **argv);
-static int _set_recovery_start(int argc, char **argv);
-static int _get_event_cb(int argc, char **argv);
-
 static congure_quic_snd_t _congure_state;
-static const shell_command_t shell_commands[] = {
-    { "state", "Prints current CongURE state object as JSON", _json_statham },
-    { "set_cwnd", "Set cwnd member for CongURE state object", _set_cwnd },
-    { "set_ssthresh", "Set ssthresh member for CongURE state object",
-      _set_ssthresh },
-    { "set_limited", "Set limited member for CongURE state object",
-      _set_limited },
-    { "set_max_ack_delay", "Set max_ack_delay member for CongURE state object",
-      _set_max_ack_delay },
-    { "set_recovery_start", "Set recovery_start member for CongURE state object",
-      _set_recovery_start },
-    { "get_event_cb",
-      "Get state of cong_event_cb mock of CongURE state object",
-      _get_event_cb },
-    { NULL, NULL, NULL }
-};
 
 int main(void)
 {
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
     return 0;
 }
 
@@ -124,6 +100,8 @@ static int _json_statham(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(state, "Prints current CongURE state object as JSON", _json_statham);
+
 static int _set_cwnd(int argc, char **argv)
 {
     uint32_t tmp;
@@ -139,6 +117,8 @@ static int _set_cwnd(int argc, char **argv)
     _congure_state.super.cwnd = (congure_wnd_size_t)tmp;
     return 0;
 }
+
+SHELL_COMMAND(set_cwnd, "Set cwnd member for CongURE state object", _set_cwnd);
 
 static int _set_ssthresh(int argc, char **argv)
 {
@@ -156,6 +136,8 @@ static int _set_ssthresh(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(set_ssthresh, "Set ssthresh member for CongURE state object", _set_ssthresh);
+
 static int _set_limited(int argc, char **argv)
 {
     uint32_t tmp;
@@ -171,6 +153,8 @@ static int _set_limited(int argc, char **argv)
     _congure_state.limited = (uint16_t)tmp;
     return 0;
 }
+
+SHELL_COMMAND(set_limited, "Set limited member for CongURE state object", _set_limited);
 
 static int _set_max_ack_delay(int argc, char **argv)
 {
@@ -188,6 +172,9 @@ static int _set_max_ack_delay(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(set_max_ack_delay,
+    "Set max_ack_delay member for CongURE state object", _set_max_ack_delay);
+
 static int _set_recovery_start(int argc, char **argv)
 {
     if (argc < 2) {
@@ -197,6 +184,9 @@ static int _set_recovery_start(int argc, char **argv)
     _congure_state.recovery_start = scn_u32_dec(argv[1], strlen(argv[1]));
     return 0;
 }
+
+SHELL_COMMAND(set_recovery_start,
+    "Set recovery_start member for CongURE state object", _set_recovery_start);
 
 static int _get_event_cb(int argc, char **argv)
 {
@@ -214,5 +204,8 @@ static int _get_event_cb(int argc, char **argv)
     print_str("}\n");
     return 0;
 }
+
+SHELL_COMMAND(get_event_cb,#
+    "Get state of cong_event_cb mock of CongURE state object", _get_event_cb);
 
 /** @} */

--- a/tests/sys/congure_reno/main.c
+++ b/tests/sys/congure_reno/main.c
@@ -28,32 +28,11 @@
 
 static char _line_buf[SHELL_BUFSIZE];
 
-static int _json_statham(int argc, char **argv);
-static int _set_mss(int argc, char **argv);
-static int _set_cwnd(int argc, char **argv);
-static int _set_ssthresh(int argc, char **argv);
-static int _get_fr_calls(int argc, char **argv);
-static int _set_same_wnd_adv_res(int argc, char **argv);
-
 static congure_reno_snd_t _congure_state;
-static const shell_command_t shell_commands[] = {
-    { "state", "Prints current CongURE state object as JSON", _json_statham },
-    { "set_cwnd", "Set cwnd member for CongURE state object", _set_cwnd },
-    { "set_mss", "Set new MSS for CongURE state object", _set_mss },
-    { "set_ssthresh", "Set ssthresh member for CongURE state object",
-      _set_ssthresh },
-    { "get_ff_calls",
-      "Get the number of calls to fast_retransmit callback of CongURE state "
-      "object", _get_fr_calls },
-    { "set_same_wnd_adv",
-      "Set the result for the same_window_advertised callback of CongURE state "
-      "object", _set_same_wnd_adv_res },
-    { NULL, NULL, NULL }
-};
 
 int main(void)
 {
-    shell_run(shell_commands, _line_buf, SHELL_BUFSIZE);
+    shell_run(NULL, _line_buf, SHELL_BUFSIZE);
     return 0;
 }
 
@@ -113,6 +92,8 @@ static int _json_statham(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(state, "Prints current CongURE state object as JSON", _json_statham);
+
 static int _set_mss(int argc, char **argv)
 {
     uint32_t tmp;
@@ -128,6 +109,8 @@ static int _set_mss(int argc, char **argv)
     congure_reno_set_mss(&_congure_state, (congure_wnd_size_t)tmp);
     return 0;
 }
+
+SHELL_COMMAND(set_mss, "Set new MSS for CongURE state object", _set_mss);
 
 static int _set_cwnd(int argc, char **argv)
 {
@@ -145,6 +128,8 @@ static int _set_cwnd(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(set_cwnd, "Set cwnd member for CongURE state object", _set_cwnd);
+
 static int _set_ssthresh(int argc, char **argv)
 {
     uint32_t tmp;
@@ -161,6 +146,8 @@ static int _set_ssthresh(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(set_ssthresh, "Set ssthresh member for CongURE state object", _set_ssthresh);
+
 static int _get_fr_calls(int argc, char **argv)
 {
     (void)argc;
@@ -171,6 +158,9 @@ static int _get_fr_calls(int argc, char **argv)
     print_str("}\n");
     return 0;
 }
+
+SHELL_COMMAND(get_ff_calls,
+    "Get the number of calls to fast_retransmit callback of CongURE state object", _get_fr_calls);
 
 static int _set_same_wnd_adv_res(int argc, char **argv)
 {
@@ -183,5 +173,9 @@ static int _set_same_wnd_adv_res(int argc, char **argv)
     );
     return 0;
 }
+
+SHELL_COMMAND(set_same_wnd_adv,
+    "Set the result for the same_window_advertised callback of CongURE state object",
+    _set_same_wnd_adv_res);
 
 /** @} */

--- a/tests/sys/congure_test/main.c
+++ b/tests/sys/congure_test/main.c
@@ -22,18 +22,12 @@
 
 #include "congure_impl.h"
 
-static int _json_statham(int argc, char **argv);
-
 static congure_test_snd_t _congure_state;
-static const shell_command_t shell_commands[] = {
-    { "state", "Prints current CongURE state object as JSON", _json_statham },
-    { NULL, NULL, NULL }
-};
 
 int main(void)
 {
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
     return 0;
 }
 
@@ -331,5 +325,7 @@ static int _json_statham(int argc, char **argv)
     print_str("}\n");
     return 0;
 }
+
+SHELL_COMMAND(state, "Prints current CongURE state object as JSON", _json_statham);
 
 /** @} */

--- a/tests/sys/heap_cmd/main.c
+++ b/tests/sys/heap_cmd/main.c
@@ -33,6 +33,8 @@ static int malloc_cmd(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(malloc, "malloc <size>", malloc_cmd);
+
 static int free_cmd(int argc, char **argv)
 {
     if (argc < 2) {
@@ -48,11 +50,7 @@ static int free_cmd(int argc, char **argv)
     return 0;
 }
 
-static const shell_command_t shell_commands[] = {
-    { "malloc", "malloc <size>", malloc_cmd },
-    { "free", "free <addr in hex> returned from malloc, e.g., 0x1234", free_cmd },
-    { NULL, NULL, NULL }
-};
+SHELL_COMMAND(free, "free <addr in hex> returned from malloc, e.g., 0x1234", free_cmd);
 
 int main(void)
 {
@@ -63,7 +61,7 @@ int main(void)
     char line_buf[SHELL_DEFAULT_BUFSIZE];
 
     /* define own shell commands */
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/sys/rng/main.c
+++ b/tests/sys/rng/main.c
@@ -27,31 +27,6 @@
 
 #include "test.h"
 
-/*
- * Forward declarations
- */
-static int cmd_distributions(int argc, char **argv);
-static int cmd_dump(int argc, char **argv);
-static int cmd_entropy(int argc, char **argv);
-static int cmd_fips(int argc, char **argv);
-static int cmd_seed(int argc, char **argv);
-static int cmd_source(int argc, char **argv);
-static int cmd_speed(int argc, char **argv);
-
-/**
- * @brief   List of command for this application.
- */
-static const shell_command_t shell_commands[] = {
-    { "distributions", "run distributions test", cmd_distributions },
-    { "dump", "dump random numbers", cmd_dump },
-    { "fips", "run FIPS 140-2 tests", cmd_fips },
-    { "entropy", "calculate entropy test", cmd_entropy },
-    { "seed", "set random seed", cmd_seed },
-    { "source", "set randomness source", cmd_source },
-    { "speed", "run speed test", cmd_speed },
-    { NULL, NULL, NULL }
-};
-
 /**
  * @brief   Distributions command, which accepts one argument (samples).
  *
@@ -75,6 +50,8 @@ static int cmd_distributions(int argc, char **argv)
 
     return 0;
 }
+
+SHELL_COMMAND(distributions, "run distributions test", cmd_distributions);
 
 /**
  * @brief   Dump command, which accepts one argument (samples).
@@ -113,6 +90,8 @@ static int cmd_dump(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(dump, "dump random numbers", cmd_dump);
+
 /**
  * @brief   Calculate Shannon's entropy (bits), which accepts one argument
  *          (samples).
@@ -138,6 +117,8 @@ static int cmd_entropy(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(entropy, "calculate entropy test", cmd_entropy);
+
 /**
  * @brief   Run the FIPS 140-2 tests.
  *
@@ -155,6 +136,8 @@ static int cmd_fips(int argc, char **argv)
 
     return 0;
 }
+
+SHELL_COMMAND(fips, "run FIPS 140-2 tests", cmd_fips);
 
 /**
  * @brief   Set the random seed.
@@ -178,6 +161,8 @@ static int cmd_seed(int argc, char **argv)
 
     return 0;
 }
+
+SHELL_COMMAND(seed, "set random seed", cmd_seed);
 
 /**
  * @brief   Helper for setting the RNG source.
@@ -219,6 +204,8 @@ static int cmd_source(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(source, "set randomness source", cmd_source);
+
 /**
  * @brief   Speed command, which accepts one argument (duration).
  *
@@ -256,11 +243,13 @@ static int cmd_speed(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(speed, "run speed test", cmd_speed);
+
 int main(void)
 {
     puts("Starting shell...");
     static char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/sys/struct_tm_utility/main.c
+++ b/tests/sys/struct_tm_utility/main.c
@@ -69,6 +69,8 @@ static int cmd_days_in(int argc, char **argv)
     }
 }
 
+SHELL_COMMAND(days_in, "Tells you the number of days in a month.", cmd_days_in);
+
 static int cmd_leap_year(int argc, char **argv)
 {
     int year;
@@ -85,6 +87,8 @@ static int cmd_leap_year(int argc, char **argv)
     }
 }
 
+SHELL_COMMAND(leap_year, "Tells you if a supplied year is a leap year.", cmd_leap_year);
+
 static int cmd_doomsday(int argc, char **argv)
 {
     int year;
@@ -100,6 +104,8 @@ static int cmd_doomsday(int argc, char **argv)
         return 0;
     }
 }
+
+SHELL_COMMAND(doomsday, "Tells you the wday Doomsday of the supplied year.", cmd_doomsday);
 
 static int cmd_day(int argc, char **argv)
 {
@@ -131,20 +137,14 @@ static int cmd_day(int argc, char **argv)
     }
 }
 
-static const shell_command_t shell_commands[] = {
-    { "days_in", "Tells you the number of days in a month.", cmd_days_in },
-    { "leap_year", "Tells you if a supplied year is a leap year.", cmd_leap_year },
-    { "doomsday", "Tells you the wday Doomsday of the supplied year.", cmd_doomsday },
-    { "day", "Tells you the day of the supplied date.", cmd_day },
-    { NULL, NULL, NULL }
-};
+SHELL_COMMAND(day, "Tells you the day of the supplied date.", cmd_day);
 
 int main(void)
 {
     puts("`struct tm` utility shell.");
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/sys/struct_tm_utility/tests/01-run.py
+++ b/tests/sys/struct_tm_utility/tests/01-run.py
@@ -12,20 +12,6 @@ import datetime
 from testrunner import run
 
 
-def _check_help(child):
-    child.sendline('help')
-    child.expect_exact('Command              Description')
-    child.expect_exact('---------------------------------------')
-    child.expect_exact('days_in              '
-                       'Tells you the number of days in a month.')
-    child.expect_exact('leap_year            '
-                       'Tells you if a supplied year is a leap year.')
-    child.expect_exact('doomsday             '
-                       'Tells you the wday Doomsday of the supplied year.')
-    child.expect_exact('day                  '
-                       'Tells you the day of the supplied date.')
-
-
 def _check_days_in(child):
     # verify usage
     child.sendline('days_in')
@@ -112,7 +98,6 @@ def _wait_prompt(child):
 
 def testfunc(child):
     _wait_prompt(child)
-    _check_help(child)
     _check_days_in(child)
     _check_leap_year(child)
     _check_doomsday(child)

--- a/tests/sys/usbus_cdc_acm_stdio/main.c
+++ b/tests/sys/usbus_cdc_acm_stdio/main.c
@@ -44,17 +44,14 @@ static int cmd_text(int argc, char **argv)
     return 0;
 }
 
-static const shell_command_t shell_commands[] = {
-    { "text",  "Generates long text for testing stdio buffer",  cmd_text },
-    { NULL, NULL, NULL }
-};
+SHELL_COMMAND(text, "Generates long text for testing stdio buffer", cmd_text);
 
 int main(void)
 {
     (void) puts("RIOT USB CDC ACM shell test");
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/sys/usbus_msc/main.c
+++ b/tests/sys/usbus_msc/main.c
@@ -84,6 +84,8 @@ static int _cmd_add_lun(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(add_lun, "Add a MTD device as new LUN",  _cmd_add_lun);
+
 static int _cmd_remove_lun(int argc, char **argv)
 {
     int dev, ret;
@@ -112,6 +114,8 @@ static int _cmd_remove_lun(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(remove_lun, "Remove existing LUN", _cmd_remove_lun);
+
 static int _cmd_usb_attach(int argc, char **argv)
 {
     (void)argc;
@@ -122,6 +126,8 @@ static int _cmd_usb_attach(int argc, char **argv)
                sizeof(usbopt_enable_t));
     return 0;
 }
+
+SHELL_COMMAND(usb_attach, "Attach USB to host", _cmd_usb_attach);
 
 static int _cmd_usb_detach(int argc, char **argv)
 {
@@ -134,6 +140,8 @@ static int _cmd_usb_detach(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(usb_detach, "Detach USB from host", _cmd_usb_detach);
+
 static int _cmd_usb_reset(int argc, char **argv)
 {
     _cmd_usb_detach(argc, argv);
@@ -142,14 +150,7 @@ static int _cmd_usb_reset(int argc, char **argv)
     return 0;
 }
 
-static const shell_command_t shell_commands[] = {
-    { "add_lun",  "Add a MTD device as new LUN",  _cmd_add_lun },
-    { "remove_lun", "Remove existing LUN", _cmd_remove_lun },
-    { "usb_attach", "Attach USB to host", _cmd_usb_attach },
-    { "usb_detach", "Detach USB from host", _cmd_usb_detach },
-    { "usb_reset", "Combine Detach and Attach with a 100ms delay", _cmd_usb_reset },
-    { NULL, NULL, NULL }
-};
+SHELL_COMMAND(usb_reset, "Combine Detach and Attach with a 100ms delay", _cmd_usb_reset);
 
 int main(void)
 {
@@ -168,8 +169,7 @@ int main(void)
     /* start shell */
     puts("All up, running the shell now");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* should be never reached */
     return 0;

--- a/tests/sys/xtimer_mutex_lock_timeout/main.c
+++ b/tests/sys/xtimer_mutex_lock_timeout/main.c
@@ -29,49 +29,17 @@
  * incompatible with xtimers tick conversion, e.g. the waspmote-pro
  */
 #ifndef XTIMER_SHIFT
-#define XTIMER_SHIFT    (0)
+#  define XTIMER_SHIFT (0)
 #endif
 
 /* timeout at one millisecond (1000 us) to make sure it does not spin. */
-#define LONG_MUTEX_TIMEOUT 1000
+#define LONG_MUTEX_TIMEOUT  1000
 
 /* timeout smaller than XTIMER_BACKOFF to make sure it spins. */
 #define SHORT_MUTEX_TIMEOUT ((1 << XTIMER_SHIFT) + 1)
 
 /* main Thread PID */
 static kernel_pid_t main_thread_pid;
-
-/**
- * Forward declarations
- */
-static int cmd_test_xtimer_mutex_lock_timeout_long_unlocked(int argc,
-                                                            char **argv);
-static int cmd_test_xtimer_mutex_lock_timeout_long_locked(int argc,
-                                                          char **argv);
-static int cmd_test_xtimer_mutex_lock_timeout_low_prio_thread(int argc,
-                                                              char **argv);
-static int cmd_test_xtimer_mutex_lock_timeout_short_unlocked(int argc,
-                                                             char **argv);
-static int cmd_test_xtimer_mutex_lock_timeout_short_locked(int argc,
-                                                           char **argv);
-
-/**
- * @brief   List of command for this application.
- */
-static const shell_command_t shell_commands[] = {
-    { "mutex_timeout_long_unlocked", "unlocked mutex (no-spin timeout)",
-      cmd_test_xtimer_mutex_lock_timeout_long_unlocked, },
-    { "mutex_timeout_long_locked", "locked mutex (no-spin timeout)",
-      cmd_test_xtimer_mutex_lock_timeout_long_locked, },
-    { "mutex_timeout_long_locked_low",
-      "lock low-prio-locked-mutex from high-prio-thread (no-spin timeout)",
-      cmd_test_xtimer_mutex_lock_timeout_low_prio_thread, },
-    { "mutex_timeout_short_unlocked", "unlocked mutex (spin timeout)",
-      cmd_test_xtimer_mutex_lock_timeout_short_unlocked, },
-    { "mutex_timeout_short_locked", "locked mutex (spin timeout)",
-      cmd_test_xtimer_mutex_lock_timeout_short_locked, },
-    { NULL, NULL, NULL }
-};
 
 /**
  * @brief   stack for
@@ -158,6 +126,9 @@ static int cmd_test_xtimer_mutex_lock_timeout_long_unlocked(int argc,
     return 0;
 }
 
+SHELL_COMMAND(mutex_timeout_long_unlocked, "unlocked mutex (no-spin timeout)",
+              cmd_test_xtimer_mutex_lock_timeout_long_unlocked);
+
 /**
  * @brief   shell command to test xtimer_mutex_lock_timeout
  *
@@ -196,6 +167,9 @@ static int cmd_test_xtimer_mutex_lock_timeout_long_locked(int argc,
 
     return 0;
 }
+
+SHELL_COMMAND(mutex_timeout_long_locked, "locked mutex (no-spin timeout)",
+    cmd_test_xtimer_mutex_lock_timeout_long_locked);
 
 /**
  * @brief   shell command to test xtimer_mutex_lock_timeout
@@ -265,6 +239,10 @@ static int cmd_test_xtimer_mutex_lock_timeout_low_prio_thread(int argc,
     return 0;
 }
 
+SHELL_COMMAND(mutex_timeout_long_locked_low,
+    "lock low-prio-locked-mutex from high-prio-thread (no-spin timeout)",
+    cmd_test_xtimer_mutex_lock_timeout_low_prio_thread);
+
 /**
  * @brief   shell command to test xtimer_mutex_lock_timeout when spinning
  *
@@ -305,6 +283,9 @@ static int cmd_test_xtimer_mutex_lock_timeout_short_locked(int argc,
     return 0;
 }
 
+SHELL_COMMAND(mutex_timeout_short_locked, "locked mutex (spin timeout)",
+    cmd_test_xtimer_mutex_lock_timeout_short_locked);
+
 /**
  * @brief   shell command to test xtimer_mutex_lock_timeout when spinning
  *
@@ -344,6 +325,9 @@ static int cmd_test_xtimer_mutex_lock_timeout_short_unlocked(int argc,
     return 0;
 }
 
+SHELL_COMMAND(mutex_timeout_short_unlocked, "unlocked mutex (spin timeout)",
+    cmd_test_xtimer_mutex_lock_timeout_short_unlocked);
+
 /**
  * @brief   main function starting shell
  *
@@ -353,7 +337,7 @@ int main(void)
 {
     puts("Starting shell...");
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/sys/xtimer_rmutex_lock_timeout/main.c
+++ b/tests/sys/xtimer_rmutex_lock_timeout/main.c
@@ -41,42 +41,10 @@
 /* timeout smaller than XTIMER_BACKOFF to make sure it spins. */
 #define SHORT_RMUTEX_TIMEOUT ((1 << XTIMER_SHIFT) + 1)
 
-/**
- * Forward declarations
- */
-static int cmd_test_xtimer_rmutex_lock_timeout_long_unlocked(int argc,
-                                                             char **argv);
-static int cmd_test_xtimer_rmutex_lock_timeout_long_locked(int argc,
-                                                           char **argv);
-static int cmd_test_xtimer_rmutex_lock_timeout_low_prio_thread(
-    int argc, char **argv);
-
-static int cmd_test_xtimer_rmutex_lock_timeout_short_unlocked(int argc,
-                                                              char **argv);
-static int cmd_test_xtimer_rmutex_lock_timeout_short_locked(int argc,
-                                                            char **argv);
-
 #define error_wrong_variables "Error: rmutex wrong variables in struct"
 #define error_rmutex_taken "Error: rmutex taken"
 #define error_timeout "Error: rmutex timed out"
 #define shell_help_output "See main.c"
-
-/**
- * @brief   List of command for this application.
- */
-static const shell_command_t shell_commands[] = {
-    { "t1", shell_help_output,
-      cmd_test_xtimer_rmutex_lock_timeout_long_unlocked, },
-    { "t2", shell_help_output,
-      cmd_test_xtimer_rmutex_lock_timeout_long_locked, },
-    { "t3", shell_help_output,
-      cmd_test_xtimer_rmutex_lock_timeout_low_prio_thread, },
-    { "t4", shell_help_output,
-      cmd_test_xtimer_rmutex_lock_timeout_short_unlocked, },
-    { "t5", shell_help_output,
-      cmd_test_xtimer_rmutex_lock_timeout_short_locked, },
-    { NULL, NULL, NULL }
-};
 
 /* main Thread PID */
 static kernel_pid_t main_thread_pid;
@@ -175,6 +143,8 @@ static int cmd_test_xtimer_rmutex_lock_timeout_long_unlocked(int argc,
     return 0;
 }
 
+SHELL_COMMAND(t1, shell_help_output, cmd_test_xtimer_rmutex_lock_timeout_long_unlocked);
+
 /**
  * @brief   shell command to test xtimer_rmutex_lock_timeout
  *
@@ -224,6 +194,8 @@ static int cmd_test_xtimer_rmutex_lock_timeout_long_locked(int argc,
 
     return 0;
 }
+
+SHELL_COMMAND(t2, shell_help_output, cmd_test_xtimer_rmutex_lock_timeout_long_locked);
 
 /**
  * @brief   shell command to test xtimer_rmutex_lock_timeout
@@ -284,6 +256,8 @@ static int cmd_test_xtimer_rmutex_lock_timeout_low_prio_thread(
     return 0;
 }
 
+SHELL_COMMAND(t3, shell_help_output, cmd_test_xtimer_rmutex_lock_timeout_low_prio_thread);
+
 /**
  * @brief   shell command to test xtimer_rmutex_lock_timeout when spinning
  *
@@ -331,6 +305,8 @@ static int cmd_test_xtimer_rmutex_lock_timeout_short_locked(int argc,
     return 0;
 }
 
+SHELL_COMMAND(t5, shell_help_output, cmd_test_xtimer_rmutex_lock_timeout_short_locked);
+
 /**
  * @brief   shell command to test xtimer_rmutex_lock_timeout when spinning
  *
@@ -371,6 +347,8 @@ static int cmd_test_xtimer_rmutex_lock_timeout_short_unlocked(int argc,
     return 0;
 }
 
+SHELL_COMMAND(t4, shell_help_output, cmd_test_xtimer_rmutex_lock_timeout_short_unlocked);
+
 /**
  * @brief   main function starting shell
  *
@@ -379,7 +357,7 @@ static int cmd_test_xtimer_rmutex_lock_timeout_short_unlocked(int argc,
 int main(void)
 {
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/sys/ztimer_rmutex_lock_timeout/main.c
+++ b/tests/sys/ztimer_rmutex_lock_timeout/main.c
@@ -34,42 +34,10 @@
 /* timeout set to 1us */
 #define SHORT_RMUTEX_TIMEOUT (1)
 
-/**
- * Forward declarations
- */
-static int cmd_test_ztimer_rmutex_lock_timeout_long_unlocked(int argc,
-                                                             char **argv);
-static int cmd_test_ztimer_rmutex_lock_timeout_long_locked(int argc,
-                                                           char **argv);
-static int cmd_test_ztimer_rmutex_lock_timeout_low_prio_thread(
-    int argc, char **argv);
-
-static int cmd_test_ztimer_rmutex_lock_timeout_short_unlocked(int argc,
-                                                              char **argv);
-static int cmd_test_ztimer_rmutex_lock_timeout_short_locked(int argc,
-                                                            char **argv);
-
 #define error_wrong_variables "Error: rmutex wrong variables in struct"
 #define error_rmutex_taken "Error: rmutex taken"
 #define error_timeout "Error: rmutex timed out"
 #define shell_help_output "See main.c"
-
-/**
- * @brief   List of command for this application.
- */
-static const shell_command_t shell_commands[] = {
-    { "t1", shell_help_output,
-      cmd_test_ztimer_rmutex_lock_timeout_long_unlocked, },
-    { "t2", shell_help_output,
-      cmd_test_ztimer_rmutex_lock_timeout_long_locked, },
-    { "t3", shell_help_output,
-      cmd_test_ztimer_rmutex_lock_timeout_low_prio_thread, },
-    { "t4", shell_help_output,
-      cmd_test_ztimer_rmutex_lock_timeout_short_unlocked, },
-    { "t5", shell_help_output,
-      cmd_test_ztimer_rmutex_lock_timeout_short_locked, },
-    { NULL, NULL, NULL }
-};
 
 /* main Thread PID */
 static kernel_pid_t main_thread_pid;
@@ -168,6 +136,8 @@ static int cmd_test_ztimer_rmutex_lock_timeout_long_unlocked(int argc,
     return 0;
 }
 
+SHELL_COMMAND(t1, shell_help_output, cmd_test_ztimer_rmutex_lock_timeout_long_unlocked);
+
 /**
  * @brief   shell command to test ztimer_rmutex_lock_timeout
  *
@@ -217,6 +187,8 @@ static int cmd_test_ztimer_rmutex_lock_timeout_long_locked(int argc,
 
     return 0;
 }
+
+SHELL_COMMAND(t2, shell_help_output, cmd_test_ztimer_rmutex_lock_timeout_long_locked);
 
 /**
  * @brief   shell command to test ztimer_rmutex_lock_timeout
@@ -277,6 +249,8 @@ static int cmd_test_ztimer_rmutex_lock_timeout_low_prio_thread(
     return 0;
 }
 
+SHELL_COMMAND(t3, shell_help_output, cmd_test_ztimer_rmutex_lock_timeout_low_prio_thread);
+
 /**
  * @brief   shell command to test ztimer_rmutex_lock_timeout when spinning
  *
@@ -324,6 +298,8 @@ static int cmd_test_ztimer_rmutex_lock_timeout_short_locked(int argc,
     return 0;
 }
 
+SHELL_COMMAND(t5, shell_help_output, cmd_test_ztimer_rmutex_lock_timeout_short_locked);
+
 /**
  * @brief   shell command to test ztimer_rmutex_lock_timeout when spinning
  *
@@ -364,6 +340,8 @@ static int cmd_test_ztimer_rmutex_lock_timeout_short_unlocked(int argc,
     return 0;
 }
 
+SHELL_COMMAND(t4, shell_help_output, cmd_test_ztimer_rmutex_lock_timeout_short_unlocked);
+
 /**
  * @brief   main function starting shell
  *
@@ -372,7 +350,7 @@ static int cmd_test_ztimer_rmutex_lock_timeout_short_unlocked(int argc,
 int main(void)
 {
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }


### PR DESCRIPTION
### Contribution description

Migrate some more applications to using the XFA SHELL_COMMAND instead of the statically allocated list (often with `extern` function declarations) in `main.c`.

### Testing procedure

CI should find build regressions.


### Issues/PRs references

Follow-up of https://github.com/RIOT-OS/RIOT/pull/21171
