### PR TITLE
tests/unittests: Add missing module dependency to enable UDP

### DIFF
--- a/tests/unittests/tests-sock_util/Makefile.include
+++ b/tests/unittests/tests-sock_util/Makefile.include
@@ -1,5 +1,6 @@
 USEMODULE += sock_util
 USEMODULE += gnrc_sock
+USEMODULE += gnrc_sock_udp
 USEMODULE += gnrc_ipv6
 USEMODULE += ipv4_addr
 USEMODULE += ipv6_addr


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hello 🦋,

this fixes an issue where the unit test `tests-sock_util` could not be compiled as types were left undefined.

### Testing procedure

`make -C tests/unittests/ tests-sock_util flash-only test`


### Issues/PRs references

Possibly introduced by either "pragma once" breaking (fixing) a header include or by #21419 which guards transitive header explicitly. 