### PR TITLE
drivers/dht: Remove deprecated enum

### DIFF
--- a/drivers/include/dht.h
+++ b/drivers/include/dht.h
@@ -40,17 +40,6 @@ extern "C" {
 #endif
 
 /**
- * @brief       Possible return codes
- *
- * @deprecated  The functions use errno codes instead now
- */
-enum {
-    DHT_OK      =  0,           /**< all good */
-    DHT_NOCSUM  = -EIO,         /**< checksum error */
-    DHT_TIMEOUT = -ETIMEDOUT,   /**< communication timed out */
-};
-
-/**
  * @brief   Data type for storing DHT sensor readings
  */
 typedef struct {

--- a/drivers/saul/init_devs/auto_init_dht.c
+++ b/drivers/saul/init_devs/auto_init_dht.c
@@ -60,7 +60,7 @@ void auto_init_dht(void)
     for (unsigned int i = 0; i < DHT_NUM; i++) {
         LOG_DEBUG("[auto_init_saul] initializing dht #%u\n", i);
 
-        if (dht_init(&dht_devs[i], &dht_params[i]) != DHT_OK) {
+        if (dht_init(&dht_devs[i], &dht_params[i]) != 0) {
             LOG_ERROR("[auto_init_saul] error initializing dht #%u\n", i);
             continue;
         }

--- a/tests/drivers/dht/main.c
+++ b/tests/drivers/dht/main.c
@@ -39,7 +39,7 @@ int main(void)
 
     /* initialize first configured sensor */
     printf("Initializing DHT sensor...\t");
-    if (dht_init(&dev, &dht_params[0]) == DHT_OK) {
+    if (dht_init(&dev, &dht_params[0]) == 0) {
         puts("[OK]\n");
     }
     else {
@@ -51,15 +51,15 @@ int main(void)
     while (1) {
         ztimer_sleep(ZTIMER_USEC, DELAY);
 
-        if (dht_read(&dev, &temp, &hum) != DHT_OK) {
+        if (dht_read(&dev, &temp, &hum) != 0) {
             puts("Error reading both values");
             continue;
         }
-        if (dht_read(&dev, &temp, NULL) != DHT_OK) {
+        if (dht_read(&dev, &temp, NULL) != 0) {
             puts("Error reading just temperature");
             continue;
         }
-        if (dht_read(&dev, NULL, &hum) != DHT_OK) {
+        if (dht_read(&dev, NULL, &hum) != 0) {
             puts("Error reading just humidity");
             continue;
         }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hello 🐴,

this removes a long deprecated enum from the DHT driver.

### Testing procedure

I think a build test is sufficient + CI.
`make -C tests/drivers/dht all`


### Issues/PRs references

Deprecated in  #19718 (~2 years ago)
