### PR TITLE
build-system: pin new docker image

### DIFF
--- a/examples/lang_support/official/rust-gcoap/Makefile
+++ b/examples/lang_support/official/rust-gcoap/Makefile
@@ -1,6 +1,9 @@
 # name of your application
 APPLICATION = rust_gcoap
 
+# TODO: Fix bug in docker image
+BOARD_BLACKLIST := native32 native64 native
+
 # The name of crate (as per Cargo.toml package name, but with '-' replaced with '_')
 #
 # The presence of this triggers building Rust code contained in this

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -5,7 +5,7 @@
 # When the docker image is updated, checks at
 # dist/tools/buildsystem_sanity_check/check.sh start complaining in CI, and
 # provide the latest values to verify and fill in.
-DOCKER_TESTED_IMAGE_REPO_DIGEST := 63a87608742890b1ecfc2eea5289d32298d6696a4bd1d9d11a9da2fd32071e4f
+DOCKER_TESTED_IMAGE_REPO_DIGEST := 116c51ffe0c80ffcf9eb693334f8f2e180cdaa66509e81a21217fdd45a2858b5
 
 DOCKER_PULL_IDENTIFIER := docker.io/riot/riotbuild@sha256:$(DOCKER_TESTED_IMAGE_REPO_DIGEST)
 export DOCKER_IMAGE ?= $(DOCKER_PULL_IDENTIFIER)


### PR DESCRIPTION
### Contribution description

This ensures that `make BUILD_IN_DOCKER=1` will use the same container that was used in the CI (Murdock).

### Testing procedure

Green CI

### Issues/PRs references

None