### PR TITLE
sys/event/thread: optimize stack usage

### DIFF
--- a/sys/event/thread.c
+++ b/sys/event/thread.c
@@ -31,7 +31,8 @@ struct event_queue_and_size {
     size_t q_numof;
 };
 
-static void *_handler_thread(void *tagged_ptr)
+/* ARM GCC ignores that this function has no exit path, hence NORETURN. */
+NORETURN static void *_handler_thread(void *tagged_ptr)
 {
     event_queue_t *qs = ptrtag_ptr(tagged_ptr);
     /* number of queues is encoded in lower pointer bits */
@@ -39,9 +40,7 @@ static void *_handler_thread(void *tagged_ptr)
     event_queues_claim(qs, n);
     /* start event loop */
     event_loop_multi(qs, n);
-
-    /* should be never reached */
-    return NULL;
+    UNREACHABLE();
 }
 
 void event_thread_init_multi(event_queue_t *queues, size_t queues_numof,

--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -416,7 +416,8 @@ event_t *event_wait_timeout_ztimer(event_queue_t *queue,
  * It is pretty much defined as:
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.c}
- *     while ((event = event_wait_multi(queues, n_queues))) {
+ *     while (1) {
+ *         event_t *event = event_wait_multi(queues, n_queues);
  *         event->handler(event);
  *     }
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -434,9 +435,8 @@ event_t *event_wait_timeout_ztimer(event_queue_t *queue,
  */
 static inline void event_loop_multi(event_queue_t *queues, size_t n_queues)
 {
-    event_t *event;
-
-    while ((event = event_wait_multi(queues, n_queues))) {
+    while (1) {
+        event_t *event = event_wait_multi(queues, n_queues);
         if (IS_USED(MODULE_EVENT_LOOP_DEBUG)) {
             uint32_t now;
             ztimer_acquire(ZTIMER_USEC);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`event_wait_multi()` always returns an event, so the `event_loop_multi()` can be rewritten s.t. it explicitly never returns. The compiler will optimize away any prologue/epilogue, saving stack and code space. 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Ran the `sys/event_thread` app on native64.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

