### PR TITLE
gnrc/rpl/control_messages: refactor `gnrc_rpl_recv_DIO`

### DIFF
--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -737,6 +737,32 @@ void gnrc_rpl_recv_DIS(gnrc_rpl_dis_t *dis, kernel_pid_t iface, ipv6_addr_t *src
     }
 }
 
+static bool _handle_DIO_opts(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio, ipv6_addr_t *src,
+                             uint16_t len, bool is_new)
+{
+    gnrc_rpl_opt_t *opts = (gnrc_rpl_opt_t *)(dio + 1);
+    uint32_t included_opts = 0;
+
+    if (!_parse_options(GNRC_RPL_ICMPV6_CODE_DIO, inst, opts, len, src, &included_opts)) {
+        DEBUG("RPL: Error encountered during DIO option parsing\n");
+        return false;
+    }
+
+    if (is_new && !(included_opts & (((uint32_t)1) << GNRC_RPL_OPT_DODAG_CONF))) {
+        if (!IS_ACTIVE(CONFIG_GNRC_RPL_DODAG_CONF_OPTIONAL_ON_JOIN)) {
+            DEBUG("RPL: DIO without DODAG_CONF option - request new DIO\n");
+            gnrc_rpl_send_DIS(NULL, src, NULL, 0);
+            return false;
+        }
+        else {
+            DEBUG("RPL: DIO without DODAG_CONF option - use default trickle parameters\n");
+            gnrc_rpl_send_DIS(NULL, src, NULL, 0);
+        }
+    }
+
+    return true;
+}
+
 void _recv_DIO_for_new_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio, kernel_pid_t iface,
                              ipv6_addr_t *src, uint16_t len)
 {
@@ -783,25 +809,9 @@ void _recv_DIO_for_new_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio, ker
     parent->rank = byteorder_ntohs(dio->rank);
     gnrc_rpl_parent_update(dodag, parent);
 
-    uint32_t included_opts = 0;
-    if (!_parse_options(GNRC_RPL_ICMPV6_CODE_DIO, inst, (gnrc_rpl_opt_t *)(dio + 1), len,
-                        src, &included_opts)) {
-        DEBUG("RPL: Error encountered during DIO option parsing - remove DODAG\n");
+    if (!_handle_DIO_opts(inst, dio, src, len, true)) {
         gnrc_rpl_instance_remove(inst);
         return;
-    }
-
-    if (!(included_opts & (((uint32_t)1) << GNRC_RPL_OPT_DODAG_CONF))) {
-        if (!IS_ACTIVE(CONFIG_GNRC_RPL_DODAG_CONF_OPTIONAL_ON_JOIN)) {
-            DEBUG("RPL: DIO without DODAG_CONF option - remove DODAG and request new DIO\n");
-            gnrc_rpl_instance_remove(inst);
-            gnrc_rpl_send_DIS(NULL, src, NULL, 0);
-            return;
-        }
-        else {
-            DEBUG("RPL: DIO without DODAG_CONF option - use default trickle parameters\n");
-            gnrc_rpl_send_DIS(NULL, src, NULL, 0);
-        }
     }
 
     /* if there was no address created manually or by a PIO on the interface,
@@ -902,9 +912,8 @@ void _recv_DIO_for_existing_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio
         parent->dtsn = dio->dtsn;
         dodag->grounded = dio->g_mop_prf >> GNRC_RPL_GROUNDED_SHIFT;
         dodag->prf = dio->g_mop_prf & GNRC_RPL_PRF_MASK;
-        uint32_t included_opts = 0;
-        if (!_parse_options(GNRC_RPL_ICMPV6_CODE_DIO, inst, (gnrc_rpl_opt_t *)(dio + 1), len,
-                            src, &included_opts)) {
+
+        if (!_handle_DIO_opts(inst, dio, src, len, false)) {
             DEBUG("RPL: Error encountered during DIO option parsing - remove DODAG\n");
             gnrc_rpl_instance_remove(inst);
             return;

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -511,6 +511,11 @@ static inline uint32_t _sec_to_ms(uint32_t sec)
     }
 }
 
+char *_ip_addr_str(ipv6_addr_t *addr)
+{
+    return ipv6_addr_to_str(addr_str, addr, (unsigned)sizeof(addr_str));
+}
+
 /** @todo allow target prefixes in target options to be of variable length */
 static bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt_t *opt,
                            uint16_t len,
@@ -637,8 +642,7 @@ static bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt
                 first_target = target;
             }
 
-            DEBUG("RPL: adding FT entry %s/%d\n",
-                  ipv6_addr_to_str(addr_str, &(target->target), (unsigned)sizeof(addr_str)),
+            DEBUG("RPL: adding FT entry %s/%d\n", _ip_addr_str(&(target->target)),
                   target->prefix_length);
 
             gnrc_ipv6_nib_ft_del(&(target->target), target->prefix_length);
@@ -658,8 +662,7 @@ static bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt
             }
 
             do {
-                DEBUG("RPL: updating FT entry %s/%d\n",
-                      ipv6_addr_to_str(addr_str, &(first_target->target), sizeof(addr_str)),
+                DEBUG("RPL: updating FT entry %s/%d\n", _ip_addr_str(&(first_target->target)),
                       first_target->prefix_length);
 
                 gnrc_ipv6_nib_ft_del(&(first_target->target),
@@ -812,8 +815,7 @@ bool _update_dodag_from_DIO(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio, ipv6
         gnrc_netif_t *netif = gnrc_netif_get_by_pid(dodag->iface);
         if (gnrc_netif_ipv6_addr_match(netif, &dodag->dodag_id) < 0) {
             DEBUG("RPL: no IPv6 address configured on interface %i to match the "
-                  "given dodag id: %s\n", netif->pid,
-                  ipv6_addr_to_str(addr_str, &(dio->dodag_id), sizeof(addr_str)); );
+                  "given dodag id: %s\n", netif->pid, _ip_addr_str(&(dio->dodag_id)));
             return false;
         }
     }
@@ -854,8 +856,7 @@ void _recv_DIO_for_new_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio, ker
 
     gnrc_rpl_dodag_init(inst, &dio->dodag_id, netif->pid);
 
-    DEBUG("RPL: Joined DODAG (%s).\n",
-          ipv6_addr_to_str(addr_str, &(dio->dodag_id), sizeof(addr_str)); );
+    DEBUG("RPL: Joined DODAG (%s).\n", _ip_addr_str(&(dio->dodag_id)));
 
     if (!_update_dodag_from_DIO(inst, dio, src, len, true)) {
         DEBUG("RPL: remove DODAG.\n");
@@ -1051,7 +1052,7 @@ void gnrc_rpl_send_DAO(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination, uint
         if (ipv6_addr_is_global(&fte.dst) &&
             !ipv6_addr_is_unspecified(&fte.next_hop)) {
             DEBUG("RPL: Send DAO - building target %s/%d\n",
-                  ipv6_addr_to_str(addr_str, &fte.dst, sizeof(addr_str)), fte.dst_len);
+                  _ip_addr_str(&fte.dst), fte.dst_len);
 
             if ((pkt = _dao_target_build(pkt, &fte.dst, fte.dst_len)) == NULL) {
                 DEBUG("RPL: Send DAO - no space left in packet buffer\n");
@@ -1061,8 +1062,7 @@ void gnrc_rpl_send_DAO(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination, uint
     }
 
     /* add own address */
-    DEBUG("RPL: Send DAO - building target %s/128\n",
-          ipv6_addr_to_str(addr_str, me, sizeof(addr_str)));
+    DEBUG("RPL: Send DAO - building target %s/128\n", _ip_addr_str(me));
     if ((pkt = _dao_target_build(pkt, me, IPV6_ADDR_BIT_LEN)) == NULL) {
         DEBUG("RPL: Send DAO - no space left in packet buffer\n");
         return;
@@ -1202,10 +1202,7 @@ void gnrc_rpl_recv_DAO(gnrc_rpl_dao_t *dao, kernel_pid_t iface, ipv6_addr_t *src
     /* check if the D flag is set before accessing the DODAG id */
     if ((dao->k_d_flags & GNRC_RPL_DAO_D_BIT)) {
         if (memcmp(&dodag->dodag_id, (ipv6_addr_t *)(dao + 1), sizeof(ipv6_addr_t)) != 0) {
-            DEBUG("RPL: DAO with unknown DODAG id (%s)\n", ipv6_addr_to_str(addr_str,
-                                                                            (ipv6_addr_t *)(dao +
-                                                                                            1),
-                                                                            sizeof(addr_str)));
+            DEBUG("RPL: DAO with unknown DODAG id (%s)\n", _ip_addr_str((ipv6_addr_t *)(dao + 1)));
             return;
         }
         opts = (gnrc_rpl_opt_t *)(((uint8_t *)opts) + sizeof(ipv6_addr_t));
@@ -1268,10 +1265,8 @@ void gnrc_rpl_recv_DAO_ACK(gnrc_rpl_dao_ack_t *dao_ack, kernel_pid_t iface, ipv6
     /* check if the D flag is set before accessing the DODAG id */
     if ((dao_ack->d_reserved & GNRC_RPL_DAO_ACK_D_BIT)) {
         if (memcmp(&dodag->dodag_id, (ipv6_addr_t *)(dao_ack + 1), sizeof(ipv6_addr_t)) != 0) {
-            DEBUG("RPL: DAO-ACK with unknown DODAG id (%s)\n", ipv6_addr_to_str(addr_str,
-                                                                                (ipv6_addr_t *)(
-                                                                                    dao_ack + 1),
-                                                                                sizeof(addr_str)));
+            DEBUG("RPL: DAO-ACK with unknown DODAG id (%s)\n",
+                  _ip_addr_str((ipv6_addr_t *)(dao_ack + 1)));
             return;
         }
     }

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -741,15 +741,14 @@ void _recv_DIO_for_new_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio, ker
                              ipv6_addr_t *src, uint16_t len)
 {
     gnrc_netif_t *netif;
+    gnrc_rpl_dodag_t *dodag;
+    gnrc_rpl_parent_t *parent = NULL;
 
     if (byteorder_ntohs(dio->rank) == GNRC_RPL_INFINITE_RANK) {
         DEBUG("RPL: ignore INFINITE_RANK DIO when we are not yet part of this DODAG\n");
         gnrc_rpl_instance_remove(inst);
         return;
     }
-
-    inst->mop = (dio->g_mop_prf >> GNRC_RPL_MOP_SHIFT) & GNRC_RPL_SHIFTED_MOP_MASK;
-    inst->of = gnrc_rpl_get_of_for_ocp(GNRC_RPL_DEFAULT_OCP);
 
     if (iface == KERNEL_PID_UNDEF) {
         netif = _find_interface_with_rpl_mcast();
@@ -759,14 +758,15 @@ void _recv_DIO_for_new_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio, ker
     }
     assert(netif != NULL);
 
+    inst->mop = (dio->g_mop_prf >> GNRC_RPL_MOP_SHIFT) & GNRC_RPL_SHIFTED_MOP_MASK;
+    inst->of = gnrc_rpl_get_of_for_ocp(GNRC_RPL_DEFAULT_OCP);
+
     gnrc_rpl_dodag_init(inst, &dio->dodag_id, netif->pid);
 
-    gnrc_rpl_dodag_t *dodag = &inst->dodag;
+    dodag = &inst->dodag;
 
     DEBUG("RPL: Joined DODAG (%s).\n",
-          ipv6_addr_to_str(addr_str, &dio->dodag_id, sizeof(addr_str)));
-
-    gnrc_rpl_parent_t *parent = NULL;
+          ipv6_addr_to_str(addr_str, &(dio->dodag_id), sizeof(addr_str)));
 
     if (!gnrc_rpl_parent_add_by_addr(dodag, src, &parent) && (parent == NULL)) {
         DEBUG("RPL: Could not allocate new parent.\n");
@@ -774,11 +774,14 @@ void _recv_DIO_for_new_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio, ker
         return;
     }
 
-    dodag->version = dio->version_number;
-    dodag->grounded = dio->g_mop_prf >> GNRC_RPL_GROUNDED_SHIFT;
-    dodag->prf = dio->g_mop_prf & GNRC_RPL_PRF_MASK;
+    gnrc_rpl_delay_dao(dodag);
+    uint32_t interval_min = 1 << dodag->dio_min;
+    uint8_t interval_max = dodag->dio_interval_doubl;
+    trickle_start(gnrc_rpl_pid, &dodag->trickle, GNRC_RPL_MSG_TYPE_TRICKLE_MSG,
+                  interval_min, interval_max, dodag->dio_redun);
 
     parent->rank = byteorder_ntohs(dio->rank);
+    gnrc_rpl_parent_update(dodag, parent);
 
     uint32_t included_opts = 0;
     if (!_parse_options(GNRC_RPL_ICMPV6_CODE_DIO, inst, (gnrc_rpl_opt_t *)(dio + 1), len,
@@ -803,20 +806,17 @@ void _recv_DIO_for_new_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio, ker
 
     /* if there was no address created manually or by a PIO on the interface,
      * leave this DODAG */
-    if (gnrc_netif_ipv6_addr_match(netif, &dodag->dodag_id) < 0) {
+    if (gnrc_netif_ipv6_addr_match(netif, &dio->dodag_id) < 0) {
         DEBUG("RPL: no IPv6 address configured on interface %i to match the "
               "given dodag id: %s\n", netif->pid,
-              ipv6_addr_to_str(addr_str, &(dodag->dodag_id), sizeof(addr_str)));
+              ipv6_addr_to_str(addr_str, &(dio->dodag_id), sizeof(addr_str)));
         gnrc_rpl_instance_remove(inst);
         return;
     }
 
-    gnrc_rpl_delay_dao(dodag);
-    trickle_start(gnrc_rpl_pid, &dodag->trickle, GNRC_RPL_MSG_TYPE_TRICKLE_MSG,
-                  (1 << dodag->dio_min), dodag->dio_interval_doubl,
-                  dodag->dio_redun);
-
-    gnrc_rpl_parent_update(dodag, parent);
+    dodag->version = dio->version_number;
+    dodag->grounded = dio->g_mop_prf >> GNRC_RPL_GROUNDED_SHIFT;
+    dodag->prf = dio->g_mop_prf & GNRC_RPL_PRF_MASK;
 }
 
 void _recv_DIO_for_existing_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio,
@@ -874,12 +874,11 @@ void _recv_DIO_for_existing_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio
         DEBUG("RPL: Could not allocate new parent.\n");
         return;
     }
-    else if (parent != NULL) {
-        trickle_increment_counter(&dodag->trickle);
-    }
 
     /* gnrc_rpl_parent_add_by_addr should have set this already */
     assert(parent != NULL);
+
+    trickle_increment_counter(&dodag->trickle);
 
     parent->rank = byteorder_ntohs(dio->rank);
 
@@ -891,11 +890,12 @@ void _recv_DIO_for_existing_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio
         if ((byteorder_ntohs(dio->rank) == GNRC_RPL_INFINITE_RANK)
             && (dodag->my_rank != GNRC_RPL_INFINITE_RANK)) {
             trickle_reset_timer(&dodag->trickle);
-            return;
         }
+        return;
     }
+
     /* incoming DIO is from pref. parent */
-    else if (parent == dodag->parents) {
+    if (parent == dodag->parents) {
         if (parent->dtsn != dio->dtsn) {
             gnrc_rpl_delay_dao(dodag);
         }

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -737,6 +737,99 @@ void gnrc_rpl_recv_DIS(gnrc_rpl_dis_t *dis, kernel_pid_t iface, ipv6_addr_t *src
     }
 }
 
+void _recv_DIO_for_existing_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio,
+                                  ipv6_addr_t *src, uint16_t len)
+{
+    gnrc_rpl_dodag_t *dodag = &inst->dodag;
+
+    /* ignore dodags with other dodag_id's for now */
+    /* TODO: choose DODAG with better rank */
+    if (memcmp(&dodag->dodag_id, &dio->dodag_id, sizeof(ipv6_addr_t)) != 0) {
+        DEBUG("RPL: DIO received from another DODAG, but same instance - ignore\n");
+        return;
+    }
+
+    if (inst->mop != ((dio->g_mop_prf >> GNRC_RPL_MOP_SHIFT) & GNRC_RPL_SHIFTED_MOP_MASK)) {
+        DEBUG("RPL: invalid MOP for this instance.\n");
+        return;
+    }
+
+#ifdef MODULE_GNRC_RPL_P2P
+    gnrc_rpl_p2p_ext_t *p2p_ext = gnrc_rpl_p2p_ext_get(dodag);
+    if ((dodag->instance->mop == GNRC_RPL_P2P_MOP) && (p2p_ext->lifetime_sec <= 0)) {
+        return;
+    }
+#endif
+
+    if (GNRC_RPL_COUNTER_GREATER_THAN(dio->version_number, dodag->version)) {
+        if (dodag->node_status == GNRC_RPL_ROOT_NODE) {
+            dodag->version = GNRC_RPL_COUNTER_INCREMENT(dio->version_number);
+            trickle_reset_timer(&dodag->trickle);
+        }
+        else {
+            dodag->version = dio->version_number;
+            gnrc_rpl_local_repair(dodag);
+        }
+    }
+    else if (GNRC_RPL_COUNTER_GREATER_THAN(dodag->version, dio->version_number)) {
+        trickle_reset_timer(&dodag->trickle);
+        return;
+    }
+
+    if (dodag->node_status == GNRC_RPL_ROOT_NODE) {
+        if (byteorder_ntohs(dio->rank) != GNRC_RPL_INFINITE_RANK) {
+            trickle_increment_counter(&dodag->trickle);
+        }
+        else {
+            trickle_reset_timer(&dodag->trickle);
+        }
+        return;
+    }
+
+    gnrc_rpl_parent_t *parent = NULL;
+
+    if (!gnrc_rpl_parent_add_by_addr(dodag, src, &parent) && (parent == NULL)) {
+        DEBUG("RPL: Could not allocate new parent.\n");
+        return;
+    }
+    else if (parent != NULL) {
+        trickle_increment_counter(&dodag->trickle);
+    }
+
+    /* gnrc_rpl_parent_add_by_addr should have set this already */
+    assert(parent != NULL);
+
+    parent->rank = byteorder_ntohs(dio->rank);
+
+    gnrc_rpl_parent_update(dodag, parent);
+
+    /* sender of incoming DIO is not a parent of mine (anymore) and has an INFINITE rank
+       and I have a rank != INFINITE_RANK */
+    if (parent->state == GNRC_RPL_PARENT_UNUSED) {
+        if ((byteorder_ntohs(dio->rank) == GNRC_RPL_INFINITE_RANK)
+            && (dodag->my_rank != GNRC_RPL_INFINITE_RANK)) {
+            trickle_reset_timer(&dodag->trickle);
+            return;
+        }
+    }
+    /* incoming DIO is from pref. parent */
+    else if (parent == dodag->parents) {
+        if (parent->dtsn != dio->dtsn) {
+            gnrc_rpl_delay_dao(dodag);
+        }
+        parent->dtsn = dio->dtsn;
+        dodag->grounded = dio->g_mop_prf >> GNRC_RPL_GROUNDED_SHIFT;
+        dodag->prf = dio->g_mop_prf & GNRC_RPL_PRF_MASK;
+        uint32_t included_opts = 0;
+        if (!_parse_options(GNRC_RPL_ICMPV6_CODE_DIO, inst, (gnrc_rpl_opt_t *)(dio + 1), len,
+                            src, &included_opts)) {
+            DEBUG("RPL: Error encountered during DIO option parsing - remove DODAG\n");
+            gnrc_rpl_instance_remove(inst);
+            return;
+        }
+    }
+}
+
 void gnrc_rpl_recv_DIO(gnrc_rpl_dio_t *dio, kernel_pid_t iface, ipv6_addr_t *src, ipv6_addr_t *dst,
                        uint16_t len)
 {
@@ -835,103 +928,12 @@ void gnrc_rpl_recv_DIO(gnrc_rpl_dio_t *dio, kernel_pid_t iface, ipv6_addr_t *src
                       dodag->dio_redun);
 
         gnrc_rpl_parent_update(dodag, parent);
-        return;
     }
     else if (inst == NULL) {
         DEBUG("RPL: Could not allocate a new instance.\n");
-        return;
     }
     else {
-        /* instance exists already */
-        /* ignore dodags with other dodag_id's for now */
-        /* TODO: choose DODAG with better rank */
-
-        dodag = &inst->dodag;
-
-        if (memcmp(&dodag->dodag_id, &dio->dodag_id, sizeof(ipv6_addr_t)) != 0) {
-            DEBUG("RPL: DIO received from another DODAG, but same instance - ignore\n");
-            return;
-        }
-    }
-
-    if (inst->mop != ((dio->g_mop_prf >> GNRC_RPL_MOP_SHIFT) & GNRC_RPL_SHIFTED_MOP_MASK)) {
-        DEBUG("RPL: invalid MOP for this instance.\n");
-        return;
-    }
-
-#ifdef MODULE_GNRC_RPL_P2P
-    gnrc_rpl_p2p_ext_t *p2p_ext = gnrc_rpl_p2p_ext_get(dodag);
-    if ((dodag->instance->mop == GNRC_RPL_P2P_MOP) && (p2p_ext->lifetime_sec <= 0)) {
-        return;
-    }
-#endif
-
-    if (GNRC_RPL_COUNTER_GREATER_THAN(dio->version_number, dodag->version)) {
-        if (dodag->node_status == GNRC_RPL_ROOT_NODE) {
-            dodag->version = GNRC_RPL_COUNTER_INCREMENT(dio->version_number);
-            trickle_reset_timer(&dodag->trickle);
-        }
-        else {
-            dodag->version = dio->version_number;
-            gnrc_rpl_local_repair(dodag);
-        }
-    }
-    else if (GNRC_RPL_COUNTER_GREATER_THAN(dodag->version, dio->version_number)) {
-        trickle_reset_timer(&dodag->trickle);
-        return;
-    }
-
-    if (dodag->node_status == GNRC_RPL_ROOT_NODE) {
-        if (byteorder_ntohs(dio->rank) != GNRC_RPL_INFINITE_RANK) {
-            trickle_increment_counter(&dodag->trickle);
-        }
-        else {
-            trickle_reset_timer(&dodag->trickle);
-        }
-        return;
-    }
-
-    gnrc_rpl_parent_t *parent = NULL;
-
-    if (!gnrc_rpl_parent_add_by_addr(dodag, src, &parent) && (parent == NULL)) {
-        DEBUG("RPL: Could not allocate new parent.\n");
-        return;
-    }
-    else if (parent != NULL) {
-        trickle_increment_counter(&dodag->trickle);
-    }
-
-    /* gnrc_rpl_parent_add_by_addr should have set this already */
-    assert(parent != NULL);
-
-    parent->rank = byteorder_ntohs(dio->rank);
-
-    gnrc_rpl_parent_update(dodag, parent);
-
-    /* sender of incoming DIO is not a parent of mine (anymore) and has an INFINITE rank
-       and I have a rank != INFINITE_RANK */
-    if (parent->state == GNRC_RPL_PARENT_UNUSED) {
-        if ((byteorder_ntohs(dio->rank) == GNRC_RPL_INFINITE_RANK)
-            && (dodag->my_rank != GNRC_RPL_INFINITE_RANK)) {
-            trickle_reset_timer(&dodag->trickle);
-            return;
-        }
-    }
-    /* incoming DIO is from pref. parent */
-    else if (parent == dodag->parents) {
-        if (parent->dtsn != dio->dtsn) {
-            gnrc_rpl_delay_dao(dodag);
-        }
-        parent->dtsn = dio->dtsn;
-        dodag->grounded = dio->g_mop_prf >> GNRC_RPL_GROUNDED_SHIFT;
-        dodag->prf = dio->g_mop_prf & GNRC_RPL_PRF_MASK;
-        uint32_t included_opts = 0;
-        if (!_parse_options(GNRC_RPL_ICMPV6_CODE_DIO, inst, (gnrc_rpl_opt_t *)(dio + 1), len,
-                            src, &included_opts)) {
-            DEBUG("RPL: Error encountered during DIO option parsing - remove DODAG\n");
-            gnrc_rpl_instance_remove(inst);
-            return;
-        }
+        _recv_DIO_for_existing_dodag(inst, dio, src, len);
     }
 }
 

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -763,12 +763,77 @@ static bool _handle_DIO_opts(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio, ipv
     return true;
 }
 
+bool _update_dodag_from_DIO(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio, ipv6_addr_t *src,
+                            uint16_t len, bool is_new)
+{
+    gnrc_rpl_dodag_t *dodag = &inst->dodag;
+    gnrc_rpl_parent_t *parent = NULL;
+
+    if (!gnrc_rpl_parent_add_by_addr(dodag, src, &parent) && (parent == NULL)) {
+        DEBUG("RPL: Could not allocate new parent.\n");
+        return false;
+    }
+
+    /* gnrc_rpl_parent_add_by_addr should have set this already */
+    assert(parent != NULL);
+
+    if (is_new) {
+        gnrc_rpl_delay_dao(dodag);
+
+        uint32_t interval_min = 1 << dodag->dio_min;
+        uint8_t interval_max = dodag->dio_interval_doubl;
+        trickle_start(gnrc_rpl_pid, &dodag->trickle, GNRC_RPL_MSG_TYPE_TRICKLE_MSG,
+                      interval_min, interval_max, dodag->dio_redun);
+    }
+    else {
+        trickle_increment_counter(&dodag->trickle);
+    }
+
+    parent->rank = byteorder_ntohs(dio->rank);
+    gnrc_rpl_parent_update(dodag, parent);
+
+    /* sender of incoming DIO is not preferred parent of mine (anymore) */
+    if (parent != dodag->parents) {
+        if ((byteorder_ntohs(dio->rank) == GNRC_RPL_INFINITE_RANK)
+            && (dodag->my_rank != GNRC_RPL_INFINITE_RANK)) {
+            trickle_reset_timer(&dodag->trickle);
+        }
+        return false;
+    }
+
+    if (!_handle_DIO_opts(inst, dio, src, len, false)) {
+        DEBUG("RPL: Error encountered during DIO option parsing\n");
+        return false;
+    }
+
+    if (is_new) {
+        /* if there was no address created manually or by a PIO on the interface,
+         * leave this DODAG */
+        gnrc_netif_t *netif = gnrc_netif_get_by_pid(dodag->iface);
+        if (gnrc_netif_ipv6_addr_match(netif, &dodag->dodag_id) < 0) {
+            DEBUG("RPL: no IPv6 address configured on interface %i to match the "
+                  "given dodag id: %s\n", netif->pid,
+                  ipv6_addr_to_str(addr_str, &(dio->dodag_id), sizeof(addr_str)); );
+            return false;
+        }
+    }
+
+    if (parent->dtsn != dio->dtsn) {
+        gnrc_rpl_delay_dao(dodag);
+    }
+
+    parent->dtsn = dio->dtsn;
+    dodag->grounded = dio->g_mop_prf >> GNRC_RPL_GROUNDED_SHIFT;
+    dodag->prf = dio->g_mop_prf & GNRC_RPL_PRF_MASK;
+    dodag->version = dio->version_number;
+
+    return true;
+}
+
 void _recv_DIO_for_new_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio, kernel_pid_t iface,
                              ipv6_addr_t *src, uint16_t len)
 {
     gnrc_netif_t *netif;
-    gnrc_rpl_dodag_t *dodag;
-    gnrc_rpl_parent_t *parent = NULL;
 
     if (byteorder_ntohs(dio->rank) == GNRC_RPL_INFINITE_RANK) {
         DEBUG("RPL: ignore INFINITE_RANK DIO when we are not yet part of this DODAG\n");
@@ -789,44 +854,14 @@ void _recv_DIO_for_new_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio, ker
 
     gnrc_rpl_dodag_init(inst, &dio->dodag_id, netif->pid);
 
-    dodag = &inst->dodag;
-
     DEBUG("RPL: Joined DODAG (%s).\n",
-          ipv6_addr_to_str(addr_str, &(dio->dodag_id), sizeof(addr_str)));
+          ipv6_addr_to_str(addr_str, &(dio->dodag_id), sizeof(addr_str)); );
 
-    if (!gnrc_rpl_parent_add_by_addr(dodag, src, &parent) && (parent == NULL)) {
-        DEBUG("RPL: Could not allocate new parent.\n");
+    if (!_update_dodag_from_DIO(inst, dio, src, len, true)) {
+        DEBUG("RPL: remove DODAG.\n");
         gnrc_rpl_instance_remove(inst);
-        return;
     }
 
-    gnrc_rpl_delay_dao(dodag);
-    uint32_t interval_min = 1 << dodag->dio_min;
-    uint8_t interval_max = dodag->dio_interval_doubl;
-    trickle_start(gnrc_rpl_pid, &dodag->trickle, GNRC_RPL_MSG_TYPE_TRICKLE_MSG,
-                  interval_min, interval_max, dodag->dio_redun);
-
-    parent->rank = byteorder_ntohs(dio->rank);
-    gnrc_rpl_parent_update(dodag, parent);
-
-    if (!_handle_DIO_opts(inst, dio, src, len, true)) {
-        gnrc_rpl_instance_remove(inst);
-        return;
-    }
-
-    /* if there was no address created manually or by a PIO on the interface,
-     * leave this DODAG */
-    if (gnrc_netif_ipv6_addr_match(netif, &dio->dodag_id) < 0) {
-        DEBUG("RPL: no IPv6 address configured on interface %i to match the "
-              "given dodag id: %s\n", netif->pid,
-              ipv6_addr_to_str(addr_str, &(dio->dodag_id), sizeof(addr_str)));
-        gnrc_rpl_instance_remove(inst);
-        return;
-    }
-
-    dodag->version = dio->version_number;
-    dodag->grounded = dio->g_mop_prf >> GNRC_RPL_GROUNDED_SHIFT;
-    dodag->prf = dio->g_mop_prf & GNRC_RPL_PRF_MASK;
 }
 
 void _recv_DIO_for_existing_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio,
@@ -878,47 +913,7 @@ void _recv_DIO_for_existing_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio
         return;
     }
 
-    gnrc_rpl_parent_t *parent = NULL;
-
-    if (!gnrc_rpl_parent_add_by_addr(dodag, src, &parent) && (parent == NULL)) {
-        DEBUG("RPL: Could not allocate new parent.\n");
-        return;
-    }
-
-    /* gnrc_rpl_parent_add_by_addr should have set this already */
-    assert(parent != NULL);
-
-    trickle_increment_counter(&dodag->trickle);
-
-    parent->rank = byteorder_ntohs(dio->rank);
-
-    gnrc_rpl_parent_update(dodag, parent);
-
-    /* sender of incoming DIO is not a parent of mine (anymore) and has an INFINITE rank
-       and I have a rank != INFINITE_RANK */
-    if (parent->state == GNRC_RPL_PARENT_UNUSED) {
-        if ((byteorder_ntohs(dio->rank) == GNRC_RPL_INFINITE_RANK)
-            && (dodag->my_rank != GNRC_RPL_INFINITE_RANK)) {
-            trickle_reset_timer(&dodag->trickle);
-        }
-        return;
-    }
-
-    /* incoming DIO is from pref. parent */
-    if (parent == dodag->parents) {
-        if (parent->dtsn != dio->dtsn) {
-            gnrc_rpl_delay_dao(dodag);
-        }
-        parent->dtsn = dio->dtsn;
-        dodag->grounded = dio->g_mop_prf >> GNRC_RPL_GROUNDED_SHIFT;
-        dodag->prf = dio->g_mop_prf & GNRC_RPL_PRF_MASK;
-
-        if (!_handle_DIO_opts(inst, dio, src, len, false)) {
-            DEBUG("RPL: Error encountered during DIO option parsing - remove DODAG\n");
-            gnrc_rpl_instance_remove(inst);
-            return;
-        }
-    }
+    _update_dodag_from_DIO(inst, dio, src, len, false);
 }
 
 void gnrc_rpl_recv_DIO(gnrc_rpl_dio_t *dio, kernel_pid_t iface, ipv6_addr_t *src, ipv6_addr_t *dst,

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -737,6 +737,88 @@ void gnrc_rpl_recv_DIS(gnrc_rpl_dis_t *dis, kernel_pid_t iface, ipv6_addr_t *src
     }
 }
 
+void _recv_DIO_for_new_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio, kernel_pid_t iface,
+                             ipv6_addr_t *src, uint16_t len)
+{
+    gnrc_netif_t *netif;
+
+    if (byteorder_ntohs(dio->rank) == GNRC_RPL_INFINITE_RANK) {
+        DEBUG("RPL: ignore INFINITE_RANK DIO when we are not yet part of this DODAG\n");
+        gnrc_rpl_instance_remove(inst);
+        return;
+    }
+
+    inst->mop = (dio->g_mop_prf >> GNRC_RPL_MOP_SHIFT) & GNRC_RPL_SHIFTED_MOP_MASK;
+    inst->of = gnrc_rpl_get_of_for_ocp(GNRC_RPL_DEFAULT_OCP);
+
+    if (iface == KERNEL_PID_UNDEF) {
+        netif = _find_interface_with_rpl_mcast();
+    }
+    else {
+        netif = gnrc_netif_get_by_pid(iface);
+    }
+    assert(netif != NULL);
+
+    gnrc_rpl_dodag_init(inst, &dio->dodag_id, netif->pid);
+
+    gnrc_rpl_dodag_t *dodag = &inst->dodag;
+
+    DEBUG("RPL: Joined DODAG (%s).\n",
+          ipv6_addr_to_str(addr_str, &dio->dodag_id, sizeof(addr_str)));
+
+    gnrc_rpl_parent_t *parent = NULL;
+
+    if (!gnrc_rpl_parent_add_by_addr(dodag, src, &parent) && (parent == NULL)) {
+        DEBUG("RPL: Could not allocate new parent.\n");
+        gnrc_rpl_instance_remove(inst);
+        return;
+    }
+
+    dodag->version = dio->version_number;
+    dodag->grounded = dio->g_mop_prf >> GNRC_RPL_GROUNDED_SHIFT;
+    dodag->prf = dio->g_mop_prf & GNRC_RPL_PRF_MASK;
+
+    parent->rank = byteorder_ntohs(dio->rank);
+
+    uint32_t included_opts = 0;
+    if (!_parse_options(GNRC_RPL_ICMPV6_CODE_DIO, inst, (gnrc_rpl_opt_t *)(dio + 1), len,
+                        src, &included_opts)) {
+        DEBUG("RPL: Error encountered during DIO option parsing - remove DODAG\n");
+        gnrc_rpl_instance_remove(inst);
+        return;
+    }
+
+    if (!(included_opts & (((uint32_t)1) << GNRC_RPL_OPT_DODAG_CONF))) {
+        if (!IS_ACTIVE(CONFIG_GNRC_RPL_DODAG_CONF_OPTIONAL_ON_JOIN)) {
+            DEBUG("RPL: DIO without DODAG_CONF option - remove DODAG and request new DIO\n");
+            gnrc_rpl_instance_remove(inst);
+            gnrc_rpl_send_DIS(NULL, src, NULL, 0);
+            return;
+        }
+        else {
+            DEBUG("RPL: DIO without DODAG_CONF option - use default trickle parameters\n");
+            gnrc_rpl_send_DIS(NULL, src, NULL, 0);
+        }
+    }
+
+    /* if there was no address created manually or by a PIO on the interface,
+     * leave this DODAG */
+    if (gnrc_netif_ipv6_addr_match(netif, &dodag->dodag_id) < 0) {
+        DEBUG("RPL: no IPv6 address configured on interface %i to match the "
+              "given dodag id: %s\n", netif->pid,
+              ipv6_addr_to_str(addr_str, &(dodag->dodag_id), sizeof(addr_str)));
+        gnrc_rpl_instance_remove(inst);
+        return;
+    }
+
+    gnrc_rpl_delay_dao(dodag);
+    trickle_start(gnrc_rpl_pid, &dodag->trickle, GNRC_RPL_MSG_TYPE_TRICKLE_MSG,
+                  (1 << dodag->dio_min), dodag->dio_interval_doubl,
+                  dodag->dio_redun);
+
+    gnrc_rpl_parent_update(dodag, parent);
+}
+
 void _recv_DIO_for_existing_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio,
                                   ipv6_addr_t *src, uint16_t len)
 {
@@ -835,7 +917,6 @@ void gnrc_rpl_recv_DIO(gnrc_rpl_dio_t *dio, kernel_pid_t iface, ipv6_addr_t *src
 {
     (void)dst;
     gnrc_rpl_instance_t *inst = NULL;
-    gnrc_rpl_dodag_t *dodag = NULL;
 
 #ifdef MODULE_NETSTATS_RPL
     gnrc_rpl_netstats_rx_DIO(&gnrc_rpl_netstats, len, (dst && !ipv6_addr_is_multicast(dst)));
@@ -850,84 +931,7 @@ void gnrc_rpl_recv_DIO(gnrc_rpl_dio_t *dio, kernel_pid_t iface, ipv6_addr_t *src
     len -= (sizeof(gnrc_rpl_dio_t) + sizeof(icmpv6_hdr_t));
 
     if (gnrc_rpl_instance_add(dio->instance_id, &inst)) {
-        /* new instance and DODAG */
-        gnrc_netif_t *netif;
-
-        if (byteorder_ntohs(dio->rank) == GNRC_RPL_INFINITE_RANK) {
-            DEBUG("RPL: ignore INFINITE_RANK DIO when we are not yet part of this DODAG\n");
-            gnrc_rpl_instance_remove(inst);
-            return;
-        }
-
-        inst->mop = (dio->g_mop_prf >> GNRC_RPL_MOP_SHIFT) & GNRC_RPL_SHIFTED_MOP_MASK;
-        inst->of = gnrc_rpl_get_of_for_ocp(GNRC_RPL_DEFAULT_OCP);
-
-        if (iface == KERNEL_PID_UNDEF) {
-            netif = _find_interface_with_rpl_mcast();
-        }
-        else {
-            netif = gnrc_netif_get_by_pid(iface);
-        }
-        assert(netif != NULL);
-
-        gnrc_rpl_dodag_init(inst, &dio->dodag_id, netif->pid);
-
-        dodag = &inst->dodag;
-
-        DEBUG("RPL: Joined DODAG (%s).\n",
-              ipv6_addr_to_str(addr_str, &dio->dodag_id, sizeof(addr_str)));
-
-        gnrc_rpl_parent_t *parent = NULL;
-
-        if (!gnrc_rpl_parent_add_by_addr(dodag, src, &parent) && (parent == NULL)) {
-            DEBUG("RPL: Could not allocate new parent.\n");
-            gnrc_rpl_instance_remove(inst);
-            return;
-        }
-
-        dodag->version = dio->version_number;
-        dodag->grounded = dio->g_mop_prf >> GNRC_RPL_GROUNDED_SHIFT;
-        dodag->prf = dio->g_mop_prf & GNRC_RPL_PRF_MASK;
-
-        parent->rank = byteorder_ntohs(dio->rank);
-
-        uint32_t included_opts = 0;
-        if (!_parse_options(GNRC_RPL_ICMPV6_CODE_DIO, inst, (gnrc_rpl_opt_t *)(dio + 1), len,
-                            src, &included_opts)) {
-            DEBUG("RPL: Error encountered during DIO option parsing - remove DODAG\n");
-            gnrc_rpl_instance_remove(inst);
-            return;
-        }
-
-        if (!(included_opts & (((uint32_t)1) << GNRC_RPL_OPT_DODAG_CONF))) {
-            if (!IS_ACTIVE(CONFIG_GNRC_RPL_DODAG_CONF_OPTIONAL_ON_JOIN)) {
-                DEBUG("RPL: DIO without DODAG_CONF option - remove DODAG and request new DIO\n");
-                gnrc_rpl_instance_remove(inst);
-                gnrc_rpl_send_DIS(NULL, src, NULL, 0);
-                return;
-            }
-            else {
-                DEBUG("RPL: DIO without DODAG_CONF option - use default trickle parameters\n");
-                gnrc_rpl_send_DIS(NULL, src, NULL, 0);
-            }
-        }
-
-        /* if there was no address created manually or by a PIO on the interface,
-         * leave this DODAG */
-        if (gnrc_netif_ipv6_addr_match(netif, &dodag->dodag_id) < 0) {
-            DEBUG("RPL: no IPv6 address configured on interface %i to match the "
-                  "given dodag id: %s\n", netif->pid,
-                  ipv6_addr_to_str(addr_str, &(dodag->dodag_id), sizeof(addr_str)));
-            gnrc_rpl_instance_remove(inst);
-            return;
-        }
-
-        gnrc_rpl_delay_dao(dodag);
-        trickle_start(gnrc_rpl_pid, &dodag->trickle, GNRC_RPL_MSG_TYPE_TRICKLE_MSG,
-                      (1 << dodag->dio_min), dodag->dio_interval_doubl,
-                      dodag->dio_redun);
-
-        gnrc_rpl_parent_update(dodag, parent);
+        _recv_DIO_for_new_dodag(inst, dio, iface, src, len);
     }
     else if (inst == NULL) {
         DEBUG("RPL: Could not allocate a new instance.\n");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `gnrc_rpl_recv_DIO` function in `gnrc_rpl_control_messages` is > 150 LOC that are quite hard to understand, especially as someone that is new to RIOT.

This PR refactors the function into smaller sub-functions and extracts logic that is common between the two main branches (creating a new DODAG and updating an existing DODAG).

I split the refactoring into separate commits that are easier to review one-by-one; can squash them together at the end.

I am not super happy with the resulting code, but I think it is a small improvement. 
Further feedback on how to improve it would be appreciated, given that I am not very proficient with C!

### Open TODOs

- [ ] Document new sub-functions?

### Testing procedure

This PR shouldn't change any logic apart from the order in which individual DODAG properties are updated (see 673e7fa4def41feb10ceba82f184bf779ce627f8).

I tested it manually: 
- `examples/networking/gnrc_networking` + added `USEMODULE += nimble_rpble`
- 9 nodes (nrf52dk), 1 node `A` set as root (`ifconfig 8 add 2001:db8:1::1/64` && `rpl root 1 2001:db8:1::1`)
- => RPL tree was created as expected with `A` as root

### Issues/PRs references

Preparation for future work on #21574.
