### PR TITLE
ieee802154/submac: add automatic ACK transmission when AUTO_ACK is not supported by driver

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_radio_ops.c
+++ b/cpu/cc2538/radio/cc2538_rf_radio_ops.c
@@ -619,6 +619,7 @@ void cc2538_rf_hal_setup(ieee802154_dev_t *hal)
 
 static const ieee802154_radio_ops_t cc2538_rf_ops = {
     .caps = IEEE802154_CAP_24_GHZ
+          | IEEE802154_CAP_AUTO_ACK
           | IEEE802154_CAP_AUTO_CSMA
           | IEEE802154_CAP_IRQ_CRC_ERROR
           | IEEE802154_CAP_IRQ_TX_DONE

--- a/cpu/esp32/esp-ieee802154/esp_ieee802154_hal.c
+++ b/cpu/esp32/esp-ieee802154/esp_ieee802154_hal.c
@@ -438,6 +438,7 @@ int esp_ieee802154_init(void)
 static const ieee802154_radio_ops_t esp_ieee802154_driver = {
     .caps = IEEE802154_CAP_24_GHZ
           | IEEE802154_CAP_PHY_OQPSK
+          | IEEE802154_CAP_AUTO_ACK
           | IEEE802154_CAP_AUTO_CSMA
           | IEEE802154_CAP_SRC_ADDR_MATCH
 #if _USE_CCA_DONE

--- a/cpu/native/Makefile.dep
+++ b/cpu/native/Makefile.dep
@@ -37,6 +37,7 @@ ifneq (,$(filter socket_zep,$(USEMODULE)))
   USEMODULE += ieee802154
   ifneq (,$(filter netdev,$(USEMODULE)))
     USEMODULE += netdev_ieee802154_submac
+    USEMODULE += netdev_ieee802154_submac_soft_ack
   endif
 endif
 

--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -257,37 +257,6 @@ static void _send_zep_hello(socket_zep_t *dev)
     }
 }
 
-static void _send_ack(void *arg)
-{
-    ieee802154_dev_t *dev = arg;
-    socket_zep_t *zepdev = dev->priv;
-    const uint8_t *rxbuf = &zepdev->rcv_buf[sizeof(zep_v2_data_hdr_t)];
-    uint8_t ack[3];
-    zep_v2_data_hdr_t hdr;
-
-    /* sending ACK should only happen if we received a frame */
-    assert(zepdev->state == ZEPDEV_STATE_RX_RECV);
-    /* ACK request bit should be set if we get here */
-    assert((rxbuf[0] & IEEE802154_FCF_ACK_REQ) != 0);
-
-    DEBUG("socket_zep::send_ack: seq_no: %u\n", rxbuf[2]);
-
-    _zep_hdr_fill(zepdev, &hdr.hdr, sizeof(ack) + IEEE802154_FCF_LEN);
-
-    ack[0] = IEEE802154_FCF_TYPE_ACK; /* FCF */
-    ack[1] = 0; /* FCF */
-    ack[2] = rxbuf[2];  /* SeqNum */
-
-    /* calculate checksum */
-    uint16_t chksum = crc16_ccitt_false_update(0, ack, 3);
-
-    real_send(zepdev->sock_fd, &hdr, sizeof(hdr), MSG_MORE);
-    real_send(zepdev->sock_fd, ack, sizeof(ack), MSG_MORE);
-    real_send(zepdev->sock_fd, &chksum, sizeof(chksum), 0);
-
-    dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_DONE);
-}
-
 static void _send_frame(void *arg)
 {
     ieee802154_dev_t *dev = arg;
@@ -359,13 +328,7 @@ static void _socket_isr(int fd, void *arg)
     zepdev->rcv_len = res;
     dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_START);
 
-    /* send ACK after 192 µs */
-    if ((((uint8_t *)(zep + 1))[0] & IEEE802154_FCF_ACK_REQ) != 0) {
-        zepdev->ack_timer.callback = _send_ack;
-        ztimer_set(ZTIMER_USEC, &zepdev->ack_timer, ACK_DELAY_US);
-    } else {
-        dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_DONE);
-    }
+    dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_DONE);
 
     return;
 out:
@@ -505,6 +468,13 @@ static int _set_frame_filter_mode(ieee802154_dev_t *dev, ieee802154_filter_mode_
     return 0;
 }
 
+static int _get_frame_filter_mode(ieee802154_dev_t *dev, ieee802154_filter_mode_t *mode)
+{
+    socket_zep_t *zepdev = dev->priv;
+    *mode = zepdev->filter_mode;
+    return 0;
+}
+
 static int _write(ieee802154_dev_t *dev, const iolist_t *iolist)
 {
     socket_zep_t *zepdev = dev->priv;
@@ -544,7 +514,7 @@ static int _request_transmit(ieee802154_dev_t *dev)
     zepdev->state = ZEPDEV_STATE_TX;
 
     /* 8 bit are mapped to 2 symbols */
-    unsigned time_tx = 2 * zepdev->snd_len * IEEE802154_SYMBOL_TIME_US;
+    unsigned time_tx = 2 * (zepdev->snd_len - sizeof(zep_v2_data_hdr_t)) * IEEE802154_SYMBOL_TIME_US;
     DEBUG("socket_zep::request_transmit(%u bytes, %u µs)\n", zepdev->snd_len, time_tx);
 
     dev->cb(dev, IEEE802154_RADIO_INDICATION_TX_START);
@@ -560,7 +530,14 @@ static int _confirm_transmit(ieee802154_dev_t *dev, ieee802154_tx_info_t *info)
 {
     (void) dev;
 
+    socket_zep_t *zepdev = dev->priv;
+
+    if (zepdev->state == ZEPDEV_STATE_TX) {
+        DEBUG("socket_zep::confirm_transmit: still in TX state\n");
+        return -EAGAIN; /* TX is still in progress */
+    }
     if (info) {
+        DEBUG("socket_zep::confirm_transmit: success\n");
         info->status = TX_STATUS_SUCCESS;
     }
 
@@ -628,6 +605,7 @@ static int _request_op(ieee802154_dev_t *dev, ieee802154_hal_op_t op, void *ctx)
     switch (op) {
     case IEEE802154_HAL_OP_TRANSMIT:
         if (zepdev->state != ZEPDEV_STATE_IDLE) {
+            DEBUG("socket_zep::request_op: request TX in state %u (busy)\n", zepdev->state);
             return -EBUSY;
         }
         res = _request_transmit(dev);
@@ -659,6 +637,7 @@ static int _request_op(ieee802154_dev_t *dev, ieee802154_hal_op_t op, void *ctx)
             ztimer_remove(ZTIMER_USEC, &zepdev->ack_timer);
             zepdev->state = ZEPDEV_STATE_IDLE;
         } else {
+            DEBUG("socket_zep::request_op: request IDLE in state TX\n");
             return -EBUSY;
         }
 
@@ -723,6 +702,7 @@ static const ieee802154_radio_ops_t socket_zep_rf_ops = {
     .config_src_addr_match = _config_src_addr_match,
     .set_csma_params = _set_csma_params,
     .set_frame_filter_mode = _set_frame_filter_mode,
+    .get_frame_filter_mode = _get_frame_filter_mode,
 };
 
 void socket_zep_hal_setup(socket_zep_t *dev, ieee802154_dev_t *hal)

--- a/cpu/nrf52/Makefile.dep
+++ b/cpu/nrf52/Makefile.dep
@@ -14,6 +14,7 @@ ifneq (,$(filter nrf802154,$(USEMODULE)))
   USEMODULE += luid
   ifneq (,$(filter netdev,$(USEMODULE)))
     USEMODULE += netdev_ieee802154_submac
+    USEMODULE += netdev_ieee802154_submac_soft_ack
   endif
 endif
 

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -69,7 +69,6 @@
 
 static uint8_t rxbuf[IEEE802154_FRAME_LEN_MAX + 3]; /* len PHR + PSDU + LQI */
 static uint8_t txbuf[IEEE802154_FRAME_LEN_MAX + 3]; /* len PHR + PSDU + LQI */
-static uint8_t ack[IEEE802154_ACK_FRAME_LEN];
 
 typedef enum {
     STATE_IDLE,
@@ -430,30 +429,6 @@ static void _set_ifs_timer(bool lifs)
     timer_start(NRF802154_TIMER);
 }
 
-static void _timer_cb(void *arg, int chan)
-{
-    (void)arg;
-    ieee802154_dev_t *dev = nrf802154_hal_dev;
-
-    if (chan == MAC_TIMER_CHAN_ACK) {
-        /* Copy sqn */
-        ack[1] = IEEE802154_FCF_TYPE_ACK;
-        if (cfg.pending) {
-            ack[1] |= IEEE802154_FCF_FRAME_PEND;
-        }
-
-        ack[3] = rxbuf[3];
-
-        NRF_RADIO->PACKETPTR = (uint32_t) &ack;
-        NRF_RADIO->TASKS_TXEN = 1;
-        dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_DONE);
-    }
-    else if (chan == MAC_TIMER_CHAN_IFS) {
-        cfg.ifs = false;
-    }
-
-    timer_stop(NRF802154_TIMER);
-}
 /**
  * @brief   Set radio into DISABLED state
  */
@@ -463,16 +438,6 @@ int nrf802154_init(void)
     /* reset buffer */
     rxbuf[0] = 0;
     txbuf[0] = 0;
-
-    ack[0] = IEEE802154_ACK_FRAME_LEN; /* PSDU length */
-    ack[1] = IEEE802154_FCF_TYPE_ACK; /* FCF */
-    ack[2] = 0; /* FCF */
-
-    int result = timer_init(NRF802154_TIMER, TIMER_FREQ, _timer_cb, NULL);
-    assert(result >= 0);
-    (void)result;
-    timer_stop(NRF802154_TIMER);
-
     /* power off peripheral (but do not release the HFXO as we never requested
      * it so far) */
     NRF_RADIO->POWER = 0;
@@ -528,9 +493,7 @@ void isr_radio(void)
         case STATE_RX:
             if (NRF_RADIO->CRCSTATUS) {
                 bool l2filter_passed = _l2filter(rxbuf+1);
-                bool is_auto_ack_en = !IS_ACTIVE(CONFIG_IEEE802154_AUTO_ACK_DISABLE);
                 bool is_ack = rxbuf[1] & IEEE802154_FCF_TYPE_ACK;
-                bool ack_req = rxbuf[1] & IEEE802154_FCF_ACK_REQ;
 
                 /* If radio is in promiscuos mode, indicate packet and
                  * don't event think of sending an ACK frame :) */
@@ -543,17 +506,9 @@ void isr_radio(void)
                  * directly or if the driver should send an ACK frame before
                  * the indication */
                 else if (l2filter_passed) {
-                    if (ack_req && is_auto_ack_en) {
-                        timer_set(NRF802154_TIMER, MAC_TIMER_CHAN_ACK, IEEE802154_SIFS_SYMS);
-                        timer_start(NRF802154_TIMER);
-                        _disable();
-                        _state = STATE_ACK;
-                    }
-                    else {
-                        DEBUG("[nrf802154] RX frame doesn't require ACK frame.\n");
-                        _state = STATE_IDLE;
-                        dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_DONE);
-                    }
+                    DEBUG("[nrf802154] RX frame doesn't require ACK frame.\n");
+                    _state = STATE_IDLE;
+                    dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_DONE);
                 }
                 /* In case the packet is an ACK and the ACK filter is disabled,
                  * indicate the frame reception */
@@ -770,6 +725,21 @@ static int _set_frame_filter_mode(ieee802154_dev_t *dev, ieee802154_filter_mode_
     return 0;
 }
 
+static int _get_frame_filter_mode(ieee802154_dev_t *dev, ieee802154_filter_mode_t *mode)
+{
+    (void) dev;
+    if (cfg.promisc) {
+        *mode = IEEE802154_FILTER_PROMISC;
+    }
+    else if (!cfg.ack_filter) {
+        *mode = IEEE802154_FILTER_ACK_ONLY;
+    }
+    else {
+        *mode = IEEE802154_FILTER_ACCEPT;
+    }
+    return 0;
+}
+
 static int _set_csma_params(ieee802154_dev_t *dev, const ieee802154_csma_be_t *bd,
                             int8_t retries)
 {
@@ -823,4 +793,5 @@ static const ieee802154_radio_ops_t nrf802154_ops = {
     .config_addr_filter = _config_addr_filter,
     .config_src_addr_match = _config_src_addr_match,
     .set_frame_filter_mode = _set_frame_filter_mode,
+    .get_frame_filter_mode = _get_frame_filter_mode,
 };

--- a/drivers/include/net/netdev/ieee802154_submac.h
+++ b/drivers/include/net/netdev/ieee802154_submac.h
@@ -49,7 +49,7 @@ typedef struct {
     netdev_ieee802154_t dev;            /**< IEEE 802.15.4 netdev descriptor */
     ieee802154_submac_t submac;         /**< IEEE 802.15.4 SubMAC descriptor */
     ztimer_t ack_timer;                 /**< ztimer descriptor for the ACK timeout timer */
-    int isr_flags;                      /**< netdev submac @ref NETDEV_EVENT_ISR flags */
+    uint32_t isr_flags;                 /**< netdev submac @ref NETDEV_EVENT_ISR flags */
     int bytes_tx;                       /**< size of the sent frame or tx error */
     int8_t retrans;                     /**< number of frame retransmissions of the last TX */
     bool dispatch;                      /**< whether an event should be dispatched or not */

--- a/drivers/kw2xrf/kw2xrf_radio_hal.c
+++ b/drivers/kw2xrf/kw2xrf_radio_hal.c
@@ -705,6 +705,7 @@ static int _set_csma_params(ieee802154_dev_t *dev, const ieee802154_csma_be_t *b
 
 static const ieee802154_radio_ops_t kw2xrf_ops = {
     .caps =  IEEE802154_CAP_24_GHZ
+          | IEEE802154_CAP_AUTO_ACK
           | IEEE802154_CAP_IRQ_CRC_ERROR
           | IEEE802154_CAP_IRQ_RX_START
           | IEEE802154_CAP_IRQ_TX_DONE

--- a/drivers/mrf24j40/mrf24j40_radio_hal.c
+++ b/drivers/mrf24j40/mrf24j40_radio_hal.c
@@ -343,6 +343,7 @@ int _set_frame_retrans(ieee802154_dev_t *hal, uint8_t retrans)
 
 static const ieee802154_radio_ops_t mrf24j40_ops = {
     .caps =  IEEE802154_CAP_24_GHZ
+          | IEEE802154_CAP_AUTO_ACK
           | IEEE802154_CAP_IRQ_TX_DONE
           | IEEE802154_CAP_FRAME_RETRANS
           | IEEE802154_CAP_FRAME_RETRANS_INFO

--- a/drivers/netdev_ieee802154_submac/Makefile.include
+++ b/drivers/netdev_ieee802154_submac/Makefile.include
@@ -1,0 +1,1 @@
+PSEUDOMODULES += netdev_ieee802154_submac_soft_ack

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -296,7 +296,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
         netdev_rx_info->lqi = rx_info.lqi;
     }
-#if !IS_ACTIVE(CONFIG_IEEE802154_AUTO_ACK_DISABLE)
+#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC_SOFT_ACK)
     const uint8_t *mhr = buf;
     if ((mhr[0] & IEEE802154_FCF_TYPE_MASK) == IEEE802154_FCF_TYPE_DATA &&
         (mhr[0] & IEEE802154_FCF_ACK_REQ)) {

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -539,8 +539,8 @@ struct ieee802154_radio_ops {
      * @param[in] dev IEEE802.15.4 device descriptor
      * @param[in] psdu PSDU frame to be sent
      *
-     * @return 0 on success
-     * @return negative errno on error
+     * @retval 0 on success
+     * @retval negative errno on error
      */
     int (*write)(ieee802154_dev_t *dev, const iolist_t *psdu);
 
@@ -579,8 +579,8 @@ struct ieee802154_radio_ops {
      * @param[in] info information of the received frame (LQI, RSSI). Can be
      *            NULL if this information is not needed.
      *
-     * @return number of bytes written in @p buffer (0 if @p buf == NULL)
-     * @return -ENOBUFS if the frame doesn't fit in @p
+     * @retval number of bytes written in @p buffer (0 if @p buf == NULL)
+     * @retval -ENOBUFS if the frame doesn't fit in @p buf
      */
     int (*read)(ieee802154_dev_t *dev, void *buf, size_t size, ieee802154_rx_info_t *info);
     /**
@@ -592,8 +592,8 @@ struct ieee802154_radio_ops {
      *
      * @post the device is off
      *
-     * @return 0 on success
-     * @return negative errno on error
+     * @retval 0 on success
+     * @retval negative errno on error
      */
     int (*off)(ieee802154_dev_t *dev);
 
@@ -607,8 +607,8 @@ struct ieee802154_radio_ops {
      *
      * @param[in] dev IEEE802.15.4 device descriptor
      *
-     * @return 0 on success
-     * @return negative errno on error
+     * @retval 0 on success
+     * @retval negative errno on error
      */
     int (*request_on)(ieee802154_dev_t *dev);
 
@@ -634,9 +634,9 @@ struct ieee802154_radio_ops {
      *
      * @param[in] dev IEEE802.15.4 device descriptor
      *
-     * @return 0 if the device is on
-     * @return -EAGAIN if the device is still busy turning on
-     * @return negative errno on error
+     * @retval 0 if the device is on
+     * @retval -EAGAIN if the device is still busy turning on
+     * @retval negative errno on error
      */
     int (*confirm_on)(ieee802154_dev_t *dev);
 
@@ -681,8 +681,8 @@ struct ieee802154_radio_ops {
      * @param[in] dev IEEE802.15.4 device descriptor
      * @param[in] threshold the threshold in dBm.
      *
-     * @return 0 on success
-     * @return negative errno on error
+     * @retval 0 on success
+     * @retval negative errno on error
      */
     int (*set_cca_threshold)(ieee802154_dev_t *dev, int8_t threshold);
 
@@ -696,9 +696,9 @@ struct ieee802154_radio_ops {
      * @param[in] dev IEEE802.15.4 device descriptor
      * @param[in] mode the CCA mode
      *
-     * @return 0 on success
-     * @return -ENOTSUP if the mode is not supported
-     * @return negative errno on error
+     * @retval 0 on success
+     * @retval -ENOTSUP if the mode is not supported
+     * @retval negative errno on error
      */
     int (*set_cca_mode)(ieee802154_dev_t *dev, ieee802154_cca_mode_t mode);
 
@@ -717,9 +717,9 @@ struct ieee802154_radio_ops {
      * @param[in] dev IEEE802.15.4 device descriptor
      * @param[in] conf the PHY configuration
      *
-     * @return 0        on success
-     * @return -EINVAL  if the configuration is not valid for the device.
-     * @return <0       error, return value is negative errno indicating the cause.
+     * @retval 0        on success
+     * @retval -EINVAL  if the configuration is not valid for the device.
+     * @retval <0       error, return value is negative errno indicating the cause.
      */
     int (*config_phy)(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf);
 
@@ -734,8 +734,8 @@ struct ieee802154_radio_ops {
      * @param[in] dev IEEE802.15.4 device descriptor
      * @param[in] retrans the number of retransmissions attempts.
      *
-     * @return 0 on success
-     * @return negative errno on error
+     * @retval 0 on success
+     * @retval negative errno on error
      */
     int (*set_frame_retrans)(ieee802154_dev_t *dev, uint8_t retrans);
 
@@ -753,9 +753,9 @@ struct ieee802154_radio_ops {
      *                    ieee802154_radio_request_transmit function is
      *                    equivalent to CCA send.
      *
-     * @return 0 on success
-     * @return -EINVAL if the settings are not supported.
-     * @return negative errno on error
+     * @retval 0 on success
+     * @retval -EINVAL if the settings are not supported.
+     * @retval negative errno on error
      */
     int (*set_csma_params)(ieee802154_dev_t *dev, const ieee802154_csma_be_t *bd,
                            int8_t retries);
@@ -768,8 +768,8 @@ struct ieee802154_radio_ops {
      * @param[in] dev IEEE802.15.4 device descriptor
      * @param[in] mode address filter mode
      *
-     * @return 0 on success
-     * @return negative errno on error
+     * @retval 0 on success
+     * @retval negative errno on error
      */
     int (*set_frame_filter_mode)(ieee802154_dev_t *dev, ieee802154_filter_mode_t mode);
 
@@ -781,8 +781,8 @@ struct ieee802154_radio_ops {
      * @param[in] dev IEEE802.15.4 device descriptor
      * @param[out] mode address filter mode
      *
-     * @return 0 on success
-     * @return negative errno on error
+     * @retval 0 on success
+     * @retval negative errno on error
      */
     int (*get_frame_filter_mode)(ieee802154_dev_t *dev, ieee802154_filter_mode_t *mode);
 
@@ -798,8 +798,8 @@ struct ieee802154_radio_ops {
      * @param[in] cmd command for the address filter
      * @param[in] value value for @p cmd.
      *
-     * @return 0 on success
-     * @return negative errno on error
+     * @retval 0 on success
+     * @retval negative errno on error
      */
     int (*config_addr_filter)(ieee802154_dev_t *dev, ieee802154_af_cmd_t cmd, const void *value);
 
@@ -818,8 +818,8 @@ struct ieee802154_radio_ops {
      * @param[in] cmd command for the source address match configuration
      * @param[in] value value associated to @p cmd.
      *
-     * @return 0 on success
-     * @return negative errno on error
+     * @retval 0 on success
+     * @retval negative errno on error
      */
     int (*config_src_addr_match)(ieee802154_dev_t *dev, ieee802154_src_match_t cmd,
                                  const void *value);

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -73,6 +73,13 @@ typedef enum {
      */
     IEEE802154_CAP_AUTO_CSMA            = BIT1,
     /**
+     * @brief the device supports automatic ACK frame transmission
+     *
+     * The device automatically sends an ACK frame when it receives a frame
+     * with the ACK Req bit set.
+     */
+    IEEE802154_CAP_AUTO_ACK             = BIT2,
+    /**
      * @brief the device support ACK timeout interrupt
      *
      * The device will automatically attempt to receive and handle the ACK
@@ -83,71 +90,71 @@ typedef enum {
      *
      * The ACK frame is not indicated to the upper layer.
      */
-    IEEE802154_CAP_IRQ_ACK_TIMEOUT      = BIT2,
+    IEEE802154_CAP_IRQ_ACK_TIMEOUT      = BIT3,
     /**
      * @brief the device supports the IEEE802.15.4 2.4 GHz band
      *
      * It's assumed that @ref IEEE802154_CAP_IRQ_TX_DONE is present.
      */
-    IEEE802154_CAP_24_GHZ               = BIT3,
+    IEEE802154_CAP_24_GHZ               = BIT4,
     /**
      * @brief the device support the IEEE802.15.4 Sub GHz band
      */
-    IEEE802154_CAP_SUB_GHZ              = BIT4,
+    IEEE802154_CAP_SUB_GHZ              = BIT5,
     /**
      * @brief the device reports reception off frames with invalid CRC.
      */
-    IEEE802154_CAP_IRQ_CRC_ERROR        = BIT5,
+    IEEE802154_CAP_IRQ_CRC_ERROR        = BIT6,
     /**
      * @brief the device reports when the transmission is done
      */
-    IEEE802154_CAP_IRQ_TX_DONE          = BIT6,
+    IEEE802154_CAP_IRQ_TX_DONE          = BIT7,
     /**
      * @brief the device reports the start of a frame (SFD) when received.
      */
-    IEEE802154_CAP_IRQ_RX_START         = BIT7,
+    IEEE802154_CAP_IRQ_RX_START         = BIT8,
     /**
      * @brief the device reports the start of a frame (SFD) was sent.
      */
-    IEEE802154_CAP_IRQ_TX_START         = BIT8,
+    IEEE802154_CAP_IRQ_TX_START         = BIT9,
     /**
      * @brief the device reports the end of the CCA procedure
      */
-    IEEE802154_CAP_IRQ_CCA_DONE         = BIT9,
+    IEEE802154_CAP_IRQ_CCA_DONE         = BIT10,
     /**
      * @brief the device provides the number of retransmissions
      *
      * It's assumed that @ref IEEE802154_CAP_FRAME_RETRANS is present.
      */
-    IEEE802154_CAP_FRAME_RETRANS_INFO   = BIT10,
+    IEEE802154_CAP_FRAME_RETRANS_INFO   = BIT11,
     /**
      * @brief the device retains all register values when off.
      */
-    IEEE802154_CAP_REG_RETENTION        = BIT11,
+    IEEE802154_CAP_REG_RETENTION        = BIT12,
     /**
      * @brief Binary Phase Shift Keying PHY mode
      */
-    IEEE802154_CAP_PHY_BPSK             = BIT12,
+    IEEE802154_CAP_PHY_BPSK             = BIT13,
     /**
      * @brief Amplitude-Shift Keying PHY mode
      */
-    IEEE802154_CAP_PHY_ASK              = BIT13,
+    IEEE802154_CAP_PHY_ASK              = BIT14,
     /**
      * @brief Offset Quadrature Phase-Shift Keying
      */
-    IEEE802154_CAP_PHY_OQPSK            = BIT14,
+    IEEE802154_CAP_PHY_OQPSK            = BIT15,
     /**
      * @brief Multi-Rate Offset Quadrature Phase-Shift Keying PHY mode
      */
-    IEEE802154_CAP_PHY_MR_OQPSK         = BIT15,
+    IEEE802154_CAP_PHY_MR_OQPSK         = BIT16,
     /**
      * @brief Multi-Rate Orthogonal Frequency-Division Multiplexing PHY mode
      */
-    IEEE802154_CAP_PHY_MR_OFDM          = BIT16,
+    IEEE802154_CAP_PHY_MR_OFDM          = BIT17,
     /**
      * @brief Multi-Rate Frequency Shift Keying PHY mode
      */
-    IEEE802154_CAP_PHY_MR_FSK           = BIT17,
+    IEEE802154_CAP_PHY_MR_FSK           = BIT18,
     /**
      * @brief the device supports source address match table.
      *
@@ -156,7 +163,7 @@ typedef enum {
      * Request command from a child node, the Frame Pending bit of the ACK is
      * set if the source address matches one from the table.
      */
-    IEEE802154_CAP_SRC_ADDR_MATCH       = BIT18,
+    IEEE802154_CAP_SRC_ADDR_MATCH       = BIT19,
 } ieee802154_rf_caps_t;
 
 /**

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -819,6 +819,20 @@ struct ieee802154_radio_ops {
 };
 
 /**
+ * @brief Check if the device has a specific capability
+ *
+ * @param[in] dev IEEE802.15.4 device descriptor
+ * @param[in] cap capabilities to check for
+ *
+ * @retval true if the device has the capability
+ * @retval false if the device doesn't have the capability
+ */
+static inline bool ieee802154_radio_has_capability(ieee802154_dev_t *dev, uint32_t cap)
+{
+    return (dev->driver->caps & cap) == cap;
+}
+
+/**
  * @brief Shortcut to @ref ieee802154_radio_ops::write
  *
  * @param[in] dev IEEE802.15.4 device descriptor

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -754,7 +754,7 @@ struct ieee802154_radio_ops {
                            int8_t retries);
 
     /**
-     * @brief Set the frame filter moder.
+     * @brief Set the frame filter mode.
      *
      * @pre the device is on
      *
@@ -765,6 +765,19 @@ struct ieee802154_radio_ops {
      * @return negative errno on error
      */
     int (*set_frame_filter_mode)(ieee802154_dev_t *dev, ieee802154_filter_mode_t mode);
+
+    /**
+     * @brief Get the frame filter mode.
+     *
+     * @pre the device is on
+     *
+     * @param[in] dev IEEE802.15.4 device descriptor
+     * @param[out] mode address filter mode
+     *
+     * @return 0 on success
+     * @return negative errno on error
+     */
+    int (*get_frame_filter_mode)(ieee802154_dev_t *dev, ieee802154_filter_mode_t *mode);
 
     /**
      * @brief Configure the address filter.
@@ -1012,6 +1025,25 @@ static inline int ieee802154_radio_set_frame_filter_mode(ieee802154_dev_t *dev,
                                                     ieee802154_filter_mode_t mode)
 {
     return dev->driver->set_frame_filter_mode(dev, mode);
+}
+
+/**
+ * @brief Shortcut to @ref ieee802154_radio_ops::get_frame_filter_mode
+ *
+ * @pre the device is on
+ *
+ * @param[in] dev IEEE802.15.4 device descriptor
+ * @param[out] mode frame filter mode
+ *
+ * @return result of @ref ieee802154_radio_ops::get_frame_filter_mode
+ */
+static inline int ieee802154_radio_get_frame_filter_mode(ieee802154_dev_t *dev,
+                                                         ieee802154_filter_mode_t *mode)
+{
+    if (dev->driver->get_frame_filter_mode) {
+        return dev->driver->get_frame_filter_mode(dev, mode);
+    }
+    return -ENOTSUP;
 }
 
 /**

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -377,21 +377,27 @@ ieee802154_fsm_state_t ieee802154_submac_process_ev(ieee802154_submac_t *submac,
 
     switch (submac->fsm_state) {
     case IEEE802154_FSM_STATE_RX:
+        DEBUG("IEEE802154 submac: ieee802154_submac_process_ev(): IEEE802154_FSM_STATE_RX + %s\n", str_ev[ev]);
         new_state = _fsm_state_rx(submac, ev);
         break;
     case IEEE802154_FSM_STATE_IDLE:
+        DEBUG("IEEE802154 submac: ieee802154_submac_process_ev(): IEEE802154_FSM_STATE_IDLE + %s\n", str_ev[ev]);
         new_state = _fsm_state_idle(submac, ev);
         break;
     case IEEE802154_FSM_STATE_PREPARE:
+        DEBUG("IEEE802154 submac: ieee802154_submac_process_ev(): IEEE802154_FSM_STATE_PREPARE + %s\n", str_ev[ev]);
         new_state = _fsm_state_prepare(submac, ev);
         break;
     case IEEE802154_FSM_STATE_TX:
+        DEBUG("IEEE802154 submac: ieee802154_submac_process_ev(): IEEE802154_FSM_STATE_TX + %s\n", str_ev[ev]);
         new_state = _fsm_state_tx(submac, ev);
         break;
     case IEEE802154_FSM_STATE_WAIT_FOR_ACK:
+        DEBUG("IEEE802154 submac: ieee802154_submac_process_ev(): IEEE802154_FSM_STATE_WAIT_FOR_ACK + %s\n", str_ev[ev]);
         new_state = _fsm_state_wait_for_ack(submac, ev);
         break;
     default:
+        DEBUG("IEEE802154 submac: ieee802154_submac_process_ev(): INVALID STATE\n");
         new_state = IEEE802154_FSM_STATE_INVALID;
     }
 
@@ -408,6 +414,7 @@ int ieee802154_send(ieee802154_submac_t *submac, const iolist_t *iolist)
     ieee802154_fsm_state_t current_state = submac->fsm_state;
 
     if (current_state != IEEE802154_FSM_STATE_RX && current_state != IEEE802154_FSM_STATE_IDLE) {
+        DEBUG("IEEE802154 submac: ieee802154_send(): Sending aborted, current state is %s\n", str_states[current_state]);
         return -EBUSY;
     }
 
@@ -809,6 +816,8 @@ int ieee802154_set_rx(ieee802154_submac_t *submac)
         }
         break;
     default:
+        DEBUG("IEEE802154 submac: ieee802154_set_rx(): Setting RX failed, currently in %s\n",
+              str_states[current_state]);
         break;
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Adds transmission of ACK on the IEEE802154 layer, if the driver does not support automatic ACK.
A submac state is added. The ACK transmission is synchronous to the driver to not accept further frame transmissions in between.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`sudo ./dist/tools/tapsetup/tapsetup`

`make -C examples/networking/gnrc/gnrc_border_router flash term PORT=tap0`

`USE_ZEP=1 make -C examples/networking/gnrc/gnrc_networking flash term PORT=tap1`

```
2025-06-09 11:31:31,639 # ping fe80::acf6:8ba:b4b9:d1e3
2025-06-09 11:31:31,643 # 12 bytes from fe80::acf6:8ba:b4b9:d1e3%7: icmp_seq=0 ttl=64 rssi=-27 dBm time=3.619 ms
2025-06-09 11:31:32,643 # 12 bytes from fe80::acf6:8ba:b4b9:d1e3%7: icmp_seq=1 ttl=64 rssi=-27 dBm time=3.680 ms
2025-06-09 11:31:33,643 # 12 bytes from fe80::acf6:8ba:b4b9:d1e3%7: icmp_seq=2 ttl=64 rssi=-26 dBm time=3.677 ms
2025-06-09 11:31:33,644 # 
2025-06-09 11:31:33,644 # --- fe80::acf6:8ba:b4b9:d1e3 PING statistics ---
2025-06-09 11:31:33,644 # 3 packets transmitted, 3 packets received, 0% packet loss
2025-06-09 11:31:33,644 # round-trip min/avg/max = 3.619/3.658/3.680 ms
> 
```

[socket_zep.pcapng.zip](https://github.com/user-attachments/files/20652516/socket_zep.pcapng.zip)


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

split out from #21202