### PR TITLE
submac: add TX power to retrievable netopts

### DIFF
--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -59,6 +59,9 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
         case NETOPT_IEEE802154_PHY:
             *((uint8_t*) value) = ieee802154_get_phy_mode(submac);
             return 1;
+        case NETOPT_TX_POWER:
+            *((int16_t *)value) = netdev_submac->dev.txpower;
+            return sizeof(int16_t);
         default:
             break;
     }

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -783,8 +783,8 @@ int ieee802154_set_phy_conf(ieee802154_submac_t *submac, const ieee802154_phy_co
 
     /* Go back to RX if needed */
     if (current_state == IEEE802154_FSM_STATE_RX) {
-        res = ieee802154_radio_set_rx(dev);
-        assert (res >= 0);
+        int rx = ieee802154_radio_set_rx(dev);
+        assert (rx >= 0);
     }
 
     return res;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Makes that TX power appears in the `ifconfig` output when using a radio hal netdev

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


```
> 2025-07-03 09:19:25,348 # ifconfig
2025-07-03 09:19:25,350 # Iface  3  HWaddr: 6F:9F  Channel: 5  Frequency: 869300000Hz  NID: 0x23  RSSI: -107  BW: 125kHz  SF: 7  CR: 4/5  PHY: LORA 
2025-07-03 09:19:25,350 #           Long HWaddr: 66:77:AA:29:EC:D5:EF:9F 
2025-07-03 09:19:25,351 #            TX-Power: 22dBm  State: IDLE 
2025-07-03 09:19:25,352 #           ACK_REQ  L2-PDU:102  Source address length: 2
2025-07-03 09:19:25,352 #           Link type: wireless

```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

#21202