### PR TITLE
makefiles/tools/esptool: force installation of version 4.9.0

### DIFF
--- a/makefiles/tools/esptool.inc.mk
+++ b/makefiles/tools/esptool.inc.mk
@@ -57,7 +57,7 @@ esptool_flash: $(PKGDIRBASE)/esptool/venv_flash/bin/esptool.py
 
 $(PKGDIRBASE)/esptool/venv_flash/bin/esptool.py:
 	python3 -m venv $(PKGDIRBASE)/esptool/venv_flash
-	$(PKGDIRBASE)/esptool/venv_flash/bin/pip install esptool
+	$(PKGDIRBASE)/esptool/venv_flash/bin/pip install esptool==4.9.0
 
 # reset tool configuration
 RESET ?= $(RIOTTOOLS)/esptools/espreset.py


### PR DESCRIPTION
### Contribution description

This PR pins the installation of the `esptool.py` Python package to version 4.9.0 also for flashing.

A couple of days ago, Espressif released version 5.0.0 of `esptool.py` and uploaded the corresponding Python package. While `esptool.py` installation was pinned to version `v4.9.0` for compilation by PR #21588, `esptool.py` version `v5.0.0` is still used for flashing. As a result, `esptools.py` is installed again and again alternating between `v4.9.0` and `v5.0.0`. 

This PR fixes this problem.

### Testing procedure

Try to compile an flash any application for any ESP32 board, for example:
```
BOARD=esp32-wroom-32 make -C tests/sys/shell flash
```
Without the PR, `epstool.py` is installed again and again and the `flash` target throws a number of deprecation warnings. With the PR `esptool.py` is installed only once, the first time it is needed.

### Issues/PRs references

Fixes PR #21588