### PR TITLE
boards/stm32: move licenses from headers to SPDX format

### DIFF
--- a/boards/nucleo-c031c6/Kconfig
+++ b/boards/nucleo-c031c6/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (C) 2024 BISSELL Homecare, Inc.
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2024 BISSELL Homecare, Inc.
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-c031c6" if BOARD_NUCLEO_C031C6

--- a/boards/nucleo-c031c6/include/periph_conf.h
+++ b/boards/nucleo-c031c6/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 BISSELL Homecare, Inc.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 BISSELL Homecare, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f030r8/Kconfig
+++ b/boards/nucleo-f030r8/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f030r8" if BOARD_NUCLEO_F030R8

--- a/boards/nucleo-f030r8/include/periph_conf.h
+++ b/boards/nucleo-f030r8/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f031k6/Kconfig
+++ b/boards/nucleo-f031k6/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f031k6" if BOARD_NUCLEO_F031K6

--- a/boards/nucleo-f031k6/include/periph_conf.h
+++ b/boards/nucleo-f031k6/include/periph_conf.h
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 2017  Inria
- * Copyright (C) 2017  OTA keys
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2017 OTA keys
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f031k6/include/periph_conf.h
+++ b/boards/nucleo-f031k6/include/periph_conf.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017  Inria
- *               2017  OTA keys
+ * Copyright (C) 2017  OTA keys
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.

--- a/boards/nucleo-f042k6/Kconfig
+++ b/boards/nucleo-f042k6/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f042k6" if BOARD_NUCLEO_F042K6

--- a/boards/nucleo-f042k6/include/periph_conf.h
+++ b/boards/nucleo-f042k6/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016  OTA keys
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f070rb/Kconfig
+++ b/boards/nucleo-f070rb/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f070rb" if BOARD_NUCLEO_F070RB

--- a/boards/nucleo-f070rb/include/periph_conf.h
+++ b/boards/nucleo-f070rb/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- * Copyright (C) 2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f070rb/include/periph_conf.h
+++ b/boards/nucleo-f070rb/include/periph_conf.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2016 Freie Universität Berlin
- *               2016 Inria
+ * Copyright (C) 2016 Inria
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/nucleo-f072rb/Kconfig
+++ b/boards/nucleo-f072rb/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f072rb" if BOARD_NUCLEO_F072RB

--- a/boards/nucleo-f072rb/include/periph_conf.h
+++ b/boards/nucleo-f072rb/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015  Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f091rc/Kconfig
+++ b/boards/nucleo-f091rc/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f091rc" if BOARD_NUCLEO_F091RC

--- a/boards/nucleo-f091rc/include/periph_conf.h
+++ b/boards/nucleo-f091rc/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015  Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f103rb/Kconfig
+++ b/boards/nucleo-f103rb/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f103rb" if BOARD_NUCLEO_F103RB

--- a/boards/nucleo-f103rb/include/periph_conf.h
+++ b/boards/nucleo-f103rb/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 TriaGnoSys GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 TriaGnoSys GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f207zg/Kconfig
+++ b/boards/nucleo-f207zg/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f207zg" if BOARD_NUCLEO_F207ZG

--- a/boards/nucleo-f207zg/include/periph_conf.h
+++ b/boards/nucleo-f207zg/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2017  OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f302r8/Kconfig
+++ b/boards/nucleo-f302r8/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f302r8" if BOARD_NUCLEO_F302R8

--- a/boards/nucleo-f302r8/include/periph_conf.h
+++ b/boards/nucleo-f302r8/include/periph_conf.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2017 Inria
- * Copyright (C) 2015 Freie Universität Berlin
- * Copyright (C) 2015 Hamburg University of Applied Sciences
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Hamburg University of Applied Sciences
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f303k8/Kconfig
+++ b/boards/nucleo-f303k8/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f303k8" if BOARD_NUCLEO_F303K8

--- a/boards/nucleo-f303k8/include/periph_conf.h
+++ b/boards/nucleo-f303k8/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017   Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f303re/Kconfig
+++ b/boards/nucleo-f303re/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f303re" if BOARD_NUCLEO_F303RE

--- a/boards/nucleo-f303re/include/periph_conf.h
+++ b/boards/nucleo-f303re/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015  Freie Universität Berlin
- * Copyright (C) 2015 Hamburg University of Applied Sciences
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Hamburg University of Applied Sciences
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f303ze/Kconfig
+++ b/boards/nucleo-f303ze/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f303ze" if BOARD_NUCLEO_F303ZE

--- a/boards/nucleo-f303ze/include/periph_conf.h
+++ b/boards/nucleo-f303ze/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f334r8/Kconfig
+++ b/boards/nucleo-f334r8/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f334r8" if BOARD_NUCLEO_F334R8

--- a/boards/nucleo-f334r8/include/periph_conf.h
+++ b/boards/nucleo-f334r8/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015  Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f401re/Kconfig
+++ b/boards/nucleo-f401re/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f401re" if BOARD_NUCLEO_F401RE

--- a/boards/nucleo-f401re/include/periph_conf.h
+++ b/boards/nucleo-f401re/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Lari Lehtomäki
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Lari Lehtomäki
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f410rb/Kconfig
+++ b/boards/nucleo-f410rb/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f410rb" if BOARD_NUCLEO_F410RB

--- a/boards/nucleo-f410rb/include/periph_conf.h
+++ b/boards/nucleo-f410rb/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f411re/Kconfig
+++ b/boards/nucleo-f411re/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f411re" if BOARD_NUCLEO_F411RE

--- a/boards/nucleo-f411re/include/periph_conf.h
+++ b/boards/nucleo-f411re/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f412zg/Kconfig
+++ b/boards/nucleo-f412zg/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f412zg" if BOARD_NUCLEO_F412ZG

--- a/boards/nucleo-f412zg/include/periph_conf.h
+++ b/boards/nucleo-f412zg/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Inria
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f413zh/Kconfig
+++ b/boards/nucleo-f413zh/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f413zh" if BOARD_NUCLEO_F413ZH

--- a/boards/nucleo-f413zh/include/periph_conf.h
+++ b/boards/nucleo-f413zh/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Inria
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f429zi/Kconfig
+++ b/boards/nucleo-f429zi/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f429zi" if BOARD_NUCLEO_F429ZI

--- a/boards/nucleo-f429zi/include/periph_conf.h
+++ b/boards/nucleo-f429zi/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f439zi/Kconfig
+++ b/boards/nucleo-f439zi/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f439zi" if BOARD_NUCLEO_F439ZI

--- a/boards/nucleo-f439zi/include/periph_conf.h
+++ b/boards/nucleo-f439zi/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f446re/Kconfig
+++ b/boards/nucleo-f446re/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f446re" if BOARD_NUCLEO_F446RE

--- a/boards/nucleo-f446re/include/periph_conf.h
+++ b/boards/nucleo-f446re/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f446ze/Kconfig
+++ b/boards/nucleo-f446ze/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f446ze" if BOARD_NUCLEO_F446ZE

--- a/boards/nucleo-f446ze/include/periph_conf.h
+++ b/boards/nucleo-f446ze/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f722ze/Kconfig
+++ b/boards/nucleo-f722ze/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f722ze" if BOARD_NUCLEO_F722ZE

--- a/boards/nucleo-f722ze/include/periph_conf.h
+++ b/boards/nucleo-f722ze/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f746zg/Kconfig
+++ b/boards/nucleo-f746zg/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f746zg" if BOARD_NUCLEO_F746ZG

--- a/boards/nucleo-f746zg/include/periph_conf.h
+++ b/boards/nucleo-f746zg/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-f767zi/Kconfig
+++ b/boards/nucleo-f767zi/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-f767zi" if BOARD_NUCLEO_F767ZI

--- a/boards/nucleo-f767zi/include/periph_conf.h
+++ b/boards/nucleo-f767zi/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-g070rb/Kconfig
+++ b/boards/nucleo-g070rb/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-g070rb" if BOARD_NUCLEO_G070RB

--- a/boards/nucleo-g070rb/include/periph_conf.h
+++ b/boards/nucleo-g070rb/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-g071rb/Kconfig
+++ b/boards/nucleo-g071rb/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-g071rb" if BOARD_NUCLEO_G071RB

--- a/boards/nucleo-g071rb/include/periph_conf.h
+++ b/boards/nucleo-g071rb/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-g431rb/Kconfig
+++ b/boards/nucleo-g431rb/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-g431rb" if BOARD_NUCLEO_G431RB

--- a/boards/nucleo-g431rb/include/periph_conf.h
+++ b/boards/nucleo-g431rb/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-g474re/Kconfig
+++ b/boards/nucleo-g474re/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-g474re" if BOARD_NUCLEO_G474RE

--- a/boards/nucleo-g474re/include/periph_conf.h
+++ b/boards/nucleo-g474re/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-l011k4/Kconfig
+++ b/boards/nucleo-l011k4/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-l011k4" if BOARD_NUCLEO_L011K4

--- a/boards/nucleo-l011k4/include/periph_conf.h
+++ b/boards/nucleo-l011k4/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-l031k6/Kconfig
+++ b/boards/nucleo-l031k6/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-l031k6" if BOARD_NUCLEO_L031K6

--- a/boards/nucleo-l031k6/include/periph_conf.h
+++ b/boards/nucleo-l031k6/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-l031k6/include/periph_conf.h
+++ b/boards/nucleo-l031k6/include/periph_conf.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017 Freie Universität Berlin
- *               2017 Inria
+ * Copyright (C) 2017 Inria
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/nucleo-l053r8/Kconfig
+++ b/boards/nucleo-l053r8/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-l053r8" if BOARD_NUCLEO_L053R8

--- a/boards/nucleo-l053r8/include/periph_conf.h
+++ b/boards/nucleo-l053r8/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-l053r8/include/periph_conf.h
+++ b/boards/nucleo-l053r8/include/periph_conf.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017 Freie Universität Berlin
- *               2017 Inria
+ * Copyright (C) 2017 Inria
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/nucleo-l073rz/Kconfig
+++ b/boards/nucleo-l073rz/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-l073rz" if BOARD_NUCLEO_L073RZ

--- a/boards/nucleo-l073rz/include/periph_conf.h
+++ b/boards/nucleo-l073rz/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-l073rz/include/periph_conf.h
+++ b/boards/nucleo-l073rz/include/periph_conf.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017 Freie Universität Berlin
- *               2017 Inria
+ * Copyright (C) 2017 Inria
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/nucleo-l152re/Kconfig
+++ b/boards/nucleo-l152re/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-l152re" if BOARD_NUCLEO_L152RE

--- a/boards/nucleo-l152re/include/periph_conf.h
+++ b/boards/nucleo-l152re/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-l412kb/Kconfig
+++ b/boards/nucleo-l412kb/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-l412kb" if BOARD_NUCLEO_L412KB

--- a/boards/nucleo-l412kb/include/periph_conf.h
+++ b/boards/nucleo-l412kb/include/periph_conf.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2019  twostairs
- *               2017  Inria
- *               2017  OTA keys
+ * Copyright (C) 2017  Inria
+ * Copyright (C) 2017  OTA keys
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/nucleo-l412kb/include/periph_conf.h
+++ b/boards/nucleo-l412kb/include/periph_conf.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2019  twostairs
- * Copyright (C) 2017  Inria
- * Copyright (C) 2017  OTA keys
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 twostairs
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2017 OTA keys
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-l432kc/Kconfig
+++ b/boards/nucleo-l432kc/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-l432kc" if BOARD_NUCLEO_L432KC

--- a/boards/nucleo-l432kc/include/periph_conf.h
+++ b/boards/nucleo-l432kc/include/periph_conf.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017  Inria
- *               2017  OTA keys
+ * Copyright (C) 2017  OTA keys
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/nucleo-l432kc/include/periph_conf.h
+++ b/boards/nucleo-l432kc/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017  Inria
- * Copyright (C) 2017  OTA keys
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2017 OTA keys
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-l433rc/Kconfig
+++ b/boards/nucleo-l433rc/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-l433rc" if BOARD_NUCLEO_L433RC

--- a/boards/nucleo-l433rc/include/periph_conf.h
+++ b/boards/nucleo-l433rc/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-l452re/Kconfig
+++ b/boards/nucleo-l452re/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-l452re" if BOARD_NUCLEO_L452RE

--- a/boards/nucleo-l452re/include/periph_conf.h
+++ b/boards/nucleo-l452re/include/periph_conf.h
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- * Copyright (C) 2017 Inria
- * Copyright (C) 2017 HAW-Hamburg
- * Copyright (C) 2018 Fundacion Inria Chile
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2017 HAW-Hamburg
+ * SPDX-FileCopyrightText: 2018 Fundacion Inria Chile
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-l452re/include/periph_conf.h
+++ b/boards/nucleo-l452re/include/periph_conf.h
@@ -1,8 +1,8 @@
 /*
  * Copyright (C) 2017 Freie Universität Berlin
- *               2017 Inria
- *               2017 HAW-Hamburg
- *               2018 Fundacion Inria Chile
+ * Copyright (C) 2017 Inria
+ * Copyright (C) 2017 HAW-Hamburg
+ * Copyright (C) 2018 Fundacion Inria Chile
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/nucleo-l476rg/Kconfig
+++ b/boards/nucleo-l476rg/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-l476rg" if BOARD_NUCLEO_L476RG

--- a/boards/nucleo-l476rg/include/periph_conf.h
+++ b/boards/nucleo-l476rg/include/periph_conf.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- * Copyright (C) 2017 Inria
- * Copyright (C) 2017 HAW-Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2017 HAW-Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-l476rg/include/periph_conf.h
+++ b/boards/nucleo-l476rg/include/periph_conf.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2017 Freie Universität Berlin
- *               2017 Inria
- *               2017 HAW-Hamburg
+ * Copyright (C) 2017 Inria
+ * Copyright (C) 2017 HAW-Hamburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/nucleo-l496zg/Kconfig
+++ b/boards/nucleo-l496zg/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-l496zg" if BOARD_NUCLEO_L496ZG

--- a/boards/nucleo-l496zg/include/periph_conf.h
+++ b/boards/nucleo-l496zg/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-l4r5zi/Kconfig
+++ b/boards/nucleo-l4r5zi/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-l4r5zi" if BOARD_NUCLEO_L4R5ZI

--- a/boards/nucleo-l4r5zi/include/periph_conf.h
+++ b/boards/nucleo-l4r5zi/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-l552ze-q/Kconfig
+++ b/boards/nucleo-l552ze-q/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-l552ze-q" if BOARD_NUCLEO_L552ZE_Q

--- a/boards/nucleo-l552ze-q/include/periph_conf.h
+++ b/boards/nucleo-l552ze-q/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-u575zi-q/include/periph_conf.h
+++ b/boards/nucleo-u575zi-q/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-wl55jc/Kconfig
+++ b/boards/nucleo-wl55jc/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Freie Universität Berlin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nucleo-wl55jc" if BOARD_NUCLEO_WL55JC

--- a/boards/nucleo-wl55jc/board.c
+++ b/boards/nucleo-wl55jc/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021  Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/nucleo-wl55jc/include/arduino_iomap.h
+++ b/boards/nucleo-wl55jc/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-wl55jc/include/board.h
+++ b/boards/nucleo-wl55jc/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-wl55jc/include/gpio_params.h
+++ b/boards/nucleo-wl55jc/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nucleo-wl55jc/include/periph_conf.h
+++ b/boards/nucleo-wl55jc/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f030f4-demo/Kconfig
+++ b/boards/stm32f030f4-demo/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "stm32f030f4-demo" if BOARD_STM32F030F4_DEMO

--- a/boards/stm32f030f4-demo/include/board.h
+++ b/boards/stm32f030f4-demo/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f030f4-demo/include/periph_conf.h
+++ b/boards/stm32f030f4-demo/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f0discovery/Kconfig
+++ b/boards/stm32f0discovery/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "stm32f0discovery" if BOARD_STM32F0DISCOVERY

--- a/boards/stm32f0discovery/include/board.h
+++ b/boards/stm32f0discovery/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f0discovery/include/gpio_params.h
+++ b/boards/stm32f0discovery/include/gpio_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f0discovery/include/gpio_params.h
+++ b/boards/stm32f0discovery/include/gpio_params.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017 Freie Universität Berlin
- *               2017 Inria
+ * Copyright (C) 2017 Inria
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/stm32f0discovery/include/periph_conf.h
+++ b/boards/stm32f0discovery/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f3discovery/Kconfig
+++ b/boards/stm32f3discovery/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "stm32f3discovery" if BOARD_STM32F3DISCOVERY

--- a/boards/stm32f3discovery/include/board.h
+++ b/boards/stm32f3discovery/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f3discovery/include/gpio_params.h
+++ b/boards/stm32f3discovery/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f3discovery/include/periph_conf.h
+++ b/boards/stm32f3discovery/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f429i-disc1/Kconfig
+++ b/boards/stm32f429i-disc1/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "stm32f429i-disc1" if BOARD_STM32F429I_DISC1

--- a/boards/stm32f429i-disc1/include/board.h
+++ b/boards/stm32f429i-disc1/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f429i-disc1/include/gpio_params.h
+++ b/boards/stm32f429i-disc1/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f429i-disc1/include/periph_conf.h
+++ b/boards/stm32f429i-disc1/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f429i-disco/Kconfig
+++ b/boards/stm32f429i-disco/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "stm32f429i-disco" if BOARD_STM32F429I_DISCO

--- a/boards/stm32f469i-disco/include/board.h
+++ b/boards/stm32f469i-disco/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 luisan00
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2021 luisan00
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f469i-disco/include/periph_conf.h
+++ b/boards/stm32f469i-disco/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 luisan00
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2021 luisan00
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f4discovery/Kconfig
+++ b/boards/stm32f4discovery/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "stm32f4discovery" if BOARD_STM32F4DISCOVERY

--- a/boards/stm32f4discovery/include/arduino_iomap.h
+++ b/boards/stm32f4discovery/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f4discovery/include/board.h
+++ b/boards/stm32f4discovery/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f4discovery/include/gpio_params.h
+++ b/boards/stm32f4discovery/include/gpio_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f4discovery/include/gpio_params.h
+++ b/boards/stm32f4discovery/include/gpio_params.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017 Freie Universität Berlin
- *               2017 Inria
+ * Copyright (C) 2017 Inria
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f723e-disco/Kconfig
+++ b/boards/stm32f723e-disco/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "stm32f723e-disco" if BOARD_STM32F723E_DISCO

--- a/boards/stm32f723e-disco/board.c
+++ b/boards/stm32f723e-disco/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/stm32f723e-disco/include/board.h
+++ b/boards/stm32f723e-disco/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f723e-disco/include/gpio_params.h
+++ b/boards/stm32f723e-disco/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f723e-disco/include/periph_conf.h
+++ b/boards/stm32f723e-disco/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f746g-disco/Kconfig
+++ b/boards/stm32f746g-disco/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2021 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "stm32f746g-disco" if BOARD_STM32F746G_DISCO

--- a/boards/stm32f746g-disco/board.c
+++ b/boards/stm32f746g-disco/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/stm32f746g-disco/include/board.h
+++ b/boards/stm32f746g-disco/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f746g-disco/include/gpio_params.h
+++ b/boards/stm32f746g-disco/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f746g-disco/include/periph_conf.h
+++ b/boards/stm32f746g-disco/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f7508-dk/Kconfig
+++ b/boards/stm32f7508-dk/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2022 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2022 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "stm32f7508-dk" if BOARD_STM32F7508_DK

--- a/boards/stm32f769i-disco/Kconfig
+++ b/boards/stm32f769i-disco/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "stm32f769i-disco" if BOARD_STM32F769I_DISCO

--- a/boards/stm32f769i-disco/include/board.h
+++ b/boards/stm32f769i-disco/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f769i-disco/include/gpio_params.h
+++ b/boards/stm32f769i-disco/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32f769i-disco/include/periph_conf.h
+++ b/boards/stm32f769i-disco/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32g0316-disco/Kconfig
+++ b/boards/stm32g0316-disco/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 BISSELL Homecare, Inc.
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 BISSELL Homecare, Inc.
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "stm32g0316-disco" if BOARD_STM32G0316_DISCO

--- a/boards/stm32g0316-disco/include/board.h
+++ b/boards/stm32g0316-disco/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 BISSELL Homecare, Inc.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 BISSELL Homecare, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32g0316-disco/include/periph_conf.h
+++ b/boards/stm32g0316-disco/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 BISSELL Homecare, Inc.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 BISSELL Homecare, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32l0538-disco/Kconfig
+++ b/boards/stm32l0538-disco/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "stm32l0538-disco" if BOARD_STM32L0538_DISCO

--- a/boards/stm32l0538-disco/include/board.h
+++ b/boards/stm32l0538-disco/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32l0538-disco/include/gpio_params.h
+++ b/boards/stm32l0538-disco/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32l0538-disco/include/periph_conf.h
+++ b/boards/stm32l0538-disco/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32l476g-disco/Kconfig
+++ b/boards/stm32l476g-disco/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "stm32l476g-disco" if BOARD_STM32L476G_DISCO

--- a/boards/stm32l476g-disco/include/board.h
+++ b/boards/stm32l476g-disco/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32l476g-disco/include/periph_conf.h
+++ b/boards/stm32l476g-disco/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32l496g-disco/Kconfig
+++ b/boards/stm32l496g-disco/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "stm32l496g-disco" if BOARD_STM32L496G_DISCO

--- a/boards/stm32l496g-disco/board.c
+++ b/boards/stm32l496g-disco/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/stm32l496g-disco/include/arduino_iomap.h
+++ b/boards/stm32l496g-disco/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32l496g-disco/include/board.h
+++ b/boards/stm32l496g-disco/include/board.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Inria
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32l496g-disco/include/board.h
+++ b/boards/stm32l496g-disco/include/board.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2018 Inria
- *               2023 Gunar Schorcht
+ * Copyright (C) 2023 Gunar Schorcht
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/stm32l496g-disco/include/gpio_params.h
+++ b/boards/stm32l496g-disco/include/gpio_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Inria
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32l496g-disco/include/gpio_params.h
+++ b/boards/stm32l496g-disco/include/gpio_params.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2018 Inria
- *               2023 Gunar Schorcht
+ * Copyright (C) 2023 Gunar Schorcht
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/stm32l496g-disco/include/periph_conf.h
+++ b/boards/stm32l496g-disco/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Inria
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32l496g-disco/include/periph_conf.h
+++ b/boards/stm32l496g-disco/include/periph_conf.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2018 Inria
- *               2023 Gunar Schorcht
+ * Copyright (C) 2023 Gunar Schorcht
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/boards/stm32mp157c-dk2/Kconfig
+++ b/boards/stm32mp157c-dk2/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (C) 2020 Savoir-faire Linux
-#
-# This file is subject to the terms and conditions of the GNU Lesser General
-# Public License v2.1. See the file LICENSE in the top level directory for more
-# details.
+# SPDX-FileCopyrightText: 2020 Savoir-faire Linux
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "stm32mp157c-dk2" if BOARD_STM32MP157C_DK2

--- a/boards/stm32mp157c-dk2/include/board.h
+++ b/boards/stm32mp157c-dk2/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Savoir-faire Linux
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Savoir-faire Linux
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/stm32mp157c-dk2/include/periph_conf.h
+++ b/boards/stm32mp157c-dk2/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Savoir-faire Linux
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Savoir-faire Linux
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once


### PR DESCRIPTION
### Contribution description

This PR moves license information from headers to SPDX format for stm32 boards definitions (including nucleo).

Except detection of missing Copyright keyword [see](https://github.com/RIOT-OS/RIOT/issues/21515#issuecomment-3058941739) which was fixed manually other work is done automatically using scripts described in PR #21515.

### Testing procedure

Review changed files.

### Issues/PRs references

Tracking https://github.com/RIOT-OS/RIOT/issues/21515