### PR TITLE
cpu/esp32: add IEEE 802.15.4 support for ESP32-H2

### DIFF
--- a/cpu/esp32/Makefile
+++ b/cpu/esp32/Makefile
@@ -28,6 +28,10 @@ ifneq (, $(filter esp_freertos, $(USEMODULE)))
     DIRS += freertos
 endif
 
+ifneq (, $(filter esp_ieee802154, $(USEMODULE)))
+    DIRS += esp-ieee802154
+endif
+
 ifneq (, $(filter esp_lcd, $(USEMODULE)))
     DIRS += esp-lcd
 endif

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -33,6 +33,19 @@ ifneq (,$(filter esp_ble,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter esp_ieee802154,$(USEMODULE)))
+  FEATURES_REQUIRED += esp_ieee802154
+  USEMODULE += esp_idf_ieee802154
+  USEMODULE += esp_idf_phy
+  USEMODULE += iolist
+  ifneq (,$(filter netdev,$(USEMODULE)))
+    USEMODULE += netdev_ieee802154_submac
+  endif
+  ifeq (esp32h2,$(CPU_FAM))
+    USEPKG += esp32_sdk_lib_phy
+  endif
+endif
+
 ifneq (,$(filter esp_eth,$(USEMODULE)))
   FEATURES_REQUIRED += periph_eth
   USEMODULE += esp_idf_eth

--- a/cpu/esp32/Makefile.features
+++ b/cpu/esp32/Makefile.features
@@ -68,6 +68,10 @@ ifneq (,$(filter esp32 esp32s3,$(CPU_FAM)))
   endif
 endif
 
+ifeq (esp32h2,$(CPU_FAM))
+  FEATURES_PROVIDED += esp_ieee802154
+endif
+
 ifneq (,$(filter esp32-wrover% esp32s2%r2 esp32s3%r2 esp32s3%r8 esp32s3%r8v,$(CPU_MODEL)))
   FEATURES_PROVIDED += esp_spi_ram
   ifneq (,$(filter esp32s3%r8 esp32s3%r8v,$(CPU_MODEL)))

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -243,6 +243,12 @@ ifneq (,$(filter esp_eth,$(USEMODULE)))
   INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_wifi/include
 endif
 
+ifneq (,$(filter esp_ieee802154,$(USEMODULE)))
+  INCLUDES += -I$(RIOTCPU)/$(CPU)/esp-ieee802154
+  INCLUDES += -I$(ESP32_SDK_DIR)/components/ieee802154/include
+  INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_coex/include
+endif
+
 ifneq (,$(filter periph_sdmmc,$(USEMODULE)))
   INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_driver_sdmmc/include
   INCLUDES += -I$(ESP32_SDK_DIR)/components/sdmmc/include
@@ -402,6 +408,15 @@ ifneq (,$(filter esp_ble,$(USEMODULE)))
     ARCHIVES += -lrtc
   else ifneq (,$(filter esp32c3 esp32s3,$(CPU_FAM)))
     ARCHIVES += -lbtbb
+  endif
+endif
+
+ifneq (,$(filter esp_ieee802154,$(USEMODULE)))
+  ifeq (esp32h2,$(CPU_FAM))
+    LINKFLAGS += -L$(ESP32_SDK_LIB_PHY_DIR)/$(CPU_FAM)
+    LINKFLAGS += -L$(ESP32_SDK_LIB_BT_DIR)
+    ARCHIVES += -lbtbb
+    ARCHIVES += -lphy
   endif
 endif
 

--- a/cpu/esp32/esp-idf/Makefile
+++ b/cpu/esp32/esp-idf/Makefile
@@ -36,6 +36,10 @@ ifneq (,$(filter esp_idf_heap,$(USEMODULE)))
   DIRS += heap
 endif
 
+ifneq (,$(filter esp_idf_ieee802154,$(USEMODULE)))
+  DIRS += ieee802154
+endif
+
 ifneq (,$(filter esp_idf_lcd,$(USEMODULE)))
   DIRS += lcd
 endif

--- a/cpu/esp32/esp-idf/common/Makefile
+++ b/cpu/esp32/esp-idf/common/Makefile
@@ -64,20 +64,26 @@ endif
 
 # TODO separate module
 ifneq (,$(filter esp_idf_phy,$(USEMODULE)))
-  ESP32_SDK_SRC += components/esp_phy/$(CPU_FAM)/phy_init_data.c
   ESP32_SDK_SRC += components/esp_phy/src/phy_common.c
-  ESP32_SDK_SRC += components/esp_phy/src/phy_init.c
-  ESP32_SDK_SRC += components/esp_system/port/soc/$(CPU_FAM)/reset_reason.c
-  ESP32_SDK_SRC += components/soc/esp32/dport_access.c
-  INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_event/include
-  INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_netif/include
   INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_phy/include
-  INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_phy/$(CPU_FAM)/include
-  INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_wifi/include
-  ifeq (,$(filter esp_idf_wifi,$(USEMODULE)))
-    ESP32_SDK_SRC += components/esp_wifi/src/wifi_init.c
-    INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/esp_supplicant/include
-    INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_coex/include
+  ifeq (esp32h2,$(CPU_FAM))
+    ESP32_SDK_SRC += components/esp_phy/src/btbb_init.c
+    ESP32_SDK_SRC += components/esp_phy/src/phy_init_esp32hxx.c
+    ESP32_SDK_SRC += components/esp_phy/src/phy_override.c
+  else
+    ESP32_SDK_SRC += components/esp_phy/$(CPU_FAM)/phy_init_data.c
+    ESP32_SDK_SRC += components/esp_phy/src/phy_init.c
+    ESP32_SDK_SRC += components/esp_system/port/soc/$(CPU_FAM)/reset_reason.c
+    ESP32_SDK_SRC += components/soc/esp32/dport_access.c
+    INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_event/include
+    INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_netif/include
+    INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_phy/$(CPU_FAM)/include
+    INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_wifi/include
+    ifeq (,$(filter esp_idf_wifi,$(USEMODULE)))
+      ESP32_SDK_SRC += components/esp_wifi/src/wifi_init.c
+      INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/esp_supplicant/include
+      INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_coex/include
+    endif
   endif
 endif
 

--- a/cpu/esp32/esp-idf/ieee802154/Makefile
+++ b/cpu/esp32/esp-idf/ieee802154/Makefile
@@ -1,0 +1,28 @@
+MODULE = esp_idf_ieee802154
+
+ESP32_SDK_SRC += components/ieee802154/driver/esp_ieee802154_ack.c
+ESP32_SDK_SRC += components/ieee802154/driver/esp_ieee802154_dev.c
+ESP32_SDK_SRC += components/ieee802154/driver/esp_ieee802154_event.c
+ESP32_SDK_SRC += components/ieee802154/driver/esp_ieee802154_frame.c
+ESP32_SDK_SRC += components/ieee802154/driver/esp_ieee802154_pib.c
+ESP32_SDK_SRC += components/ieee802154/driver/esp_ieee802154_sec.c
+ESP32_SDK_SRC += components/ieee802154/driver/esp_ieee802154_timer.c
+ESP32_SDK_SRC += components/ieee802154/driver/esp_ieee802154_util.c
+ESP32_SDK_SRC += components/ieee802154/esp_ieee802154.c
+ESP32_SDK_SRC += components/soc/$(CPU_FAM)/ieee802154_periph.c
+
+INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_coex/include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_phy/include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_phy/$(CPU_FAM)/include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/ieee802154/include
+INCLUDES += -I$(ESP32_SDK_DIR)/components/ieee802154/private_include
+
+#CFLAGS += -Wno-cast-function-type
+#CFLAGS += -Wno-implicit-fallthrough
+
+include $(RIOTBASE)/Makefile.base
+
+ESP32_SDK_BIN = $(BINDIR)/$(MODULE)
+
+include ../esp_idf.mk
+include ../esp_idf_cflags.mk

--- a/cpu/esp32/esp-ieee802154/Makefile
+++ b/cpu/esp32/esp-ieee802154/Makefile
@@ -1,0 +1,3 @@
+MODULE = esp_ieee802154
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/esp32/esp-ieee802154/esp_ieee802154_hal.c
+++ b/cpu/esp32/esp-ieee802154/esp_ieee802154_hal.c
@@ -1,0 +1,470 @@
+/*
+ * Copyright (C) 2025 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include "esp_ieee802154.h"
+
+#include "esp_ieee802154_hal.h"
+#include "iolist.h"
+#include "log.h"
+#include "net/ieee802154/radio.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+/* ACK frame timeout in microseconds, should be a multiple of 16 */
+#define ESP_IEEE802154_ACK_TIMEOUT_US (3456)
+
+_Static_assert((3456 % 16 == 0), "ACK frame timeout should be a multiple of 16");
+
+/* Although the device driver supports IEEE802154_CAP_IRQ_TX_START,
+ * IEEE802154_CAP_IRQ_RX_START and IEEE802154_CAP_IRQ_CCA_DONE, we are not
+ * using it for now to avoid unnecessary performance degradation as it is
+ * not used by any link layer driver */
+#define _USE_RX_START   0
+#define _USE_TX_START   0
+#define _USE_CCA_DONE   0
+
+#define _USE_SET_RX     1
+#define _USE_SET_IDLE   1
+
+static const ieee802154_radio_ops_t esp_ieee802154_driver;
+static ieee802154_dev_t *esp_ieee802154_dev;
+
+static uint8_t  _tx_frame[IEEE802154_FRAME_LEN_MAX + 1]; /* additional byte 0 is used for length */
+static uint8_t *_rx_frame;
+static const uint8_t *_ack_frame;
+
+static esp_ieee802154_frame_info_t *_rx_frame_info;
+static esp_ieee802154_frame_info_t *_ack_frame_info;
+
+static bool _channel_clear;
+
+static esp_ieee802154_tx_error_t _tx_error;     /* error on last transmit */
+
+static int _write(ieee802154_dev_t *dev, const iolist_t *psdu)
+{
+    (void)dev;
+
+    DEBUG("[esp_ieee802154] %s\n", __func__);
+
+    assert(psdu);
+
+    /* copy packet data into the _tx_frame buffer */
+    uint8_t *dst = &_tx_frame[1];   /* first byte is frame length */
+
+    for (; psdu; psdu = psdu->iol_next) {
+        if (psdu->iol_len) {
+            assert(((dst - &_tx_frame[1]) +
+                    psdu->iol_len + IEEE802154_FCS_LEN) < ARRAY_SIZE(_tx_frame));
+            memcpy(dst, psdu->iol_base, psdu->iol_len);
+            dst += psdu->iol_len;
+        }
+    }
+
+    /* length of the package. */
+    _tx_frame[0] = (dst - &_tx_frame[1]) + IEEE802154_FCS_LEN;
+
+    DEBUG("[esp_ieee802154] %s: put %d bytes to _tx_frame\n", __func__, _tx_frame[0]);
+
+    return 0;
+}
+
+static int _len(ieee802154_dev_t *dev)
+{
+    (void)dev;
+    DEBUG("[esp_ieee802154] %s\n", __func__);
+    return _rx_frame[0] - IEEE802154_FCS_LEN;
+}
+
+static int _read(ieee802154_dev_t *dev, void *buf, size_t size, ieee802154_rx_info_t *info)
+{
+    (void)dev;
+
+    DEBUG("[esp_ieee802154] %s: buf=%p size=%u info=%p\n",
+          __func__, buf, size, info);
+
+    unsigned len = _rx_frame[0] - IEEE802154_FCS_LEN;
+    int res = 0;
+
+    if (size < len) {
+        DEBUG("[esp_ieee802154] %s: buffer to small (%u < %u)\n",
+              __func__, size, len);
+        res = -ENOBUFS;
+    }
+    else if (buf) {
+        DEBUG("[esp_ieee802154] %s: read packet of length %d\n", __func__, len);
+        if (info) {
+            info->rssi = ieee802154_dbm_to_rssi(_rx_frame[len]);
+            info->lqi = _rx_frame[len+1];
+        }
+        memcpy(buf, &_rx_frame[1], len);
+        res = len;
+    }
+
+    esp_ieee802154_receive_handle_done(_rx_frame);
+
+    return res;
+}
+
+static int _off(ieee802154_dev_t *dev)
+{
+    (void)dev;
+    DEBUG("[esp_ieee802154] %s\n", __func__);
+    esp_ieee802154_disable();
+    return 0;
+}
+
+static int _request_on(ieee802154_dev_t *dev)
+{
+    (void)dev;
+    DEBUG("[esp_ieee802154] %s\n", __func__);
+    esp_ieee802154_enable();
+    return 0;
+}
+
+static int _confirm_on(ieee802154_dev_t *dev)
+{
+    (void)dev;
+    DEBUG("[esp_ieee802154] %s\n", __func__);
+    return 0;
+}
+
+static int _request_op(ieee802154_dev_t *dev, ieee802154_hal_op_t op, void *ctx)
+{
+    (void)dev;
+    (void)ctx;
+
+    switch (op) {
+    case IEEE802154_HAL_OP_TRANSMIT:
+        DEBUG("[esp_ieee802154] %s: IEEE802154_HAL_OP_TRANSMIT\n", __func__);
+        _tx_error = ESP_IEEE802154_TX_ERR_NONE;
+        _ack_frame = NULL;
+        _ack_frame_info = NULL;
+        return esp_ieee802154_transmit(_tx_frame, true) ? -EIO : 0;
+    case IEEE802154_HAL_OP_SET_RX:
+        DEBUG("[esp_ieee802154] %s: IEEE802154_HAL_OP_SET_RX\n", __func__);
+        return (IS_ACTIVE(_USE_SET_RX) && esp_ieee802154_receive()) ? -EIO : 0;
+    case IEEE802154_HAL_OP_SET_IDLE:
+        /* TODO: ctx = (bool *force) */
+        DEBUG("[esp_ieee802154] %s: IEEE802154_HAL_OP_SET_IDLE\n", __func__);
+        return (IS_ACTIVE(_USE_SET_IDLE) && esp_ieee802154_sleep()) ? -EIO : 0;
+        return 0;
+    case IEEE802154_HAL_OP_CCA:
+        extern esp_err_t esp_ieee802154_cca(void);
+        DEBUG("[esp_ieee802154] %s: IEEE802154_HAL_OP_CCA\n", __func__);
+        return esp_ieee802154_cca();
+    }
+
+    return -EINVAL;
+}
+
+static int _confirm_op(ieee802154_dev_t *dev, ieee802154_hal_op_t op, void *ctx)
+{
+    (void)dev;
+
+    esp_ieee802154_state_t state = esp_ieee802154_get_state();
+
+    switch (op) {
+    case IEEE802154_HAL_OP_TRANSMIT:
+        DEBUG("[esp_ieee802154] %s: IEEE802154_HAL_OP_TRANSMIT\n", __func__);
+
+        if (ctx) {
+            ieee802154_tx_info_t *info = ctx;
+
+            switch (_tx_error) {
+            case ESP_IEEE802154_TX_ERR_NONE:
+                info->status = TX_STATUS_SUCCESS;
+                if (_ack_frame_info && _ack_frame_info->pending) {
+                    info->status = TX_STATUS_FRAME_PENDING;
+                }
+                break;
+            case ESP_IEEE802154_TX_ERR_CCA_BUSY:
+                info->status = TX_STATUS_MEDIUM_BUSY;
+                break;
+            case ESP_IEEE802154_TX_ERR_NO_ACK:
+                info->status = TX_STATUS_NO_ACK;
+                break;
+            default:
+                break;
+            }
+        }
+        esp_ieee802154_receive_handle_done(_ack_frame);
+        return 0;
+    case IEEE802154_HAL_OP_SET_RX:
+        DEBUG("[esp_ieee802154] %s: IEEE802154_HAL_OP_SET_RX\n", __func__);
+        return (!IS_ACTIVE(_USE_SET_RX) ||
+                (state == ESP_IEEE802154_RADIO_RECEIVE)) ? 0 : -EAGAIN;
+    case IEEE802154_HAL_OP_SET_IDLE:
+        DEBUG("[esp_ieee802154] %s: IEEE802154_HAL_OP_SET_IDLE\n", __func__);
+        return (!IS_ACTIVE(_USE_SET_IDLE) ||
+                ((state == ESP_IEEE802154_RADIO_IDLE) ||
+                 (state == ESP_IEEE802154_RADIO_SLEEP))) ? 0 : -EAGAIN;
+    case IEEE802154_HAL_OP_CCA:
+        DEBUG("[esp_ieee802154] %s: IEEE802154_HAL_OP_CCA\n", __func__);
+        assert(ctx);
+        *((bool *)ctx) = _channel_clear;
+        return 0;
+    }
+
+    return -EINVAL;
+}
+
+static int _set_cca_threshold(ieee802154_dev_t *dev, int8_t threshold)
+{
+    (void)dev;
+    DEBUG("[esp_ieee802154] %s: threshold %i\n", __func__, threshold);
+    return esp_ieee802154_set_cca_threshold(threshold) ? -EIO : 0;
+}
+
+static int _set_cca_mode(ieee802154_dev_t *dev, ieee802154_cca_mode_t mode)
+{
+    (void)dev;
+
+    switch (mode) {
+    case IEEE802154_CCA_MODE_ED_THRESHOLD:
+        DEBUG("[esp_ieee802154] %s: set IEEE802154_CCA_MODE_ED_THRESHOLD\n", __func__);
+        return esp_ieee802154_set_cca_mode(ESP_IEEE802154_CCA_MODE_ED) ? -EIO : 0;
+    case IEEE802154_CCA_MODE_CARRIER_SENSING:
+        DEBUG("[esp_ieee802154] %s: set IEEE802154_CCA_MODE_CARRIER_SENSING\n", __func__);
+        return esp_ieee802154_set_cca_mode(ESP_IEEE802154_CCA_MODE_CARRIER) ? -EIO : 0;
+    case IEEE802154_CCA_MODE_ED_THRESH_AND_CS:
+        DEBUG("[esp_ieee802154] %s: set IEEE802154_CCA_MODE_ED_THRESH_AND_CS\n", __func__);
+        return esp_ieee802154_set_cca_mode(ESP_IEEE802154_CCA_MODE_CARRIER_AND_ED) ? -EIO : 0;
+    case IEEE802154_CCA_MODE_ED_THRESH_OR_CS:
+        DEBUG("[esp_ieee802154] %s: IEEE802154_CCA_MODE_ED_THRESH_OR_CS\n", __func__);
+        return esp_ieee802154_set_cca_mode(ESP_IEEE802154_CCA_MODE_CARRIER_OR_ED) ? -EIO : 0;
+    }
+
+    return -EINVAL;
+}
+
+static int _config_phy(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf)
+{
+    (void)dev;
+
+    assert(conf);
+
+    DEBUG("[esp_ieee802154] %s\n", __func__);
+
+    if (esp_ieee802154_set_txpower(conf->pow) ||
+        esp_ieee802154_set_channel(conf->channel)) {
+        return -EIO;
+    }
+
+    return 0;
+}
+
+static int _set_frame_retrans(ieee802154_dev_t *dev, uint8_t retrans)
+{
+    (void)dev;
+    DEBUG("[esp_ieee802154] %s\n", __func__);
+    return -ENOTSUP;
+}
+
+static int _set_csma_params(ieee802154_dev_t *dev, const ieee802154_csma_be_t *bd,
+                            int8_t retries)
+{
+    (void)dev;
+    DEBUG("[esp_ieee802154] %s\n", __func__);
+    return -ENOTSUP;
+}
+
+static int _set_frame_filter_mode(ieee802154_dev_t *dev, ieee802154_filter_mode_t mode)
+{
+    (void)dev;
+    DEBUG("[esp_ieee802154] %s\n", __func__);
+    return -ENOTSUP;
+}
+
+static int _config_addr_filter(ieee802154_dev_t *dev, ieee802154_af_cmd_t cmd, const void *value)
+{
+    (void)dev;
+
+    assert(value);
+
+    const uint8_t *addr = value;
+
+    switch (cmd) {
+    case IEEE802154_AF_SHORT_ADDR:
+        DEBUG("[esp_ieee802154] %s: set IEEE802154_AF_SHORT_ADDR %02x:%02x\n",
+              __func__, addr[0], addr[1]);
+        return esp_ieee802154_set_short_address(*((const uint16_t *)value)) ? -EIO : 0;
+    case IEEE802154_AF_EXT_ADDR:
+        DEBUG("[esp_ieee802154] %s: set IEEE802154_AF_EXT_ADDR "
+              "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x\n", __func__,
+              addr[0], addr[1], addr[2], addr[3], addr[4], addr[5], addr[6], addr[7]);
+        return esp_ieee802154_set_extended_address(addr) ? -EIO : 0;
+    case IEEE802154_AF_PANID:
+        DEBUG("[esp_ieee802154] %s: set IEEE802154_AF_PANID %02x:%02x\n",
+              __func__, addr[1], addr[0]);
+        return esp_ieee802154_set_panid(*((const uint16_t *)value)) ? -EIO : 0;
+    case IEEE802154_AF_PAN_COORD:
+        DEBUG("[esp_ieee802154] %s: set IEEE802154_AF_PAN_COORD not supported\n", __func__);
+        return -ENOTSUP;
+    }
+
+    return -EINVAL;
+}
+
+static int _config_src_addr_match(ieee802154_dev_t *dev, ieee802154_src_match_t cmd,
+                                  const void *value)
+{
+    (void)dev;
+
+    bool enable = *((bool*)value);
+
+    switch (cmd) {
+    case IEEE802154_SRC_MATCH_EN:
+        DEBUG("[esp_ieee802154] %s: IEEE802154_SRC_MATCH_EN %d\n", __func__, enable);
+        return esp_ieee802154_set_pending_mode(enable
+                                                ? ESP_IEEE802154_AUTO_PENDING_ENABLE
+                                                : ESP_IEEE802154_AUTO_PENDING_DISABLE) ? -EIO : 0;
+    case IEEE802154_SRC_MATCH_SHORT_ADD:
+        DEBUG("[esp_ieee802154] %s: set IEEE802154_SRC_MATCH_SHORT_ADD\n", __func__);
+        return esp_ieee802154_add_pending_addr(value, true) ? -ENOMEM : 0;
+    case IEEE802154_SRC_MATCH_SHORT_CLEAR:
+        DEBUG("[esp_ieee802154] %s: set IEEE802154_SRC_MATCH_SHORT_CLEAR\n", __func__);
+        return esp_ieee802154_clear_pending_addr(value, true) ? -ENOENT : 0;
+    case IEEE802154_SRC_MATCH_EXT_ADD:
+        DEBUG("[esp_ieee802154] %s: set IEEE802154_SRC_MATCH_EXT_ADD\n", __func__);
+        return esp_ieee802154_add_pending_addr(value, false) ? -ENOMEM : 0;
+    case IEEE802154_SRC_MATCH_EXT_CLEAR:
+        DEBUG("[esp_ieee802154] %s: set IEEE802154_SRC_MATCH_EXT_CLEAR\n", __func__);
+        return esp_ieee802154_clear_pending_addr(value, false) ? -ENOENT : 0;
+    }
+
+    return -EINVAL;
+}
+
+/* following functions are called back from ESP-IDF driver */
+
+void esp_ieee802154_cca_done(bool channel_busy)
+{
+    DEBUG("[esp_ieee802154] %s %d\n", __func__, channel_busy);
+    _channel_clear = !channel_busy;
+
+    if (IS_ACTIVE(_USE_CCA_DONE)) {
+        esp_ieee802154_dev->cb(esp_ieee802154_dev, IEEE802154_RADIO_CONFIRM_CCA);
+    }
+}
+
+void esp_ieee802154_receive_sfd_done(void)
+{
+    DEBUG("[esp_ieee802154] %s\n", __func__);
+    if (IS_ACTIVE(_USE_RX_START)) {
+        esp_ieee802154_dev->cb(esp_ieee802154_dev, IEEE802154_RADIO_INDICATION_RX_START);
+    }
+}
+
+void esp_ieee802154_receive_done(uint8_t *frame, esp_ieee802154_frame_info_t *frame_info)
+{
+    assert(frame);
+    assert(frame_info);
+
+    DEBUG("[esp_ieee802154] %s: frame=%p frame_info=%p\n",
+          __func__, frame, frame_info);
+
+    _rx_frame = frame;
+    _rx_frame_info = frame_info;
+
+    esp_ieee802154_dev->cb(esp_ieee802154_dev, IEEE802154_RADIO_INDICATION_RX_DONE);
+}
+
+void esp_ieee802154_transmit_sfd_done(uint8_t *frame)
+{
+    DEBUG("[esp_ieee802154] %s: frame=%p\n", __func__, frame);
+    if (IS_ACTIVE(_USE_TX_START)) {
+        esp_ieee802154_dev->cb(esp_ieee802154_dev, IEEE802154_RADIO_INDICATION_TX_START);
+    }
+}
+
+void esp_ieee802154_transmit_done(const uint8_t *frame, const uint8_t *ack,
+                                  esp_ieee802154_frame_info_t *ack_frame_info)
+{
+    DEBUG("[esp_ieee802154] %s: frame=%p ack_frame=%p ack_frame_info=%p\n",
+          __func__, frame, ack, ack_frame_info);
+
+    _ack_frame = ack;
+    _ack_frame_info = ack_frame_info;
+
+    esp_ieee802154_dev->cb(esp_ieee802154_dev, IEEE802154_RADIO_CONFIRM_TX_DONE);
+}
+
+void esp_ieee802154_transmit_failed(const uint8_t *frame, esp_ieee802154_tx_error_t error)
+{
+    DEBUG("[esp_ieee802154] %s: frame=%p error=%u\n", __func__, frame, error);
+
+    _tx_error = error;
+
+    esp_ieee802154_dev->cb(esp_ieee802154_dev, IEEE802154_RADIO_CONFIRM_TX_DONE);
+}
+
+void esp_ieee802154_energy_detect_done(int8_t power)
+{
+    DEBUG("[esp_ieee802154] %s: power %i\n", __func__, power);
+}
+
+void esp_ieee802154_setup(ieee802154_dev_t *dev)
+{
+    assert(dev);
+
+    DEBUG("[esp_ieee802154] %s: dev=%p\n", __func__, dev);
+
+    dev->driver = &esp_ieee802154_driver;
+    esp_ieee802154_dev = dev;
+}
+
+int esp_ieee802154_init(void)
+{
+    DEBUG("[esp_ieee802154] %s\n", __func__);
+
+    esp_ieee802154_enable();
+    esp_ieee802154_reset_pending_table(true);
+    esp_ieee802154_reset_pending_table(false);
+    esp_ieee802154_set_rx_when_idle(true);
+    esp_ieee802154_receive();
+    esp_ieee802154_set_cca_mode(ESP_IEEE802154_CCA_MODE_ED);
+    esp_ieee802154_set_ack_timeout(ESP_IEEE802154_ACK_TIMEOUT_US);
+    esp_ieee802154_set_promiscuous(false);
+
+    return 0;
+}
+
+static const ieee802154_radio_ops_t esp_ieee802154_driver = {
+    .caps = IEEE802154_CAP_24_GHZ
+          | IEEE802154_CAP_PHY_OQPSK
+          | IEEE802154_CAP_AUTO_CSMA
+          | IEEE802154_CAP_SRC_ADDR_MATCH
+#if _USE_CCA_DONE
+          | IEEE802154_CAP_IRQ_CCA_DONE
+#endif
+#if _USE_RX_START
+          | IEEE802154_CAP_IRQ_RX_START
+#endif
+#if _USE_TX_START
+          | IEEE802154_CAP_IRQ_TX_START
+#endif
+          | IEEE802154_CAP_IRQ_TX_DONE
+          | IEEE802154_CAP_IRQ_ACK_TIMEOUT,
+    .write = _write,
+    .read = _read,
+    .request_on = _request_on,
+    .confirm_on = _confirm_on,
+    .len = _len,
+    .off = _off,
+    .request_op = _request_op,
+    .confirm_op = _confirm_op,
+    .set_cca_threshold = _set_cca_threshold,
+    .set_cca_mode = _set_cca_mode,
+    .config_phy = _config_phy,
+    .set_csma_params = _set_csma_params,
+    .config_addr_filter = _config_addr_filter,
+    .config_src_addr_match = _config_src_addr_match,
+    .set_frame_filter_mode = _set_frame_filter_mode,
+    .set_frame_retrans = _set_frame_retrans,
+};

--- a/cpu/esp32/esp-ieee802154/esp_ieee802154_hal.h
+++ b/cpu/esp32/esp-ieee802154/esp_ieee802154_hal.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#pragma once
+
+/**
+ * @defgroup    cpu_esp32_esp_ieee802154 ESP32x IEEE 802.15.4 driver
+ * @ingroup     drivers_netdev
+ * @{
+ *
+ * @file
+ * @brief       ESP32x IEEE 802.15.4 driver
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include <stdbool.h>
+
+#include "net/ieee802154/radio.h"
+
+/**
+ * @brief   Setup ESP32x in order to be used with the IEEE 802.15.4 Radio HAL
+ *
+ * @param[in] dev  pointer to the HAL descriptor associated to the device.
+ */
+void esp_ieee802154_setup(ieee802154_dev_t *dev);
+
+/**
+ * @brief Initialize the ESP32x IEEE 802.15.4 module.
+ *
+ * The function
+ * - initializes the ESP32x 802.15.4 subsystem,
+ * - clears the source matching table for short and extended addresses,
+ * - enables the radio in idle state,
+ * - sets the CCA mode to energy detection only (IEEE802154_CCA_MODE_ED_THRESHOLD),
+ * - sets the timeout for the ACK frame, and
+ * - disables the promicuous mode.
+ *
+ * @retval 0 on success
+ * @retval negative errno on error
+ */
+int esp_ieee802154_init(void);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/cpu/esp32/include/irq_arch.h
+++ b/cpu/esp32/include/irq_arch.h
@@ -62,6 +62,7 @@ extern "C" {
 #define CPU_INUM_SDMMC          21  /**< Level interrupt with medium priority 2 */
 #define CPU_INUM_TIMER          22  /**< Edge  interrupt with medium priority 2 */
 #define CPU_INUM_WDT            23  /**< Level interrupt with medium priority 3 */
+#define CPU_INUM_ZMAC           27  /**< Level interrupt with medium priority 3 */
 #define CPU_INUM_SOFTWARE       29  /**< Software interrupt with medium priority 3 */
 /** @} */
 

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -66,7 +66,14 @@ extern "C" {
 /**
  * @brief   Length of the CPU_ID in octets
  */
-#define CPUID_LEN               (6U)
+#if defined(CPU_FAM_ESP32H2) && defined(CONFIG_IEEE802154_ENABLED)
+/* ESP32H2 has IEEE802.15.4 radio which has an EUI64 address. Function
+ * esp_efuse_mac_get_default will return this 8 byte address if
+ * CONFIG_IEEE802154_ENABLED */
+#  define CPUID_LEN             (8U)
+#else
+#  define CPUID_LEN             (6U)
+#endif
 
 /**
  * @name   GPIO configuration

--- a/cpu/esp32/include/sdkconfig.h
+++ b/cpu/esp32/include/sdkconfig.h
@@ -113,6 +113,18 @@
 #endif
 
 /**
+ * ESP32-H2 IEEE 802.15.4 driver configuration (DO NOT CHANGE)
+ */
+#if MODULE_ESP_IEEE802154
+#  define CONFIG_IEEE802154_ENABLED             1
+#  define CONFIG_IEEE802154_CCA_ED              1
+#  define CONFIG_IEEE802154_CCA_MODE            1
+#  define CONFIG_IEEE802154_CCA_THRESHOLD       -60
+#  define CONFIG_IEEE802154_PENDING_TABLE_SIZE  20
+#  define CONFIG_IEEE802154_RX_BUFFER_SIZE      20
+#endif
+
+/**
  * SPI RAM configuration (DO NOT CHANGE)
  */
 #if MODULE_ESP_SPI_RAM

--- a/cpu/esp32/irq_arch.c
+++ b/cpu/esp32/irq_arch.c
@@ -90,6 +90,9 @@ static const struct intr_handle_data_t _irq_data_table[] = {
 #if defined(SOC_EMAC_SUPPORTED)
     { ETS_ETH_MAC_INTR_SOURCE, CPU_INUM_ETH, 1 },
 #endif
+#if SOC_IEEE802154_SUPPORTED
+    { ETS_ZB_MAC_INTR_SOURCE, CPU_INUM_ZMAC, 3},
+#endif
 #if defined(SOC_RMT_SUPPORTED)
     { ETS_RMT_INTR_SOURCE, CPU_INUM_RMT, 1 },
 #endif

--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -45,7 +45,7 @@ endif
 
 ifneq (,$(filter netdev_default,$(USEMODULE)))
   ifeq (esp32h2,$(CPU_FAM))
-    # There is no network interface for ESP32-H2 for the moment
+    USEMODULE += esp_ieee802154
   else ifneq (,$(filter lwip,$(USEMODULE)))
     # for lwip, use esp_wifi as default netdev if no other netdev is enabled
     ifeq (,$(filter esp_eth,$(USEMODULE)))

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -335,6 +335,7 @@ typedef enum {
     NETDEV_CDC_ECM,
     NETDEV_TINYUSB,
     NETDEV_W5500,
+    NETDEV_ESP_IEEE802154,
     /* add more if needed */
 } netdev_type_t;
 /** @} */

--- a/features.yaml
+++ b/features.yaml
@@ -160,6 +160,8 @@ groups:
               ESP32-S3 variant.
       - name: esp_hw_counter
         help: The used ESP32x SoC supports HW counters that can be used as timers.
+      - name: esp_ieee802154
+        help: The ESP32x IEEE 802.15.4 driver
       - name: esp_rmt
         help: The ESP32x SoC has an RMT (Remote Control Transceiver) peripheral.
       - name: esp_rtc_timer_32k

--- a/makefiles/features_existing.inc.mk
+++ b/makefiles/features_existing.inc.mk
@@ -117,6 +117,7 @@ FEATURES_EXISTING := \
     esp_ble_esp32 \
     esp_ble_esp32c3 \
     esp_hw_counter \
+    esp_ieee802154 \
     esp_jtag \
     esp_now \
     esp_rmt \

--- a/pkg/esp32_sdk/patches/0034-ieee802154-driver-fix-misssing-include.patch
+++ b/pkg/esp32_sdk/patches/0034-ieee802154-driver-fix-misssing-include.patch
@@ -1,0 +1,24 @@
+From 06c5e3e1804a06e14d3965beaa1b42f7a3ff06e0 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Mon, 7 Apr 2025 14:54:49 +0200
+Subject: [PATCH 34/34] ieee802154/driver: fix misssing include
+
+---
+ components/ieee802154/driver/esp_ieee802154_dev.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/components/ieee802154/driver/esp_ieee802154_dev.c b/components/ieee802154/driver/esp_ieee802154_dev.c
+index d7a1b4f269..a38957b4a0 100644
+--- a/components/ieee802154/driver/esp_ieee802154_dev.c
++++ b/components/ieee802154/driver/esp_ieee802154_dev.c
+@@ -14,6 +14,7 @@
+ #include "esp_check.h"
+ #include "esp_coex_i154.h"
+ #include "esp_err.h"
++#include "esp_intr_types.h"
+ #include "esp_log.h"
+ #include "esp_timer.h"
+ #include "esp_ieee802154_ack.h"
+-- 
+2.34.1
+

--- a/sys/net/gnrc/netif/init_devs/auto_init_esp_ieee802154.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_esp_ieee802154.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2025 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/*
+ * @ingroup sys_auto_init_gnrc_netif
+ * @{
+ *
+ * @file
+ * @brief   Auto initialization for the ESP32x IEEE 802.15.4 network interface
+ *
+ * @author  Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include "log.h"
+#include "net/gnrc/netif/ieee802154.h"
+#include "include/init_devs.h"
+
+#include "esp_ieee802154_hal.h"
+#include "net/netdev/ieee802154_submac.h"
+
+/**
+ * @brief   Stack size for the MAC layer thread
+ */
+#ifndef ESP_IEEE802154_MAC_STACKSIZE
+#  define ESP_IEEE802154_MAC_STACKSIZE     (IEEE802154_STACKSIZE_DEFAULT)
+#endif
+
+/**
+ * @brief   Priority of the MAC layer thread
+ */
+#ifndef ESP_IEEE802154_MAC_PRIO
+#  define ESP_IEEE802154_MAC_PRIO          (GNRC_NETIF_PRIO)
+#endif
+
+static char _esp_ieee802154_stack[ESP_IEEE802154_MAC_STACKSIZE];
+
+static netdev_ieee802154_submac_t esp_ieee802154_netdev;
+static gnrc_netif_t _netif;
+
+void auto_init_esp_ieee802154(void)
+{
+    LOG_DEBUG("[auto_init_netif] initializing ESP32x IEEE 802.15.4 interface\n");
+
+    esp_ieee802154_init();
+
+    netdev_register(&esp_ieee802154_netdev.dev.netdev, NETDEV_ESP_IEEE802154, 0);
+    netdev_ieee802154_submac_init(&esp_ieee802154_netdev);
+
+    esp_ieee802154_setup(&esp_ieee802154_netdev.submac.dev);
+
+    gnrc_netif_ieee802154_create(&_netif, _esp_ieee802154_stack,
+                                 ESP_IEEE802154_MAC_STACKSIZE,
+                                 ESP_IEEE802154_MAC_PRIO, "esp_ieee802154",
+                                 &esp_ieee802154_netdev.dev.netdev);
+}

--- a/sys/net/gnrc/netif/init_devs/init.c
+++ b/sys/net/gnrc/netif/init_devs/init.c
@@ -77,6 +77,11 @@ void gnrc_netif_init_devs(void)
         auto_init_esp_eth();
     }
 
+    if (IS_USED(MODULE_ESP_IEEE802154)) {
+        extern void auto_init_esp_ieee802154(void);
+        auto_init_esp_ieee802154();
+    }
+
     /* don't change the order of auto_init_esp_now and auto_init_esp_wifi */
     if (IS_USED(MODULE_ESP_NOW)) {
         extern void auto_init_esp_now(void);

--- a/tests/net/ieee802154_hal/init_devs.c
+++ b/tests/net/ieee802154_hal/init_devs.c
@@ -29,6 +29,10 @@
 #include "cc2538_rf.h"
 #endif
 
+#ifdef MODULE_ESP_IEEE802154
+#include "esp_ieee802154_hal.h"
+#endif
+
 #ifdef MODULE_NRF802154
 #include "nrf802154.h"
 #endif
@@ -79,6 +83,13 @@ void ieee802154_hal_test_init_devs(ieee802154_dev_cb_t cb, void *opaque)
     if ((radio = cb(IEEE802154_DEV_TYPE_CC2538_RF, opaque)) ){
         cc2538_rf_hal_setup(radio);
         cc2538_init();
+    }
+#endif
+
+#ifdef MODULE_ESP_IEEE802154
+    if ((radio = cb(IEEE802154_DEV_TYPE_ESP_IEEE802154, opaque)) ){
+        esp_ieee802154_setup(radio);
+        esp_ieee802154_init();
     }
 #endif
 

--- a/tests/net/ieee802154_hal/main.c
+++ b/tests/net/ieee802154_hal/main.c
@@ -157,7 +157,7 @@ static event_t _rx_done_event = {
 static void _hal_radio_cb(ieee802154_dev_t *dev, ieee802154_trx_ev_t status)
 {
     (void) dev;
-    switch(status) {
+    switch (status) {
         case IEEE802154_RADIO_CONFIRM_TX_DONE:
         case IEEE802154_RADIO_CONFIRM_CCA:
             mutex_unlock(&lock);
@@ -182,7 +182,8 @@ static void _tx_finish_handler(event_t *event)
     expect(ieee802154_radio_confirm_transmit(&_radio, &tx_info) >= 0);
 
     ieee802154_radio_set_rx(&_radio);
-    if (!ieee802154_radio_has_irq_ack_timeout(&_radio) && !ieee802154_radio_has_frame_retrans(&_radio)) {
+    if (!ieee802154_radio_has_irq_ack_timeout(&_radio) &&
+        !ieee802154_radio_has_frame_retrans(&_radio)) {
         /* This is just to show how the MAC layer would handle ACKs... */
         xtimer_set(&timer_ack, ACK_TIMEOUT_TIME);
     }
@@ -227,7 +228,7 @@ static void _send(iolist_t *pkt)
     ieee802154_radio_write(&_radio, pkt);
 
     /* Block until the radio confirms the state change */
-    while(ieee802154_radio_confirm_set_idle(&_radio) == -EAGAIN);
+    while (ieee802154_radio_confirm_set_idle(&_radio) == -EAGAIN) {}
 
     /* Set the frame filter to receive ACKs */
     ieee802154_radio_set_frame_filter_mode(&_radio, IEEE802154_FILTER_ACK_ONLY);
@@ -252,7 +253,7 @@ static ieee802154_dev_t *_reg_callback(ieee802154_dev_type_t type, void *opaque)
 {
     struct _reg_container *reg = opaque;
     printf("Trying to register ");
-    switch(type) {
+    switch (type) {
         case IEEE802154_DEV_TYPE_CC2538_RF:
             printf("cc2538_rf");
             break;
@@ -267,6 +268,9 @@ static ieee802154_dev_t *_reg_callback(ieee802154_dev_type_t type, void *opaque)
             break;
         case IEEE802154_DEV_TYPE_MRF24J40:
             printf("mrf24j40");
+            break;
+        case IEEE802154_DEV_TYPE_ESP_IEEE802154:
+            printf("esp_ieee802154");
             break;
     }
 
@@ -300,7 +304,7 @@ static int _init(void)
      * The transceiver state will be "TRX_OFF" */
     res = ieee802154_radio_request_on(&_radio);
     expect(res >= 0);
-    while(ieee802154_radio_confirm_on(&_radio) == -EAGAIN) {}
+    while (ieee802154_radio_confirm_on(&_radio) == -EAGAIN) {}
 
     ieee802154_radio_set_frame_filter_mode(&_radio, IEEE802154_FILTER_ACCEPT);
 
@@ -318,7 +322,9 @@ static int _init(void)
     expect(res >= 0);
 
     /* Set PHY configuration */
-    ieee802154_phy_conf_t conf = {.channel=CONFIG_IEEE802154_DEFAULT_CHANNEL, .page=CONFIG_IEEE802154_DEFAULT_SUBGHZ_PAGE, .pow=CONFIG_IEEE802154_DEFAULT_TXPOWER};
+    ieee802154_phy_conf_t conf = { .channel=CONFIG_IEEE802154_DEFAULT_CHANNEL,
+                                   .page=CONFIG_IEEE802154_DEFAULT_SUBGHZ_PAGE,
+                                   .pow=CONFIG_IEEE802154_DEFAULT_TXPOWER};
 
     res = ieee802154_radio_config_phy(&_radio, &conf);
     expect(res >= 0);
@@ -334,7 +340,8 @@ static int _init(void)
     return 0;
 }
 
-uint8_t payload[] = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ornare lacinia mi elementum interdum ligula.";
+uint8_t payload[] = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+                    "Etiam ornare lacinia mi elementum interdum ligula.";
 
 static int send(uint8_t *dst, size_t dst_len,
                 size_t len, bool ack_req)
@@ -426,7 +433,7 @@ int _test_states(int argc, char **argv)
                                            ? "FAIL"
                                            : "PASS");
 
-    printf("Testing RX<->TX transition time");
+    printf("Testing RX<->TX transition time: ");
     a = xtimer_now();
     res = ieee802154_radio_set_idle(&_radio, true);
     assert(res == 0);

--- a/tests/net/ieee802154_hal/test_common.h
+++ b/tests/net/ieee802154_hal/test_common.h
@@ -29,7 +29,8 @@
                      IS_USED(MODULE_NRF802154) + \
                      SOCKET_ZEP_MAX + \
                      IS_USED(MODULE_MRF24J40) + \
-                     IS_USED(MODULE_KW2XRF)
+                     IS_USED(MODULE_KW2XRF) + \
+                     IS_USED(MODULE_ESP_IEEE802154)
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,6 +47,7 @@ typedef enum {
     IEEE802154_DEV_TYPE_SOCKET_ZEP,
     IEEE802154_DEV_TYPE_KW2XRF,
     IEEE802154_DEV_TYPE_MRF24J40,
+    IEEE802154_DEV_TYPE_ESP_IEEE802154,
 } ieee802154_dev_type_t;
 
 typedef ieee802154_dev_t* (*ieee802154_dev_cb_t)(ieee802154_dev_type_t type,

--- a/tests/net/ieee802154_submac/main.c
+++ b/tests/net/ieee802154_submac/main.c
@@ -194,6 +194,9 @@ static ieee802154_dev_t *_reg_callback(ieee802154_dev_type_t type, void *opaque)
     case IEEE802154_DEV_TYPE_MRF24J40:
         printf("mrf24j40");
         break;
+    case IEEE802154_DEV_TYPE_ESP_IEEE802154:
+        printf("esp_ieee802154");
+        break;
     }
 
     puts(".");


### PR DESCRIPTION
### Contribution description

This PR provides the support for the IEEE 802.15.4 interface for the ESP32-H2.

### Testing procedure

Flash the test application `examples/networking/gnrc/gnrc_networking`
```
BOARD=esp32h2-devkit make -C examples/networking/gnrc/gnrc_networking flash term
```
which uses the IEEE 802.15.4 interface as `netdev_default`. It should be possible to ping other IEEE 802.15.4 nodes.

IEEE 802.15.4 for ESP32-H2 has been tested with an `esp32h2-devkit` board together with a `waveshare-nrf52840-eval-kit` board:

```
main(): This is RIOT! (Version: 2025.07-devel-513-g0af92-cpu/esp32/add_esp32h2_ieee802154)
RIOT network stack example application
All up, running the shell now
> ifconfig
Iface  8  HWaddr: 5B:72  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: EE:DD:84:74:AB:D8:DB:72 
           TX-Power: 0dBm  State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::ecdd:8474:abd8:db72  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffd8:db72
          inet6 group: ff02::1a
          
          Statistics for Layer 2
            RX packets 0  bytes 0
            TX packets 3 (Multicast: 3)  bytes 0
            TX succeeded 0 errors 0
          Statistics for IPv6
            RX packets 0  bytes 0
            TX packets 3 (Multicast: 3)  bytes 178
            TX succeeded 3 errors 0

> 
> ping fe80::5c8f:194d:70fd:c9e6
12 bytes from fe80::5c8f:194d:70fd:c9e6%8: icmp_seq=0 ttl=64 rssi=1 dBm time=12.952 ms
12 bytes from fe80::5c8f:194d:70fd:c9e6%8: icmp_seq=1 ttl=64 rssi=1 dBm time=13.746 ms
12 bytes from fe80::5c8f:194d:70fd:c9e6%8: icmp_seq=2 ttl=64 rssi=1 dBm time=11.358 ms
```

```
You are running RIOT on a(n) waveshare-nrf52840-eval-kit board.
This board features a(n) nrf52 CPU.
main(): This is RIOT! (Version: 2025.07-devel-516-g4e85e-cpu/esp32/add_esp32h2_ieee802154)
RIOT network stack example application
All up, running the shell now
> ifconfig
Iface  6  HWaddr: 49:E6  Channel: 26  NID: 0x23  PHY: O-QPSK 
          Long HWaddr: 5E:8F:19:4D:70:FD:C9:E6 
           TX-Power: 0dBm  State: IDLE 
          ACK_REQ  L2-PDU:102  MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::5c8f:194d:70fd:c9e6  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:fffd:c9e6
          inet6 group: ff02::1a
          
          Statistics for Layer 2
            RX packets 4  bytes 158
            TX packets 5 (Multicast: 5)  bytes 0
            TX succeeded 0 errors 0
          Statistics for IPv6
            RX packets 4  bytes 242
            TX packets 5 (Multicast: 5)  bytes 306
            TX succeeded 5 errors 0

> 
> ping fe80::ecdd:8474:abd8:db72
12 bytes from fe80::ecdd:8474:abd8:db72%6: icmp_seq=0 ttl=64 rssi=-44 dBm time=6.785 ms
12 bytes from fe80::ecdd:8474:abd8:db72%6: icmp_seq=1 ttl=64 rssi=-43 dBm time=8.704 ms
12 bytes from fe80::ecdd:8474:abd8:db72%6: icmp_seq=2 ttl=64 rssi=-43 dBm time=8.828 ms
```
### Issues/PRs references