### PR TITLE
makefiles/docker: update riotbuild digest

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -5,7 +5,7 @@
 # When the docker image is updated, checks at
 # dist/tools/buildsystem_sanity_check/check.sh start complaining in CI, and
 # provide the latest values to verify and fill in.
-DOCKER_TESTED_IMAGE_REPO_DIGEST := 116c51ffe0c80ffcf9eb693334f8f2e180cdaa66509e81a21217fdd45a2858b5
+DOCKER_TESTED_IMAGE_REPO_DIGEST := 21c416fbbb94a99c3d9c76341baf5a9740608b1d1af89967127c7a171248fd7b
 
 DOCKER_PULL_IDENTIFIER := docker.io/riot/riotbuild@sha256:$(DOCKER_TESTED_IMAGE_REPO_DIGEST)
 export DOCKER_IMAGE ?= $(DOCKER_PULL_IDENTIFIER)


### PR DESCRIPTION
### Contribution description

This PR updates docker `riotbuild` digest. Without this Murdoc static tests ends with error:

```
./dist/tools/buildsystem_sanity_check/check.sh x
  Command output:
  
  	Update manifest digest to 21c416fbbb94a99c3d9c76341baf5a9740608b1d1af89967127c7a171248fd7b:
  		makefiles/docker.inc.mk:8:DOCKER_TESTED_IMAGE_REPO_DIGEST := 116c51ffe0c80ffcf9eb693334f8f2e180cdaa66509e81a21217fdd45a2858b5
```

### Testing procedure

Green CI

### Issues/PRs references

None