### PR TITLE
sys/net/gnrc/pktdump: ease setup

### DIFF
--- a/examples/advanced/opendsme/main.c
+++ b/examples/advanced/opendsme/main.c
@@ -17,10 +17,7 @@
 #include <string.h>
 #include "opendsme/opendsme.h"
 
-#include "net/gnrc.h"
-#include "net/gnrc/pktdump.h"
-#include "net/gnrc/netreg.h"
-
+#include "msg.h"
 #include "shell.h"
 
 #define MAIN_QUEUE_SIZE     (8)
@@ -29,10 +26,6 @@ static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 int main(void)
 {
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
-
-    gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
-                                                          gnrc_pktdump_pid);
-    gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);

--- a/examples/basic/default/main.c
+++ b/examples/basic/default/main.c
@@ -27,17 +27,8 @@
 
 #include "shell.h"
 
-#include "net/gnrc/pktdump.h"
-#include "net/gnrc.h"
-
 int main(void)
 {
-#ifdef MODULE_GNRC_PKTDUMP
-    gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
-                                                          gnrc_pktdump_pid);
-    gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
-#endif
-
     (void) puts("Welcome to RIOT!");
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];

--- a/examples/networking/gnrc/gnrc_lorawan/main.c
+++ b/examples/networking/gnrc/gnrc_lorawan/main.c
@@ -16,34 +16,16 @@
  * @}
  */
 
-#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "thread.h"
 #include "shell.h"
-
-#include "board.h"
-
-#include "net/gnrc/netapi.h"
-#include "net/gnrc/netif.h"
-
-#include "net/gnrc/pktbuf.h"
-#include "net/gnrc/netreg.h"
-#include "net/gnrc/pktdump.h"
-#include "net/loramac.h"
 
 int main(void)
 {
     /* start the shell */
     puts("Initialization successful - starting the shell now");
-
-    /* Receive LoRaWAN packets in GNRC pktdump */
-    gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
-                                                          gnrc_pktdump_pid);
-
-    gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);

--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -157,9 +157,14 @@ int gnrc_netreg_register(gnrc_nettype_t type, gnrc_netreg_entry_t *entry)
     gnrc_netreg_entry_t *e;
     LL_FOREACH(netreg[type], e) {
         assert(entry != e);
+        if (e->target.pid == entry->target.pid) {
+            entry = NULL;
+            break;
+        }
     }
-
-    LL_PREPEND(netreg[type], entry);
+    if (entry) {
+        LL_PREPEND(netreg[type], entry);
+    }
     _gnrc_netreg_release_exclusive();
 
     return 0;

--- a/tests/drivers/cc110x/main.c
+++ b/tests/drivers/cc110x/main.c
@@ -74,12 +74,14 @@ static int sc_dump(int argc, char **argv)
         }
 
         if (new_state) {
+            gnrc_netreg_entry_init_pid(&dump, GNRC_NETREG_DEMUX_CTX_ALL, gnrc_pktdump_pid);
             if (gnrc_netreg_register(GNRC_NETTYPE_SIXLOWPAN, &dump)) {
                 puts("Failed to register packet dumping");
             }
         }
         else {
             gnrc_netreg_unregister(GNRC_NETTYPE_SIXLOWPAN, &dump);
+            gnrc_netreg_entry_init_pid(&dump, 0, KERNEL_PID_UNDEF);
         }
 
         is_enabled = new_state;
@@ -95,9 +97,6 @@ int main(void)
     /* we need a message queue for the thread running the shell in order to
      * receive potentially fast incoming networking packets */
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
-
-    gnrc_netreg_entry_init_pid(&dump, GNRC_NETREG_DEMUX_CTX_ALL,
-                               gnrc_pktdump_pid);
 
     puts("cc110x driver test application\n"
          "==============================\n"

--- a/tests/net/gnrc_gomach/main.c
+++ b/tests/net/gnrc_gomach/main.c
@@ -18,20 +18,12 @@
  * @}
  */
 
-#include <stdio.h>
 #include <string.h>
 
-#include "thread.h"
 #include "shell.h"
-#include "net/gnrc/pktdump.h"
-#include "net/gnrc.h"
 
 int main(void)
 {
-    gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
-                                                          gnrc_pktdump_pid);
-    gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
-
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 

--- a/tests/net/gnrc_lwmac/main.c
+++ b/tests/net/gnrc_lwmac/main.c
@@ -26,19 +26,11 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "thread.h"
 #include "shell.h"
-
-#include "net/gnrc/pktdump.h"
-#include "net/gnrc.h"
 
 int main(void)
 {
     puts("LWMAC test application");
-
-    gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
-                                                          gnrc_pktdump_pid);
-    gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);

--- a/tests/net/gnrc_netif/common.c
+++ b/tests/net/gnrc_netif/common.c
@@ -33,7 +33,7 @@ netdev_t *devs[DEFAULT_DEVS_NUMOF];
 
 #define MSG_QUEUE_SIZE  (8)
 
-static gnrc_netreg_entry_t dumper_undef, dumper_ipv6;
+static gnrc_netreg_entry_t dumper_ipv6;
 static msg_t _main_msg_queue[MSG_QUEUE_SIZE];
 static uint8_t tmp_buffer[ETHERNET_DATA_LEN];
 static size_t tmp_buffer_bytes = 0;
@@ -188,11 +188,8 @@ void _tests_init(void)
         netdev_test_set_get_cb(&_devs[i], NETOPT_MAX_PDU_SIZE,
                                _get_netdev_max_packet_size);
     }
-    gnrc_netreg_entry_init_pid(&dumper_undef, GNRC_NETREG_DEMUX_CTX_ALL,
-                               gnrc_pktdump_pid);
     gnrc_netreg_entry_init_pid(&dumper_ipv6, GNRC_NETREG_DEMUX_CTX_ALL,
                                gnrc_pktdump_pid);
-    gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dumper_undef);
     gnrc_netreg_register(GNRC_NETTYPE_IPV6, &dumper_ipv6);
 }
 

--- a/tests/net/netdev_common/main.c
+++ b/tests/net/netdev_common/main.c
@@ -17,20 +17,10 @@
  * @}
  */
 
-#include "thread.h"
 #include "shell.h"
-
-#include "net/gnrc/pktdump.h"
-#include "net/gnrc.h"
 
 int main(void)
 {
-    /* enable pktdump output */
-    gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
-                                                          gnrc_pktdump_pid);
-
-    gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
-
     /* start the shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];
 

--- a/tests/net/slip/main.c
+++ b/tests/net/slip/main.c
@@ -21,30 +21,15 @@
 #include <stdio.h>
 
 #include "shell.h"
-#include "net/gnrc.h"
-#include "net/gnrc/pktdump.h"
 
 /**
  * @brief   Maybe you are a golfer?!
  */
 int main(void)
 {
-    gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
-                                                          gnrc_pktdump_pid);
-
     puts("SLIP test");
-
-    /* register pktdump */
-    if (dump.target.pid <= KERNEL_PID_UNDEF) {
-        puts("Error starting pktdump thread");
-        return -1;
-    }
-
-    gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
-
     /* start the shell */
     puts("Initialization OK, starting shell now");
-
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This should make it easier to use `pktdump` with just `USEMODULE+=gnrc_pktdumo`, without having to set up a default `netreg` for `GNRC_NETTYPE_UNDEF`

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
split out from #21202