### PR TITLE
examples/advanced/suit_update: simplify setup

### DIFF
--- a/examples/advanced/suit_update/Makefile
+++ b/examples/advanced/suit_update/Makefile
@@ -65,6 +65,10 @@ endif
 
 # Change this to 0 to not use ethos
 USE_ETHOS ?= 1
+# see SUIT_CLIENT and SUIT_COAP_SERVER
+SUIT_COAP_SERVER_PREFIX ?= 2001:db8::/64
+# you may need to run dist/tools/tapsetup/tapsetup to create tap0
+SUIT_COAP_SERVER_IFACE ?= tap0
 
 ifeq (1,$(USE_ETHOS))
   USEMODULE += stdio_ethos
@@ -76,15 +80,8 @@ ifeq (1,$(USE_ETHOS))
 
   # make sure ethos and uhcpd are built
   TERMDEPS += host-tools
-
-  # For local testing, run
-  #
-  #     $ cd dist/tools/ethos; sudo ./setup_network.sh riot0 2001:db8::0/64
-  #
-  #... in another shell and keep it running.
-  IFACE ?= riot0
-  TERMPROG = $(RIOTTOOLS)/ethos/ethos
-  TERMFLAGS = $(IFACE) $(PORT)
+  TERMPROG = $(RIOTTOOLS)/ethos/start_network.sh
+  TERMFLAGS = $(PORT) $(SUIT_COAP_SERVER_IFACE) $(SUIT_COAP_SERVER_PREFIX)
 else
   USEMODULE += netdev_default
 endif
@@ -107,11 +104,11 @@ TESTRUNNER_RESET_AFTER_TERM ?= 1
 # with ed25519 support.
 TEST_ON_CI_BLACKLIST = all
 
+# Add custom SUIT targets and constants before including the global Makefile.include
+include $(CURDIR)/Makefile.suit.custom
+
 # Include global Makefile.include first to apply board aliasses
 include $(RIOTBASE)/Makefile.include
-
-# Add custom SUIT targets
-include $(CURDIR)/Makefile.suit.custom
 
 # export IFACE for test
 $(call target-export-variables,test-with-config test-with-config/check-config,IFACE)
@@ -130,9 +127,16 @@ ifndef CONFIG_GNRC_PKTBUF_SIZE
 endif
 endif
 
-.PHONY: host-tools
+.PHONY: host-tools suit_coap_server
 
 host-tools:
 	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTTOOLS)
 
+suit_coap_server:
+	aiocoap-fileserver --bind [::] $(SUIT_COAP_FSROOT)
+
 include $(RIOTMAKE)/default-radio-settings.inc.mk
+
+ifneq (1,$(USE_ETHOS))
+  TERMPROG := $(CURDIR)/start_network.sh -r $(SUIT_COAP_SERVER_PREFIX) -i $(SUIT_COAP_SERVER_IFACE) $(TERMPROG)
+endif

--- a/examples/advanced/suit_update/Makefile.suit.custom
+++ b/examples/advanced/suit_update/Makefile.suit.custom
@@ -9,11 +9,9 @@ EPOCH = $(call memoized,EPOCH,$(shell date +%s))
 APP_VER ?= $(EPOCH)
 
 # Default addressing if following README.native.md
-ifneq (,$(filter native native32 native64,$(BOARD)))
-  SUIT_CLIENT ?= [2001:db8::2]
-  SUIT_COAP_SERVER ?= [2001:db8::1]
-  $(call target-export-variables,test-with-config,SUIT_COAP_SERVER)
-endif
+SUIT_CLIENT ?= [2001:db8::2]
+SUIT_COAP_SERVER ?= [2001:db8::1]
+$(call target-export-variables,test-with-config,SUIT_COAP_SERVER)
 
 ifneq (,$(filter native native32 native64,$(BOARD)))
   # Set settings for publishing fake fw payloads to native

--- a/examples/advanced/suit_update/start_network.sh
+++ b/examples/advanced/suit_update/start_network.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+
+SCRIPT_DIR="$(dirname $(readlink -f $0))"
+RIOTBASE=${RIOTBASE:-${SCRIPT_DIR}/../../..}
+
+init_iface() {
+  sudo sysctl -w net.ipv6.conf.${IFACE}.forwarding=1
+  sudo sysctl -w net.ipv6.conf.${IFACE}.accept_ra=0
+  sudo ip a a fe80::${PREFIX_IID}/64 dev ${IFACE}
+  sudo ip a a ${PREFIX}${PREFIX_IID}/128 dev ${IFACE}
+  sudo ip link set ${IFACE} up
+}
+
+deinit_iface() {
+  sudo ip a d fe80::${PREFIX_IID}/64 dev ${IFACE}
+  sudo ip a d ${PREFIX}${PREFIX_IID}/128 dev ${IFACE}
+}
+
+cleanup() {
+  echo "Cleaning up..."
+  deinit_iface
+  trap "" INT QUIT TERM EXIT
+}
+
+start_radvd() {
+  sudo sysctl net.ipv6.conf."${IFACE}".accept_ra=2
+  sudo sysctl net.ipv6.conf."${IFACE}".accept_ra_rt_info_max_plen=64
+  sudo ${RADVD} -c ${IFACE} ${PREFIX}/${PREFIX_LEN}
+}
+
+USE_RADVD=0
+POSITIONAL_ARGS=
+
+while [ $# -gt 0 ]; do
+  case $1 in
+    -h|--help)
+      echo "Environment variables:"
+      echo ""
+      echo "Usage: $0 [-r|--radvd] <PREFIX_WITH_LENGTH>"
+      echo "          [-i|--iface] <INTERFACE_NAME>"
+      exit 0
+      ;;
+    -r|--radvd)
+      USE_RADVD=1
+      ARG_PREFIX="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -i|--iface)
+      ARG_IFACE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    *)
+      POSITIONAL_ARGS="$POSITIONAL_ARGS $1"
+      shift # past argument
+      ;;
+  esac
+done
+
+eval "set -- $POSITIONAL_ARGS"
+
+IFACE="${1:-tap0}"
+PREFIX_IID="1"
+
+if [ ! -z ${ARG_IFACE} ]; then
+  IFACE=${ARG_IFACE}
+else
+  IFACE="tap0"
+fi
+
+if [ ! -z ${ARG_PREFIX} ]; then
+  PREFIX=$(echo "$ARG_PREFIX" | cut -d'/' -f1)
+  PREFIX_LEN=$(echo "$ARG_PREFIX" | cut -d'/' -f2)
+else
+  PREFIX="fd00:dead:beef::"
+  PREFIX_LEN="64"
+fi
+
+trap "cleanup" INT QUIT TERM EXIT
+
+init_iface
+
+if [ ${USE_RADVD} -eq 1 ]; then
+  RADVD=${RIOTBASE}/dist/tools/radvd/radvd.sh
+  start_radvd
+fi
+
+# calls TERMPROG with TERMFLAGS
+${POSITIONAL_ARGS}

--- a/sys/shell/cmds/suit.c
+++ b/sys/shell/cmds/suit.c
@@ -48,7 +48,17 @@ static int _suit_handler(int argc, char **argv)
     }
 
     if (strcmp(argv[1], "fetch") == 0) {
-        suit_worker_trigger(argv[2], strlen(argv[2]));
+        if (argc > 2) {
+            suit_worker_trigger(argv[2], strlen(argv[2]));
+        }
+        else {
+#ifdef SUIT_MANIFEST_RESOURCE
+            suit_worker_trigger(SUIT_MANIFEST_RESOURCE, strlen(SUIT_MANIFEST_RESOURCE));
+#else
+            printf("No manifest URL provided, and SUIT_MANIFEST_RESOURCE not defined.\n");
+            return -1;
+#endif
+        }
     }
     else if (strcmp(argv[1], "seq_no") == 0) {
         uint32_t seq_no = 0;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Because I always run into pitfalls when trying to test the SUIT example, I wanted to ease the setup for me a little bit.
This PR
- adds a  `start_network.sh` for the SUIT example
- alters the Makefiles a bit
- adds a constant SUIT manifest URL the the `suit fetch` command.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Client:
`USE_ETHOS=0 SUIT_COAP_SERVER_IFACE=enp1s0f0 BOARD=same54-xpro make -C examples/advanced/suit_update/ flash term`
```
Welcome to pyterm!
Type '/exit' to exit.
ifconfig
2025-06-27 10:46:55,741 # ifconfig
2025-06-27 10:46:55,746 # Iface  5  HWaddr: FC:C2:3D:2F:8E:90  Link: up 
2025-06-27 10:46:55,752 #           L2-PDU:1500  MTU:1500  HL:64  Source address length: 6
2025-06-27 10:46:55,754 #           Link type: wired
2025-06-27 10:46:55,760 #           inet6 addr: fe80::fec2:3dff:fe2f:8e90  scope: link  VAL
2025-06-27 10:46:55,766 #           inet6 addr: 2001:db8::fec2:3dff:fe2f:8e90  scope: global  VAL
2025-06-27 10:46:55,769 #           inet6 group: ff02::1
2025-06-27 10:46:55,773 #           inet6 group: ff02::1:ff2f:8e90
2025-06-27 10:46:55,773 # 
```

Server:
`make -C examples/advanced/suit_update/ suit_coap_server`

Publish:
`USE_ETHOS=0 SUIT_COAP_SERVER_IFACE=enp1s0f0 BOARD=same54-xpro make -C examples/advanced/suit_update/ clean suit/publish`

Fetch:

```
2025-06-27 10:48:31,218 # suit fetch
2025-06-27 10:48:31,220 # suit_worker: started.
2025-06-27 10:48:31,229 # suit_worker: downloading "coap://[2001:db8::1]/fw/suit_update/same54-xpro/riot.suit.latest.bin"
> 2025-06-27 10:48:31,238 # suit_worker: got manifest with size 485
2025-06-27 10:48:31,241 # suit: verifying manifest signature
2025-06-27 10:48:32,384 # suit: validated manifest version
2025-06-27 10:48:32,389 # Manifest seq_no: 1751014057, highest available: 1751013903
2025-06-27 10:48:32,392 # suit: validated sequence number
2025-06-27 10:48:32,394 # Formatted component name: 
2025-06-27 10:48:32,399 # Comparing manifest offset 4000 with other slot offset
2025-06-27 10:48:32,404 # Comparing manifest offset 82000 with other slot offset
2025-06-27 10:48:32,406 # validating vendor ID
2025-06-27 10:48:32,414 # Comparing 547d0d74-6d3a-5a92-9662-4881afd9407b to 547d0d74-6d3a-5a92-9662-4881afd9407b from manifest
2025-06-27 10:48:32,417 # validating vendor ID: OK
2025-06-27 10:48:32,418 # validating class id
2025-06-27 10:48:32,427 # Comparing 50244518-6a7c-5ce7-932b-88b318336c82 to 50244518-6a7c-5ce7-932b-88b318336c82 from manifest
2025-06-27 10:48:32,429 # validating class id: OK
2025-06-27 10:48:32,434 # Comparing manifest offset 4000 with other slot offset
2025-06-27 10:48:32,439 # Comparing manifest offset 82000 with other slot offset
2025-06-27 10:48:32,441 # SUIT policy check OK.
2025-06-27 10:48:32,443 # Formatted component name: 
2025-06-27 10:48:32,449 # riotboot_flashwrite: initializing update to target slot 1
2025-06-27 10:48:32,485 # Fetching firmware |█████████████████████████| 100%
2025-06-27 10:48:54,538 # Finalizing payload store
2025-06-27 10:48:54,540 # Verifying image digest
2025-06-27 10:48:54,544 # Starting digest verification against image
2025-06-27 10:48:54,646 # Install correct payload
2025-06-27 10:48:54,649 # Verified installed payload
2025-06-27 10:48:54,651 # Verifying image digest
2025-06-27 10:48:54,654 # Starting digest verification against image
2025-06-27 10:48:54,757 # Verified installed payload
2025-06-27 10:48:54,760 # Image magic_number: 0x544f4952
2025-06-27 10:48:54,762 # Image Version: 0x685e5aa9
2025-06-27 10:48:54,765 # Image start address: 0x00082400
2025-06-27 10:48:54,767 # Header chksum: 0x494384b1
2025-06-27 10:48:54,768 # 
2025-06-27 10:48:55,770 # suit_worker: update successful
2025-06-27 10:48:55,772 # suit_worker: rebooting...
2025-06-27 10:48:55,810 # main(): This is RIOT! (Version: 2025.07-devel-350-g22ddb-pr/suit_update_simplification)
2025-06-27 10:48:55,813 # RIOT SUIT update example application
2025-06-27 10:48:55,815 # Running from slot 1
2025-06-27 10:48:55,818 # Image magic_number: 0x544f4952
2025-06-27 10:48:55,820 # Image Version: 0x685e5aa9
2025-06-27 10:48:55,823 # Image start address: 0x00082400
2025-06-27 10:48:55,825 # Header chksum: 0x494384b1
2025-06-27 10:48:55,825 # 
2025-06-27 10:48:55,827 # Starting the shell
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
