### PR TITLE
sys/event/deferred_callback: disable timer before modifying event

### DIFF
--- a/sys/include/event/deferred_callback.h
+++ b/sys/include/event/deferred_callback.h
@@ -69,6 +69,10 @@ static inline void event_deferred_callback_post(event_deferred_callback_t *event
                                                 ztimer_clock_t *clock, uint32_t timeout,
                                                 void (*callback)(void *), void *arg)
 {
+    /* cancel the event if it has already been queued */
+    ztimer_remove(clock, &event->timer);
+    event_cancel(queue, &event->event.super);
+
     event->event = (event_callback_t) {
         .super.handler = _event_callback_handler,
         .callback = callback,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Remove the event from the timer queue before modifying it's contents. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
