### PR TITLE
docs: Migrating mastodon account

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,6 @@ https://www.riot-os.org
 [stackoverflow-badge]: https://img.shields.io/badge/stackoverflow-%5Briot--os%5D-yellow
 [stackoverflow-link]: https://stackoverflow.com/questions/tagged/riot-os
 [mastodon-badge]: https://img.shields.io/badge/social-Mastodon-informational.svg
-[mastodon-link]: https://fosstodon.org/@RIOT_OS
+[mastodon-link]: https://floss.social/@RIOT_OS
 [wiki-badge]: https://img.shields.io/badge/docs-Wiki-informational.svg
 [wiki-link]: https://github.com/RIOT-OS/RIOT/wiki

--- a/doc/doxygen/src/mainpage.md
+++ b/doc/doxygen/src/mainpage.md
@@ -46,7 +46,7 @@ RIOT is developed by an open community that anyone is welcome to join:
  - Contact us on Matrix for live support and discussions:
    [riot-os:matrix.org](https://matrix.to/#/#riot-os:matrix.org)
 
-[mastodon-link]: https://fosstodon.org/@RIOT_OS
+[mastodon-link]: https://floss.social/@RIOT_OS
 
 The quickest start                                        {#the-quickest-start}
 ==================

--- a/doc/guides/index.md
+++ b/doc/guides/index.md
@@ -49,4 +49,4 @@ RIOT is developed by an open community that anyone is welcome to join:
 - Contact us on Matrix for live support and discussions:
   [riot-os:matrix.org](https://matrix.to/#/#riot-os:matrix.org)
 
-[mastodon-link]: https://fosstodon.org/@RIOT_OS
+[mastodon-link]: https://floss.social/@RIOT_OS

--- a/doc/starlight/astro.config.mjs
+++ b/doc/starlight/astro.config.mjs
@@ -17,7 +17,7 @@ export default defineConfig({
         {
           icon: "mastodon",
           label: "Mastodon",
-          href: "https://fosstodon.org/@RIOT_OS",
+          href: "https://floss.social/@RIOT_OS",
         },
         {
           icon: "matrix",


### PR DESCRIPTION
### Contribution description

As discussed in the 2025-06-11 moderation call, we're moving our Mastodon account from fosstodon.org to floss.social.

For those who ere not there, my summary of the rationale is that there have been allegations of problematic moderation on fosstodon.org. None of us is really qualified to understand (or has the resources to read up on) the full situation, but people whose opinion we value have looked into it and were sufficiently unhappy with fosstodon that they defederate it, effectively reducing our reach if we stayed. Fortunately, moving is easy and nondestructive on Mastodon, so we part on good terms, thank fosstodon for hosting us so far, and foss.social for being our new host.

### Testing procedure

We can't really test this before merging: Only after merging, the effect will be that some links that are green (verified) on https://fosstodon.org/@RIOT_OS will turn gray, and instead turn green on https://floss.social/@RIOT_OS/.

### Further steps

* [x] Switch the link in the forum
* [x] Switch the link on the website
* [x] Push the migrate button (I don't want to do that until at least some of the links are green, to avoid that people worry we've been hijacked)