### PR TITLE
boards/*avr*: Update the link to the AVaRICE documentation

### DIFF
--- a/boards/arduino-mega2560/doc.md
+++ b/boards/arduino-mega2560/doc.md
@@ -132,7 +132,7 @@ MCUs.
 ### Debugging RIOT on the Arduino Mega 2560
 
 `make BOARD=arduino-mega2560 debug-server`: starts an
-[avarice](http://avarice.sourceforge.net/) (avarice needs to be installed)
+[avarice](https://github.com/avrdudes/avarice) (avarice needs to be installed)
 server that `avr-gdb` can connect to.
 
 `make BOARD=arduino-mega2560 debug`: starts an avarice server and connects

--- a/boards/arduino-mega2560/doc.md
+++ b/boards/arduino-mega2560/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_arduino-mega2560 Arduino Mega 2560
 @ingroup     boards
 @brief       Support for the Arduino Mega 2560 board
@@ -192,4 +191,3 @@ In order to install it, you must download and install a CDC-ACM driver from
 (Go to Support and Downloads/Software & Driver/Mac Software).
 
 A reboot should be enough to find your Arduino on `/dev/tty.usbmodem*`
- */

--- a/boards/arduino-nano/doc.md
+++ b/boards/arduino-nano/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_arduino-nano Arduino Nano
 @ingroup     boards
 @brief       Support for the Arduino Nano board
@@ -159,4 +158,3 @@ avoid any issues. You might want to do the same, e.g. via:
 
 ## Caution
 Don't expect having a working network stack due to very limited resources.
- */

--- a/boards/arduino-nano/doc.md
+++ b/boards/arduino-nano/doc.md
@@ -92,11 +92,8 @@ permanent). After this modification, flashing via bootloader requires a manual
 press on the reset button.
 
 #### Software
-You need to have [AVaRICE](http://avarice.sourceforge.net/) installed. Some
-distros have this packaged already. If you need to compile it by hand, go for
-the latest SVN revision. The latest release cannot be compiled on anything but
-historic platforms and contains bugs that prevent it from debugging the
-ATmega328P anyway.
+You need to have [AVaRICE](https://github.com/avrdudes/avarice) installed. Some
+distros have this packaged already.
 
 #### Fuses
 In order to use On-Chip Debugging, the `DWEN` bit in the high fuse needs to be

--- a/boards/arduino-uno/doc.md
+++ b/boards/arduino-uno/doc.md
@@ -81,11 +81,8 @@ Keep in mind that the capacitor will likely be destroyed when removed by force
 and it will be difficult to restore the auto-reset feature of the clones.
 
 #### Software
-You need to have [AVaRICE](http://avarice.sourceforge.net/) installed. Some
-distros have this packaged already. If you need to compile it by hand, go for
-the latest SVN revision. The latest release cannot be compiled on anything but
-historic platforms and contains bugs that prevent it from debugging the
-ATmega328P anyway.
+You need to have [AVaRICE](e539724b20) installed. Some
+distros have this packaged already.
 
 #### Fuses
 In order to use On-Chip Debugging, the `DWEN` bit in the high fuse needs to be

--- a/boards/arduino-uno/doc.md
+++ b/boards/arduino-uno/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_arduino-uno Arduino Uno
 @ingroup     boards
 @brief       Support for the Arduino Uno board
@@ -155,5 +154,3 @@ original instruction to break on. Once this break instruction is reached, the
 original instruction is restored. This is not only super slow, but also
 wastes two flash cycles every time a breakpoint is hit. This cumulates to
 significant flash wear during long debugging sessions.
-
-*/

--- a/boards/atmega1284p/doc.md
+++ b/boards/atmega1284p/doc.md
@@ -119,10 +119,7 @@ started using
 #### Software Requirements
 
 In order to debug you'll need an GDB version with AVR support and
-[AVaRICE](http://avarice.sourceforge.net/). Note that AVaRICE sadly is not
-being actively maintained and the latest release will not compile on most
-systems. Thus, unless your distribution already ships a package of the SVN
-version of AVaRICE, you'll have to build the tool from source.
+[AVaRICE](https://github.com/avrdudes/avarice).
 
 ### JTAG Pin Mapping
 

--- a/boards/atmega1284p/doc.md
+++ b/boards/atmega1284p/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_atmega1284p Standalone ATmega1284P
 @ingroup     boards
 @brief       Support for using the ATmega1284P as standalone board
@@ -143,5 +142,3 @@ pins will no longer be available as GPIOs when this fuse is set. With the
 default settings the MCUs are preprogrammed during manufacturing, the `JTAGEN`
 fuse is already set. So with a new and unused package, you're ready directly
 ready to go.
-
- */

--- a/boards/atmega328p-xplained-mini/doc.md
+++ b/boards/atmega328p-xplained-mini/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_atmega328p_xplained_mini ATmega328p Xplained Mini
 @ingroup     boards
 @brief       Support for using the ATmega328p Xplained Mini board
@@ -122,4 +121,3 @@ cold boot and the ATmega328P will have debugWIRE enabled again.
 
 There is a how to ATWINC1500 802.11 b/g/n Wi-Fi Network with this board
 (AN_42552).
- */

--- a/boards/atmega328p-xplained-mini/doc.md
+++ b/boards/atmega328p-xplained-mini/doc.md
@@ -78,7 +78,8 @@ type to get terminal:
 
 ## On-Chip Debugging (OCD)
 
-E.g. with the AVR Xplained Mini and [AVaRICE](http://avarice.sourceforge.net/)
+E.g. with the AVR Xplained Mini and
+[AVaRICE](https://github.com/avrdudes/avarice)
 you can debug the ATmega328P using the debugWIRE interface.  Compared to the
 ATmega MCUs with JTAG interface the debug facilities are however significantly
 reduced: Only a single hardware breakpoint and no watchpoints are supported.

--- a/boards/atmega328p/doc.md
+++ b/boards/atmega328p/doc.md
@@ -110,7 +110,7 @@ the TTL adapter. Usually everything between 3.3 V and 5 V should work.
 
 ## On-Chip Debugging (OCD)
 
-E.g. with the AVR Dragon and [AVaRICE](http://avarice.sourceforge.net/) you
+E.g. with the AVR Dragon and [AVaRICE](https://github.com/avrdudes/avarice) you
 can debug the ATmega328P using the debugWIRE interface. Compared to the ATmega
 MCUs with JTAG interface the debug facilities are however significantly reduced:
 Only a single hardware breakpoint and no watchpoints are supported. The

--- a/boards/atmega328p/doc.md
+++ b/boards/atmega328p/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_atmega328p Standalone ATmega328p
 @ingroup     boards
 @brief       Support for using the ATmega328p as standalone board
@@ -158,4 +157,3 @@ cold boot and the ATmega328P will have debugWIRE enabled again.
 
 ## Caution
 Don't expect having a working network stack due to very limited resources ;-)
- */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

During the review of #21573 the AVaRICE debugger came up and our documentation is a bit out of date.
While the development of AVaRICE is still slow, it is not stopped (anymore) and there was a release in 2020. When the documentation was written, there hasn't been a release for nearly a decade, so I decided to remove the remarks about AVaRICE's ancient code base.

RFC: It would be possible to add a remark that AVaRICE should probably still be built from code instead of using the release version, as half a decade is also quite old already...

While touching the files, I moved them to Markdown format as discussed in #21220.

It would be nice to have a single documentation for AVaRICE, because currently it's a bit redundant with varying levels of completeness, but I didn't feel like diving into another rabbit hole today, sorry 😅 


### Testing procedure

Check that the documentation still looks good.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

This came up in #21573.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
