### PR TITLE
core/thread: add thread_join()

### DIFF
--- a/core/sched.c
+++ b/core/sched.c
@@ -316,6 +316,13 @@ NORETURN void sched_task_exit(void)
 #endif
 
     (void)irq_disable();
+
+    if (me->exit_val != (void *)UINTPTR_MAX) {
+        /* this^ && status > THREAD_ZOMBIFY  -> joinable */
+        thread_zombify();
+        UNREACHABLE();
+    }
+
     sched_threads[thread_getpid()] = NULL;
     sched_num_threads--;
 

--- a/tests/core/thread_join/Makefile
+++ b/tests/core/thread_join/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.core_common
+
+USEMODULE += ztimer_msec
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/core/thread_join/main.c
+++ b/tests/core/thread_join/main.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025 Mihai Renea <mihai.renea@ml-pa.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief   Thread join test application
+ *
+ * @author  Mihai Renea <mihai.renea@ml-pa.com>
+ *
+ * @}
+ */
+
+#include <errno.h>
+#include <stdio.h>
+
+#include "test_utils/expect.h"
+#include "thread.h"
+#include "ztimer.h"
+
+static void *joinee_f(void *arg)
+{
+    (void)arg;
+    ztimer_sleep(ZTIMER_MSEC, 100);
+
+    return NULL;
+}
+
+static kernel_pid_t _spawn_joinee(bool joinable)
+{
+    static char joinee_stack[THREAD_STACKSIZE_MAIN];
+    return thread_create(joinee_stack, sizeof(joinee_stack),
+                         THREAD_PRIORITY_MAIN,
+                         joinable ? THREAD_CREATE_JOINABLE : 0,
+                         joinee_f,
+                         NULL,
+                         "joinee");
+}
+
+int main(void)
+{
+    puts("START");
+
+    kernel_pid_t joinee_pid = _spawn_joinee(true);
+    expect(joinee_pid >= 0);
+
+    int res = thread_join(joinee_pid, NULL);
+    expect(res == 0);
+    expect(thread_get(joinee_pid) == NULL);
+
+    joinee_pid = _spawn_joinee(true);
+    expect(joinee_pid >= 0);
+
+    ztimer_sleep(ZTIMER_MSEC, 150);
+
+    thread_t *joinee = thread_get(joinee_pid);
+    expect(joinee && joinee->status == STATUS_ZOMBIE);
+
+    res = thread_join(joinee_pid, NULL);
+    expect(res == 0);
+    expect(thread_get(joinee_pid) == NULL);
+
+    joinee_pid = _spawn_joinee(false);
+
+    res = thread_join(joinee_pid, NULL);
+    expect(res == -EINVAL);
+
+    puts("SUCCESS");
+
+    return 0;
+}

--- a/tests/core/thread_join/tests/01-run.py
+++ b/tests/core/thread_join/tests/01-run.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect("START")
+    child.expect("SUCCESS")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
#### Motivation
Currently there is no clean way of ensuring a thread ends. One can e.g.

```c
void *joinee_fn(void *arg)
{
    ...
    mutex_unlock(arg);
    return NULL;
}

int main(void)
{
    mutex_t exit_signal = MUTEX_INIT_LOCKED;
    thread_create(stack, sizeof(stack),
                           THREAD_PRIORITY_MAIN - 1,
                           0,
                           joinee_fn,
                           &exit_signal,
                           "joinee");

    ...

    mutex_lock(&exit_signal);
    // we can only guarantee joinee finished at this point it its prio was higher!
}
```
But this only works if the priority of the joinee (the thread we're joining) was higher, 
otherwise there's no guarantee of progress past `mutex_unlock(arg)`.

This PR adds `thread_join()`, which guarantees a thread is finished and its resources
can be reused.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

#### Implementation
:warning: This implementation is rather experimental. Some features are not implemented. It also aims to remain 100% backwards compatible, but it needs not be so. See below.

#### Backwards compatibility
The implementation adds a new thread creation flag. If not explicitly set, the threads life cycle remains unchanged, and it cannot be `thread_join()`ed. But if set, the thread goes into zombie state instead of stopping on exit, and `thread_join()` will eventually stop it. I added this distinction for compatibility with any application relying on threads to automatically stop on exit. However, one can also argue that any app doing so is buggy (see above), and as such there is a point in lifting this distinction and making all threads go into zombie mode on exit. 

#### Return values
Return values are not implemented yet: the `exit_value` pointer passed to `thread_join()` will always be set to NULL. This is so because the thread function "returns" into `sched_task_exit()`, so without any CPU-specific preamble there is no way to catch the return value.

### Testing procedure
Ran the test app on native and a cortex-m board.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

