### PR TITLE
ieee802154/submac: handle non standard modulations

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_radio_ops.c
+++ b/cpu/cc2538/radio/cc2538_rf_radio_ops.c
@@ -345,7 +345,7 @@ static int _set_cca_threshold(ieee802154_dev_t *dev, int8_t threshold)
     return 0;
 }
 
-static int _config_phy(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf)
+static int _config_phy(ieee802154_dev_t *dev, ieee802154_phy_conf_t *conf)
 {
     (void) dev;
     int8_t pow = conf->pow;

--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -419,7 +419,7 @@ static int _set_csma_params(ieee802154_dev_t *dev, const ieee802154_csma_be_t *b
     return 0;
 }
 
-static int _config_phy(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf)
+static int _config_phy(ieee802154_dev_t *dev, ieee802154_phy_conf_t *conf)
 {
     socket_zep_t *zepdev = dev->priv;
 

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -580,7 +580,7 @@ static int _request_on(ieee802154_dev_t *dev)
     return 0;
 }
 
-static int _config_phy(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf)
+static int _config_phy(ieee802154_dev_t *dev, ieee802154_phy_conf_t *conf)
 {
     (void)dev;
     int8_t pow = conf->pow;

--- a/drivers/kw2xrf/kw2xrf_radio_hal.c
+++ b/drivers/kw2xrf/kw2xrf_radio_hal.c
@@ -545,7 +545,7 @@ static const uint16_t pll_frac_lt[16] = {
     2048, 12288, 22528, 32768
 };
 
-static int _config_phy(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf)
+static int _config_phy(ieee802154_dev_t *dev, ieee802154_phy_conf_t *conf)
 {
     kw2xrf_t *kw_dev = dev->priv;
     kw2xrf_set_tx_power(kw_dev, conf->pow);

--- a/drivers/mrf24j40/mrf24j40_radio_hal.c
+++ b/drivers/mrf24j40/mrf24j40_radio_hal.c
@@ -249,7 +249,7 @@ static int _set_cca_mode(ieee802154_dev_t *dev, ieee802154_cca_mode_t mode)
     return 0;
 }
 
-static int _config_phy(ieee802154_dev_t *hal, const ieee802154_phy_conf_t *conf)
+static int _config_phy(ieee802154_dev_t *hal, ieee802154_phy_conf_t *conf)
 {
     mrf24j40_t *dev = hal->priv;
     int8_t pow = conf->pow;

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -167,7 +167,7 @@ void ieee802154_submac_ack_timer_set(ieee802154_submac_t *submac)
                                                              netdev_ieee802154_submac_t,
                                                              submac);
     ieee802154_submac_ack_timer_cancel(submac);
-    DEBUG("IEEE802154 submac: Setting ACK timeout %"PRIu16" us\n", submac->ack_timeout_us);
+    DEBUG("IEEE802154 submac: Setting ACK timeout %"PRIu32" us\n", submac->ack_timeout_us);
     ztimer_set(ZTIMER_USEC, &netdev_submac->ack_timer, submac->ack_timeout_us);
 }
 

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -120,6 +120,77 @@ extern "C" {
 #define IEEE802154_ACK_TIMEOUT_SYMS     (54)
 
 /**
+ * @name    Time in µs per symbol for different OQPSK PHYs depending on frequency band
+ *
+ * @see IEEE 802.15.4-2020, Section 12. O-QPSK PHY
+ *
+ * 8 symbols == 4 octets => 1 symbol == 4 bits
+ * 2450MHz, 915MHz, 780MHz, 2380MHz: 250 kb/s ==> 62.5 ksymbol/s ==> 16 us/symbol
+ * 868MHz: 100 kb/s ==> 25 ksymbol/s ==> 40 us/symbol
+ * @{
+ */
+/**
+ * @brief Symbol time for IEEE 802.15.4 868MHz OQPSK PHY in µs
+ */
+#define IEEE802154_OQPSK_868_SYMBOL_TIME_US     (40)
+/**
+ * @brief Symbol time for IEEE 802.15.4 2450MHz OQPSK PHY in µs
+ */
+#define IEEE802154_OQPSK_2450_SYMBOL_TIME_US    (16)
+/**
+ * @brief Symbol time for IEEE 802.15.4 2380MHz OQPSK PHY in µs
+ */
+#define IEEE802154_OQPSK_2380_SYMBOL_TIME_US    (16)
+/**
+ * @brief Symbol time for IEEE 802.15.4 915MHz OQPSK PHY in µs
+ */
+#define IEEE802154_OQPSK_915_SYMBOL_TIME_US     (16)
+/**
+ * @brief Symbol time for IEEE 802.15.4 780MHz OQPSK PHY in µs
+ */
+#define IEEE802154_OQPSK_780_SYMBOL_TIME_US     (16)
+/** @} */
+
+/**
+ * @name    Time in µs per symbol for different BPSK PHYs depending on frequency band
+ *
+ * @see IEEE 802.15.4-2020, Section 13. Binary phase-shift keying (BPSK) PHY
+ *
+ * 32 symbols == 4 octets => 1 symbol = 1 bit
+ * 868 MHz: 20kb/s ==> 50us/symbol
+ * 915 MHz: 40kb/s ==> 25us/symbol
+ * @{
+ */
+/**
+ * @brief Symbol time for IEEE 802.15.4 BPSK PHY in µs
+ */
+#define IEEE802154_BPSK_868_SYMBOL_TIME_US       (50)
+/**
+ * @brief Symbol time for IEEE 802.15.4 BPSK PHY in µs
+ */
+#define IEEE802154_BPSK_915_SYMBOL_TIME_US       (25)
+/** @} */
+
+/**
+ * @name    Time in µs per symbol for different ASK PHYs depending on frequency band
+ *
+ * @see IEEE 802.15.4-2015, Section 14. Amplitude shift keying (ASK) PHY
+ *
+ * 868 MHz: 250 kb/s ==> 12.5 ksymbol/s ==> 80 us/symbol
+ * 915 MHz: 250 kb/s ==> 50 ksymbols/s ==> 20 us/symbol
+ * @{
+ */
+/**
+ * @brief Symbol time for IEEE 802.15.4 ASK 868MHz PHY in µs
+ */
+#define IEEE802154_ASK_868_SYMBOL_TIME_US        (80)
+/**
+ * @brief Symbol time for IEEE 802.15.4 ASK 915MHz PHY in µs
+ */
+#define IEEE802154_ASK_915_SYMBOL_TIME_US        (20)
+/** @} */
+
+/**
  * @brief Symbol time for IEEE 802.15.4 MR-OFDM in µs
  */
 #define IEEE802154_MR_OFDM_SYMBOL_TIME_US   (120)
@@ -188,6 +259,15 @@ extern "C" {
  * [1] all but MR-O-QPSK
  */
 #define IEEE802154_CCA_DURATION_IN_SYMBOLS      (8)
+
+/**
+ * IEEE Std 802.15.4-2020
+ * Table 8-93—MAC sublayer constants: For all PHYs except SUN PHYs
+ * operating in the 920 MHz band, aTurnaroundTime + aCcaTime.
+ * For SUN PHYs operating in the 920 MHz band, aTurnaround-Time + phyCcaDuration.
+ */
+#define IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS   (IEEE802154_ATURNAROUNDTIME_IN_SYMBOLS + \
+                                                     IEEE802154_CCA_DURATION_IN_SYMBOLS)
 
 /**
  * @brief   802.15.4 PHY modes

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -280,6 +280,7 @@ typedef enum {
     IEEE802154_PHY_MR_OQPSK,        /**< Multi-Rate Offset Quadrature Phase-Shift Keying */
     IEEE802154_PHY_MR_OFDM,         /**< Multi-Rate Orthogonal Frequency-Division Multiplexing */
     IEEE802154_PHY_MR_FSK,          /**< Multi-Rate Frequency Shift Keying */
+    IEEE802154_PHY_LORA,            /**< LoRa modulation (no standard for IEEE 802.15.4) */
 
     IEEE802154_PHY_NO_OP,           /**< don't change PHY configuration */
 } ieee802154_phy_mode_t;

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -456,13 +456,23 @@ typedef enum {
 } ieee802154_cca_mode_t;
 
 /**
+ * @brief   Derived submac parameters from PHY configuration
+ */
+typedef struct {
+    uint32_t ack_timeout_us;            /**< Ack timeout in µs */
+    uint16_t csma_backoff_us;           /**< CSMA sender backoff period in µs */
+    uint16_t sifs_period_us;            /**< SIFS period in µs */
+} ieee802154_phy_conf_result_t;
+
+/**
  * @brief Holder of the PHY configuration
  */
 typedef struct {
-    ieee802154_phy_mode_t phy_mode; /**< IEEE802.15.4 PHY mode */
-    uint16_t channel;               /**< IEEE802.15.4 channel number */
-    uint8_t page;                   /**< IEEE802.15.4 channel page */
-    int8_t pow;                     /**< TX power in dBm */
+    ieee802154_phy_mode_t phy_mode;     /**< IEEE802.15.4 PHY mode */
+    uint16_t channel;                   /**< IEEE802.15.4 channel number */
+    uint8_t page;                       /**< IEEE802.15.4 channel page */
+    int8_t pow;                         /**< TX power in dBm */
+    ieee802154_phy_conf_result_t res;   /**< PHY configuration deduced parameters */
 } ieee802154_phy_conf_t;
 
 /**
@@ -736,13 +746,13 @@ struct ieee802154_radio_ops {
      * @pre the transceiver state is IDLE.
      *
      * @param[in] dev IEEE802.15.4 device descriptor
-     * @param[in] conf the PHY configuration
+     * @param[in,out] conf the PHY configuration
      *
      * @retval 0        on success
      * @retval -EINVAL  if the configuration is not valid for the device.
      * @retval <0       error, return value is negative errno indicating the cause.
      */
-    int (*config_phy)(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf);
+    int (*config_phy)(ieee802154_dev_t *dev, ieee802154_phy_conf_t *conf);
 
     /**
      * @brief Set number of frame retransmissions
@@ -998,7 +1008,7 @@ static inline int ieee802154_radio_set_cca_mode(ieee802154_dev_t *dev,
  * @return result of @ref ieee802154_radio_ops::config_phy
  */
 static inline int ieee802154_radio_config_phy(ieee802154_dev_t *dev,
-                                              const ieee802154_phy_conf_t *conf)
+                                              ieee802154_phy_conf_t *conf)
 {
     return dev->driver->config_phy(dev, conf);
 }

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -466,6 +466,27 @@ typedef struct {
 } ieee802154_phy_conf_t;
 
 /**
+ * @brief extension for IEEE 802.15.4 OQPSK PHY
+ */
+typedef struct {
+    ieee802154_phy_conf_t super;        /**< common settings */
+} ieee802154_oqpsk_conf_t;
+
+/**
+ * @brief extension for IEEE 802.15.4 BPSK PHY
+ */
+typedef struct {
+    ieee802154_phy_conf_t super;        /**< common settings */
+} ieee802154_bpsk_conf_t;
+
+/**
+ * @brief extension for IEEE 802.15.4 ASK PHY
+ */
+typedef struct {
+    ieee802154_phy_conf_t super;        /**< common settings */
+} ieee802154_ask_conf_t;
+
+/**
  * @brief extension for IEEE 802.15.4g MR-OQPSK PHY
  */
 typedef struct {

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -156,6 +156,10 @@ typedef enum {
      */
     IEEE802154_CAP_PHY_MR_FSK           = BIT18,
     /**
+     * @brief LoRa capability mode (not standardized in IEEE 802.15.4)
+     */
+    IEEE802154_CAP_PHY_LORA             = BIT19,
+    /**
      * @brief the device supports source address match table.
      *
      * A Source Address Match table contains source addresses with pending
@@ -163,7 +167,7 @@ typedef enum {
      * Request command from a child node, the Frame Pending bit of the ACK is
      * set if the source address matches one from the table.
      */
-    IEEE802154_CAP_SRC_ADDR_MATCH       = BIT19,
+    IEEE802154_CAP_SRC_ADDR_MATCH       = BIT20,
 } ieee802154_rf_caps_t;
 
 /**
@@ -175,7 +179,8 @@ typedef enum {
     | IEEE802154_CAP_PHY_OQPSK      \
     | IEEE802154_CAP_PHY_MR_OQPSK   \
     | IEEE802154_CAP_PHY_MR_OFDM    \
-    | IEEE802154_CAP_PHY_MR_FSK)    \
+    | IEEE802154_CAP_PHY_MR_FSK     \
+    | IEEE802154_CAP_PHY_LORA)      \
 
 /**
  * @brief Transmission status
@@ -1683,6 +1688,8 @@ static inline uint32_t ieee802154_phy_mode_to_cap(
             return IEEE802154_CAP_PHY_MR_OFDM;
         case IEEE802154_PHY_MR_FSK:
             return IEEE802154_CAP_PHY_MR_FSK;
+        case IEEE802154_PHY_LORA:
+            return IEEE802154_CAP_PHY_LORA;
 
         case IEEE802154_PHY_DISABLED:
         default:
@@ -1718,6 +1725,8 @@ static inline ieee802154_phy_mode_t ieee802154_cap_to_phy_mode(uint32_t cap)
             return IEEE802154_PHY_MR_OFDM;
         case IEEE802154_CAP_PHY_MR_FSK:
             return IEEE802154_PHY_MR_FSK;
+        case IEEE802154_CAP_PHY_LORA:
+            return IEEE802154_PHY_LORA;
 
         default:
             break;

--- a/sys/include/net/ieee802154/submac.h
+++ b/sys/include/net/ieee802154/submac.h
@@ -197,6 +197,7 @@ struct ieee802154_submac {
     bool wait_for_ack;                  /**< SubMAC is waiting for an ACK frame */
     uint16_t ack_timeout_us;            /**< ACK timeout in µs */
     uint16_t csma_backoff_us;           /**< CSMA sender backoff period in µs */
+    uint16_t sifs_period_us;            /**< SIFS period in µs */
     uint16_t panid;                     /**< IEEE 802.15.4 PAN ID */
     uint16_t channel_num;               /**< IEEE 802.15.4 channel number */
     uint8_t channel_page;               /**< IEEE 802.15.4 channel page */

--- a/sys/include/net/ieee802154/submac.h
+++ b/sys/include/net/ieee802154/submac.h
@@ -195,7 +195,7 @@ struct ieee802154_submac {
     const ieee802154_submac_cb_t *cb;   /**< pointer to the SubMAC callbacks */
     ieee802154_csma_be_t be;            /**< CSMA-CA backoff exponent params */
     bool wait_for_ack;                  /**< SubMAC is waiting for an ACK frame */
-    uint16_t ack_timeout_us;            /**< ACK timeout in µs */
+    uint32_t ack_timeout_us;            /**< ACK timeout in µs */
     uint16_t csma_backoff_us;           /**< CSMA sender backoff period in µs */
     uint16_t sifs_period_us;            /**< SIFS period in µs */
     uint16_t panid;                     /**< IEEE 802.15.4 PAN ID */
@@ -313,7 +313,7 @@ static inline ieee802154_phy_mode_t ieee802154_get_phy_mode(
  * @brief Set IEEE 802.15.4 PHY configuration (channel, TX power)
  *
  * @param[in] submac pointer to the SubMAC descriptor
- * @param[in] conf   pointer to the PHY configuration
+ * @param[in,out] conf   pointer to the PHY configuration
  *
  * @return 0 on success
  * @return -ENOTSUP if the PHY settings are not supported
@@ -322,7 +322,7 @@ static inline ieee802154_phy_mode_t ieee802154_get_phy_mode(
  *         @ref ieee802154_submac_cb_t::tx_done
  * @return negative errno on error
  */
-int ieee802154_set_phy_conf(ieee802154_submac_t *submac, const ieee802154_phy_conf_t *conf);
+int ieee802154_set_phy_conf(ieee802154_submac_t *submac, ieee802154_phy_conf_t *conf);
 
 /**
  * @brief Set IEEE 802.15.4 channel number
@@ -342,7 +342,7 @@ int ieee802154_set_phy_conf(ieee802154_submac_t *submac, const ieee802154_phy_co
 static inline int ieee802154_set_channel_number(ieee802154_submac_t *submac,
                                                 uint16_t channel_num)
 {
-    const ieee802154_phy_conf_t conf = {
+    ieee802154_phy_conf_t conf = {
         .phy_mode = IEEE802154_PHY_NO_OP,
         .channel = channel_num,
         .page = submac->channel_page,
@@ -370,7 +370,7 @@ static inline int ieee802154_set_channel_number(ieee802154_submac_t *submac,
 static inline int ieee802154_set_channel_page(ieee802154_submac_t *submac,
                                               uint16_t channel_page)
 {
-    const ieee802154_phy_conf_t conf = {
+    ieee802154_phy_conf_t conf = {
         .phy_mode = IEEE802154_PHY_NO_OP,
         .channel = submac->channel_num,
         .page = channel_page,
@@ -398,7 +398,7 @@ static inline int ieee802154_set_channel_page(ieee802154_submac_t *submac,
 static inline int ieee802154_set_tx_power(ieee802154_submac_t *submac,
                                           int8_t tx_pow)
 {
-    const ieee802154_phy_conf_t conf = {
+    ieee802154_phy_conf_t conf = {
         .phy_mode = IEEE802154_PHY_NO_OP,
         .channel = submac->channel_num,
         .page = submac->channel_page,

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -16,6 +16,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+#include "compiler_hints.h"
 #include "net/ieee802154/submac.h"
 #include "net/ieee802154.h"
 #include "ztimer.h"
@@ -502,6 +503,214 @@ int ieee802154_send(ieee802154_submac_t *submac, const iolist_t *iolist)
 }
 
 /*
+ * macAckWaitDuration [symbol periods] =
+ * aUnitBackoffPeriod + aTurnaroundTime + phySHRDuration + 6 x phySymbolsPerOctet
+ *
+ *  54 symbols
+ */
+static inline uint16_t _oqpsk_ack_timeout_symbols(const ieee802154_oqpsk_conf_t *conf)
+{
+    (void)conf;
+    return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS +
+           IEEE802154_ATURNAROUNDTIME_IN_SYMBOLS +
+           10 + /* SHR: 32bit preamble + 8 bit SFD => 40 bit => 10 symbols */
+           6 * 2; /* 2 symbols per octet and 4 bit per symbol */
+}
+
+/*
+ * macAckWaitDuration [us] = macAckWaitDuration [symbol periods] * symbol duration [us]
+ *
+ * IEEE 802.15.4-2006, 6.1.2.2 Channel pages, Table 2—Channel page and channel number
+ */
+static inline uint16_t _oqpsk_ack_timeout_us(const ieee802154_oqpsk_conf_t *conf)
+{
+    if (conf->super.page == 2 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return _oqpsk_ack_timeout_symbols(conf) * IEEE802154_OQPSK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 2 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return _oqpsk_ack_timeout_symbols(conf) * IEEE802154_OQPSK_915_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 0 && conf->super.channel >= 11 && conf->super.channel <= 26) {
+        /* 2.4 GHz */
+        return _oqpsk_ack_timeout_symbols(conf) * IEEE802154_OQPSK_2450_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+static inline uint16_t _oqpsk_csma_backoff_period_us(const ieee802154_oqpsk_conf_t *conf)
+{
+    if (conf->super.page == 2 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS * IEEE802154_OQPSK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 2 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS * IEEE802154_OQPSK_915_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 0 && conf->super.channel >= 11 && conf->super.channel <= 26) {
+        /* 2.4 GHz */
+        return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS * IEEE802154_OQPSK_2450_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+static inline uint16_t _oqpsk_sifs_period_us(const ieee802154_oqpsk_conf_t *conf)
+{
+    if (conf->super.page == 2 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return IEEE802154_SIFS_SYMS * IEEE802154_OQPSK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 2 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return IEEE802154_SIFS_SYMS * IEEE802154_OQPSK_915_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 0 && conf->super.channel >= 11 && conf->super.channel <= 26) {
+        /* 2.4 GHz */
+        return IEEE802154_SIFS_SYMS * IEEE802154_OQPSK_2450_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+/*
+ * macAckWaitDuration [symbol periods] =
+ * aUnitBackoffPeriod + aTurnaroundTime + phySHRDuration + 6 x phySymbolsPerOctet
+ *
+ * 120 symbols
+ */
+static inline uint16_t _bpsk_ack_timeout_symbols(const ieee802154_bpsk_conf_t *conf)
+{
+    (void)conf;
+    return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS +
+           IEEE802154_ATURNAROUNDTIME_IN_SYMBOLS +
+           40 + /* SHR: 32bit preamble + 8 bit SFD => 40 bit => 40 symbols */
+           6 * 8; /* 8 symbols per octet and 1 bit per symbol */
+}
+
+/*
+ * macAckWaitDuration [us] = macAckWaitDuration [symbol periods] * symbol duration [us]
+ *
+ * IEEE 802.15.4-2006, 6.1.2.2 Channel pages, Table 2—Channel page and channel number
+ */
+static inline uint16_t _bpsk_ack_timeout_us(const ieee802154_bpsk_conf_t *conf)
+{
+    if (conf->super.page == 0 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return _bpsk_ack_timeout_symbols(conf) * IEEE802154_BPSK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 0 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return _bpsk_ack_timeout_symbols(conf) * IEEE802154_BPSK_915_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+static inline uint16_t _bpsk_csma_backoff_period_us(const ieee802154_bpsk_conf_t *conf)
+{
+    if (conf->super.page == 0 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS * IEEE802154_BPSK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 0 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS * IEEE802154_BPSK_915_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+static inline uint16_t _bpsk_sifs_period_us(const ieee802154_bpsk_conf_t *conf)
+{
+    if (conf->super.page == 0 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return IEEE802154_SIFS_SYMS * IEEE802154_BPSK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 0 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return IEEE802154_SIFS_SYMS * IEEE802154_BPSK_915_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+/*
+ * macAckWaitDuration [symbol periods] =
+ * aUnitBackoffPeriod + aTurnaroundTime + phySHRDuration + 6 x phySymbolsPerOctet
+ *
+ * IEEE 802.15.4-2006, Section 6.3 PPDU format
+ * SHR duration is different for 868 MHz and 915 MHz
+ *
+ * IEEE 802.15.4-2006, 6.1.2.2 Channel pages, Table 2—Channel page and channel number
+ * Page 1, Channel 0: 868 MHz
+ * Page 1, Channel 1-10: 915 MHz
+ */
+static inline uint16_t _ask_ack_timeout_symbols(const ieee802154_ask_conf_t *conf)
+{
+    (void)conf;
+    return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS +
+           IEEE802154_ATURNAROUNDTIME_IN_SYMBOLS +
+           conf->super.page == 1 && conf->super.channel == 0
+            /* 868 MHz */
+            ? (3 + /* SHR: 2 symbols preamble + 1 symbol SFD */
+               (uint16_t)(6 * 0.4f + 0.5f)) /* 0.4 symbols per octet (+0.5 to round up) */
+            /* 915 MHz */
+            : (7 + /* SHR: 6 symbols preamble + 1 symbol SFD */
+               (uint16_t)(6 * 1.6f + 0.5f)); /* 1.6 symbols per octet (+0.5 to round up) */
+}
+
+/*
+ * macAckWaitDuration [us] = macAckWaitDuration [symbol periods] * symbol duration [us]
+ *
+ * IEEE 802.15.4-2006, 6.1.2.2 Channel pages, Table 2—Channel page and channel number
+ */
+static inline uint16_t _ask_ack_timeout_us(const ieee802154_ask_conf_t *conf)
+{
+    if (conf->super.page == 1 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return _ask_ack_timeout_symbols(conf) * IEEE802154_ASK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 1 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return _ask_ack_timeout_symbols(conf) * IEEE802154_ASK_915_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+static inline uint16_t _ask_csma_backoff_period_us(const ieee802154_ask_conf_t *conf)
+{
+    if (conf->super.page == 1 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS * IEEE802154_ASK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 1 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return IEEE802154_AUNITBACKOFF_PERIOD_IN_SYMBOLS * IEEE802154_ASK_915_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+static inline uint16_t _ask_sifs_period_us(const ieee802154_ask_conf_t *conf)
+{
+    if (conf->super.page == 1 && conf->super.channel == 0) {
+        /* 868 MHz */
+        return IEEE802154_SIFS_SYMS * IEEE802154_ASK_868_SYMBOL_TIME_US;
+    }
+    if (conf->super.page == 1 && conf->super.channel >= 1 && conf->super.channel <= 10) {
+        /* 915 MHz */
+        return IEEE802154_SIFS_SYMS * IEEE802154_ASK_915_SYMBOL_TIME_US;
+    }
+    /* invalid */
+    return 0;
+}
+
+/*
  * MR-OQPSK timing calculations
  *
  * The standard unfortunately does not list the formula, instead it has to be pieced together
@@ -588,6 +797,12 @@ static inline uint16_t _mr_oqpsk_csma_backoff_period_us(const ieee802154_mr_oqps
          + IEEE802154G_ATURNAROUNDTIME_US;
 }
 
+MAYBE_UNUSED
+static inline uint16_t _mr_oqpsk_sifs_period_us(const ieee802154_mr_oqpsk_conf_t *conf)
+{
+    return IEEE802154_SIFS_SYMS * _mr_oqpsk_symbol_duration_us(conf->chips);
+}
+
 /*
  * MR-OFDM timing calculations
  *
@@ -620,6 +835,13 @@ static inline uint16_t _mr_ofdm_csma_backoff_period_us(const ieee802154_mr_ofdm_
 }
 
 MAYBE_UNUSED
+static inline uint16_t _mr_ofdm_sifs_period_us(const ieee802154_mr_ofdm_conf_t *conf)
+{
+    (void)conf;
+    return IEEE802154_SIFS_SYMS * IEEE802154_MR_OFDM_SYMBOL_TIME_US;
+}
+
+MAYBE_UNUSED
 static inline uint16_t _mr_ofdm_ack_timeout_us(const ieee802154_mr_ofdm_conf_t *conf)
 {
     return _mr_ofdm_csma_backoff_period_us(conf)
@@ -641,6 +863,13 @@ static inline uint16_t _mr_fsk_csma_backoff_period_us(const ieee802154_mr_fsk_co
 
     return IEEE802154_CCA_DURATION_IN_SYMBOLS * IEEE802154_MR_FSK_SYMBOL_TIME_US
          + IEEE802154G_ATURNAROUNDTIME_US;
+}
+
+MAYBE_UNUSED
+static inline uint16_t _mr_fsk_sifs_period_us(const ieee802154_mr_fsk_conf_t *conf)
+{
+    (void)conf;
+    return IEEE802154_SIFS_SYMS * IEEE802154_MR_FSK_SYMBOL_TIME_US;
 }
 
 MAYBE_UNUSED
@@ -672,26 +901,40 @@ static int ieee802154_submac_config_phy(ieee802154_submac_t *submac,
                                         const ieee802154_phy_conf_t *conf)
 {
     switch (conf->phy_mode) {
+    case IEEE802154_PHY_BPSK:
+        submac->ack_timeout_us = _bpsk_ack_timeout_us((void *)conf);
+        submac->csma_backoff_us = _bpsk_csma_backoff_period_us((void *)conf);
+        submac->sifs_period_us = _bpsk_sifs_period_us((void *)conf);
+        break;
+    case IEEE802154_PHY_ASK:
+        submac->ack_timeout_us = _ask_ack_timeout_us((void *)conf);
+        submac->csma_backoff_us = _ask_csma_backoff_period_us((void *)conf);
+        submac->sifs_period_us = _ask_sifs_period_us((void *)conf);
+        break;
     case IEEE802154_PHY_OQPSK:
-        submac->ack_timeout_us = ACK_TIMEOUT_US;
-        submac->csma_backoff_us = CSMA_SENDER_BACKOFF_PERIOD_UNIT_US;
+        submac->ack_timeout_us = _oqpsk_ack_timeout_us((void *)conf);
+        submac->csma_backoff_us = _oqpsk_csma_backoff_period_us((void *)conf);
+        submac->sifs_period_us = _oqpsk_sifs_period_us((void *)conf);
         break;
 #ifdef MODULE_NETDEV_IEEE802154_MR_OQPSK
     case IEEE802154_PHY_MR_OQPSK:
         submac->ack_timeout_us = _mr_oqpsk_ack_timeout_us((void *)conf);
         submac->csma_backoff_us = _mr_oqpsk_csma_backoff_period_us((void *)conf);
+        submac->sifs_period_us = _mr_oqpsk_sifs_period_us((void *)conf);
         break;
 #endif
 #ifdef MODULE_NETDEV_IEEE802154_MR_OFDM
     case IEEE802154_PHY_MR_OFDM:
         submac->ack_timeout_us = _mr_ofdm_ack_timeout_us((void *)conf);
         submac->csma_backoff_us = _mr_ofdm_csma_backoff_period_us((void *)conf);
+        submac->sifs_period_us = _mr_ofdm_sifs_period_us((void *)conf);
         break;
 #endif
 #ifdef MODULE_NETDEV_IEEE802154_MR_FSK
     case IEEE802154_PHY_MR_FSK:
         submac->ack_timeout_us = _mr_fsk_ack_timeout_us((void *)conf);
         submac->csma_backoff_us = _mr_fsk_csma_backoff_period_us((void *)conf);
+        submac->sifs_period_us = _mr_fsk_sifs_period_us((void *)conf);
         break;
 #endif
     case IEEE802154_PHY_NO_OP:
@@ -784,6 +1027,7 @@ int ieee802154_submac_init(ieee802154_submac_t *submac, const network_uint16_t *
         ieee802154_mr_fsk_conf_t mr_fsk;
 #endif
     } conf;
+    memset(&conf, 0, sizeof(conf));
 
 #ifdef MODULE_NETDEV_IEEE802154_MR_OQPSK
     if (submac->phy_mode == IEEE802154_PHY_MR_OQPSK) {

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -289,7 +289,7 @@ static ieee802154_fsm_state_t _fsm_state_prepare(ieee802154_submac_t *submac,
         }
         else if (ftype == IEEE802154_FCF_TYPE_ACK) {
             /* no backoff for ACK frames but wait for SIFSPeriod */
-            ztimer_sleep(ZTIMER_USEC, SIFS_PERIOD_US);
+            ztimer_sleep(ZTIMER_USEC, submac->sifs_period_us);
         }
 
         while (ieee802154_radio_request_transmit(dev) == -EBUSY) {}

--- a/sys/shell/cmds/gnrc_netif.c
+++ b/sys/shell/cmds/gnrc_netif.c
@@ -531,7 +531,8 @@ static const char *_netopt_ieee802154_phy_str[] = {
     [IEEE802154_PHY_OQPSK] = "O-QPSK",
     [IEEE802154_PHY_MR_OQPSK] = "MR-O-QPSK",
     [IEEE802154_PHY_MR_OFDM] = "MR-OFDM",
-    [IEEE802154_PHY_MR_FSK] = "MR-FSK"
+    [IEEE802154_PHY_MR_FSK] = "MR-FSK",
+    [IEEE802154_PHY_LORA] = "LORA",
 };
 #endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

The key feature of this PR is to reuse the `conf` parameter as an output in
```C
static int _config_phy(ieee802154_dev_t *dev, ieee802154_phy_conf_t *conf)
```

So the driver that is using an unknown IEEE.802.15.4 modulation can set ACK timeout and CSMA backoff.

This is crucial for #21202.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Follow up from #19668.
Split out from #21202 