### PR TITLE
drivers/st77xx: Fix initialization order to allow C++ compilation [2]

### DIFF
--- a/drivers/st77xx/include/st77xx_params.h
+++ b/drivers/st77xx/include/st77xx_params.h
@@ -202,7 +202,6 @@ extern "C" {
                                       ST77XX_PARAM_IF_SPI \
                                       ST77XX_PARAM_IF_PAR \
                                       ST77XX_PARAM_IF_PAR_16BIT \
-                                      .cntrl = ST77XX_PARAM_CNTRL, \
                                       .cs_pin = ST77XX_PARAM_CS, \
                                       .dcx_pin = ST77XX_PARAM_DCX, \
                                       .rst_pin = ST77XX_PARAM_RST, \
@@ -213,6 +212,7 @@ extern "C" {
                                       .rotation = ST77XX_PARAM_ROTATION, \
                                       .offset_x = ST77XX_PARAM_OFFSET_X, \
                                       .offset_y = ST77XX_PARAM_OFFSET_Y, \
+                                      .cntrl = ST77XX_PARAM_CNTRL, \
                                     }
 #endif /* ST77XX_PARAMS */
 /** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

New pull request of #21537, since that is not re-openable. See this PR for more details.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#21537

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
