### PR TITLE
boards/nucleo-l4: fix VBAT capable boards list

### DIFF
--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -60,7 +60,7 @@ STM32_WITH_VBAT = stm32f031% stm32f038% stm32f042% stm32f048% \
                   stm32f7% \
                   stm32g0% \
                   stm32g4% stm32gbk1cb \
-                  stm32l4% \
+                  stm32l433% stm32l45% stm32l47% stm32l49% stm32l4r% \
                   stm32l5% \
                   stm32u5% \
                   stm32wb% \


### PR DESCRIPTION
### Contribution description

This PR updates list of `nucleo-l4` boards which has VBAT capability.

For example `nucleo-l432kc` accordingly to the datasheet do not have
capability to monitor VBAT (lack of section "VBAT battery voltage monitoring").

### Testing procedure

Green CI

### Issues/PRs references

PR #21546 
