### PR TITLE
guides: use absolute path to fix url

### DIFF
--- a/doc/guides/getting-started/install-wsl.mdx
+++ b/doc/guides/getting-started/install-wsl.mdx
@@ -8,7 +8,7 @@ The following guide is for Windows users only.
 
 It explains the process of installing Ubuntu LTS via Windows Subsystem for Linux (WSL) on a Windows machine.
 
-If you are using a different operating system, please refer to [the general guide on how to use RIOT](getting-started/installing).
+If you are using a different operating system, please refer to [the general guide on how to use RIOT](/getting-started/installing).
 :::
 
 ## Install Ubuntu LTS


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The link in the box on https://guide.riot-os.org/getting-started/install-wsl/ is broken.


### Testing procedure

Check the guides preview (do we have that?).


### Issues/PRs references

Also, I'm a bit surprised to find the WSL installation guide above the general "Setup Development Environment" in the navigation tree, is that intentional @AnnsAnns ?
