### PR TITLE
boards: rename doc.txt -> doc.md for particle, Microchip, nrf ... boards

### DIFF
--- a/boards/blackpill-stm32f103c8/doc.md
+++ b/boards/blackpill-stm32f103c8/doc.md
@@ -1,5 +1,4 @@
-/**
-@defgroup    boards_blackpill_stm32f103cb Blackpill STM32F103CB board (128KiB flash)
+@defgroup    boards_blackpill_stm32f103c8 Blackpill STM32F103C8 board
 @ingroup     boards
 @brief       Support for the stm32f103c8 based blackpill board.
 
@@ -12,5 +11,3 @@ in @ref boards_common_blxxxpill instead.
 
 The [STM32-base](https://stm32-base.org/boards/STM32F103C8T6-Black-Pill.html)
 page on the blackpill contains additional info on the hardware.
-
- */

--- a/boards/blackpill-stm32f103cb/doc.md
+++ b/boards/blackpill-stm32f103cb/doc.md
@@ -1,5 +1,4 @@
-/**
-@defgroup    boards_blackpill_stm32f103c8 Blackpill STM32F103C8 board
+@defgroup    boards_blackpill_stm32f103cb Blackpill STM32F103CB board (128KiB flash)
 @ingroup     boards
 @brief       Support for the stm32f103c8 based blackpill board.
 
@@ -12,5 +11,3 @@ in @ref boards_common_blxxxpill instead.
 
 The [STM32-base](https://stm32-base.org/boards/STM32F103C8T6-Black-Pill.html)
 page on the blackpill contains additional info on the hardware.
-
- */

--- a/boards/bluepill-stm32f030c8/doc.md
+++ b/boards/bluepill-stm32f030c8/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_bluepill-stm32f030c8 STM32F030C8 based Bluepill
 @ingroup     boards
 @brief       Support for the STM32F030C8 based Bluepill
@@ -61,5 +60,3 @@ reset button.
 You can work around this by pressing the reset button when OpenOCD wants to connect
 to the Blue Pill, or keep it pressed until OpenOCD tries to connect.
 Hit the reset button again after flashing in order to boot the newly flashed image.
-
- */

--- a/boards/bluepill-stm32f103c8/doc.md
+++ b/boards/bluepill-stm32f103c8/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_bluepill_stm32f103c8 Bluepill STM32F103C8 board
 @ingroup     boards
 @brief       Support for the stm32f103c8 based bluepill board.
@@ -12,5 +11,3 @@ in @ref boards_common_blxxxpill instead.
 
 The [STM32-base](https://stm32-base.org/boards/STM32F103C8T6-Blue-Pill.html)
 page on the bluepill contains additional info on the hardware.
-
- */

--- a/boards/bluepill-stm32f103cb/doc.md
+++ b/boards/bluepill-stm32f103cb/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_bluepill_stm32f103cb Bluepill STM32F103CB board (128KiB flash)
 @ingroup     boards
 @brief       Support for the stm32f103cb based bluepill board.
@@ -12,5 +11,3 @@ in @ref boards_common_blxxxpill instead.
 
 The [STM32-base](https://stm32-base.org/boards/STM32F103C8T6-Blue-Pill.html)
 page on the bluepill contains additional info on the hardware.
-
- */

--- a/boards/cc1312-launchpad/doc.md
+++ b/boards/cc1312-launchpad/doc.md
@@ -1,19 +1,18 @@
-/**
-@defgroup        boards_cc1352p_launchpad TI CC1352P LaunchPad
+@defgroup        boards_cc1312_launchpad TI CC1312 LaunchPad
 @ingroup         boards
-@brief           Texas Instruments SimpleLink(TM) CC1352P Wireless MCU LaunchPad(TM) Kit
+@brief           Texas Instruments SimpleLink(TM) CC1312 Wireless MCU LaunchPad(TM) Kit
 
 ## Overview
 
-The [LAUNCHXL-CC1352P](http://www.ti.com/tool/LAUNCHXL-CC1352P) is a Texas
-Instrument's development kit for the CC1352P SoC which combines dual-band wireless MCU
-with integrated power amplifier.
+The [LAUNCHXL-CC1312R1](http://www.ti.com/tool/LAUNCHXL-CC1312R1) is a Texas
+Instrument's development kit for the CC1312R1 SoC MCU which combines a
+Cortex-M4F microcontroller alongside a dedicated Cortex-M0 to control radio.
 
 ## Hardware
 
-![LAUNCHPAD-CC1352P](http://www.ti.com/diagrams/launchxl-cc1352p_launchxl-cc1352p_mcu041a_cc1352p1.jpg)
+![LAUNCHXL-CC1312R1](http://www.ti.com/diagrams/launchxl-cc1312r1_cc1312r1-top-prof1.jpg)
 
-| MCU               | CC1352R1              |
+| MCU               | CC1312R1              |
 |:----------------- |:--------------------- |
 | Family            | ARM Cortex-M4F        |
 | Vendor            | Texas Instruments     |
@@ -27,17 +26,12 @@ with integrated power amplifier.
 | SPIs              | 2                     |
 | I2Cs              | 1                     |
 | Vcc               | 1.8V - 3.8V           |
-| Datasheet         | [Datasheet](http://www.ti.com/lit/ds/symlink/cc1352p.pdf) (pdf file) |
+| Datasheet         | [Datasheet](http://www.ti.com/lit/ds/symlink/cc1312r.pdf) (pdf file) |
 | Reference Manual  | [Reference Manual](http://www.ti.com/lit/ug/swcu185d/swcu185d.pdf) |
-
-The board comes in two variants with different RF matching network on the 20 dBm PA output port:
-
-- LAUNCHXL-CC1352P1: 868/915 MHz up to 20 dBm, 2.4 GHz up to 5 dBm
-- LAUNCHXL-CC1352P-2: 868/915 MHz up to 14 dBm, 2.4 GHz up to 20 dBm.
 
 ## Board pinout
 
-The [LAUNCHXL-CC1352P1 Quick Start Guide](https://www.ti.com/lit/ug/swau108a/swau108a.pdf)
+The [LAUNXHL-CC1312R Quick Start Guide](http://www.ti.com/lit/ml/swru535c/swru535c.pdf)
 provides the default pinout for the board.
 
 ## Flashing the Device
@@ -49,7 +43,7 @@ installed just connect the board using the Micro-USB port to your computer and
 type:
 
 ```
-make flash BOARD=cc1352p-launchpad
+make flash BOARD=cc1312-launchpad
 ```
 
 To use OpenOCD instead of uniflash we need to set the `PROGRAMMER` environment
@@ -61,9 +55,6 @@ export PROGRAMMER=openocd
 
 Now we can just do `make flash` and `make debug`, this all using OpenOCD.
 
-For detailed information about CC1352P MCUs as well as configuring, compiling
-RIOT and installation of flashing tools for CC1352P boards,
+For detailed information about CC1312 MCUs as well as configuring, compiling
+RIOT and installation of flashing tools for CC1312 boards,
 see \ref cc26xx_cc13xx_riot.
-
-
-*/

--- a/boards/cc1350-launchpad/doc.md
+++ b/boards/cc1350-launchpad/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup        boards_cc1350_launchpad TI CC1350 LaunchPad XL
 @ingroup         boards
 @brief           Texas Instruments SimpleLink(TM) CC1350 Wireless MCU LaunchPad(TM) Kit
@@ -76,5 +75,3 @@ level shifter when connecting to 5V UART.
 For detailed information about CC1350 MCUs as well as configuring, compiling
 RIOT and installation of flashing tools for CC1350 boards,
 see \ref cc26xx_cc13xx_riot.
-
-*/

--- a/boards/cc1352-launchpad/doc.md
+++ b/boards/cc1352-launchpad/doc.md
@@ -1,19 +1,18 @@
-/**
-@defgroup        boards_cc1312_launchpad TI CC1312 LaunchPad
+@defgroup        boards_cc1352_launchpad TI CC1352 LaunchPad
 @ingroup         boards
-@brief           Texas Instruments SimpleLink(TM) CC1312 Wireless MCU LaunchPad(TM) Kit
+@brief           Texas Instruments SimpleLink(TM) CC1352 Wireless MCU LaunchPad(TM) Kit
 
 ## Overview
 
-The [LAUNCHXL-CC1312R1](http://www.ti.com/tool/LAUNCHXL-CC1312R1) is a Texas
-Instrument's development kit for the CC1312R1 SoC MCU which combines a
+The [LAUNCHXL-CC1352R1](https://www.ti.com/tool/LAUNCHXL-CC1352R1) is a Texas
+Instrument's development kit for the CC1352R1 SoC MCU which combines a
 Cortex-M4F microcontroller alongside a dedicated Cortex-M0 to control radio.
 
 ## Hardware
 
-![LAUNCHXL-CC1312R1](http://www.ti.com/diagrams/launchxl-cc1312r1_cc1312r1-top-prof1.jpg)
+![LAUNCHXL-CC1352R1](https://www.ti.com/diagrams/launchxl-cc1352r1_launchxl-cc1352r1-angled.jpg)
 
-| MCU               | CC1312R1              |
+| MCU               | CC1352R1              |
 |:----------------- |:--------------------- |
 | Family            | ARM Cortex-M4F        |
 | Vendor            | Texas Instruments     |
@@ -27,12 +26,12 @@ Cortex-M4F microcontroller alongside a dedicated Cortex-M0 to control radio.
 | SPIs              | 2                     |
 | I2Cs              | 1                     |
 | Vcc               | 1.8V - 3.8V           |
-| Datasheet         | [Datasheet](http://www.ti.com/lit/ds/symlink/cc1312r.pdf) (pdf file) |
+| Datasheet         | [Datasheet](http://www.ti.com/lit/ds/symlink/cc1352r.pdf) (pdf file) |
 | Reference Manual  | [Reference Manual](http://www.ti.com/lit/ug/swcu185d/swcu185d.pdf) |
 
 ## Board pinout
 
-The [LAUNXHL-CC1312R Quick Start Guide](http://www.ti.com/lit/ml/swru535c/swru535c.pdf)
+The [LAUNCHXL-CC1352R1 Quick Start Guide](https://www.ti.com/lit/ml/swru525e/swru525e.pdf)
 provides the default pinout for the board.
 
 ## Flashing the Device
@@ -44,7 +43,7 @@ installed just connect the board using the Micro-USB port to your computer and
 type:
 
 ```
-make flash BOARD=cc1312-launchpad
+make flash BOARD=cc1352-launchpad
 ```
 
 To use OpenOCD instead of uniflash we need to set the `PROGRAMMER` environment
@@ -56,8 +55,22 @@ export PROGRAMMER=openocd
 
 Now we can just do `make flash` and `make debug`, this all using OpenOCD.
 
-For detailed information about CC1312 MCUs as well as configuring, compiling
-RIOT and installation of flashing tools for CC1312 boards,
-see \ref cc26xx_cc13xx_riot.
+## Accessing RIOT shell
 
-*/
+Default RIOT shell access utilize XDS110 debug probe integrated with launchpad board.
+It provides virtual serials via USB interface - for connecting to RIOT shell, use
+the first one.
+
+If a physical connection to UART is needed, disconnect jumpers RXD and TXD joining
+cc1352 microcontroller with XDS110 and connect UART to pin RXD/DIO12 and TXD/DIO13.
+
+The default baud rate is 115 200 - in both connection types.
+
+@warning Launchpad cc1352 board is not 5V tolerant. Use voltage divider or logic
+level shifter when connecting to 5V UART.
+
+## More information
+
+For detailed information about CC1352R1 MCUs as well as configuring, compiling
+RIOT and installation of flashing tools for CC1352R1 boards,
+see \ref cc26xx_cc13xx_riot.

--- a/boards/cc1352p-launchpad/doc.md
+++ b/boards/cc1352p-launchpad/doc.md
@@ -1,17 +1,16 @@
-/**
-@defgroup        boards_cc1352_launchpad TI CC1352 LaunchPad
+@defgroup        boards_cc1352p_launchpad TI CC1352P LaunchPad
 @ingroup         boards
-@brief           Texas Instruments SimpleLink(TM) CC1352 Wireless MCU LaunchPad(TM) Kit
+@brief           Texas Instruments SimpleLink(TM) CC1352P Wireless MCU LaunchPad(TM) Kit
 
 ## Overview
 
-The [LAUNCHXL-CC1352R1](https://www.ti.com/tool/LAUNCHXL-CC1352R1) is a Texas
-Instrument's development kit for the CC1352R1 SoC MCU which combines a
-Cortex-M4F microcontroller alongside a dedicated Cortex-M0 to control radio.
+The [LAUNCHXL-CC1352P](http://www.ti.com/tool/LAUNCHXL-CC1352P) is a Texas
+Instrument's development kit for the CC1352P SoC which combines dual-band wireless MCU
+with integrated power amplifier.
 
 ## Hardware
 
-![LAUNCHXL-CC1352R1](https://www.ti.com/diagrams/launchxl-cc1352r1_launchxl-cc1352r1-angled.jpg)
+![LAUNCHPAD-CC1352P](http://www.ti.com/diagrams/launchxl-cc1352p_launchxl-cc1352p_mcu041a_cc1352p1.jpg)
 
 | MCU               | CC1352R1              |
 |:----------------- |:--------------------- |
@@ -27,12 +26,17 @@ Cortex-M4F microcontroller alongside a dedicated Cortex-M0 to control radio.
 | SPIs              | 2                     |
 | I2Cs              | 1                     |
 | Vcc               | 1.8V - 3.8V           |
-| Datasheet         | [Datasheet](http://www.ti.com/lit/ds/symlink/cc1352r.pdf) (pdf file) |
+| Datasheet         | [Datasheet](http://www.ti.com/lit/ds/symlink/cc1352p.pdf) (pdf file) |
 | Reference Manual  | [Reference Manual](http://www.ti.com/lit/ug/swcu185d/swcu185d.pdf) |
+
+The board comes in two variants with different RF matching network on the 20 dBm PA output port:
+
+- LAUNCHXL-CC1352P1: 868/915 MHz up to 20 dBm, 2.4 GHz up to 5 dBm
+- LAUNCHXL-CC1352P-2: 868/915 MHz up to 14 dBm, 2.4 GHz up to 20 dBm.
 
 ## Board pinout
 
-The [LAUNCHXL-CC1352R1 Quick Start Guide](https://www.ti.com/lit/ml/swru525e/swru525e.pdf)
+The [LAUNCHXL-CC1352P1 Quick Start Guide](https://www.ti.com/lit/ug/swau108a/swau108a.pdf)
 provides the default pinout for the board.
 
 ## Flashing the Device
@@ -44,7 +48,7 @@ installed just connect the board using the Micro-USB port to your computer and
 type:
 
 ```
-make flash BOARD=cc1352-launchpad
+make flash BOARD=cc1352p-launchpad
 ```
 
 To use OpenOCD instead of uniflash we need to set the `PROGRAMMER` environment
@@ -56,24 +60,6 @@ export PROGRAMMER=openocd
 
 Now we can just do `make flash` and `make debug`, this all using OpenOCD.
 
-## Accessing RIOT shell
-
-Default RIOT shell access utilize XDS110 debug probe integrated with launchpad board.
-It provides virtual serials via USB interface - for connecting to RIOT shell, use
-the first one.
-
-If a physical connection to UART is needed, disconnect jumpers RXD and TXD joining
-cc1352 microcontroller with XDS110 and connect UART to pin RXD/DIO12 and TXD/DIO13.
-
-The default baud rate is 115 200 - in both connection types.
-
-@warning Launchpad cc1352 board is not 5V tolerant. Use voltage divider or logic
-level shifter when connecting to 5V UART.
-
-## More information
-
-For detailed information about CC1352R1 MCUs as well as configuring, compiling
-RIOT and installation of flashing tools for CC1352R1 boards,
+For detailed information about CC1352P MCUs as well as configuring, compiling
+RIOT and installation of flashing tools for CC1352P boards,
 see \ref cc26xx_cc13xx_riot.
-
-*/

--- a/boards/cc2538dk/doc.md
+++ b/boards/cc2538dk/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_cc2538dk CC2538DK
 @ingroup     boards
 @brief       Support for the Texas Instruments CC2538DK board.
@@ -147,4 +146,3 @@ $ sudo kextload /System/Library/Extensions/FTDIUSBSerialDriver.kext
 
 If everything worked, the XDS will be enumerated as
 `/dev/tty.usbserial-<serial-number>`
- */

--- a/boards/cc2650-launchpad/doc.md
+++ b/boards/cc2650-launchpad/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup        boards_cc2650_launchpad TI CC2650 LaunchPad XL
 @ingroup         boards
 @brief           Texas Instruments SimpleLink(TM) CC2650 Wireless MCU LaunchPad(TM) Kit
@@ -59,5 +58,3 @@ Now we can just do `make flash` and `make debug`, this all using OpenOCD.
 For detailed information about CC2650 MCUs as well as configuring, compiling
 RIOT and installation of flashing tools for CC2650 boards,
 see \ref cc26xx_cc13xx_riot.
-
-*/

--- a/boards/cc2650stk/doc.md
+++ b/boards/cc2650stk/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_cc2650stk CC2650STK
 @ingroup     boards
 @brief       Support for the SimpleLink™ CC2650 sensor tag
@@ -215,4 +214,3 @@ on all three channels you can create three ble_rop_cmd_t commands and chain them
 via `cmd.pNextOp`.
 3. Send the command to be executed to the RF core via the `rfc_send_cmd()`
 function
- */

--- a/boards/nrf51dk/doc.md
+++ b/boards/nrf51dk/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nrf51dk nRF51DK Development Kit
 @ingroup     boards
 @brief       Support for the Nordic nRF51DK Development Kit
@@ -31,4 +30,3 @@ To flash the board, use the following command:
 $ make BOARD=nrf51dk flash
 ```
 from any application directory.
- */

--- a/boards/nrf51dongle/doc.md
+++ b/boards/nrf51dongle/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nrf51dongle nRF51 Dongle
 @ingroup     boards
 @brief       Support for the Nordic nRF51 Dongle
@@ -51,4 +50,3 @@ To interact with the board just start the tool using the following command:
 For RIOT itself there is a Flash-Script available. When using any of the
 Examples type in the following command:
 `# Make -B clean flash`
- */

--- a/boards/nrf52832-mdk/doc.md
+++ b/boards/nrf52832-mdk/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nrf52832-mdk nRF52832-MDK
 @ingroup     boards
 @brief       Support for the nRF52832-MDK
@@ -44,4 +43,3 @@ Use the `term` target to connect to the board serial port<br/>
 ```
     make BOARD=nrf52832-mdk -C examples/basic/hello-world term
 ```
- */

--- a/boards/nrf52840-mdk-dongle/doc.md
+++ b/boards/nrf52840-mdk-dongle/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nrf52840-mdk-dongle nRF52840 MDK USB Dongle
 @ingroup     boards
 @brief       Support for the nRF52840 MDK USB Dongle
@@ -58,5 +57,3 @@ To ease debugging,
 pins 0.6 and 0.7 are configured as RX and TX, respectively.
 They provide stdio if no CDC-ACM is disabled,
 and can be used as a custom UART otherwise.
-
- */

--- a/boards/nrf52840-mdk/doc.md
+++ b/boards/nrf52840-mdk/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nrf52840-mdk nRF52840-MDK
 @ingroup     boards
 @brief       Support for the nRF52840-MDK
@@ -34,4 +33,3 @@ Use the `term` target to connect to the board serial port<br/>
 ```
     make BOARD=nrf52840-mdk -C examples/basic/hello-world term
 ```
- */

--- a/boards/nrf52dk/doc.md
+++ b/boards/nrf52dk/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nrf52dk nRF52 DK
 @ingroup     boards
 @brief       Support for the nRF52 DK
@@ -64,4 +63,3 @@ Use the `term` target to connect to the board serial port<br/>
 ```
     make BOARD=nrf52dk -C examples/basic/hello-world term
 ```
- */

--- a/boards/nrf5340dk-app/doc.md
+++ b/boards/nrf5340dk-app/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nrf5340dk-app nRF5340DK
 @ingroup     boards
 @brief       Support for the nRF5340DK-app board
@@ -34,5 +33,3 @@ Use the `term` target to connect to the board serial port<br/>
 ```
     make BOARD=nrf5340dk-app -C examples/basic/hello-world term
 ```
-
- */

--- a/boards/nrf9160dk/doc.md
+++ b/boards/nrf9160dk/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_nrf9160dk nRF9160DK
 @ingroup     boards
 @brief       Support for the nRF9160DK board
@@ -31,5 +30,3 @@ Use the `term` target to connect to the board serial port<br/>
 ```
     make BOARD=nrf9160dk -C examples/basic/hello-world term
 ```
-
- */

--- a/boards/particle-argon/doc.md
+++ b/boards/particle-argon/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_particle-argon Particle Argon
 @ingroup     boards
 @brief       Support for the Particle Argon
@@ -27,5 +26,3 @@ voltage for the Particle Argon, please report this!
 ### Flash the board
 
 See the `Flashing` section in @ref boards_common_particle-mesh.
-
- */

--- a/boards/particle-boron/doc.md
+++ b/boards/particle-boron/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_particle-boron Particle Boron
 @ingroup     boards
 @brief       Support for the Particle Boron
@@ -27,5 +26,3 @@ voltage for the Particle Boron, please report this!
 ### Flash the board
 
 See the `Flashing` section in @ref boards_common_particle-mesh.
-
- */

--- a/boards/particle-xenon/doc.md
+++ b/boards/particle-xenon/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_particle-xenon Particle Xenon
 @ingroup     boards
 @brief       Support for the Particle Xenon
@@ -21,5 +20,3 @@ The board datasheet is available [here](https://docs.particle.io/assets/pdfs/dat
 ### Flash the board
 
 See the `Flashing` section in @ref boards_common_particle-mesh.
-
- */

--- a/boards/sam4s-xpro/doc.md
+++ b/boards/sam4s-xpro/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_sam4s-xpro ATSAM4S Xplained Pro board
 @ingroup     boards
 @brief       Support for the ATSAM4S Xplained Pro board
@@ -44,5 +43,3 @@ featuring a SAM4SD32 (Cortex-M4) SoC running up to 120 MHz. This MCU comes with
 By default, openOCD is used for both flashing and debugging.
 EDBG programmer is also available with:
 `PROGRAMMER=edbg BOARD=sam4s-xpro make -C tests/leds flash`
-
- */

--- a/boards/samd10-xmini/doc.md
+++ b/boards/samd10-xmini/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_samd10-xmini Atmel SAM D10 Xplained Mini
 @ingroup     boards
 @brief       Support for the Atmel SAM D10 Xplained Mini board.
@@ -72,5 +71,3 @@ sudo service udev restart
 The I2C pins on the board do not have any pull-ups connected to them.
 That means that running e.g. `i2c_scan` without any I2C slaves connected
 will run into timeouts.
-
- */

--- a/boards/samd20-xpro/doc.md
+++ b/boards/samd20-xpro/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_samd20-xpro Atmel SAM D20 Xplained Pro
 @ingroup     boards
 @brief       Support for the Atmel SAM D20 Xplained Pro board.
@@ -78,5 +77,3 @@ helpful to understanding how to set up a solid RIOT development environment for
 the SAMD20: http://watr.li/samr21-dev-setup-ubuntu.html
 
 ## Known Issues / Problems
-
- */

--- a/boards/samd21-xpro/doc.md
+++ b/boards/samd21-xpro/doc.md
@@ -1,30 +1,24 @@
-/**
-@defgroup    boards_saml21-xpro Atmel SAM L21 Xplained Pro
+@defgroup    boards_samd21-xpro Atmel SAM D21 Xplained Pro
 @ingroup     boards
-@brief       Support for the Atmel SAM L21 Xplained Pro board.
+@brief       Support for the Atmel SAM D21 Xplained Pro board.
 
 ## Overview
 
-The `SAML21 Xplained Pro` is an ultra-low power evaluation board by Atmel
-featuring a ATSAML21J18A SoC. The SoC includes a SAML21 ARM Cortex-M0+ micro-
+The `SAMD21 Xplained Pro` is an ultra-low power evaluation board by Atmel
+featuring an ATSAMD21J18A SoC. The SoC includes a SAMD21 ARM Cortex-M0+ micro-
 controller. For programming the MCU comes with 32Kb of RAM and 256Kb of flash
 memory.
 
-The saml21-xpro is available from various hardware vendors for ~50USD (as of
-oct. 2015).
-
-*Please note:*  ATMEL's most recent SAML21s are the `B` variant, or
-`ATSAML21J18B`.  Because the driver changes are mostly small, throughout this
-reference the device will continue to be referred to as the `ATSAML21J18[A/B]`
-indiscriminately;
+The samd21-xpro is available from various hardware vendors for ~30USD (as of
+2017 May).
 
 ## Hardware
 
-![saml21-xpro image](https://www.microchip.com/_ImagedCopy/ATSAML21-XPRO-B_angle.jpg)
+![samd21-xpro image](http://www.microchip.com/_ImagedCopy/ATSAMD21-XPRO_angle.jpg)
 
 
 ### MCU
-| MCU        | ATSAML21J18A      |
+| MCU        | ATSAMD21J18A      |
 |:------------- |:--------------------- |
 | Family | ARM Cortex-M0+    |
 | Vendor | Atmel |
@@ -32,14 +26,14 @@ indiscriminately;
 | Flash      | 256Kb             |
 | Frequency  | up to 48MHz |
 | FPU        | no                |
-| Timers | 8 (16-bit)    |
+| Timers | 5 (16-bit)    |
 | ADCs       | 1x 12-bit (20 channels)           |
 | UARTs      | max 6 (shared with SPI and I2C)               |
 | SPIs       | max 6 (see UART)                  |
 | I2Cs       | max 6 (see UART)              |
-| Vcc        | 1.8V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.atmel.com/Images/Atmel-42385-SAM-L21-Datasheet.pdf) |
-| Board Manual   | [Board Manual](http://www.atmel.com/Images/Atmel-42405-SAML21-Xplained-Pro_User-Guide.pdf)|
+| Vcc        | 1.62V - 3.63V         |
+| Datasheet  | [Datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM_D21_DA1_Family_Data%20Sheet_DS40001882E.pdf) |
+| Board Manual   | [Board Manual](http://www.atmel.com/Images/Atmel-42220-SAMD21-Xplained-Pro_User-Guide.pdf)|
 
 ### User Interface
 
@@ -47,41 +41,38 @@ indiscriminately;
 
 | Device | PIN |
 |:------ |:--- |
-| LED0   | PB10 |
-| SW0 (button) | PA02 |
+| LED0   | PB30 |
+| SW0 (button) | PA15 |
 
 
 ## Implementation Status
 
 | Device | ID        | Supported | Comments  |
 |:------------- |:------------- |:------------- |:------------- |
-| MCU        | saml21        | yes    |  |
+| MCU        | samd21    | yes    | |
 | Low-level driver | GPIO    | yes       | |
-|        | PWM       | yes       | |
+|        | ADC       | yes   | |
+|        | PWM       | yes   | |
 |        | UART      | yes       | |
 |        | I2C       | yes       | |
 |        | SPI       | yes       | |
 |        | USB       | yes       | |
 |        | RTT       | yes       | |
 |        | RTC       | yes       | |
-|        | RNG       | yes       | |
 |        | Timer     | yes       | |
-|        | ADC       | yes       | |
-|        | DAC       | yes       | |
-
-
 
 ## Flashing the device
 
-Connect the device to your Micro-USB cable using the port labeled as *EDBG*.
+Connect the device to your Micro-USB cable using the port labeled as *DEBUG
+USB*.
 
-The standard method for flashing RIOT to the saml21-xpro is using [edbg](https://github.com/ataradov/edbg).
-by calling: `make BOARD=saml21-xpro -C tests/leds flash`
+The standard method for flashing RIOT to the samd21-xpro is using [edbg](https://github.com/ataradov/edbg).
+by calling: `make BOARD=samd21-xpro -C tests/leds flash`
 
 Note that on Linux, you will need libudev-dev package to be installed.
 
 Users can also use openOCD to flash and/or debug the board using:
-`PROGRAMMER=openocd make BOARD=saml21-xpro -C tests/leds flash`
+`PROGRAMMER=openocd make BOARD=samd21-xpro -C tests/leds flash`
 
 On Linux you will have to add a **udev** rule for hidraw, like
 ```
@@ -103,8 +94,6 @@ yaourt -S openocd-git
 ### Ubuntu
 Although this refers to setting up the SAMR21, this guide is still very
 helpful to understanding how to set up a solid RIOT development environment for
-the SAML21: http://watr.li/samr21-dev-setup-ubuntu.html
+the SAMD21: http://watr.li/samr21-dev-setup-ubuntu.html
 
 ## Known Issues / Problems
-
- */

--- a/boards/same51-curiosity-nano/doc.md
+++ b/boards/same51-curiosity-nano/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_same51-curiosity-nano Microchip SAM E51 Curiosity Nano
 @ingroup     boards
 @brief       Support for the Microchip SAM E51 Curiosity Nano board.
@@ -82,5 +81,3 @@ sudo service udev restart
 ```
 
 ## Known Issues / Problems
-
- */

--- a/boards/same54-xpro/doc.md
+++ b/boards/same54-xpro/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_same54-xpro Microchip SAM E54 Xplained Pro
 @ingroup     boards
 @brief       Support for the Microchip SAM E54 Xplained Pro board.
@@ -91,5 +90,3 @@ sudo service udev restart
 ```
 
 ## Known Issues / Problems
-
- */

--- a/boards/saml10-xpro/doc.md
+++ b/boards/saml10-xpro/doc.md
@@ -1,22 +1,21 @@
-/**
-@defgroup    boards_saml11-xpro Microchip SAML11 Xplained Pro
+@defgroup    boards_saml10-xpro Microchip SAML10 Xplained Pro
 @ingroup     boards
-@brief       Support for the Microchip SAML11 Xplained Pro board.
+@brief       Support for the Microchip SAML10 Xplained Pro board.
 
 ## Overview
 
-The `SAML11 Xplained Pro` is an ultra-low power evaluation board by Microchip
-featuring a ATSAML11E16A SoC. The SoC includes a SAML11 ARM Cortex-M23 micro-
+The `SAML10 Xplained Pro` is an ultra-low power evaluation board by Microchip
+featuring a ATSAML10E16A SoC. The SoC includes a SAML10 ARM Cortex-M23 micro-
 controller. For programming the MCU comes with 16KB of RAM and 64KB of flash
-memory. In addition, this SoC features the ARM TrustZone technology.
+memory.
 
 ## Hardware
 
-![saml11-xpro image](https://www.microchip.com/_ImagedCopy/Converted-146683-1559149241-C16616-180424-MCU32-PHOTO-DM320205-Front-Transparent.png)
+![saml10-xpro image](https://www.microchip.com/_ImagedCopy/SAML10%20Xpro%20Front%20Title.jpg)
 
 
 ### MCU
-| MCU        | ATSAML11E14A      |
+| MCU        | ATSAML10E16A      |
 |:------------- |:--------------------- |
 | Family | ARM Cortex-M23    |
 | Vendor | Microchip |
@@ -47,36 +46,21 @@ memory. In addition, this SoC features the ARM TrustZone technology.
 
 | Device | ID        | Supported | Comments  |
 |:------------- |:------------- |:------------- |:------------- |
-| MCU        | saml11    | partly    | PLL clock not implemented |
+| MCU        | saml10    | partly    | PLL clock not implemented |
 | Low-level driver | GPIO    | yes       | |
 |        | PWM       | no            | |
 |        | UART      | yes           | |
 |        | I2C       | yes        | |
 |        | SPI       | yes        | |
 |        | USB       | no        | |
-|        | RTT       | yes       | |
+|        | RTT       | yes        | |
 |        | RTC       | yes      |  |
 |        | RNG       | yes        |  |
 |        | Timer     | yes           | |
 |        | ADC       | yes         | |
 
-
-
 ## Flashing the device
 
 Connect the device to your Micro-USB cable.
 
-The standard method for flashing RIOT to the saml11-xpro is using EDBG.
-
-## Special case
-
-SERCOM1 (available on EXT1 connector) needs an extra step to be usable.
-By default, this SERCOM is only available in the secure world. As RIOT
-doesn't support it for now, the only option, to use it, is to enable
-SERCOM non-secure mode. To do so, a fuse bit must be set in User ROW
-flash memory. Such action can be done with the following EDBG command:
-'edbg -t saml11 -F w0,194,1'
-or pass it as argument when calling make:
-EDBG_ARGS="-F w0,194,1" BOARD=saml11-xpro make flash term -C tests/periph/uart
-
-*/
+The standard method for flashing RIOT to the saml10-xpro is using EDBG.

--- a/boards/saml11-xpro/doc.md
+++ b/boards/saml11-xpro/doc.md
@@ -1,22 +1,21 @@
-/**
-@defgroup    boards_saml10-xpro Microchip SAML10 Xplained Pro
+@defgroup    boards_saml11-xpro Microchip SAML11 Xplained Pro
 @ingroup     boards
-@brief       Support for the Microchip SAML10 Xplained Pro board.
+@brief       Support for the Microchip SAML11 Xplained Pro board.
 
 ## Overview
 
-The `SAML10 Xplained Pro` is an ultra-low power evaluation board by Microchip
-featuring a ATSAML10E16A SoC. The SoC includes a SAML10 ARM Cortex-M23 micro-
+The `SAML11 Xplained Pro` is an ultra-low power evaluation board by Microchip
+featuring a ATSAML11E16A SoC. The SoC includes a SAML11 ARM Cortex-M23 micro-
 controller. For programming the MCU comes with 16KB of RAM and 64KB of flash
-memory.
+memory. In addition, this SoC features the ARM TrustZone technology.
 
 ## Hardware
 
-![saml10-xpro image](https://www.microchip.com/_ImagedCopy/SAML10%20Xpro%20Front%20Title.jpg)
+![saml11-xpro image](https://www.microchip.com/_ImagedCopy/Converted-146683-1559149241-C16616-180424-MCU32-PHOTO-DM320205-Front-Transparent.png)
 
 
 ### MCU
-| MCU        | ATSAML10E16A      |
+| MCU        | ATSAML11E14A      |
 |:------------- |:--------------------- |
 | Family | ARM Cortex-M23    |
 | Vendor | Microchip |
@@ -47,23 +46,34 @@ memory.
 
 | Device | ID        | Supported | Comments  |
 |:------------- |:------------- |:------------- |:------------- |
-| MCU        | saml10    | partly    | PLL clock not implemented |
+| MCU        | saml11    | partly    | PLL clock not implemented |
 | Low-level driver | GPIO    | yes       | |
 |        | PWM       | no            | |
 |        | UART      | yes           | |
 |        | I2C       | yes        | |
 |        | SPI       | yes        | |
 |        | USB       | no        | |
-|        | RTT       | yes        | |
+|        | RTT       | yes       | |
 |        | RTC       | yes      |  |
 |        | RNG       | yes        |  |
 |        | Timer     | yes           | |
 |        | ADC       | yes         | |
 
+
+
 ## Flashing the device
 
 Connect the device to your Micro-USB cable.
 
-The standard method for flashing RIOT to the saml10-xpro is using EDBG.
+The standard method for flashing RIOT to the saml11-xpro is using EDBG.
 
- */
+## Special case
+
+SERCOM1 (available on EXT1 connector) needs an extra step to be usable.
+By default, this SERCOM is only available in the secure world. As RIOT
+doesn't support it for now, the only option, to use it, is to enable
+SERCOM non-secure mode. To do so, a fuse bit must be set in User ROW
+flash memory. Such action can be done with the following EDBG command:
+'edbg -t saml11 -F w0,194,1'
+or pass it as argument when calling make:
+EDBG_ARGS="-F w0,194,1" BOARD=saml11-xpro make flash term -C tests/periph/uart

--- a/boards/saml21-xpro/doc.md
+++ b/boards/saml21-xpro/doc.md
@@ -1,25 +1,29 @@
-/**
-@defgroup    boards_samd21-xpro Atmel SAM D21 Xplained Pro
+@defgroup    boards_saml21-xpro Atmel SAM L21 Xplained Pro
 @ingroup     boards
-@brief       Support for the Atmel SAM D21 Xplained Pro board.
+@brief       Support for the Atmel SAM L21 Xplained Pro board.
 
 ## Overview
 
-The `SAMD21 Xplained Pro` is an ultra-low power evaluation board by Atmel
-featuring an ATSAMD21J18A SoC. The SoC includes a SAMD21 ARM Cortex-M0+ micro-
+The `SAML21 Xplained Pro` is an ultra-low power evaluation board by Atmel
+featuring a ATSAML21J18A SoC. The SoC includes a SAML21 ARM Cortex-M0+ micro-
 controller. For programming the MCU comes with 32Kb of RAM and 256Kb of flash
 memory.
 
-The samd21-xpro is available from various hardware vendors for ~30USD (as of
-2017 May).
+The saml21-xpro is available from various hardware vendors for ~50USD (as of
+oct. 2015).
+
+*Please note:*  ATMEL's most recent SAML21s are the `B` variant, or
+`ATSAML21J18B`.  Because the driver changes are mostly small, throughout this
+reference the device will continue to be referred to as the `ATSAML21J18[A/B]`
+indiscriminately;
 
 ## Hardware
 
-![samd21-xpro image](http://www.microchip.com/_ImagedCopy/ATSAMD21-XPRO_angle.jpg)
+![saml21-xpro image](https://www.microchip.com/_ImagedCopy/ATSAML21-XPRO-B_angle.jpg)
 
 
 ### MCU
-| MCU        | ATSAMD21J18A      |
+| MCU        | ATSAML21J18A      |
 |:------------- |:--------------------- |
 | Family | ARM Cortex-M0+    |
 | Vendor | Atmel |
@@ -27,14 +31,14 @@ The samd21-xpro is available from various hardware vendors for ~30USD (as of
 | Flash      | 256Kb             |
 | Frequency  | up to 48MHz |
 | FPU        | no                |
-| Timers | 5 (16-bit)    |
+| Timers | 8 (16-bit)    |
 | ADCs       | 1x 12-bit (20 channels)           |
 | UARTs      | max 6 (shared with SPI and I2C)               |
 | SPIs       | max 6 (see UART)                  |
 | I2Cs       | max 6 (see UART)              |
-| Vcc        | 1.62V - 3.63V         |
-| Datasheet  | [Datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM_D21_DA1_Family_Data%20Sheet_DS40001882E.pdf) |
-| Board Manual   | [Board Manual](http://www.atmel.com/Images/Atmel-42220-SAMD21-Xplained-Pro_User-Guide.pdf)|
+| Vcc        | 1.8V - 3.6V           |
+| Datasheet  | [Datasheet](http://www.atmel.com/Images/Atmel-42385-SAM-L21-Datasheet.pdf) |
+| Board Manual   | [Board Manual](http://www.atmel.com/Images/Atmel-42405-SAML21-Xplained-Pro_User-Guide.pdf)|
 
 ### User Interface
 
@@ -42,38 +46,41 @@ The samd21-xpro is available from various hardware vendors for ~30USD (as of
 
 | Device | PIN |
 |:------ |:--- |
-| LED0   | PB30 |
-| SW0 (button) | PA15 |
+| LED0   | PB10 |
+| SW0 (button) | PA02 |
 
 
 ## Implementation Status
 
 | Device | ID        | Supported | Comments  |
 |:------------- |:------------- |:------------- |:------------- |
-| MCU        | samd21    | yes    | |
+| MCU        | saml21        | yes    |  |
 | Low-level driver | GPIO    | yes       | |
-|        | ADC       | yes   | |
-|        | PWM       | yes   | |
+|        | PWM       | yes       | |
 |        | UART      | yes       | |
 |        | I2C       | yes       | |
 |        | SPI       | yes       | |
 |        | USB       | yes       | |
 |        | RTT       | yes       | |
 |        | RTC       | yes       | |
+|        | RNG       | yes       | |
 |        | Timer     | yes       | |
+|        | ADC       | yes       | |
+|        | DAC       | yes       | |
+
+
 
 ## Flashing the device
 
-Connect the device to your Micro-USB cable using the port labeled as *DEBUG
-USB*.
+Connect the device to your Micro-USB cable using the port labeled as *EDBG*.
 
-The standard method for flashing RIOT to the samd21-xpro is using [edbg](https://github.com/ataradov/edbg).
-by calling: `make BOARD=samd21-xpro -C tests/leds flash`
+The standard method for flashing RIOT to the saml21-xpro is using [edbg](https://github.com/ataradov/edbg).
+by calling: `make BOARD=saml21-xpro -C tests/leds flash`
 
 Note that on Linux, you will need libudev-dev package to be installed.
 
 Users can also use openOCD to flash and/or debug the board using:
-`PROGRAMMER=openocd make BOARD=samd21-xpro -C tests/leds flash`
+`PROGRAMMER=openocd make BOARD=saml21-xpro -C tests/leds flash`
 
 On Linux you will have to add a **udev** rule for hidraw, like
 ```
@@ -95,8 +102,6 @@ yaourt -S openocd-git
 ### Ubuntu
 Although this refers to setting up the SAMR21, this guide is still very
 helpful to understanding how to set up a solid RIOT development environment for
-the SAMD21: http://watr.li/samr21-dev-setup-ubuntu.html
+the SAML21: http://watr.li/samr21-dev-setup-ubuntu.html
 
 ## Known Issues / Problems
-
- */

--- a/boards/samr21-xpro/doc.md
+++ b/boards/samr21-xpro/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_samr21-xpro Atmel SAM R21 Xplained Pro
 @ingroup     boards
 @brief       Support for the Atmel SAM R21 Xplained Pro board.
@@ -203,4 +202,3 @@ But when you try to flash again, you could get a CMSIS-DAP related error. It
 seems to only happen with USB 3.0 ports. You can take a look at
 [Vagrant](http://en.wikipedia.org/wiki/Vagrant_%28software%29) and use a virtual
 Linux to run the virtual RIOT, and flash from macOS.
- */

--- a/boards/samr34-xpro/doc.md
+++ b/boards/samr34-xpro/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_samr34-xpro Microchip SAM R34 Xplained Pro
 @ingroup     boards
 @brief       Support for the Microchip SAM R34 Xplained Pro and WLR089 Xplained Pro
@@ -36,5 +35,3 @@ An evaluation board for the radio certified WLR089 module exists as the WLR089 X
 | Vcc        | 1.8V - 3.6V           |
 | Datasheet  | [Datasheet](https://ww1.microchip.com/downloads/en/DeviceDoc/SAMR34-R35-Low-Power-LoRa-Sub-GHz-SiP-Data-Sheet-DS70005356B.pdf) |
 | Board Manual | [SAM R34 XPro](https://www.microchip.com/en-us/development-tool/DM320111)<br>[WLR089 XPro](https://www.microchip.com/en-us/development-tool/EV23M25A)|
-
- */

--- a/boards/sensebox_samd21/doc.md
+++ b/boards/sensebox_samd21/doc.md
@@ -1,7 +1,6 @@
-/**
- * @defgroup    boards_sensebox_samd21 SenseBox MCU with SAMD21
- * @ingroup     boards
- * @brief       Support for the SenseBox MCU with SAMD21 board.
+@defgroup    boards_sensebox_samd21 SenseBox MCU with SAMD21
+@ingroup     boards
+@brief       Support for the SenseBox MCU with SAMD21 board.
 
 ### General information
 
@@ -66,4 +65,3 @@ This has the following limitations:
 - FSK mode is not possible
 - The interrupt pins can have different configurations, so caution is required
 when making changes.
- */

--- a/boards/waveshare-nrf52840-eval-kit/doc.md
+++ b/boards/waveshare-nrf52840-eval-kit/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup   boards_waveshare_nrf52840_eval_kit Waveshare nRF52840 Eval Kit
 @ingroup    boards
 @brief      Support for the Waveshare nRF52840 Eval Kit
@@ -156,5 +155,3 @@ RESET_PIN='GPIO_PIN\(0,18\)' make BOARD=waveshare-nrf52840-eval-kit -C dist/tool
 ```
 Simply compile, flash, and run that tool on your board, and the reset pin should
 work for the time being.
-
- */

--- a/boards/yunjia-nrf51822/doc.md
+++ b/boards/yunjia-nrf51822/doc.md
@@ -1,4 +1,3 @@
-/**
 @defgroup    boards_yunjia-nrf51822 Yunjia NRF51822
 @ingroup     boards
 @brief       Support for the Yunjia NRF51822 board
@@ -239,4 +238,3 @@ configuration script with: `openocd -f boards/yunjia-nrf51822/dist/openocd.cfg`.
 `nrf51 mass_erase`.
 
 This should have erased the whole memory of the device.
- */


### PR DESCRIPTION
### Contribution description

This PR moves doc.txt to doc.md accordingly to the guide from ISSUE #21220. 

In this PR boards designed by particle, Microchip, NRF, {blue, black}pill, and Texas Instruments 
are moved.

### Testing procedure

Generate doc and check if everything looks good:

```
make doc
xdg-open ./doc/doxygen/html/group__boards__samd10-xmini.html 
dg-open ./doc/doxygen/html/group__boards__particle-xenon.html
xdg-open ./doc/doxygen/html/group__boards__cc1350__launchpad.html 
xdg-open ./doc/doxygen/html/group__boards__nrf52840dongle.html
.  .  .
```

### Issues/PRs references

ISSUE #21220.