### PR TITLE
cpu/cortexm_common: add .backup.noinit section

### DIFF
--- a/cpu/cortexm_common/include/cpu_conf_common.h
+++ b/cpu/cortexm_common/include/cpu_conf_common.h
@@ -162,6 +162,12 @@ extern "C" {
  *          and initialized with user provided data on cold boot.
  */
 #define BACKUP_RAM_DATA __attribute__((section(".backup.data")))
+
+/**
+ * @brief   Memory marked with this attribute is retained during deep sleep
+ *          and never initialized.
+ */
+#define BACKUP_RAM_NOINIT __attribute__((section(".backup.noinit")))
 #endif /* CPU_HAS_BACKUP_RAM */
 
 /**

--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -229,6 +229,12 @@ SECTIONS
         . = ALIGN(4);
     } > bkup_ram
 
+    .backup.noinit (NOLOAD) : ALIGN(4) {
+        _sbackup_noinit = .;
+        *(.backup.noinit)
+        _ebackup_noinit = .;
+    } > bkup_ram
+
     .heap3 (NOLOAD) : ALIGN(4) {
         _sheap1 = . ;
         _eheap1 = ORIGIN(bkup_ram) + LENGTH(bkup_ram);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
It is practical to have a backup RAM section that is persisted on reboot. This PR adds a `.backup.noinit` section to the Cortex M CPU.

:warning: My linker script skills are rusty, please double-check.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Tested on a same54 custom board.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
