### PR TITLE
cpu/esp32: add BLE support for ESP32-H2

### DIFF
--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -27,6 +27,9 @@ ifneq (,$(filter esp_ble,$(USEMODULE)))
   ifeq (esp32,$(CPU_FAM))
     FEATURES_REQUIRED += esp_ble_esp32
     USEPKG += esp32_sdk_lib_bt_esp32
+  else ifeq (esp32h2,$(CPU_FAM))
+    FEATURES_REQUIRED += esp_ble_esp32h2
+    USEPKG += esp32_sdk_lib_bt_esp32h2
   else ifneq (,$(filter esp32c3 esp32s3,$(CPU_FAM)))
     FEATURES_REQUIRED += esp_ble_esp32c3
     USEPKG += esp32_sdk_lib_bt_esp32c3
@@ -161,9 +164,15 @@ endif
 ifneq (,$(filter nimble,$(USEPKG)))
   USEMODULE += esp_ble
   USEMODULE += esp_ble_nimble
+  USEMODULE += esp_idf_nvs_flash
   USEMODULE += nimble_host
   USEMODULE += nimble_transport_hci_h4
   USEMODULE += ztimer_msec
+  ifeq (esp32h2,$(CPU_FAM))
+    # TODO for the moment, we use tinycrypt for encryption
+    # USEPKG += esp32_sdk_mbedtls
+    USEPKG += esp32_sdk_lib_coexist
+  endif
 endif
 
 ifneq (,$(filter periph_adc,$(USEMODULE)))

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -24,15 +24,10 @@ ifneq (,$(filter esp_ble,$(USEMODULE)))
   USEMODULE += esp_idf_nvs_flash
   USEMODULE += esp_idf_phy
   USEPKG += esp32_sdk_lib_phy
-  ifeq (esp32,$(CPU_FAM))
-    FEATURES_REQUIRED += esp_ble_esp32
-    USEPKG += esp32_sdk_lib_bt_esp32
-  else ifeq (esp32h2,$(CPU_FAM))
-    FEATURES_REQUIRED += esp_ble_esp32h2
-    USEPKG += esp32_sdk_lib_bt_esp32h2
-  else ifneq (,$(filter esp32c3 esp32s3,$(CPU_FAM)))
-    FEATURES_REQUIRED += esp_ble_esp32c3
+  ifeq (esp32s3,$(CPU_FAM))
     USEPKG += esp32_sdk_lib_bt_esp32c3
+  else
+    USEPKG += esp32_sdk_lib_bt_$(CPU_FAM)
   endif
 endif
 

--- a/cpu/esp32/Makefile.features
+++ b/cpu/esp32/Makefile.features
@@ -49,16 +49,10 @@ ifneq (,$(filter esp32 esp32c3 esp32h2 esp32s3,$(CPU_FAM)))
   FEATURES_PROVIDED += ble_nimble
   FEATURES_PROVIDED += ble_nimble_netif
   FEATURES_PROVIDED += esp_ble
-endif
-
-ifeq (esp32,$(CPU_FAM))
-  FEATURES_PROVIDED += esp_ble_esp32
-else ifeq (esp32h2,$(CPU_FAM))
-  FEATURES_PROVIDED += esp_ble_esp32h2
-else ifneq (,$(filter esp32c3 esp32s3,$(CPU_FAM)))
-  FEATURES_PROVIDED += ble_adv_ext
-  FEATURES_PROVIDED += ble_phy_2mbit
-  FEATURES_PROVIDED += esp_ble_esp32c3
+  ifneq (esp32,$(CPU_FAM))
+    FEATURES_PROVIDED += ble_adv_ext
+    FEATURES_PROVIDED += ble_phy_2mbit
+  endif
 endif
 
 ifneq (,$(filter esp32 esp32s3,$(CPU_FAM)))

--- a/cpu/esp32/Makefile.features
+++ b/cpu/esp32/Makefile.features
@@ -45,17 +45,19 @@ ifneq (esp32h2,$(CPU_FAM))
   FEATURES_PROVIDED += esp_wifi_enterprise
 endif
 
-ifeq (esp32,$(CPU_FAM))
+ifneq (,$(filter esp32 esp32c3 esp32h2 esp32s3,$(CPU_FAM)))
   FEATURES_PROVIDED += ble_nimble
   FEATURES_PROVIDED += ble_nimble_netif
   FEATURES_PROVIDED += esp_ble
+endif
+
+ifeq (esp32,$(CPU_FAM))
   FEATURES_PROVIDED += esp_ble_esp32
+else ifeq (esp32h2,$(CPU_FAM))
+  FEATURES_PROVIDED += esp_ble_esp32h2
 else ifneq (,$(filter esp32c3 esp32s3,$(CPU_FAM)))
   FEATURES_PROVIDED += ble_adv_ext
-  FEATURES_PROVIDED += ble_nimble
-  FEATURES_PROVIDED += ble_nimble_netif
   FEATURES_PROVIDED += ble_phy_2mbit
-  FEATURES_PROVIDED += esp_ble
   FEATURES_PROVIDED += esp_ble_esp32c3
 endif
 

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -184,6 +184,9 @@ ifneq (,$(filter esp_ble,$(USEMODULE)))
     INCLUDES += -I$(ESP32_SDK_DIR)/components/bt/include/esp32c3/include
   endif
   ifeq (esp32h2,$(CPU_FAM))
+    CFLAGS += -Ddefault_RNG_defined=0
+    CFLAGS += -DNIMBLE_OS_MSYS_INIT_IN_CONTROLLER=1
+    CFLAGS += -DNIMBLE_G_MSYS_POOL_LIST_IN_CONTROLLER=1
     INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/port/$(CPU_FAM)/private_include
   endif
 endif
@@ -211,6 +214,7 @@ endif
 
 ifneq (,$(filter esp_idf_nvs_flash,$(USEMODULE)))
   INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_partition/include
+  INCLUDES += -I$(ESP32_SDK_DIR)/components/nvs_flash/include
   CFLAGS += -DMBEDTLS_CIPHER_MODE_XTS
 endif
 
@@ -401,12 +405,18 @@ endif
 # Libraries needed when using esp_ble
 ifneq (,$(filter esp_ble,$(USEMODULE)))
   LINKFLAGS += -L$(ESP32_SDK_LIB_PHY_DIR)/$(CPU_FAM)
-  LINKFLAGS += -L$(ESP32_SDK_LIB_BT_DIR)/$(CPU_FAM)
-  ARCHIVES += -lbtdm_app
   ARCHIVES += -lphy -lstdc++
+  ifneq (,$(filter esp32 esp32c3 esp32s3,$(CPU_FAM)))
+    LINKFLAGS += -L$(ESP32_SDK_LIB_BT_DIR)/$(CPU_FAM)
+    ARCHIVES += -lbtdm_app
+  else ifeq (esp32h2,$(CPU_FAM))
+    LINKFLAGS += -L$(ESP32_SDK_LIB_COEXIST_DIR)/$(CPU_FAM)
+    LINKFLAGS += -L$(ESP32_SDK_LIB_BT_DIR)
+    ARCHIVES += -lble_app -lcoexist
+  endif
   ifeq (esp32,$(CPU_FAM))
     ARCHIVES += -lrtc
-  else ifneq (,$(filter esp32c3 esp32s3,$(CPU_FAM)))
+  else ifneq (,$(filter esp32c3 esp32h2 esp32s3,$(CPU_FAM)))
     ARCHIVES += -lbtbb
   endif
 endif

--- a/cpu/esp32/esp-ble-nimble/esp_ble_nimble.c
+++ b/cpu/esp32/esp-ble-nimble/esp_ble_nimble.c
@@ -22,13 +22,15 @@
 #include "log.h"
 #include "esp_bt.h"
 #include "mutex.h"
+#include "nimble_riot.h"
 #include "od.h"
 
 #include "host/ble_hs.h"
 #include "nimble/hci_common.h"
-#include "nimble/nimble_port.h"
 #include "nimble/transport/hci_h4.h"
 #include "sysinit/sysinit.h"
+
+#include "nvs_flash.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -45,6 +47,23 @@
 
 #define BLE_VHCI_TIMEOUT_MS             2000
 
+#if CPU_FAM_ESP32 || CPU_FAM_ESP32S3 || CPU_FAM_ESP32C3
+/* On ESP32, ESP32-S3 and ESP32-C3, the BT Controller calls the
+ * notify_host_send_available callback function when it becomes ready to
+ * receive commands from the host. It can be used to unlock a mutex that
+ * is used to synchronize the access to the BT Controller by different
+ * threads. */
+#  define BT_CTRL_SUPPORTS_READY_CB         1
+#elif CPU_FAM_ESP32C2 || CPU_FAM_ESP32C6 || CPU_FAM_ESP32H2
+/* On other ESP32x variants like ESP32-C2, ESP32-C6 and ESP32-H2,
+ * this callback function is not used and we have to use another mechanism. */
+#  define BT_CTRL_SUPPORTS_READY_CB         0
+#  define BT_CTRL_WAIT_READY_CYCLES         10
+#  define BT_CTRL_WAIT_READY_INTERVALL_MS   10
+#else
+#  error "Platform implementation is missing"
+#endif
+
 /* Definition of UART H4 packet types */
 enum {
     BLE_HCI_UART_H4_NONE = 0x00,
@@ -56,19 +75,30 @@ enum {
 
 static const char *LOG_TAG = "esp_nimble";
 
+#if BT_CTRL_SUPPORTS_READY_CB
 static mutex_t _esp_vhci_semaphore = MUTEX_INIT;
+#endif
 
 static struct hci_h4_sm _esp_h4sm;
 
 static void _ble_vhci_controller_ready_cb(void)
 {
+    DEBUG("%s\n", __func__);
+
+#if BT_CTRL_SUPPORTS_READY_CB
     mutex_unlock(&_esp_vhci_semaphore);
+#endif
 }
 
 static int _ble_vhci_packet_received_cb(uint8_t *data, uint16_t len)
 {
+    DEBUG("%s: data=%p len=%u\n", __func__, data, len);
+
     /* process the HCI H4 formatted packet and call ble_transport_to_hs_* */
-    len = hci_h4_sm_rx(&_esp_h4sm, data, len);
+    if (nimble_port_initialized) {
+        len = hci_h4_sm_rx(&_esp_h4sm, data, len);
+    }
+
     return 0;
 }
 
@@ -81,6 +111,9 @@ static inline int _ble_transport_to_ll(uint8_t *packet, uint16_t len)
 {
     uint8_t rc = 0;
 
+    DEBUG("%s: controller status=%d\n", __func__, esp_bt_controller_get_status());
+
+#if BT_CTRL_SUPPORTS_READY_CB
     /* check whether the controller is ready to accept packets */
     if (!esp_vhci_host_check_send_available()) {
         LOG_TAG_DEBUG(LOG_TAG, "Controller not ready to accept packets");
@@ -94,6 +127,23 @@ static inline int _ble_transport_to_ll(uint8_t *packet, uint16_t len)
     else {
         rc = BLE_HS_ETIMEOUT_HCI;
     }
+#else
+    unsigned i = 0;
+    for (; i < BT_CTRL_WAIT_READY_CYCLES; i++) {
+        if (esp_vhci_host_check_send_available()) {
+            break;
+        }
+        ztimer_sleep(ZTIMER_MSEC, BT_CTRL_WAIT_READY_INTERVALL_MS);
+    }
+    if (i < BT_CTRL_WAIT_READY_CYCLES) {
+        esp_vhci_host_send_packet(packet, len);
+    }
+    else {
+        LOG_TAG_DEBUG(LOG_TAG, "Controller not ready to accept packets");
+        rc = BLE_HS_ETIMEOUT_HCI;
+    }
+#endif
+
     return rc;
 }
 
@@ -113,8 +163,8 @@ int ble_transport_to_ll_cmd_impl(void *buf)
     packet[0] = BLE_HCI_UART_H4_CMD;         /* first byte is the packet indicator */
     memcpy(packet + 1, cmd, len - 1);
 
+    DEBUG("%s: CMD host to ctrl\n", __func__);
     if (ENABLE_DEBUG && IS_USED(MODULE_OD)) {
-        printf("CMD host to ctrl:\n");
         od_hex_dump(packet + 1, len - 1, OD_WIDTH_DEFAULT);
     }
 
@@ -147,8 +197,8 @@ int ble_transport_to_ll_acl_impl(struct os_mbuf *om)
     packet[0] = BLE_HCI_UART_H4_ACL;
     len++;
 
+    DEBUG("%s: ACL host to ctrl\n", __func__);
     if (ENABLE_DEBUG && IS_USED(MODULE_OD)) {
-        printf("ACL host to ctrl:\n");
         od_hex_dump(packet + 1,
                     (om->om_len < 32) ? om->om_len : 32, OD_WIDTH_DEFAULT);
     }
@@ -169,17 +219,19 @@ static int _esp_hci_h4_frame_cb(uint8_t pkt_type, void *data)
 {
     int rc = 0;
 
+    DEBUG("%s: pkt_type=%d data=%p\n", __func__, pkt_type, data);
+
     switch (pkt_type) {
     case HCI_H4_ACL:
+        DEBUG("%s: ACL ctrl to host\n", __func__);
         if (ENABLE_DEBUG && IS_USED(MODULE_OD)) {
-            printf("ACL ctrl to host:\n");
             od_hex_dump((uint8_t *)data, 4, OD_WIDTH_DEFAULT);
         }
         rc = ble_transport_to_hs_acl(data);
         break;
     case HCI_H4_EVT:
+        DEBUG("%s: EVT ctrl to host\n", __func__);
         if (ENABLE_DEBUG && IS_USED(MODULE_OD)) {
-            printf("EVT ctrl to host:\n");
             od_hex_dump((uint8_t *)data, ((uint8_t *)data)[1] + 2, OD_WIDTH_DEFAULT);
         }
         rc = ble_transport_to_hs_evt(data);
@@ -197,6 +249,12 @@ void esp_ble_nimble_init(void)
     esp_err_t ret;
     esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
 
+    if (IS_ACTIVE(CONFIG_ESP_WIFI_NVS_ENABLED) && !IS_USED(MODULE_ESP_WIFI_ANY)) {
+        if (nvs_flash_init() != ESP_OK) {
+            LOG_ERROR("nfs_flash_init failed\n");
+        }
+    }
+
     /* TODO: BLE mode only used, the memory for BT Classic could be released
     if ((ret = esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);) != ESP_OK) {
         LOG_TAG_ERROR(LOG_TAG,
@@ -206,16 +264,22 @@ void esp_ble_nimble_init(void)
     }
     */
 
+    DEBUG("%s: ctrl status=%d\n", __func__, esp_bt_controller_get_status());
+
     /* init and enable the Bluetooth LE controller */
     if ((ret = esp_bt_controller_init(&bt_cfg)) != ESP_OK) {
         LOG_TAG_ERROR(LOG_TAG, "Bluetooth controller initialize failed: %d", ret);
         assert(0);
     }
 
+    DEBUG("%s: ctrl status=%d\n", __func__, esp_bt_controller_get_status());
+
     if ((ret = esp_bt_controller_enable(ESP_BT_MODE_BLE)) != ESP_OK) {
         LOG_TAG_ERROR(LOG_TAG, "Bluetooth controller enable failed: %d", ret);
         assert(0);
     }
+
+    DEBUG("%s: ctrl status=%d\n", __func__, esp_bt_controller_get_status());
 
     /* register callbacks from Bluetooth LE controller */
     if ((ret = esp_vhci_host_register_callback(&vhci_host_cb)) != ESP_OK) {

--- a/cpu/esp32/esp-idf/ble/Makefile
+++ b/cpu/esp32/esp-idf/ble/Makefile
@@ -1,13 +1,28 @@
 MODULE = esp_idf_ble
 
 ifeq (esp32,$(CPU_FAM))
-  # source files to be compiled for this module
+  # source files to be compiled for this module for ESP32
   ESP32_SDK_SRC += components/bt/controller/$(CPU_FAM)/bt.c
   ESP32_SDK_SRC += components/esp_system/esp_system.c
+else ifeq (esp32h2,$(CPU_FAM))
+  # source files to be compiled for this module for ESP32H2
+  ESP32_SDK_SRC += components/bt/controller/$(CPU_FAM)/bt.c
+  ESP32_SDK_SRC += components/bt/porting/mem/bt_osi_mem.c
+  ESP32_SDK_SRC += components/bt/porting/mem/os_msys_init.c
+  ESP32_SDK_SRC += components/bt/porting/npl/freertos/src/npl_os_freertos.c
+  ESP32_SDK_SRC += components/bt/porting/transport/driver/vhci/hci_driver_standard.c
+  ESP32_SDK_SRC += components/bt/porting/transport/src/hci_transport.c
 else ifneq (,$(filter esp32s3 esp32c3,$(CPU_FAM)))
-  # source files to be compiled for this module
+  # source files to be compiled for this module for ESP32C3 and ESP32S3
   ESP32_SDK_SRC += components/bt/controller/esp32c3/bt.c
   ESP32_SDK_SRC += components/esp_system/esp_system.c
+endif
+
+ifeq (esp32h2,$(CPU_FAM))
+  # ESP-IDF npl includes have to be found before the includes of pkg/nimble
+  INCLUDES := -I$(ESP32_SDK_DIR)/components/bt/porting/npl/freertos/include $(INCLUDES)
+  INCLUDES += -I$(ESP32_SDK_DIR)/components/bt/porting/transport/include
+  INCLUDES += -I$(ESP32_SDK_DIR)/components/bt/porting/include
 endif
 
 INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_coex/include

--- a/cpu/esp32/include/irq_arch.h
+++ b/cpu/esp32/include/irq_arch.h
@@ -49,6 +49,7 @@ extern "C" {
 #endif
 #define CPU_INUM_GPIO            2  /**< Level interrupt with low priority 1 */
 #define CPU_INUM_BLE             5  /**< Level interrupt with low priority 1 */
+#define CPU_INUM_BT_MAC          8  /**< Level interrupt with low priority 1 */
 #define CPU_INUM_RTT             9  /**< Level interrupt with low priority 1 */
 #define CPU_INUM_SERIAL_JTAG    10  /**< Edge  interrupt with low priority 1 */
 #define CPU_INUM_I2C            12  /**< Level interrupt with low priority 1 */

--- a/cpu/esp_common/freertos/queue.c
+++ b/cpu/esp_common/freertos/queue.c
@@ -564,8 +564,10 @@ BaseType_t IRAM_ATTR xQueueReceiveFromISR (QueueHandle_t xQueue,
                                0, pxHigherPriorityTaskWoken);
 }
 
-UBaseType_t uxQueueMessagesWaiting( QueueHandle_t xQueue )
+UBaseType_t uxQueueMessagesWaiting(QueueHandle_t xQueue)
 {
+    DEBUG("%s queue=%p isr=%d\n", __func__, xQueue, irq_is_in());
+
     assert(xQueue != NULL);
 
     _queue_t* queue = (_queue_t*)xQueue;
@@ -581,6 +583,23 @@ BaseType_t xQueueGiveFromISR (QueueHandle_t xQueue,
 
     return _queue_generic_send(xQueue, NULL, queueSEND_TO_BACK,
                                0, pxHigherPriorityTaskWoken);
+}
+
+UBaseType_t uxQueueMessagesWaitingFromISR(const QueueHandle_t xQueue)
+{
+    return uxQueueMessagesWaiting(xQueue);
+}
+
+BaseType_t xQueueIsQueueEmpty(const QueueHandle_t xQueue)
+{
+    DEBUG("%s queue=%p isr=%d\n", __func__, xQueue, irq_is_in());
+    return uxQueueMessagesWaitingFromISR(xQueue) == 0;
+}
+
+BaseType_t xQueueIsQueueEmptyFromISR(const QueueHandle_t xQueue)
+{
+    DEBUG("%s queue=%p\n", __func__, xQueue);
+    return xQueueIsQueueEmpty(xQueue);
 }
 
 #endif /* DOXYGEN */

--- a/cpu/esp_common/freertos/task.c
+++ b/cpu/esp_common/freertos/task.c
@@ -148,12 +148,15 @@ void vTaskSuspend(TaskHandle_t xTaskToSuspend)
     }
 }
 
+static bool _suspend_all = false;
+
 void vTaskSuspendAll(void)
 {
     /* TODO:
      * It has to be implemented once there is a mechanism in RIOT to suspend
      * the scheduler without disabling interrupts. At the moment it is a
      * placeholder to make the linker happy. */
+    _suspend_all = true;
 }
 
 void vTaskResume(TaskHandle_t xTaskToResume)
@@ -169,8 +172,21 @@ void vTaskResume(TaskHandle_t xTaskToResume)
 BaseType_t xTaskResumeAll(void)
 {
     /* TODO */
+    _suspend_all = false;
     return pdFALSE;
 }
+
+BaseType_t xTaskGetSchedulerState(void)
+{
+    if (thread_get_active() == KERNEL_PID_UNDEF) {
+        return taskSCHEDULER_NOT_STARTED;
+    }
+    else if (_suspend_all) {
+        return taskSCHEDULER_SUSPENDED;
+    }
+
+    return taskSCHEDULER_RUNNING;
+};
 
 void vTaskDelay(const TickType_t xTicksToDelay)
 {

--- a/cpu/esp_common/include/freertos/FreeRTOS.h
+++ b/cpu/esp_common/include/freertos/FreeRTOS.h
@@ -45,6 +45,8 @@ extern "C" {
 
 #define xSemaphoreHandle        SemaphoreHandle_t
 
+typedef void (* TaskFunction_t)( void * );
+
 uint32_t xPortGetTickRateHz(void);
 BaseType_t xPortInIsrContext(void);
 

--- a/cpu/esp_common/include/freertos/queue.h
+++ b/cpu/esp_common/include/freertos/queue.h
@@ -145,6 +145,10 @@ UBaseType_t uxQueueMessagesWaiting( QueueHandle_t xQueue );
         xQueueGenericSend( ( xQueue ), ( pvItemToQueue ), ( xTicksToWait ), \
                            queueSEND_TO_BACK )
 
+#define xQueueSendToFront( xQueue, pvItemToQueue, xTicksToWait ) \
+        xQueueGenericSend( ( xQueue ), ( pvItemToQueue ), ( xTicksToWait ), \
+                           queueSEND_TO_FRONT )
+
 #define xQueueSendFromISR( xQueue, pvItemToQueue, pxHigherPriorityTaskWoken ) \
         xQueueGenericSendFromISR( ( xQueue ), ( pvItemToQueue ), \
                                   ( pxHigherPriorityTaskWoken ), \
@@ -154,6 +158,11 @@ UBaseType_t uxQueueMessagesWaiting( QueueHandle_t xQueue );
         xQueueGenericSendFromISR( ( xQueue ), ( pvItemToQueue ), \
                                   ( pxHigherPriorityTaskWoken ), \
                                   queueSEND_TO_BACK )
+
+#define xQueueSendToFrontFromISR( xQueue, pvItemToQueue, pxHigherPriorityTaskWoken ) \
+        xQueueGenericSendFromISR( ( xQueue ), ( pvItemToQueue ), \
+                                  ( pxHigherPriorityTaskWoken ), \
+                                  queueSEND_TO_FRONT )
 
 #define xQueueOverwriteFromISR( xQueue, pvItemToQueue, pxHigherPriorityTaskWoken ) \
         xQueueGenericSendFromISR( ( xQueue ), ( pvItemToQueue ), \

--- a/cpu/esp_common/include/freertos/semphr.h
+++ b/cpu/esp_common/include/freertos/semphr.h
@@ -79,6 +79,9 @@ void vPortCPUReleaseMutex (portMUX_TYPE *mux);
         xQueueCreateCountingSemaphoreStatic( ( uxMaxCount ), ( uxInitialCount ), \
                                              ( pxSemaphoreBuffer ) )
 
+#define uxSemaphoreGetCount( xSemaphore ) \
+        uxQueueMessagesWaiting( ( QueueHandle_t ) ( xSemaphore ) )
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/esp_common/include/freertos/task.h
+++ b/cpu/esp_common/include/freertos/task.h
@@ -30,6 +30,7 @@ extern "C" {
 #define taskENTER_CRITICAL          portENTER_CRITICAL
 #define taskEXIT_CRITICAL           portEXIT_CRITICAL
 
+#define taskSCHEDULER_SUSPENDED     0
 #define taskSCHEDULER_NOT_STARTED   1
 #define taskSCHEDULER_RUNNING       2
 

--- a/features.yaml
+++ b/features.yaml
@@ -152,14 +152,6 @@ groups:
         help: ESP WiFi SoftAP support is present.
       - name: esp_wifi_enterprise
         help: The ESP WiFi interface supports WPA2 enterprise mode.
-      - name: esp_ble_esp32
-        help: The ESP32x SoC uses the SDK Bluetooth LE library for the ESP32
-              variant.
-      - name: esp_ble_esp32c3
-        help: The ESP32x SoC uses the SDK Bluetooth LE library for the ESP32-C3 or
-              ESP32-S3 variant.
-      - name: esp_ble_esp32h2
-        help: The ESP32x SoC uses the SDK Bluetooth LE library for the ESP32-H2 variant.
       - name: esp_hw_counter
         help: The used ESP32x SoC supports HW counters that can be used as timers.
       - name: esp_ieee802154
@@ -177,7 +169,7 @@ groups:
               case additional GPIOs are used for the SPI interface and cannot be
               used for other purposes.
       - name: esp_ble
-        help: An ESP32 Bluetooth LE transceiver is present.
+        help: An ESP32x Bluetooth LE transceiver is present.
     - title: nordic nRF Specific Features
       features:
       - name: radio_nrf802154

--- a/features.yaml
+++ b/features.yaml
@@ -158,6 +158,8 @@ groups:
       - name: esp_ble_esp32c3
         help: The ESP32x SoC uses the SDK Bluetooth LE library for the ESP32-C3 or
               ESP32-S3 variant.
+      - name: esp_ble_esp32h2
+        help: The ESP32x SoC uses the SDK Bluetooth LE library for the ESP32-H2 variant.
       - name: esp_hw_counter
         help: The used ESP32x SoC supports HW counters that can be used as timers.
       - name: esp_ieee802154

--- a/makefiles/features_existing.inc.mk
+++ b/makefiles/features_existing.inc.mk
@@ -116,6 +116,7 @@ FEATURES_EXISTING := \
     esp_ble \
     esp_ble_esp32 \
     esp_ble_esp32c3 \
+    esp_ble_esp32h2 \
     esp_hw_counter \
     esp_ieee802154 \
     esp_jtag \

--- a/makefiles/features_existing.inc.mk
+++ b/makefiles/features_existing.inc.mk
@@ -114,9 +114,6 @@ FEATURES_EXISTING := \
     efm32_coretemp \
     emulator_renode \
     esp_ble \
-    esp_ble_esp32 \
-    esp_ble_esp32c3 \
-    esp_ble_esp32h2 \
     esp_hw_counter \
     esp_ieee802154 \
     esp_jtag \

--- a/pkg/esp32_sdk/patches/0035-bt-controller-fix-include-path-for-esp32h2.patch
+++ b/pkg/esp32_sdk/patches/0035-bt-controller-fix-include-path-for-esp32h2.patch
@@ -1,0 +1,25 @@
+From 1357b5b40f12686aa0265df131c43c9a87bb8897 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Sun, 30 Mar 2025 13:07:34 +0200
+Subject: [PATCH 35/35] bt/controller: fix include path for esp32h2
+
+---
+ components/bt/include/esp32h2/include/esp_bt.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/components/bt/include/esp32h2/include/esp_bt.h b/components/bt/include/esp32h2/include/esp_bt.h
+index c21a1bc854..ff047aace5 100644
+--- a/components/bt/include/esp32h2/include/esp_bt.h
++++ b/components/bt/include/esp32h2/include/esp_bt.h
+@@ -14,7 +14,7 @@
+ #include "esp_task.h"
+ 
+ #include "nimble/nimble_npl.h"
+-#include "../../../../controller/esp32h2/esp_bt_cfg.h"
++#include "../../../controller/esp32h2/esp_bt_cfg.h"
+ #include "esp_private/esp_modem_clock.h"
+ 
+ #ifdef CONFIG_BT_LE_HCI_INTERFACE_USE_UART
+-- 
+2.34.1
+

--- a/pkg/esp32_sdk/patches/0036-bt-porting-npl_os_freertos-fix-missing-include.patch
+++ b/pkg/esp32_sdk/patches/0036-bt-porting-npl_os_freertos-fix-missing-include.patch
@@ -1,0 +1,24 @@
+From 9df2d320e918e2e39fcb3b47fca67301804f8a9b Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Thu, 17 Apr 2025 14:19:11 +0200
+Subject: [PATCH 36/36] bt/porting/npl_os_freertos: fix missing include
+
+---
+ components/bt/porting/npl/freertos/src/npl_os_freertos.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/components/bt/porting/npl/freertos/src/npl_os_freertos.c b/components/bt/porting/npl/freertos/src/npl_os_freertos.c
+index 9e5c9863c3..f7552ee4e1 100644
+--- a/components/bt/porting/npl/freertos/src/npl_os_freertos.c
++++ b/components/bt/porting/npl/freertos/src/npl_os_freertos.c
+@@ -19,6 +19,7 @@
+ 
+ #include "os/os_mempool.h"
+ #include "esp_log.h"
++#include "esp_idf_version.h"
+ #include "soc/soc_caps.h"
+ #include "esp_bt.h"
+ #include "bt_osi_mem.h"
+-- 
+2.34.1
+

--- a/pkg/esp32_sdk_lib_bt_esp32/Makefile.dep
+++ b/pkg/esp32_sdk_lib_bt_esp32/Makefile.dep
@@ -1,4 +1,3 @@
 # This package can only be used with the ESP32 CPU
 FEATURES_REQUIRED += arch_esp32
 FEATURES_REQUIRED += esp_ble
-FEATURES_REQUIRED += esp_ble_esp32

--- a/pkg/esp32_sdk_lib_bt_esp32c3/Makefile.dep
+++ b/pkg/esp32_sdk_lib_bt_esp32c3/Makefile.dep
@@ -1,4 +1,3 @@
 # This package can only be used with the ESP32 CPU
 FEATURES_REQUIRED += arch_esp32
 FEATURES_REQUIRED += esp_ble
-FEATURES_REQUIRED += esp_ble_esp32c3

--- a/pkg/esp32_sdk_lib_bt_esp32h2/Makefile
+++ b/pkg/esp32_sdk_lib_bt_esp32h2/Makefile
@@ -1,0 +1,10 @@
+PKG_NAME=esp32_sdk_lib_bt_esp32h2
+PKG_URL=https://github.com/espressif/esp32h2-bt-lib
+# This is a version in the v5.4 release branch
+PKG_VERSION=59c26f308e18809cc02351febcbecad542a365c9
+PKG_LICENSE=Apache-2.0
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+# there is nothing to compile
+all:

--- a/pkg/esp32_sdk_lib_bt_esp32h2/Makefile.dep
+++ b/pkg/esp32_sdk_lib_bt_esp32h2/Makefile.dep
@@ -1,0 +1,4 @@
+# This package can only be used with the ESP32 CPU
+FEATURES_REQUIRED += arch_esp32
+FEATURES_REQUIRED += esp_ble
+FEATURES_REQUIRED += esp_ble_esp32h2

--- a/pkg/esp32_sdk_lib_bt_esp32h2/Makefile.dep
+++ b/pkg/esp32_sdk_lib_bt_esp32h2/Makefile.dep
@@ -1,4 +1,3 @@
 # This package can only be used with the ESP32 CPU
 FEATURES_REQUIRED += arch_esp32
 FEATURES_REQUIRED += esp_ble
-FEATURES_REQUIRED += esp_ble_esp32h2

--- a/pkg/esp32_sdk_lib_bt_esp32h2/Makefile.include
+++ b/pkg/esp32_sdk_lib_bt_esp32h2/Makefile.include
@@ -1,0 +1,3 @@
+export ESP32_SDK_LIB_BT_DIR ?= $(PKGDIRBASE)/esp32_sdk_lib_bt_esp32h2
+
+PSEUDOMODULES += esp32_sdk_lib_bt_esp32h2

--- a/pkg/esp32_sdk_lib_bt_esp32h2/doc.md
+++ b/pkg/esp32_sdk_lib_bt_esp32h2/doc.md
@@ -1,0 +1,4 @@
+@defgroup pkg_esp32_sdk_lib_bt_esp32h2  ESP32 SDK Bluetooth library for the ESP32-H2 SoC
+@ingroup  pkg_esp32_sdk
+@brief    Vendor SDK Bluetooth library for ESP32-H2 SoC by Espressif
+@see      https://github.com/espressif/esp32h2-bt-lib

--- a/pkg/nimble/contrib/include/nimble_riot.h
+++ b/pkg/nimble/contrib/include/nimble_riot.h
@@ -22,6 +22,7 @@
 #ifndef NIMBLE_RIOT_H
 #define NIMBLE_RIOT_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include "kernel_defines.h"
 
@@ -60,8 +61,6 @@ extern "C" {
 #endif
 #endif
 
-
-
 /**
  * @brief   Stacksize used for NimBLE's host thread
  */
@@ -87,6 +86,21 @@ typedef enum {
  * @brief   Export our own address type for later usage
  */
 extern uint8_t nimble_riot_own_addr_type;
+
+/**
+ * @brief   Indicates whether Setup NimBLE's controller has been initialized
+ *
+ * `nimble_port_initialized` is false by default and is set to true as soon as
+ * `nimble_port_init` has been called by nimble_riot_init, i.e. that the NimBLE
+ * stack has been initialized.
+ *
+ * The variable can be used to decide whether events from the low-level
+ * BLE controller driver should be forwarded to the NimBLE stack. It is
+ * necessary to avoid crashes in the case that the higher-prioritized thread
+ * of the low-level BLE controller driver starts sending events to the host
+ * before the NimBLE stack has been initialized by the lower-prioritized
+ * host thread. */
+extern bool nimble_port_initialized;
 
 /**
  * @brief   Setup and run NimBLE's controller and host threads

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -70,11 +70,14 @@ static char _stack_host[NIMBLE_HOST_STACKSIZE];
 
 uint8_t nimble_riot_own_addr_type;
 
+bool nimble_port_initialized = false;
+
 static void *_host_thread(void *arg)
 {
     (void)arg;
 
     nimble_port_init();
+    nimble_port_initialized = true;
 
 #ifdef MODULE_NIMBLE_CONTROLLER
     /* XXX: NimBLE needs the nRF5x's LF clock to run */

--- a/pkg/nimble/patches/0002-porting-nimble-os_mbuf-conditional-definition-of-g_m.patch
+++ b/pkg/nimble/patches/0002-porting-nimble-os_mbuf-conditional-definition-of-g_m.patch
@@ -19,7 +19,7 @@ index cebdb29f..0b09e978 100644
  
 +/* If `g_msys_pool_list` is defined in the low-level BLE Controller driver,
 + * which is the case for the ESP32-H2, for example, `g_msys_pool_list` must
-+ * be declared extern here instead of definint it. */
++ * be declared extern here instead of defining it. */
 +#if NIMBLE_G_MSYS_POOL_LIST_IN_CONTROLLER
 +extern STAILQ_HEAD(, os_mbuf_pool) g_msys_pool_list;
 +#else

--- a/pkg/nimble/patches/0002-porting-nimble-os_mbuf-conditional-definition-of-g_m.patch
+++ b/pkg/nimble/patches/0002-porting-nimble-os_mbuf-conditional-definition-of-g_m.patch
@@ -1,0 +1,42 @@
+From 50faaa367abe07c63f2071fade997c8a2f2bbde2 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Mon, 7 Apr 2025 18:35:59 +0200
+Subject: [PATCH 2/4] porting/nimble/os_mbuf: conditional definition of
+ g_msys_pool_list
+
+BLE library for ESP32x defines its own g_msys_pool_list in binary libraries. To avoid multiple definitions, the definition of g_msys_pool_list is conditional here.
+---
+ porting/nimble/src/os_mbuf.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/porting/nimble/src/os_mbuf.c b/porting/nimble/src/os_mbuf.c
+index cebdb29f..0b09e978 100644
+--- a/porting/nimble/src/os_mbuf.c
++++ b/porting/nimble/src/os_mbuf.c
+@@ -48,9 +48,15 @@
+  *   @{
+  */
+ 
++/* If `g_msys_pool_list` is defined in the low-level BLE Controller driver,
++ * which is the case for the ESP32-H2, for example, `g_msys_pool_list` must
++ * be declared extern here instead of definint it. */
++#if NIMBLE_G_MSYS_POOL_LIST_IN_CONTROLLER
++extern STAILQ_HEAD(, os_mbuf_pool) g_msys_pool_list;
++#else
+ STAILQ_HEAD(, os_mbuf_pool) g_msys_pool_list =
+     STAILQ_HEAD_INITIALIZER(g_msys_pool_list);
+-
++#endif
+ 
+ int
+ os_mqueue_init(struct os_mqueue *mq, ble_npl_event_fn *ev_cb, void *arg)
+@@ -1242,4 +1248,4 @@ os_mbuf_pack_chains(struct os_mbuf *m1, struct os_mbuf *m2)
+     }
+ 
+     return m1;
+-}
+\ No newline at end of file
++}
+-- 
+2.34.1
+

--- a/pkg/nimble/patches/0003-porting-nimble-os_msys_init-conditional-compilation.patch
+++ b/pkg/nimble/patches/0003-porting-nimble-os_msys_init-conditional-compilation.patch
@@ -1,0 +1,38 @@
+From dc727e2b086de03b7c456b3d6e24eb0d5049a6cb Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Thu, 17 Apr 2025 14:22:01 +0200
+Subject: [PATCH 3/4] porting/nimble/os_msys_init: conditional compilation
+
+BLE library for ESP32x implements its own version of `os_msys_init`, which is used by the BLE controller implementation for ESP32x and is implicitly called when the BLE controller is enabled.
+---
+ porting/nimble/src/os_msys_init.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/porting/nimble/src/os_msys_init.c b/porting/nimble/src/os_msys_init.c
+index d22ae351..6917d833 100644
+--- a/porting/nimble/src/os_msys_init.c
++++ b/porting/nimble/src/os_msys_init.c
+@@ -17,6 +17,11 @@
+  * under the License.
+  */
+ 
++/* If `os_msys_init` is realized by the low-level BLE Controller driver,
++ * which is the case for the ESP32-H2, for example, this file must not
++ * be compiled. */
++#if !NIMBLE_OS_MSYS_INIT_IN_CONTROLLER
++
+ #include <assert.h>
+ #include "os/os.h"
+ #include "mem/mem.h"
+@@ -153,4 +158,6 @@ os_msys_init(void)
+     rc = os_sanity_check_register(&os_msys_sc);
+     SYSINIT_PANIC_ASSERT(rc == 0);
+ #endif
+-}
+\ No newline at end of file
++}
++
++#endif /* !NIMBLE_OS_MSYS_INIT_IN_CONTROLLER */
+-- 
+2.34.1
+

--- a/pkg/nimble/patches/0004-porting-nimble-nimble_port-call-os_msys_init-conditi.patch
+++ b/pkg/nimble/patches/0004-porting-nimble-nimble_port-call-os_msys_init-conditi.patch
@@ -1,0 +1,28 @@
+From 9c2896697b2fbd3f7aaec87f55bdc20cfea591d5 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Thu, 17 Apr 2025 14:40:51 +0200
+Subject: [PATCH 4/4] porting/nimble/nimble_port: call os_msys_init
+ conditionally
+
+BLE library for ESP32x implements its own version of `os_msys_init`, which is used by the BLE controller implementation for ESP32x and is implicitly called when the BLE controller is enabled.
+---
+ porting/nimble/src/nimble_port.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/porting/nimble/src/nimble_port.c b/porting/nimble/src/nimble_port.c
+index 1bd57f2b..5e180206 100644
+--- a/porting/nimble/src/nimble_port.c
++++ b/porting/nimble/src/nimble_port.c
+@@ -39,7 +39,9 @@ nimble_port_init(void)
+     ble_npl_eventq_init(&g_eventq_dflt);
+     /* Initialize the global memory pool */
+     os_mempool_module_init();
++#if !NIMBLE_OS_MSYS_INIT_IN_CONTROLLER
+     os_msys_init();
++#endif
+     /* Initialize transport */
+     ble_transport_init();
+     /* Initialize the host */
+-- 
+2.34.1
+

--- a/pkg/tinycrypt/patches/0002-ecc_platform_specific-conditional-define_RNG_default.patch
+++ b/pkg/tinycrypt/patches/0002-ecc_platform_specific-conditional-define_RNG_default.patch
@@ -1,0 +1,27 @@
+From daf508e6e9f4bc9bdcfa2f9bda523f17444603af Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Mon, 14 Apr 2025 15:49:37 +0200
+Subject: [PATCH 2/2] ecc_platform_specific: conditional define_RNG_default
+
+To be able to control whether `default_CSPNRG` is used or not during compilation, `define_RNG_default` is defined conditionally.
+---
+ lib/include/tinycrypt/ecc_platform_specific.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/include/tinycrypt/ecc_platform_specific.h b/lib/include/tinycrypt/ecc_platform_specific.h
+index e2c8823..f2385b6 100644
+--- a/lib/include/tinycrypt/ecc_platform_specific.h
++++ b/lib/include/tinycrypt/ecc_platform_specific.h
+@@ -74,7 +74,9 @@
+  * for some platforms, such as Unix and Linux. For other platforms, you may need
+  * to provide another PRNG function.
+ */
++#ifndef default_RNG_defined
+ #define default_RNG_defined 1
++#endif
+ 
+ int default_CSPRNG(uint8_t *dest, unsigned int size);
+ 
+-- 
+2.34.1
+

--- a/tests/build_system/external_board_dirs/esp-ci-boards/esp32h2-ci/Kconfig
+++ b/tests/build_system/external_board_dirs/esp-ci-boards/esp32h2-ci/Kconfig
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
+
+config BOARD
+    default "esp32h2-ci" if BOARD_ESP32H2_CI
+
+config BOARD_ESP32H2_CI
+    bool
+    default y
+    select BOARD_COMMON_ESP32H2
+    select CPU_MODEL_ESP32H2_MINI_1X_H4S
+
+source "$(RIOTBOARD)/common/esp32h2/Kconfig"

--- a/tests/build_system/external_board_dirs/esp-ci-boards/esp32h2-ci/Makefile
+++ b/tests/build_system/external_board_dirs/esp-ci-boards/esp32h2-ci/Makefile
@@ -1,0 +1,6 @@
+# This must be a different name than 'board' as it is implemented by 'esp32h2-devkit'
+MODULE = board_esp32h2-ci
+
+DIRS += $(RIOTBOARD)/esp32h2-devkit
+
+include $(RIOTBASE)/Makefile.base

--- a/tests/build_system/external_board_dirs/esp-ci-boards/esp32h2-ci/Makefile.dep
+++ b/tests/build_system/external_board_dirs/esp-ci-boards/esp32h2-ci/Makefile.dep
@@ -1,0 +1,17 @@
+# This must be a different name than 'board' as it is implemented by 'esp32h2-devkit'
+USEMODULE += board_esp32h2-ci
+
+USEMODULE += esp_idf_heap
+USEMODULE += esp_jtag
+USEMODULE += esp_log_startup
+USEMODULE += esp_log_tagged
+
+ifneq (,$(filter periph_i2c,$(USEMODULE)))
+  USEMODULE += esp_i2c_hw
+endif
+
+ifneq (,$(filter ws281x,$(USEMODULE)))
+  USEMODULE += ws281x_esp32_sw
+endif
+
+include $(RIOTBOARD)/esp32h2-devkit/Makefile.dep

--- a/tests/build_system/external_board_dirs/esp-ci-boards/esp32h2-ci/Makefile.features
+++ b/tests/build_system/external_board_dirs/esp-ci-boards/esp32h2-ci/Makefile.features
@@ -1,0 +1,3 @@
+FEATURES_PROVIDED += esp_rtc_timer_32k
+
+include $(RIOTBOARD)/esp32h2-devkit/Makefile.features

--- a/tests/build_system/external_board_dirs/esp-ci-boards/esp32h2-ci/Makefile.include
+++ b/tests/build_system/external_board_dirs/esp-ci-boards/esp32h2-ci/Makefile.include
@@ -1,0 +1,5 @@
+# We must duplicate the include done by $(RIOTBASE)/Makefile.include
+# to also include the main board header
+INCLUDES += $(addprefix -I,$(wildcard $(RIOTBOARD)/esp32h2-devkit/include))
+
+include $(RIOTBOARD)/esp32h2-devkit/Makefile.include

--- a/tests/periph/i2c/Makefile
+++ b/tests/periph/i2c/Makefile
@@ -11,6 +11,6 @@ USEMODULE += xtimer
 # avoid running Kconfig by default
 SHOULD_RUN_KCONFIG ?=
 
-EXTERNAL_BOARD_DIRS += $(CURDIR)/../external_board_dirs/esp-ci-boards
+EXTERNAL_BOARD_DIRS += $(RIOTBASE)/tests/build_system/external_board_dirs/esp-ci-boards
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

The PR adds the BLE support for the BLE controller used by ESP32-H2 and ESP32-C6.

### Testing procedure

Compile and flash `nimble_scanner` test application:
```python
BOARD=esp32h2-devkit make -C examples/networking/ble/nimble/nimble_scanner flash term`
```

Output should be something like:
```
> scan
Scanning for 1000 ms now ...
Done, results:
[ 0] 1C:AF:4A:0C:1F:19 (public)  [NONCONN_IND] phy:1M-1M "undefined", adv_msg_cnt: 2, adv_int: 459289us, last_rssi: -99
[ 1] FA:BA:BE:32:1A:8C (random)  [IND] phy:1M-1M "undefined", adv_msg_cnt: 8, adv_int: 180487us, last_rssi: -96
[ 2] 00:7C:2D:C3:4D:6D (public)  [NONCONN_IND] phy:1M-1M "undefined", adv_msg_cnt: 7, adv_int: 198098us, last_rssi: -96
[ 3] 44:81:98:59:81:38 (random)  [IND] phy:1M-1M "undefined", adv_msg_cnt: 4, adv_int: 104517us, last_rssi: -80
[ 4] 08:EF:3B:6A:EA:91 (public)  [SCAN_IND] phy:1M-1M "undefined", adv_msg_cnt: 9, adv_int: 139569us, last_rssi: -92
[ 5] E2:BB:9E:17:80:10 (public)  [IND] phy:1M-1M "undefined", adv_msg_cnt: 8, adv_int: 156562us, last_rssi: -92
```

### Issues/PRs references
