### PR TITLE
netdev_ieee802154_submac: add opportunity to use legacy netdev driver

### DIFF
--- a/drivers/include/net/netdev/ieee802154_submac.h
+++ b/drivers/include/net/netdev/ieee802154_submac.h
@@ -54,17 +54,26 @@ typedef struct {
     int8_t retrans;                     /**< number of frame retransmissions of the last TX */
     bool dispatch;                      /**< whether an event should be dispatched or not */
     netdev_event_t ev;                  /**< event to be dispatched */
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC_LEGACY)
+    netdev_t *legacy;                   /**< For drivers that also implement the old netdev API,
+                                             this pointer shall be set to the netdev_t inside the driver struct,
+                                             to have the old netdev driver's get and set functions,
+                                             supporting device specific netopts. */
+#endif
 } netdev_ieee802154_submac_t;
 
 /**
  * @brief Init the IEEE 802.15.4 SubMAC netdev adoption.
  *
  * @param[in] netdev_submac pointer to the netdev submac descriptor.
+ * @param[in] legacy pointer to an old netdev, set up with the old netdev driver.
+ *
+ * @note @p legacy can be NULL. If not, it should have been set up in *_hal_setup().
  *
  * @return 0 on success.
  * @return negative errno on failure.
  */
-int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac);
+int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac, netdev_t *legacy);
 
 #ifdef __cplusplus
 }

--- a/drivers/netdev_ieee802154_submac/Makefile.include
+++ b/drivers/netdev_ieee802154_submac/Makefile.include
@@ -1,1 +1,2 @@
 PSEUDOMODULES += netdev_ieee802154_submac_soft_ack
+PSEUDOMODULES += netdev_ieee802154_submac_legacy

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -64,7 +64,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
     netdev_ieee802154_t *netdev_ieee802154 = container_of(netdev, netdev_ieee802154_t, netdev);
     netdev_ieee802154_submac_t *netdev_submac = container_of(netdev_ieee802154, netdev_ieee802154_submac_t, dev);
     ieee802154_submac_t *submac = &netdev_submac->submac;
-
+    DEBUG("IEEE802154 submac: _get(): opt %d\n", opt);
     switch (opt) {
         case NETOPT_STATE:
             *((netopt_state_t*) value) = _get_submac_state(submac);
@@ -85,8 +85,21 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
             break;
     }
 
-    return netdev_ieee802154_get(container_of(netdev, netdev_ieee802154_t, netdev), opt,
-                                 value, max_len);
+    int get =  netdev_ieee802154_get(container_of(netdev, netdev_ieee802154_t, netdev), opt,
+                                     value, max_len);
+    if (get > 0) {
+        return get;
+    }
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC_LEGACY)
+    netdev_t *legacy = netdev_submac->legacy;
+    if (legacy && legacy->driver && legacy->driver->get) {
+        if ((get = legacy->driver->get(legacy, opt, value, max_len))) {
+            return get;
+        }
+    }
+#endif
+
+    return -ENOTSUP;
 }
 
 static int _set_submac_state(ieee802154_submac_t *submac, netopt_state_t state)
@@ -114,7 +127,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value,
 
     int res;
     int16_t tx_power;
-
+    DEBUG("IEEE802154 submac: _set(): opt %d\n", opt);
     switch (opt) {
     case NETOPT_ADDRESS:
         ieee802154_set_short_addr(submac, value);
@@ -145,8 +158,21 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value,
         break;
     }
 
-    return netdev_ieee802154_set(container_of(netdev, netdev_ieee802154_t, netdev),
-                                 opt, value, value_len);
+    int set =  netdev_ieee802154_set(container_of(netdev, netdev_ieee802154_t, netdev), opt,
+                                     value, value_len);
+    if (set > 0) {
+        return set;
+    }
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC_LEGACY)
+    netdev_t *legacy = netdev_submac->legacy;
+    if (legacy && legacy->driver && legacy->driver->set) {
+        if ((set = legacy->driver->set(legacy, opt, value, value_len))) {
+            return set;
+        }
+    }
+#endif
+
+    return -ENOTSUP;
 }
 
 void ieee802154_submac_bh_request(ieee802154_submac_t *submac)
@@ -454,7 +480,7 @@ static int _confirm_send(netdev_t *netdev, void *info)
     return netdev_submac->bytes_tx;
 }
 
-int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac)
+int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac, netdev_t *legacy)
 {
     netdev_t *netdev = &netdev_submac->dev.netdev;
 
@@ -468,6 +494,10 @@ int netdev_ieee802154_submac_init(netdev_ieee802154_submac_t *netdev_submac)
 
     netdev_submac->ack_timer.callback = _ack_timeout;
     netdev_submac->ack_timer.arg = netdev_submac;
+    (void)legacy;
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC_LEGACY)
+    netdev_submac->legacy = legacy;
+#endif
 
     return 0;
 }

--- a/pkg/lwip/init_devs/auto_init_cc2538_rf.c
+++ b/pkg/lwip/init_devs/auto_init_cc2538_rf.c
@@ -31,7 +31,7 @@ static netdev_ieee802154_submac_t cc2538_rf_netdev;
 static void auto_init_cc2538_rf(void)
 {
     netdev_register(&cc2538_rf_netdev.dev.netdev, NETDEV_CC2538, 0);
-    netdev_ieee802154_submac_init(&cc2538_rf_netdev);
+    netdev_ieee802154_submac_init(&cc2538_rf_netdev, NULL);
     cc2538_rf_hal_setup(&cc2538_rf_netdev.submac.dev);
 
     cc2538_init();

--- a/pkg/lwip/init_devs/auto_init_kw2xrf.c
+++ b/pkg/lwip/init_devs/auto_init_kw2xrf.c
@@ -44,7 +44,7 @@ static void auto_init_kw2xrf(void)
                     bhp_event_isr_cb, &netif[i].bhp);
 
         netdev_register(&kw2xrf_netdev[i].dev.netdev, NETDEV_KW2XRF, i);
-        netdev_ieee802154_submac_init(&kw2xrf_netdev[i]);
+        netdev_ieee802154_submac_init(&kw2xrf_netdev[i], NULL);
 
         if (lwip_add_6lowpan(&netif[i], &kw2xrf_netdev[i].dev.netdev) == NULL) {
             DEBUG("Could not add kw2xrf device\n");

--- a/pkg/lwip/init_devs/auto_init_mrf24j40.c
+++ b/pkg/lwip/init_devs/auto_init_mrf24j40.c
@@ -45,7 +45,7 @@ static void auto_init_mrf24j40(void)
 
 
         netdev_register(&mrf24j40_netdev[i].dev.netdev, NETDEV_MRF24J40, i);
-        netdev_ieee802154_submac_init(&mrf24j40_netdev[i]);
+        netdev_ieee802154_submac_init(&mrf24j40_netdev[i], NULL);
 
         if (lwip_add_6lowpan(&netif[i], &mrf24j40_netdev[i].dev.netdev) == NULL) {
             DEBUG("Could not add mrf24j40 device\n");

--- a/pkg/lwip/init_devs/auto_init_nrf802154.c
+++ b/pkg/lwip/init_devs/auto_init_nrf802154.c
@@ -31,7 +31,7 @@ static netdev_ieee802154_submac_t nrf802154_netdev;
 static void auto_init_nrf802154(void)
 {
     netdev_register(&nrf802154_netdev.dev.netdev, NETDEV_NRF802154, 0);
-    netdev_ieee802154_submac_init(&nrf802154_netdev);
+    netdev_ieee802154_submac_init(&nrf802154_netdev, NULL);
 
     nrf802154_hal_setup(&nrf802154_netdev.submac.dev);
     nrf802154_init();

--- a/pkg/lwip/init_devs/auto_init_socket_zep.c
+++ b/pkg/lwip/init_devs/auto_init_socket_zep.c
@@ -36,7 +36,7 @@ static void auto_init_socket_zep(void)
 {
     for (unsigned i = 0; i < NETIF_SOCKET_ZEP_NUMOF; i++) {
         netdev_register(&socket_zep_netdev[i].dev.netdev, NETDEV_SOCKET_ZEP, i);
-        netdev_ieee802154_submac_init(&socket_zep_netdev[i]);
+        netdev_ieee802154_submac_init(&socket_zep_netdev[i], NULL);
         socket_zep_hal_setup(&socket_zep_devs[i], &socket_zep_netdev[i].submac.dev);
 
         socket_zep_setup(&socket_zep_devs[i], &socket_zep_params[i]);

--- a/pkg/openthread/contrib/openthread.c
+++ b/pkg/openthread/contrib/openthread.c
@@ -87,14 +87,14 @@ void openthread_bootstrap(void)
 #endif
 #ifdef MODULE_CC2538_RF
     netdev_register(&cc2538_rf_netdev.dev.netdev, NETDEV_CC2538, 0);
-    netdev_ieee802154_submac_init(&cc2538_rf_netdev);
+    netdev_ieee802154_submac_init(&cc2538_rf_netdev, NULL);
     cc2538_rf_hal_setup(&cc2538_rf_netdev.submac.dev);
     cc2538_init();
     netdev_t *netdev = &cc2538_rf_netdev.dev.netdev;
 #endif
 #ifdef MODULE_NRF802154
     netdev_register(&nrf802154_netdev.dev.netdev, NETDEV_NRF802154, 0);
-    netdev_ieee802154_submac_init(&nrf802154_netdev);
+    netdev_ieee802154_submac_init(&nrf802154_netdev, NULL);
     nrf802154_hal_setup(&nrf802154_netdev.submac.dev);
     nrf802154_init();
     netdev_t *netdev = &nrf802154_netdev.dev.netdev;

--- a/sys/net/gnrc/netif/init_devs/auto_init_cc2538_rf.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_cc2538_rf.c
@@ -42,7 +42,7 @@ void auto_init_cc2538_rf(void)
     LOG_DEBUG("[auto_init_netif] initializing cc2538 radio\n");
 
     netdev_register(&cc2538_rf_netdev.dev.netdev, NETDEV_CC2538, 0);
-    netdev_ieee802154_submac_init(&cc2538_rf_netdev);
+    netdev_ieee802154_submac_init(&cc2538_rf_netdev, NULL);
     cc2538_rf_hal_setup(&cc2538_rf_netdev.submac.dev);
 
     cc2538_init();

--- a/sys/net/gnrc/netif/init_devs/auto_init_esp_ieee802154.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_esp_ieee802154.c
@@ -50,7 +50,7 @@ void auto_init_esp_ieee802154(void)
     esp_ieee802154_init();
 
     netdev_register(&esp_ieee802154_netdev.dev.netdev, NETDEV_ESP_IEEE802154, 0);
-    netdev_ieee802154_submac_init(&esp_ieee802154_netdev);
+    netdev_ieee802154_submac_init(&esp_ieee802154_netdev, NULL);
 
     esp_ieee802154_setup(&esp_ieee802154_netdev.submac.dev);
 

--- a/sys/net/gnrc/netif/init_devs/auto_init_kw2xrf.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_kw2xrf.c
@@ -62,7 +62,7 @@ void auto_init_kw2xrf(void)
                         bhp_event_isr_cb, &kw2xrf_bhp[i]);
 
         netdev_register(&kw2xrf_netdev[i].dev.netdev, NETDEV_KW2XRF, i);
-        netdev_ieee802154_submac_init(&kw2xrf_netdev[i]);
+        netdev_ieee802154_submac_init(&kw2xrf_netdev[i], NULL);
 
         gnrc_netif_ieee802154_create(&_netif[i], _kw2xrf_stacks[i], KW2XRF_MAC_STACKSIZE,
                                      KW2XRF_MAC_PRIO, "kw2xrf",

--- a/sys/net/gnrc/netif/init_devs/auto_init_mrf24j40.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_mrf24j40.c
@@ -58,7 +58,7 @@ void auto_init_mrf24j40(void)
                         bhp_event_isr_cb, &mrf24j40_bhp[i]);
 
         netdev_register(&mrf24j40_netdev[i].dev.netdev, NETDEV_MRF24J40, i);
-        netdev_ieee802154_submac_init(&mrf24j40_netdev[i]);
+        netdev_ieee802154_submac_init(&mrf24j40_netdev[i], NULL);
 
         gnrc_netif_ieee802154_create(&_netif[i], _mrf24j40_stacks[i],
                                      MRF24J40_MAC_STACKSIZE, MRF24J40_MAC_PRIO,

--- a/sys/net/gnrc/netif/init_devs/auto_init_nrf802154.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_nrf802154.c
@@ -63,7 +63,7 @@ void auto_init_nrf802154(void)
                                  NRF802154_MAC_PRIO, "nrf802154",
                                  (netdev_t*) &nrf802154_netdev.submac.dev);
 #else
-        netdev_ieee802154_submac_init(&nrf802154_netdev);
+        netdev_ieee802154_submac_init(&nrf802154_netdev, NULL);
         nrf802154_hal_setup(&nrf802154_netdev.submac.dev);
         gnrc_netif_ieee802154_create(&_netif, _stack,
                                  NRF802154_MAC_STACKSIZE,

--- a/sys/net/gnrc/netif/init_devs/auto_init_socket_zep.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_socket_zep.c
@@ -49,7 +49,7 @@ void auto_init_socket_zep(void)
         LOG_DEBUG("[auto_init_netif: initializing socket ZEP device #%u\n", i);
         /* setup netdev device */
         netdev_register(&_socket_zep_netdev[i].dev.netdev, NETDEV_SOCKET_ZEP, i);
-        netdev_ieee802154_submac_init(&_socket_zep_netdev[i]);
+        netdev_ieee802154_submac_init(&_socket_zep_netdev[i], NULL);
         socket_zep_hal_setup(&_socket_zeps[i], &_socket_zep_netdev[i].submac.dev);
 
         socket_zep_setup(&_socket_zeps[i], &socket_zep_params[i]);

--- a/tests/drivers/cc2538_rf/main.c
+++ b/tests/drivers/cc2538_rf/main.c
@@ -31,7 +31,7 @@ int netdev_ieee802154_minimal_init_devs(netdev_event_cb_t cb) {
     puts("Initializing CC2538_RF device");
 
     netdev_register(netdev, NETDEV_CC2538, 0);
-    netdev_ieee802154_submac_init(&cc2538_rf);
+    netdev_ieee802154_submac_init(&cc2538_rf, NULL);
 
     /* set the application-provided callback */
     netdev->event_callback = cb;

--- a/tests/drivers/kw2xrf/main.c
+++ b/tests/drivers/kw2xrf/main.c
@@ -132,7 +132,7 @@ int netdev_ieee802154_minimal_init_devs(netdev_event_cb_t cb) {
     for (unsigned i = 0; i < KW2XRF_NUM; i++) {
         printf("%d out of %d\n", i + 1, KW2XRF_NUM);
         netdev_register(&kw2xrf_netdev[i].dev.netdev, NETDEV_KW2XRF, 0);
-        netdev_ieee802154_submac_init(&kw2xrf_netdev[i]);
+        netdev_ieee802154_submac_init(&kw2xrf_netdev[i], NULL);
 
         /* set the application-provided callback */
         kw2xrf_netdev[i].dev.netdev.event_callback = cb;

--- a/tests/drivers/mrf24j40/main.c
+++ b/tests/drivers/mrf24j40/main.c
@@ -46,7 +46,7 @@ int netdev_ieee802154_minimal_init_devs(netdev_event_cb_t cb) {
     for (unsigned i = 0; i < MRF24J40_NUM; i++) {
         printf("%d out of %u\n", i + 1, (unsigned)MRF24J40_NUM);
         netdev_register(&mrf24j40_netdev[i].dev.netdev, NETDEV_MRF24J40, 0);
-        netdev_ieee802154_submac_init(&mrf24j40_netdev[i]);
+        netdev_ieee802154_submac_init(&mrf24j40_netdev[i], NULL);
 
         /* set the application-provided callback */
         mrf24j40_netdev[i].dev.netdev.event_callback = cb;

--- a/tests/drivers/nrf802154/main.c
+++ b/tests/drivers/nrf802154/main.c
@@ -31,7 +31,7 @@ int netdev_ieee802154_minimal_init_devs(netdev_event_cb_t cb) {
     puts("Initializing NRF802154 device");
 
     netdev_register(netdev, NETDEV_CC2538, 0);
-    netdev_ieee802154_submac_init(&nrf802154);
+    netdev_ieee802154_submac_init(&nrf802154, NULL);
 
     /* set the application-provided callback */
     netdev->event_callback = cb;

--- a/tests/net/socket_zep/main.c
+++ b/tests/net/socket_zep/main.c
@@ -53,7 +53,7 @@ static void test_init(void)
            p->local_addr, p->local_port, p->remote_addr, p->remote_port);
     netdev_register(&_socket_zep_netdev.dev.netdev, NETDEV_SOCKET_ZEP, 0);
     netdev->event_callback = _event_cb;
-    netdev_ieee802154_submac_init(&_socket_zep_netdev);
+    netdev_ieee802154_submac_init(&_socket_zep_netdev, NULL);
     socket_zep_hal_setup(&_dev, &_socket_zep_netdev.submac.dev);
     socket_zep_setup(&_dev, p);
     expect(netdev->driver->init(netdev) >= 0);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

When using the IEEE 802.15.4 radio HAL, I think support of a few netopts is lost becaus ethey have been implemented in the old `_netdev.c` implementation.
This PR add a pointer to an optional old instance of the netdev driver to have its `_get` and `_set` function.
For example when runnin IEEE802154 over LoRa I still want to see the currently used spreading factor, coding rate etc. 

An old netdev instance can be set like here:
```C
extern const netdev_driver_t sx126x_driver;

void sx126x_hal_setup(sx126x_t *dev, const sx126x_params_t *params, uint8_t index,
                      ieee802154_dev_t *hal, void (*event_cb)(void *arg), void *arg)
{
    (void)dev;
    (void)params;
    (void)hal;
    (void)index;
    (void)event_cb;
    (void)arg;
    /* legacy */
    memset((uint8_t *)dev + sizeof(dev->netdev), 0, sizeof(*dev) - sizeof(dev->netdev));
    netdev_t *netdev = &dev->netdev;
    netdev->driver = &sx126x_driver;
```

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Split out from #21202 
