### PR TITLE
dist/tools: include UF2 folder in `distclean` and fix setup

### DIFF
--- a/dist/tools/uf2/Makefile
+++ b/dist/tools/uf2/Makefile
@@ -15,3 +15,10 @@ $(CURDIR)/uf2conv.py:
 
 $(CURDIR)/uf2families.json:
 	cp $(PKG_SOURCE_DIR)/utils/uf2families.json .
+
+# avoid that the files are accessed before they were copied
+.NOTPARALLEL: $(CURDIR)/uf2conv.py $(CURDIR)/uf2families.json
+
+clean::
+	@rm -rf $(CURDIR)/uf2conv.py
+	@rm -rf $(CURDIR)/uf2families.json


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

In the current master, the setup of `uf2conv` tends to fail with weird errors. The reason for that is that `make` executes multiple targets parallel, one of which tries to access the file that has not been copied yet (or sometimes it has, race condition).
It works on the second try.
Perhaps it's caused by using multiple threads.

Also, during `make distclean`, the `dist/tools/uf2` folder is not cleaned up.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Current `master` (note there is no actual board connected):
```
cbuec@W11nMate:~/RIOTstuff/riot-security/RIOT$ BOARD=seeedstudio-xiao-nrf52840 make -C tests/minimal flash -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-security/RIOT/tests/minimal'
Building application "tests_minimal" for "seeedstudio-xiao-nrf52840" with CPU "nrf52".

"make" -C /home/cbuec/RIOTstuff/riot-security/RIOT/pkg/cmsis/
...
"make" -C /home/cbuec/RIOTstuff/riot-security/RIOT/cpu/cortexm_common/periph
   text    data     bss     dec     hex filename
   4628     108    1028    5764    1684 /home/cbuec/RIOTstuff/riot-security/RIOT/tests/minimal/bin/seeedstudio-xiao-nrf52840/tests_minimal.elf
stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
stty: /dev/ttyACM0: No such file or directory
make: [/home/cbuec/RIOTstuff/riot-security/RIOT/tests/minimal/../../Makefile.include:868: preflash] Error 1 (ignored)
sleep 3
[INFO] uf2conv.py not found - fetching it from GitHub now
CC= CFLAGS= make -C /home/cbuec/RIOTstuff/riot-security/RIOT/dist/tools/uf2
cp /home/cbuec/RIOTstuff/riot-security/RIOT/build/pkg/UF2/utils/uf2conv.py .
cp /home/cbuec/RIOTstuff/riot-security/RIOT/build/pkg/UF2/utils/uf2families.json .
cp: cannot stat '/home/cbuec/RIOTstuff/riot-security/RIOT/build/pkg/UF2/utils/uf2families.json': No such file or directory
make[1]: *** [Makefile:17: /home/cbuec/RIOTstuff/riot-security/RIOT/dist/tools/uf2/uf2families.json] Error 1
make[1]: *** Waiting for unfinished jobs....
cp: cannot stat '/home/cbuec/RIOTstuff/riot-security/RIOT/build/pkg/UF2/utils/uf2conv.py': No such file or directory
make[1]: *** [Makefile:13: /home/cbuec/RIOTstuff/riot-security/RIOT/dist/tools/uf2/uf2conv.py] Error 1
make: *** [/home/cbuec/RIOTstuff/riot-security/RIOT/makefiles/tools/targets.inc.mk:66: /home/cbuec/RIOTstuff/riot-security/RIOT/dist/tools/uf2/uf2conv.py] Error 2
make: Leaving directory '/home/cbuec/RIOTstuff/riot-security/RIOT/tests/minimal'

cbuec@W11nMate:~/RIOTstuff/riot-security/RIOT$ ls dist/tools/uf2/
Makefile  nrf52_softdevice_check.sh

cbuec@W11nMate:~/RIOTstuff/riot-security/RIOT$ BOARD=seeedstudio-xiao-nrf52840 make -C tests/minimal flash -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-security/RIOT/tests/minimal'
Building application "tests_minimal" for "seeedstudio-xiao-nrf52840" with CPU "nrf52".

"make" -C /home/cbuec/RIOTstuff/riot-security/RIOT/pkg/cmsis/
...
"make" -C /home/cbuec/RIOTstuff/riot-security/RIOT/cpu/nrf5x_common/periph
   text    data     bss     dec     hex filename
   4628     108    1028    5764    1684 /home/cbuec/RIOTstuff/riot-security/RIOT/tests/minimal/bin/seeedstudio-xiao-nrf52840/tests_minimal.elf
stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
stty: /dev/ttyACM0: No such file or directory
make: [/home/cbuec/RIOTstuff/riot-security/RIOT/tests/minimal/../../Makefile.include:868: preflash] Error 1 (ignored)
sleep 3
[INFO] uf2conv.py not found - fetching it from GitHub now
CC= CFLAGS= make -C /home/cbuec/RIOTstuff/riot-security/RIOT/dist/tools/uf2
cp /home/cbuec/RIOTstuff/riot-security/RIOT/build/pkg/UF2/utils/uf2conv.py .
cp /home/cbuec/RIOTstuff/riot-security/RIOT/build/pkg/UF2/utils/uf2families.json .
chmod a+x uf2conv.py
[INFO] uf2conv.py successfully fetched!
No device with UF2 bootloader found!
make: *** [/home/cbuec/RIOTstuff/riot-security/RIOT/makefiles/tools/uf2conv.inc.mk:13: uf2-softdevice-check] Error 1
make: Leaving directory '/home/cbuec/RIOTstuff/riot-security/RIOT/tests/minimal'
```

With this PR (note there is no actual board connected):
```
cbuec@W11nMate:~/RIOTstuff/riot-security/RIOT$ BOARD=seeedstudio-xiao-nrf52840 make -C tests/minimal flash -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-security/RIOT/tests/minimal'
Building application "tests_minimal" for "seeedstudio-xiao-nrf52840" with CPU "nrf52".

"make" -C /home/cbuec/RIOTstuff/riot-security/RIOT/pkg/cmsis/
...
"make" -C /home/cbuec/RIOTstuff/riot-security/RIOT/sys/stdio_null
   text    data     bss     dec     hex filename
   4628     108    1028    5764    1684 /home/cbuec/RIOTstuff/riot-security/RIOT/tests/minimal/bin/seeedstudio-xiao-nrf52840/tests_minimal.elf
stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
stty: /dev/ttyACM0: No such file or directory
make: [/home/cbuec/RIOTstuff/riot-security/RIOT/tests/minimal/../../Makefile.include:868: preflash] Error 1 (ignored)
sleep 3
[INFO] uf2conv.py not found - fetching it from GitHub now
CC= CFLAGS= make -C /home/cbuec/RIOTstuff/riot-security/RIOT/dist/tools/uf2
[INFO] uf2conv.py successfully fetched!
No device with UF2 bootloader found!
make: *** [/home/cbuec/RIOTstuff/riot-security/RIOT/makefiles/tools/uf2conv.inc.mk:13: uf2-softdevice-check] Error 1
make: Leaving directory '/home/cbuec/RIOTstuff/riot-security/RIOT/tests/minimal'
```

<hr/>

`make distclean` with `master`:
```
cbuec@W11nMate:~/RIOTstuff/riot-security/RIOT$ ls dist/tools/uf2/
Makefile  nrf52_softdevice_check.sh  uf2conv.py  uf2families.json
cbuec@W11nMate:~/RIOTstuff/riot-security/RIOT$ make distclean -j
...
Cleaned everything.
cbuec@W11nMate:~/RIOTstuff/riot-security/RIOT$ ls dist/tools/uf2/
Makefile  nrf52_softdevice_check.sh  uf2conv.py  uf2families.json
```

`make distclean` with this PR:
```
cbuec@W11nMate:~/RIOTstuff/riot-security/RIOT$ ls dist/tools/uf2/
Makefile  nrf52_softdevice_check.sh  uf2conv.py  uf2families.json
cbuec@W11nMate:~/RIOTstuff/riot-security/RIOT$ make distclean -j
...
Cleaned everything.
cbuec@W11nMate:~/RIOTstuff/riot-security/RIOT$ ls dist/tools/uf2/
Makefile  nrf52_softdevice_check.sh
```


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.
