### PR TITLE
tests/drivers/{st77xx,ili9341}: fix coordinates in lcd_fill()

### DIFF
--- a/tests/drivers/ili9341/main.c
+++ b/tests/drivers/ili9341/main.c
@@ -53,22 +53,24 @@ int main(void)
     }
 
     puts("lcd TFT display filling map");
-    lcd_fill(&dev, 0, dev.params->lines, 0, dev.params->rgb_channels, 0x0000);
+    lcd_fill(&dev, 0, dev.params->lines - 1, 0, dev.params->rgb_channels - 1,
+             0x0000);
     puts("lcd TFT display map filled");
 
     /* Fill square with blue */
     puts("Drawing blue rectangle");
-    lcd_fill(&dev, 0, dev.params->lines / 3, 0, dev.params->rgb_channels, 0x001F);
+    lcd_fill(&dev, 0, dev.params->lines / 3, 0, dev.params->rgb_channels - 1,
+             0x001F);
     ztimer_sleep(ZTIMER_MSEC, 1 * MS_PER_SEC);
 
     puts("Drawing green rectangle");
     lcd_fill(&dev, dev.params->lines / 3, 2 * (dev.params->lines / 3), 0,
-             dev.params->rgb_channels, 0x07E0);
+             dev.params->rgb_channels - 1, 0x07E0);
     ztimer_sleep(ZTIMER_MSEC, 1 * MS_PER_SEC);
 
     puts("Drawing red rectangle");
     lcd_fill(&dev, 2 * (dev.params->lines / 3), dev.params->lines, 0,
-             dev.params->rgb_channels, 0xf800);
+             dev.params->rgb_channels - 1, 0xf800);
     ztimer_sleep(ZTIMER_MSEC, 1 * MS_PER_SEC);
 
     lcd_invert_on(&dev);
@@ -78,7 +80,8 @@ int main(void)
     puts("lcd TFT display normal");
 
     puts("lcd TFT display clear screen");
-    lcd_fill(&dev, 0, dev.params->lines, 0, dev.params->rgb_channels, 0x0000);
+    lcd_fill(&dev, 0, dev.params->lines - 1, 0, dev.params->rgb_channels - 1,
+             0x0000);
 #ifndef CONFIG_NO_RIOT_IMAGE
     /* Approximate middle of the display */
     uint8_t x1 = (dev.params->lines / 2) - (RIOT_LOGO_WIDTH / 2);

--- a/tests/drivers/st77xx/main.c
+++ b/tests/drivers/st77xx/main.c
@@ -69,22 +69,24 @@ int main(void)
 #endif
 
     puts("lcd TFT display filling map");
-    lcd_fill(&dev, 0, dev.params->lines, 0, dev.params->rgb_channels, 0x0000);
+    lcd_fill(&dev, 0, dev.params->lines - 1, 0, dev.params->rgb_channels - 1,
+             0x0000);
     puts("lcd TFT display map filled");
 
     /* Fill square with blue */
     puts("Drawing blue rectangle");
-    lcd_fill(&dev, 0, dev.params->lines / 3, 0, dev.params->rgb_channels, 0x001F);
+    lcd_fill(&dev, 0, dev.params->lines / 3, 0, dev.params->rgb_channels - 1,
+             0x001F);
     ztimer_sleep(ZTIMER_MSEC, 1 * MS_PER_SEC);
 
     puts("Drawing green rectangle");
     lcd_fill(&dev, dev.params->lines / 3, 2 * (dev.params->lines / 3), 0,
-             dev.params->rgb_channels, 0x07E0);
+             dev.params->rgb_channels - 1, 0x07E0);
     ztimer_sleep(ZTIMER_MSEC, 1 * MS_PER_SEC);
 
     puts("Drawing red rectangle");
     lcd_fill(&dev, 2 * (dev.params->lines / 3), dev.params->lines, 0,
-             dev.params->rgb_channels, 0xf800);
+             dev.params->rgb_channels - 1, 0xf800);
     ztimer_sleep(ZTIMER_MSEC, 1 * MS_PER_SEC);
 
     lcd_invert_on(&dev);
@@ -95,7 +97,10 @@ int main(void)
 
     puts("lcd TFT display clear screen with benchmarking");
     BENCHMARK_FUNC("fill", 1,
-                   lcd_fill(&dev, 0, dev.params->lines, 0, dev.params->rgb_channels, 0x0000));
+                   lcd_fill(&dev,
+                            0, dev.params->lines - 1,
+                            0, dev.params->rgb_channels - 1,
+                            0x0000));
 
 #ifndef CONFIG_NO_RIOT_IMAGE
     printf("Write pixmap of size %u x %u with benchmarking\n",


### PR DESCRIPTION
The lcd_fill() argument x2 (y2) must be less than dev.params->lines (dev.params->rgb_channels) to not draw to invalid LCD coordinates.

Tested on a Xiao nRF52840 with a ST7735 attached.

This is my first contribution to RIOT and to be honest I did not completely read the Linux kernel coding style guide, but I wrapped the long lines according to https://docs.kernel.org/process/coding-style.html#breaking-long-lines-and-strings.
