### PR TITLE
core/panic: reboot on DEVELHELP=1 too

### DIFF
--- a/core/lib/include/panic.h
+++ b/core/lib/include/panic.h
@@ -29,15 +29,9 @@ extern "C" {
 
 /**
  * @brief   Automatically reboot the system on panic()
- *
- * By default this is on when @ref DEVELHELP is disabled.
  */
 #ifndef CONFIG_CORE_REBOOT_ON_PANIC
-#ifdef DEVELHELP
-#define CONFIG_CORE_REBOOT_ON_PANIC (0)
-#else
-#define CONFIG_CORE_REBOOT_ON_PANIC (1)
-#endif
+#  define CONFIG_CORE_REBOOT_ON_PANIC (1)
 #endif
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Make reboot on panic an opt-out with `DEVELHELP=1` too.

#### Rationale

`DEVELHELP=1` should change the behavior of the system as little as possible. Some systems may rely on a reboot for safety reasons,  and enabling debugging effectively affects the expected behavior.

Reboot loops when debugging are now a problem, but they can still be disabled by setting `CONFIG_CORE_REBOOT_ON_PANIC=0` manually, rendering them only a mild inconvenience.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Nothing to test.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
