### PR TITLE
sys/suit: add suit_get_public_key()

### DIFF
--- a/sys/include/suit.h
+++ b/sys/include/suit.h
@@ -325,6 +325,17 @@ static inline bool suit_component_check_flag(suit_component_t *component,
 int suit_component_name_to_string(const suit_manifest_t *manifest,
                                   const suit_component_t *component,
                                   char separator, char *buf, size_t buf_len);
+
+/**
+ * @brief Get public key accepted by SUIT
+ *
+ * @param[in] idx   Index of the key to query
+ * @param[out] key  The public key used to verify the signature
+ *
+ * @returns         True if a key at that index exists
+ */
+bool suit_get_public_key(uint8_t idx, cose_key_t *key);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/suit/handlers_envelope.c
+++ b/sys/suit/handlers_envelope.c
@@ -32,8 +32,21 @@
 #include "suit/handlers.h"
 #include "suit.h"
 
+bool suit_get_public_key(uint8_t idx, cose_key_t *pkey)
+{
+    if (idx >= ARRAY_SIZE(public_key)) {
+        return false;
+    }
+
+    /* Initialize key from hardcoded public key */
+    cose_key_init(pkey);
+    cose_key_set_keys(pkey, COSE_EC_CURVE_ED25519, COSE_ALGO_EDDSA,
+                      (void *)public_key[idx], NULL, NULL);
+    return true;
+}
+
 static int _verify_with_key(suit_manifest_t *manifest, const nanocbor_value_t *it,
-                            const void *key)
+                            cose_key_t *pkey)
 {
     cose_sign_dec_t verify;
     const uint8_t *cose_buf;
@@ -47,12 +60,6 @@ static int _verify_with_key(suit_manifest_t *manifest, const nanocbor_value_t *i
         LOG_INFO("Unable to get auth container\n");
         return SUIT_ERR_INVALID_MANIFEST;
     }
-
-    /* Initialize key from hardcoded public key */
-    cose_key_t pkey;
-    cose_key_init(&pkey);
-    cose_key_set_keys(&pkey, COSE_EC_CURVE_ED25519, COSE_ALGO_EDDSA,
-                      (void *)key, NULL, NULL);
 
     nanocbor_value_t _cont, arr;
     nanocbor_decoder_init(&_cont, auth_container, auth_container_len);
@@ -87,7 +94,7 @@ static int _verify_with_key(suit_manifest_t *manifest, const nanocbor_value_t *i
             }
             LOG_INFO("suit: verifying manifest signature\n");
             int verification = cose_sign_verify(&verify, &signature,
-                                                &pkey, manifest->validation_buf,
+                                                pkey, manifest->validation_buf,
                                                 SUIT_COSE_BUF_SIZE);
             if (verification == 0) {
                 manifest->state |= SUIT_STATE_COSE_AUTHENTICATED;
@@ -111,9 +118,11 @@ static int _auth_handler(suit_manifest_t *manifest, int key,
     (void)key;
 
     int res = 0;
+    unsigned idx = 0;
+    cose_key_t pkey;
 
-    for (unsigned i = 0; i < ARRAY_SIZE(public_key); ++i) {
-        res = _verify_with_key(manifest, it, public_key[i]);
+    while (suit_get_public_key(idx++, &pkey)) {
+        res = _verify_with_key(manifest, it, &pkey);
         if (res != SUIT_ERR_SIGNATURE) {
             break;
         }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

It can be handy to know which public keys are accepted by SUIT.
This adds a simple helper function `suit_get_public_key()` that gives access to the internal `public_key` array.



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
