### PR TITLE
pkg/esptool: force installation of version 4.9.0

### DIFF
--- a/pkg/esptool/Makefile
+++ b/pkg/esptool/Makefile
@@ -13,4 +13,4 @@ clean::
 
 $(PKG_SOURCE_DIR)/venv/bin/esptool.py:
 	python3 -m venv $(PKG_SOURCE_DIR)/venv
-	$(PKG_SOURCE_DIR)/venv/bin/pip install esptool
+	$(PKG_SOURCE_DIR)/venv/bin/pip install esptool==4.9.0


### PR DESCRIPTION
### Contribution description

It seems that Espressif recently released version 5.0.0 of `esptool.py` and uploaded the corresponding Python package. This version throws a number of depcrecation warnings when compiling applications for any ESP board:
```
Warning: DEPRECATED: 'esptool.py' is deprecated. Please use 'esptool' instead. The '.py' suffix will be removed in a future major release.
Warning: Deprecated: Option '--flash_mode' is deprecated. Use '--flash-mode' instead.
Warning: Deprecated: Option '--flash_size' is deprecated. Use '--flash-size' instead.
Warning: Deprecated: Option '--flash_freq' is deprecated. Use '--flash-freq' instead.
```
This PR pins the installation of the `esptool.py` Python package to version 4.9.0 so that compilation works without these deprecation warnings.

### Testing procedure

Compile any application for any ESP32 board, for example:
```
BOARD=esp32-wroom-32 make -C tests/sys/shell
```
Without the PR, you should get the deprecation warnings, with the PR the compilation should work without the deprecation warnings.

### Issues/PRs references
