### PR TITLE
boards/nucleo-l412kb: enable ADC

### DIFF
--- a/boards/nucleo-l412kb/Makefile.features
+++ b/boards/nucleo-l412kb/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 CPU_MODEL = stm32l412kb
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtt

--- a/boards/nucleo-l412kb/include/periph_conf.h
+++ b/boards/nucleo-l412kb/include/periph_conf.h
@@ -138,6 +138,14 @@ static const spi_conf_t spi_config[] = {
  *
  * For Nucleo-L431KB this information is in board manual,
  * Table 15 or STM32L412KB MCU datasheet - Table 14.
+ *
+ * VBAT is connected ADC1_IN18 internal line and a voltage divider
+ * is used, so that only 1/3 of the actual VBAT is measured. This
+ * allows for a supply voltage higher than the reference voltage.
+ *
+ * For STM32L412KB more information is provided in the MCU datasheet,
+ * in section 3.15.3 - Vbat battery voltage monitoring.
+ *
  * @{
  */
 static const adc_conf_t adc_config[] = {
@@ -146,12 +154,17 @@ static const adc_conf_t adc_config[] = {
     {GPIO_PIN(PORT_A, 3),  .dev = 0, .chan = 8},  /* ADC1_IN8  */
     {GPIO_PIN(PORT_A, 4),  .dev = 0, .chan = 9},  /* ADC1_IN9  */
     {GPIO_PIN(PORT_A, 7),  .dev = 0, .chan = 12}, /* ADC1_IN12 */
+    {GPIO_UNDEF,           .dev = 0, .chan = 18}, /* VBAT */
 };
 
 /**
  * @brief Number of ADC devices
  */
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
+
+#define VBAT_ADC            ADC_LINE(5) /**< VBAT ADC line */
+
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/boards/nucleo-l412kb/include/periph_conf.h
+++ b/boards/nucleo-l412kb/include/periph_conf.h
@@ -117,6 +117,10 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
+static const adc_conf_t adc_config[] = {{}};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-l412kb/include/periph_conf.h
+++ b/boards/nucleo-l412kb/include/periph_conf.h
@@ -117,8 +117,40 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
-static const adc_conf_t adc_config[] = {{}};
+/**
+ * @brief ADC configuration
+ *
+ * Note that we do not configure all ADC channels,
+ * and not in the STM32L412KB order. Instead, we
+ * just define 5 ADC channels, for the Nucleo
+ * Arduino Nano header pins A0-A3 and A6 - all which are
+ * enabled by default and without collision with other
+ * features, for example, I2C or VCP_TX.
+ *
+* To find appropriate device and channel find in the
+ * board manual, table showing pin assignments and
+ * information about ADC - a text similar to ADC[X]_IN[Y],
+ * where:
+ * [X] - describes used device - indexed from 0,
+ * for example ADC1_IN10 is device 0,
+ * [Y] - describes used channel - indexed from 1,
+ * for example ADC1_IN10 is channel 10
+ *
+ * For Nucleo-L431KB this information is in board manual,
+ * Table 15 or STM32L412KB MCU datasheet - Table 14.
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 0),  .dev = 0, .chan = 5},  /* ADC1_IN5  */
+    {GPIO_PIN(PORT_A, 1),  .dev = 0, .chan = 6},  /* ADC1_IN6  */
+    {GPIO_PIN(PORT_A, 3),  .dev = 0, .chan = 8},  /* ADC1_IN8  */
+    {GPIO_PIN(PORT_A, 4),  .dev = 0, .chan = 9},  /* ADC1_IN9  */
+    {GPIO_PIN(PORT_A, 7),  .dev = 0, .chan = 12}, /* ADC1_IN12 */
+};
 
+/**
+ * @brief Number of ADC devices
+ */
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
 
 #ifdef __cplusplus

--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -60,7 +60,7 @@ STM32_WITH_VBAT = stm32f031% stm32f038% stm32f042% stm32f048% \
                   stm32f7% \
                   stm32g0% \
                   stm32g4% stm32gbk1cb \
-                  stm32l433% stm32l45% stm32l47% stm32l49% stm32l4r% \
+                  stm32l412% stm32l433% stm32l45% stm32l47% stm32l49% stm32l4r% \
                   stm32l5% \
                   stm32u5% \
                   stm32wb% \

--- a/cpu/stm32/include/periph/l4/periph_cpu.h
+++ b/cpu/stm32/include/periph/l4/periph_cpu.h
@@ -36,10 +36,11 @@ extern "C" {
 #error "Can't determine the number of ADC devices"
 #endif
 
-#if defined(CPU_MODEL_STM32L476RG) || defined(CPU_MODEL_STM32L476VG) || \
-    defined(CPU_MODEL_STM32L475VG) || defined(CPU_MODEL_STM32L452RE) || \
-    defined(CPU_MODEL_STM32L432KC) || defined(CPU_MODEL_STM32L496ZG) || \
-    defined(CPU_MODEL_STM32L4R5ZI) || defined(CPU_MODEL_STM32L496AG)
+#if defined(CPU_MODEL_STM32L412KB) || defined(CPU_MODEL_STM32L476RG) || \
+    defined(CPU_MODEL_STM32L476VG) || defined(CPU_MODEL_STM32L475VG) || \
+    defined(CPU_MODEL_STM32L452RE) || defined(CPU_MODEL_STM32L432KC) || \
+    defined(CPU_MODEL_STM32L496ZG) || defined(CPU_MODEL_STM32L4R5ZI) || \
+    defined(CPU_MODEL_STM32L496AG)
 /**
  * @brief   ADC voltage regulator start-up time [us]
  */

--- a/cpu/stm32/periph/adc_l4_wb.c
+++ b/cpu/stm32/periph/adc_l4_wb.c
@@ -35,6 +35,9 @@
 #if defined ADC_DEVS && ADC_DEVS == 1
 #define ADC ADC1_COMMON
 #endif
+#if defined ADC_DEVS && ADC_DEVS == 2
+#define ADC ADC12_COMMON
+#endif
 #if defined ADC_DEVS && ADC_DEVS == 3
 #define ADC ADC123_COMMON
 #endif


### PR DESCRIPTION
### Contribution description

This PR enables ADC for `nucleo-l412kb` board.

I don't have access to this boards, but because ADC pinout is the same as for `nucleo-l432kc` (see board manual tables 15 and 16) code should works fine. I compile code without any warnings.

### Testing procedure

Flash the board using `tests/periph/adc` and `tests/periph/vbat` programs.

The outputs should be similar to the ones presented in https://github.com/RIOT-OS/RIOT/pull/21238#issuecomment-2694298250

### Issues/PRs references

None.