### PR TITLE
dist/tools/compile_test: specify toolchain and exit code

### DIFF
--- a/dist/tools/compile_test/compile_like_murdock.py
+++ b/dist/tools/compile_test/compile_like_murdock.py
@@ -194,9 +194,9 @@ def _modules_packages(app, board, jobs, env, cwd, args):
         _print_module_or_pkg_mismatch(app, board, lines, args)
 
 
-def _build(app, board, jobs, env, cwd, args):
+def _build(app, board, toolchain, jobs, env, cwd, args):
     cmd = (f'/bin/bash -c "source .murdock; JOBS={jobs} '
-           f'compile {app} {board}:gnu"')
+           f'compile {app} {board}:{toolchain}"')
     try:
         out = __exec_cmd(cmd, shell=True, env=env, cwd=cwd,
                          stderr=subprocess.STDOUT)
@@ -235,6 +235,8 @@ def main():
     parser.add_argument("-a", "--apps", nargs="+",
                         help=("A list of apps to test on the supported boards."
                               " If empty we will choose what is tested."))
+    parser.add_argument("-t", "--toolchain", choices=["gnu", "llvm"], default="gnu",
+                        help=("Toolchain to use"))
     parser.add_argument("-d", "--dry-run", action="store_true",
                         help=("Show each of the boards and apps to be compiled"
                               " without spending super long to compile them"))
@@ -281,7 +283,8 @@ def main():
                 _modules_packages(app, board, args.jobs, full_env, riot_dir,
                                   args)
             else:
-                _build(app, board, args.jobs, full_env, riot_dir, args)
+                _build(app, board, args.toolchain, args.jobs, full_env,
+                       riot_dir, args)
     elapse_time = datetime.datetime.now() - start_time
     _end(elapse_time.total_seconds(), args.jobs)
 

--- a/dist/tools/compile_test/compile_like_murdock.py
+++ b/dist/tools/compile_test/compile_like_murdock.py
@@ -203,6 +203,7 @@ def _build(app, board, toolchain, jobs, env, cwd, args):
         if args.very_very_verbose:
             print(out)
         print(f"{app: <30} {board: <30} PASS")
+        return True
     except subprocess.CalledProcessError as err:
         err.output = err.output.decode("utf-8", errors="replace")
         lines = err.output.split("\n")
@@ -215,6 +216,7 @@ def _build(app, board, toolchain, jobs, env, cwd, args):
             print(f"{app: <30} {board: <30} FAIL: Kconfig hash mismatch")
         else:
             print(f"{app: <30} {board: <30} FAIL")
+        return False
 
 
 def main():
@@ -263,6 +265,7 @@ def main():
     if 'all' in apps:
         apps = _all_apps(riot_dir)
 
+    ret = 0
     for app in apps:
         test_dir = str(pathlib.PurePath(riot_dir, app))
         if not pathlib.Path(test_dir).exists():
@@ -283,10 +286,12 @@ def main():
                 _modules_packages(app, board, args.jobs, full_env, riot_dir,
                                   args)
             else:
-                _build(app, board, args.toolchain, args.jobs, full_env,
-                       riot_dir, args)
+                if not _build(app, board, args.toolchain, args.jobs, full_env,
+                              riot_dir, args):
+                    ret = -1
     elapse_time = datetime.datetime.now() - start_time
     _end(elapse_time.total_seconds(), args.jobs)
+    exit(ret)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Contribution description

This PR changes `dist/tools/compile_test/compile_like_murdock.py` to
1. allow specifying the used toolchain (hardcoded to `gnu` (backwards-compatible default) and `llvm`)
2. return an error code on exit if any of the builds failed (this is a breaking change as it was before always returning success)


### Testing procedure

Let's hope no other tool was relying on the exit code being always zero, hopefully CI would catch that.

You can test the script locally with

```
dist/tools/compile_test/compile_like_murdock.py -a tests/pkg/fff tests/sys/shell -b native32 -t gnu
dist/tools/compile_test/compile_like_murdock.py -a tests/pkg/fff tests/sys/shell -b native32 -t llvm
```
The first should succeed, the latter fail.

### Issues/PRs references

This is needed for https://github.com/RIOT-OS/riotdocker/pull/256 and transitively to unblock the failing CI tests. Will need to be backported to the last release.
