### PR TITLE
pkg/littlefs2: bump to 2.11.1

### DIFF
--- a/pkg/littlefs2/Makefile
+++ b/pkg/littlefs2/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=littlefs2
 PKG_URL=https://github.com/littlefs-project/littlefs.git
-# v2.11.0
-PKG_VERSION=16ceb6793449fa159f99aed4a766c2823f59cf3e
+# v2.11.1
+PKG_VERSION=8e251dd675da00342d45dac78b6f627f119aed03
 PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is a minor bug fix release 

### Testing procedure

CI will take care that `tests/pkg/littlefs2` still works.


### Issues/PRs references

https://github.com/littlefs-project/littlefs/releases/tag/v2.11.1
