### PR TITLE
doc/guides: fix examples directories

### DIFF
--- a/doc/guides/build-system/build-in-docker.md
+++ b/doc/guides/build-system/build-in-docker.md
@@ -35,7 +35,7 @@ When building in docker one might want for the command ran in docker to inherit
 variables that might have been set in the command line. e.g.:
 
 ```shell
-BOARD=samr21-xpro USEMODULE=xtimer make -C examples/hello-world
+BOARD=samr21-xpro USEMODULE=xtimer make -C examples/basic/hello-world
 ```
 
 In `docker.ink.mk` the origin of a variable listed in `DOCKER_ENV_VARS` is checked
@@ -46,11 +46,11 @@ You can also set in `DOCKER_ENV_VARS` in the environment to add variables to the
 list, e.g.:
 
 ```shell
-DOCKER_ENV_VARS=BEER_TYPE BEER_TYPE="imperial stout" BUILD_IN_DOCKER=1 make -C examples/hello-world/
+DOCKER_ENV_VARS=BEER_TYPE BEER_TYPE="imperial stout" BUILD_IN_DOCKER=1 make -C examples/basic/hello-world/
 docker run --rm -t -u "$(id -u)" \
     ...
     -e 'BEER_TYPE=imperial stout' \
-    -w '/data/riotbuild/riotbase/examples/hello-world/' \
+    -w '/data/riotbuild/riotbase/examples/basic/hello-world/' \
     'riot/riotbuild:latest' make
 ```
 
@@ -64,11 +64,11 @@ but will need to be prefixed with `-e` (see [option-summary]).
 e.g.:
 
 ```
-DOCKER_ENVIRONMENT_CMDLINE='-e BEER_TYPE="imperial stout"' BUILD_IN_DOCKER=1 make -C examples/hello-world/
+DOCKER_ENVIRONMENT_CMDLINE='-e BEER_TYPE="imperial stout"' BUILD_IN_DOCKER=1 make -C examples/basic/hello-world/
 docker run --rm -t -u "$(id -u)" \
     ...
     -e 'BEER_TYPE=imperial stout' \
-    -w '/data/riotbuild/riotbase/examples/hello-world/' \
+    -w '/data/riotbuild/riotbase/examples/basic/hello-world/' \
     'riot/riotbuild:latest' make
 ```
 

--- a/doc/guides/getting-started/building_example.mdx
+++ b/doc/guides/getting-started/building_example.mdx
@@ -16,7 +16,7 @@ with the name of your board.
 
 RIOT provides a number of examples in the `examples/` directory. Every example
 has a README that documents its usage and its purpose. You can build them by
-opening a shell, navigating to an example (e.g. `examples/default`), and
+opening a shell, navigating to an example (e.g. `examples/basic/default`), and
 running:
 
 ```bash
@@ -67,7 +67,7 @@ the `dist/tools/pyterm/` directory. If you choose to use another terminal
 program you can set `TERMPROG` (and if need be the `TERMFLAGS`) macros:
 
 ```bash
-make -C examples/gnrc_networking/ term \
+make -C examples/networking/gnrc/gnrc_networking/ term \
     BOARD=samr21-xpro \
     TERMPROG=gtkterm \
     TERMFLAGS="-s 115200 -p /dev/ttyACM0 -e"
@@ -97,5 +97,5 @@ To create a bridge and two (or `count` at your option) tap interfaces:
     sudo ./dist/tools/tapsetup/tapsetup [-c [<count>]]
 ```
 
-A detailed example can be found in `examples/gnrc_networking`.
+A detailed example can be found in `examples/networking/gnrc/gnrc_networking`.
 :::

--- a/doc/guides/getting-started/flashing.mdx
+++ b/doc/guides/getting-started/flashing.mdx
@@ -26,11 +26,12 @@ board. The guide should mostly apply to all other boards as well.
 ![VS Code in WSL](img/08-Flash_Real_Hardware-03.png)
 
 1. Open the `examples` folder
-2. Open the `default` folder within `examples`
-3. Open the `main.c` file in the `default` folder
-4. Select the "Terminal" tab at the bottom
-5. Enter `cd ~/RIOT/examples/default` to enter the `default` folder also in the terminal
-6. Run `make BOARD=esp32-mh-et-live-minikit compile-commands`
+2. Open the `basic` folder within `examples`
+3. Open the `default` folder within `basic`
+4. Open the `main.c` file in the `default` folder
+5. Select the "Terminal" tab at the bottom
+6. Enter `cd ~/RIOT/examples/basic/default` to enter the `default` folder also in the terminal
+7. Run `make BOARD=esp32-mh-et-live-minikit compile-commands`
     - You can replace `esp32-mh-et-live-minikit` with the name of any other supported board
 
 :::note

--- a/doc/guides/getting-started/installing.mdx
+++ b/doc/guides/getting-started/installing.mdx
@@ -81,7 +81,7 @@ You will still need a "clone" of the RIOT Repository to work with.
 - Open the terminal.
 - Type `git clone https://github.com/RIOT-OS/RIOT` and confirm with the return-key
 - This may take some time. Eventually, it will print `done.` when it completed
-- Type `cd RIOT/examples/hello-world` and confirm with the return-key to enter
+- Type `cd RIOT/examples/basic/hello-world` and confirm with the return-key to enter
   the folder `hello-world` example app in the RIOT repo
 - Type `make` and confirm with the return key to build the app for the board
   `native`
@@ -112,12 +112,12 @@ The app should behave the same when run on real hardware.
 ![Ubuntu terminal running `make compile-commands` in the `hello-world` app](img/06-Use_VS_Code-00.png)
 
 - If not already open, open the terminal
-- Confirm that the terminal is pointed to the folder `~/RIOT/examples/hello-world`
+- Confirm that the terminal is pointed to the folder `~/RIOT/examples/basic/hello-world`
     - The blue part left of the prompt (the `$` sign in the terminal) shows
       the current working directory for the terminal
-    - If the blue string is not `~/RIOT/examples/hello-world`, type
-      `cd ~/RIOT/examples/hello-world` to enter that path
-- Inside `~/RIOT/examples/hello-world` run the command `make compile-commands`
+    - If the blue string is not `~/RIOT/examples/basic/hello-world`, type
+      `cd ~/RIOT/examples/basic/hello-world` to enter that path
+- Inside `~/RIOT/examples/basic/hello-world` run the command `make compile-commands`
 - The output should look like above
 
 ![Launching VS Code from Ubuntu](img/06-Use_VS_Code-01.png)
@@ -132,7 +132,8 @@ The app should behave the same when run on real hardware.
 1. Click on "Yes, I trust the authors"
 
 - Now, use the tree view in the left and open the `examples` folder
-- Open the `hello-world` folder inside the `examples` folder
+- Open the `basic` folder inside the `examples` folder
+- Open the `hello-world` folder inside the `basic` folder
 - Open the `main.c` file in the `hello-world` folder within `examples`
 - The file should open and look like this:
 
@@ -182,7 +183,7 @@ Re-run `make compile-commands` when:
   in the source code
 - Save the modified source code (e.g. `Ctrl`+`S`)
 - Open the integrated terminal by clicking on the terminal tab at the bottom
-- Navigate to `~/RIOT/examples/hello-world` using `cd ~/RIOT/examples/hello-world`
+- Navigate to `~/RIOT/examples/basic/hello-world` using `cd ~/RIOT/examples/basic/hello-world`
 - Run the `make` command to build the code
 - Run make `make term` to launch the application
 - The result should look like:


### PR DESCRIPTION
### Contribution description

This PR fix some examples directories names (restructured by PR #21135) in the starlight guides.

### Testing procedure

Check if everything in guides is OK - `make doc-starlight` and connect to the dev server http:localhost:4321.

### Issues/PRs references

PR #21135