### PR TITLE
cpu/nrf{52,9160}: set GPIO modes correctly for MISO/MOSI SPI signals

### DIFF
--- a/cpu/nrf5x_common/periph/spi_nrf52_nrf9160.c
+++ b/cpu/nrf5x_common/periph/spi_nrf52_nrf9160.c
@@ -152,11 +152,11 @@ int spi_init_with_gpio_mode(spi_t bus, const spi_gpio_mode_t* mode)
     assert(bus < SPI_NUMOF);
 
     if (gpio_is_valid(spi_config[bus].mosi)) {
-        gpio_init(spi_config[bus].miso, mode->mosi);
+        gpio_init(spi_config[bus].mosi, mode->mosi);
     }
 
     if (gpio_is_valid(spi_config[bus].miso)) {
-        gpio_init(spi_config[bus].mosi, mode->miso);
+        gpio_init(spi_config[bus].miso, mode->miso);
     }
 
     if (gpio_is_valid(spi_config[bus].sclk)) {


### PR DESCRIPTION
Commit 4906353c introduced a bug that changed the behavior of spi_init_pins(): MISO is erroneously set to GPIO_OUT, and MOSI is erroneously set to GPIO_IN. The bug was caused by a simple typo.