### PR TITLE
net/l2filter: fix incorrect length check

### DIFF
--- a/sys/include/net/l2filter.h
+++ b/sys/include/net/l2filter.h
@@ -83,8 +83,10 @@ typedef struct {
  * @pre     @p addr != NULL
  * @pre     @p addr_maxlen <= @ref CONFIG_L2FILTER_ADDR_MAXLEN
  *
- * @return  0 on success
- * @return  -ENOMEM if no empty slot left in list
+ * @retval  0 on success
+ * @retval  -ENOMEM if no empty slot left in list
+ * @retval  -EINVAL if `addr_len > CONFIG_L2FILTER_ADDR_MAXLEN` **AND** `NDEBUG` is enabled.
+ *          Otherwise this condition will trip an `assert()`.
  */
 int l2filter_add(l2filter_t *list, const void *addr, size_t addr_len);
 

--- a/sys/net/link_layer/l2filter/l2filter.c
+++ b/sys/net/link_layer/l2filter/l2filter.c
@@ -44,7 +44,11 @@ void l2filter_init(l2filter_t *list)
 
 int l2filter_add(l2filter_t *list, const void *addr, size_t addr_len)
 {
-    assert(list && addr && (addr_len <= CONFIG_L2FILTER_ADDR_MAXLEN));
+    assert(list && addr);
+    if (addr_len > CONFIG_L2FILTER_ADDR_MAXLEN) {
+        assert(0);
+        return -EINVAL;
+    }
 
     int res = -ENOMEM;
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hey 🐫,

this fixes a ineffective length check.

It is very unlikely to be exploitable in the wild. It is an internal, developer oriented API that usually will not be used in an untrustworthy context.

### Testing procedure

CI + Build will be sufficient.

### Issues/PRs references

 GHSA-7972-w7f9-3j9m / CVE-2025-53888
