### PR TITLE
boards/nucleo-f042k6: doc improvment

### DIFF
--- a/boards/nucleo-f042k6/doc.md
+++ b/boards/nucleo-f042k6/doc.md
@@ -1,7 +1,6 @@
-/**
- * @defgroup    boards_nucleo-f042k6 STM32 Nucleo-F042K6
- * @ingroup     boards_common_nucleo32
- * @brief       Support for the STM32 Nucleo-F042K6
+@defgroup    boards_nucleo-f042k6 STM32 Nucleo-F042K6
+@ingroup     boards_common_nucleo32
+@brief       Support for the STM32 Nucleo-F042K6
 
 ## Overview
 
@@ -47,5 +46,3 @@ make BOARD=nucleo-f042k6 PROGRAMMER=cpy2remed flash
 ```
 @note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
       can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
-
- */

--- a/boards/nucleo-f042k6/doc.txt
+++ b/boards/nucleo-f042k6/doc.txt
@@ -8,6 +8,10 @@
 The Nucleo-F042K6 is a board from ST's Nucleo family supporting ARM Cortex-M0
 STM32F042K6 microcontroller with 6KiB of RAM and 32KiB of Flash.
 
+## Pinout
+
+@image html pinouts/nucleo-f031k6-and-more.svg "Pinout for the Nucleo-F042K6 (from ST User Manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 31)" width=25%
+
 ### MCU
 
 | MCU        |    STM32F042K6      |

--- a/boards/nucleo-f042k6/doc.txt
+++ b/boards/nucleo-f042k6/doc.txt
@@ -8,6 +8,29 @@
 The Nucleo-F042K6 is a board from ST's Nucleo family supporting ARM Cortex-M0
 STM32F042K6 microcontroller with 6KiB of RAM and 32KiB of Flash.
 
+### MCU
+
+| MCU        |    STM32F042K6      |
+|:---------- |:------------------- |
+| Family     | ARM Cortex-M0       |
+| Vendor     | ST Microelectronics |
+| RAM        | 6KiB                |
+| Flash      | 32KiB               |
+| Frequency  | up to 48MHz         |
+| FPU        | no                  |
+| Timers     | 9 (5x 16-bit, 1x 32, 1x Systick, 2x Watchdog) |
+| ADC        | 1x 12-bit (10 channels) |
+| UARTs      | 2 (two USARTs)      |
+| SPIs       | 1                   |
+| CANs       | 1                   |
+| RTC        | 1                   |
+| I2Cs       | 1                   |
+| Vcc        | 2.0V - 3.6V         |
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32f042k6.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0091-stm32f0x1stm32f0x2stm32f0x8-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) |
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0215-stm32f0-series-cortexm0-programming-manual-stmicroelectronics.pdf) |
+| Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf) |
+
 ## Flashing the Board Using ST-LINK Removable Media
 
 On-board ST-LINK programmer provides via composite USB device removable media.


### PR DESCRIPTION
### Contribution description

This PR updates `nucleo-f042k6` board doc page, by:
- adding board pinout,
- adding MCU table,
- renaming doc.txt to doc.md accordingly to the PR #21255.

### Testing procedure

Generate doc and check if everything looks good:
```
make doc
xdg-open ./doc/doxygen/html/group__boards__nucleo-f042k6.html 
```
### Issues/PRs references

PR #21255