### PR TITLE
gnrc, nimble/ble: notify network layer of BLE connection events

### DIFF
--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -331,6 +331,24 @@ end:
     ble_l2cap_recv_ready(event->receive.chan, rxb);
 }
 
+/**
+ * @brief   Sends a netapi notification for a connection event.
+ *
+ * @param[in] notify    The type of notification event.
+ * @param[in] addr      BLE address of the node that (dis-)connected.
+ */
+static inline void _dispatch_connection_event(netnotify_t notify, uint8_t *addr)
+{
+    netnotify_l2_connec_t event = {
+        .l2addr = addr,
+        .l2addr_len = BLE_ADDR_LEN,
+        .if_pid = _netif.pid,
+    };
+
+    gnrc_netapi_notify(GNRC_NETTYPE_L2_DISCOVERY, GNRC_NETREG_DEMUX_CTX_ALL,
+                       notify, &event, sizeof(netnotify_l2_connec_t));
+}
+
 static int _on_l2cap_client_evt(struct ble_l2cap_event *event, void *arg)
 {
     int handle = (int)arg;
@@ -349,6 +367,7 @@ static int _on_l2cap_client_evt(struct ble_l2cap_event *event, void *arg)
             conn->state |= NIMBLE_NETIF_L2CAP_CLIENT;
             conn->state &= ~NIMBLE_NETIF_CONNECTING;
             _notify(handle, NIMBLE_NETIF_CONNECTED_MASTER, conn->addr);
+            _dispatch_connection_event(NETNOTIFY_L2_CONNECTED, conn->addr);
             break;
         case BLE_L2CAP_EVENT_COC_DISCONNECTED:
             assert(conn->state & NIMBLE_NETIF_L2CAP_CLIENT);
@@ -404,6 +423,7 @@ static int _on_l2cap_server_evt(struct ble_l2cap_event *event, void *arg)
             }
 
             _notify(handle, NIMBLE_NETIF_CONNECTED_SLAVE, conn->addr);
+            _dispatch_connection_event(NETNOTIFY_L2_CONNECTED, conn->addr);
             break;
         case BLE_L2CAP_EVENT_COC_DISCONNECTED:
             conn = nimble_netif_conn_from_gaphandle(event->disconnect.conn_handle);
@@ -498,6 +518,7 @@ static int _on_gap_master_evt(struct ble_gap_event *event, void *arg)
             nimble_netif_conn_free(handle, addr);
             thread_flags_set(_netif_thread, FLAG_TX_NOTCONN);
             _notify(handle, type, addr);
+            _dispatch_connection_event(NETNOTIFY_L2_DISCONNECTED, addr);
             break;
         }
         case BLE_GAP_EVENT_CONN_UPDATE:
@@ -542,6 +563,7 @@ static int _on_gap_slave_evt(struct ble_gap_event *event, void *arg)
             nimble_netif_conn_free(handle, addr);
             thread_flags_set(_netif_thread, FLAG_TX_NOTCONN);
             _notify(handle, type, addr);
+            _dispatch_connection_event(NETNOTIFY_L2_DISCONNECTED, addr);
             break;
         }
         case BLE_GAP_EVENT_CONN_UPDATE:

--- a/pkg/nimble/rpble/nimble_rpble.c
+++ b/pkg/nimble/rpble/nimble_rpble.c
@@ -222,9 +222,6 @@ static void _on_netif_evt(int handle, nimble_netif_event_t event,
         case NIMBLE_NETIF_CONNECTED_MASTER:
             /* parent selected */
             assert(_current_parent == handle);
-            /* send a DIS once connected to a (new) parent) */
-            gnrc_rpl_send_DIS(NULL, (ipv6_addr_t *) &ipv6_addr_all_rpl_nodes,
-                              NULL, 0);
             break;
         case NIMBLE_NETIF_CONNECTED_SLAVE:
             /* child added */

--- a/sys/include/net/gnrc/ipv6/nib/nc.h
+++ b/sys/include/net/gnrc/ipv6/nib/nc.h
@@ -233,6 +233,29 @@ static inline unsigned gnrc_ipv6_nib_nc_get_ar_state(const gnrc_ipv6_nib_nc_t *e
 int gnrc_ipv6_nib_nc_set(const ipv6_addr_t *ipv6, unsigned iface,
                          const uint8_t *l2addr, size_t l2addr_len);
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN) || defined(DOXYGEN)
+/**
+ * @brief   Adds an unmanaged neighbor entry to the NIB if the interface represents a 6LN node
+ *          and the IPv6 address can be constructed from the L2 address @p l2addr.
+ *
+ * @param[in] iface         The interface to the neighbor.
+ * @param[in] l2addr        The neighbor's layer 2 address.
+ * @param[in] l2addr_len    Length of @p l2addr.
+ *
+ * @return  0 on success.
+ * @return  -ENOTSUP, if the interface does not represent a 6LN or when
+ *           gnrc_netif_t::device_type of the iface does not support IID conversion.
+ * @return  -EINVAL, when @p addr_len is invalid for the
+ *          gnrc_netif_t::device_type of @p netif.
+ * @return  -ENOMEM, if no space is left in neighbor cache.
+ */
+int gnrc_ipv6_nib_nc_try_set_6ln(unsigned iface, const uint8_t *l2addr,
+                                 size_t l2addr_len);
+#else /* CONFIG_GNRC_IPV6_NIB_6LN */
+#define gnrc_ipv6_nib_nc_try_set_6ln(unsigned iface, const uint8_t *l2addr,
+                                 size_t l2addr_len)   (-ENOTSUP)
+#endif /* CONFIG_GNRC_IPV6_NIB_6LN */
+
 /**
  * @brief   Deletes neighbor with address @p ipv6 from NIB
  *
@@ -244,6 +267,21 @@ int gnrc_ipv6_nib_nc_set(const ipv6_addr_t *ipv6, unsigned iface,
  * If the @p ipv6 can't be found for a neighbor in the NIB nothing happens.
  */
 void gnrc_ipv6_nib_nc_del(const ipv6_addr_t *ipv6, unsigned iface);
+
+/**
+ * @brief   Deletes neighbor with link-layer address @p l2addr from NIB.
+ *
+ * @param[in] iface         The interface to the neighbor.
+ * @param[in] l2addr        The neighbor's l2addr address.
+ * @param[in] l2addr_len    Length of @p l2addr.
+ *
+ *
+ * If the @p l2addr can't be found for a neighbor in the NIB nothing happens.
+ *
+ * @return  True, if a neighbor with @p l2addr existed.
+ * @return  False, otherwise.
+ */
+bool gnrc_ipv6_nib_nc_del_l2(unsigned iface, const uint8_t *l2addr, size_t l2addr_len);
 
 /**
  * @brief   Mark neighbor with address @p ipv6 as reachable

--- a/sys/include/net/gnrc/netapi.h
+++ b/sys/include/net/gnrc/netapi.h
@@ -60,6 +60,7 @@
 
 #include "thread.h"
 #include "net/netopt.h"
+#include "net/gnrc/netnotify.h"
 #include "net/gnrc/nettype.h"
 #include "net/gnrc/pkt.h"
 
@@ -88,9 +89,14 @@ extern "C" {
 #define GNRC_NETAPI_MSG_TYPE_GET        (0x0204)
 
 /**
- * @brief   @ref core_msg type for replying to get and set option messages
+ * @brief   @ref core_msg type for replying to get/ set option, and notify messages.
  */
 #define GNRC_NETAPI_MSG_TYPE_ACK        (0x0205)
+
+/**
+ * @brief   @ref core_msg type for sending event notifications to the network stack.
+ */
+#define GNRC_NETAPI_MSG_TYPE_NOTIFY      (0x0207)
 
 /**
  * @brief   Data structure to be send for setting (@ref GNRC_NETAPI_MSG_TYPE_SET)
@@ -102,6 +108,15 @@ typedef struct {
     void *data;                 /**< data to set or buffer to read into */
     uint16_t data_len;          /**< size of the data / the buffer */
 } gnrc_netapi_opt_t;
+
+/**
+ * @brief   Data structure to be send for notification events.
+ */
+typedef struct {
+    netnotify_t event;          /**< the type of event */
+    void *data;                 /**< event data */
+    uint16_t data_len;          /**< size of the data */
+} gnrc_netapi_notify_t;
 
 /**
  * @brief   Shortcut function for sending @ref GNRC_NETAPI_MSG_TYPE_SND or
@@ -182,6 +197,24 @@ static inline int gnrc_netapi_dispatch_send(gnrc_nettype_t type, uint32_t demux_
 {
     return gnrc_netapi_dispatch(type, demux_ctx, GNRC_NETAPI_MSG_TYPE_SND, pkt);
 }
+
+/**
+ * @brief   Sends a @ref GNRC_NETAPI_MSG_TYPE_NOTIFY command to all subscribers to
+ *          (@p type, @p demux_ctx).
+ *
+ * @note    This blocks the sender until all registered subscribers have ack'ed the notification
+ *          or sending has failed. The @p data can be freed after the function returned.
+ *
+ * @param[in] type          Type of the targeted network module.
+ * @param[in] demux_ctx     Demultiplexing context for @p type.
+ * @param[in] event         Notification event type.
+ * @param[in] data          Data associated with the event.
+ * @param[in] data_len      Size of @p data.
+ *
+ * @return Number of subscribers to (@p type, @p demux_ctx).
+ */
+int gnrc_netapi_notify(gnrc_nettype_t type, uint32_t demux_ctx, netnotify_t event,
+                       void *data, size_t data_len);
 
 /**
  * @brief   Shortcut function for sending @ref GNRC_NETAPI_MSG_TYPE_RCV messages

--- a/sys/include/net/gnrc/netnotify.h
+++ b/sys/include/net/gnrc/netnotify.h
@@ -22,6 +22,8 @@ extern "C" {
 typedef enum {
     NETNOTIFY_L2_CONNECTED,
     NETNOTIFY_L2_DISCONNECTED,
+    NETNOTIFY_L3_DISCOVERED,
+    NETNOTIFY_L3_UNREACHABLE,
 } netnotify_t;
 
 /**

--- a/sys/include/net/gnrc/netnotify.h
+++ b/sys/include/net/gnrc/netnotify.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 Elena Frank <elena.frank@tu-dresden.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "sched.h"
+
+/**
+ * @brief   Definition of notification event types in the network stack.
+ *
+ * @note    Expand at will.
+ */
+typedef enum {
+    NETNOTIFY_L2_CONNECTED,
+    NETNOTIFY_L2_DISCONNECTED,
+} netnotify_t;
+
+/**
+ * @brief   L2 (dis-)connection event data.
+ */
+typedef struct netnotify_l2_connec {
+    uint8_t *l2addr;            /**< L2 address of the node */
+    uint8_t l2addr_len;         /**< length of L2 address in byte */
+    kernel_pid_t if_pid;        /**< PID of network interface */
+} netnotify_l2_connec_t;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -105,6 +105,8 @@ typedef enum {
     GNRC_NETTYPE_ICMPV6,        /**< Protocol is ICMPv6 */
 #endif
 
+    GNRC_NETTYPE_L2_DISCOVERY,  /**< L2 node discovery */
+
 #if IS_USED(MODULE_GNRC_NETTYPE_CCN) || defined(DOXYGEN)
     GNRC_NETTYPE_CCN,           /**< Protocol is CCN */
     GNRC_NETTYPE_CCN_CHUNK,     /**< Protocol is CCN, packet contains a content

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -107,6 +107,8 @@ typedef enum {
 
     GNRC_NETTYPE_L2_DISCOVERY,  /**< L2 node discovery */
 
+    GNRC_NETTYPE_L3_ROUTING,    /**< L3 routing info */
+
 #if IS_USED(MODULE_GNRC_NETTYPE_CCN) || defined(DOXYGEN)
     GNRC_NETTYPE_CCN,           /**< Protocol is CCN */
     GNRC_NETTYPE_CCN_CHUNK,     /**< Protocol is CCN, packet contains a content

--- a/sys/include/net/gnrc/rpl/dodag.h
+++ b/sys/include/net/gnrc/rpl/dodag.h
@@ -130,6 +130,18 @@ bool gnrc_rpl_parent_add_by_addr(gnrc_rpl_dodag_t *dodag, ipv6_addr_t *addr,
                                  gnrc_rpl_parent_t **parent);
 
 /**
+ * @brief   Iterate over all parents in all DODAGs with @p IPv6 address.
+ *
+ * @param[in]   idx         Index to start searching from.
+ * @param[in]   addr        IPV6 address of the parent.
+ * @param[out]  parent      Pointer to the parent if one was found. Otherwise NULL.
+ *
+ * @return  Index > 0 to continue next search from, if parent was found.
+ * @return  -ENONENT if not found
+ */
+int gnrc_rpl_parent_iter_by_addr(ipv6_addr_t *addr, gnrc_rpl_parent_t **parent, int idx);
+
+/**
  * @brief   Remove the @p parent from its DODAG.
  *
  * @param[in] parent     Pointer to the parent.

--- a/sys/net/gnrc/netapi/gnrc_netapi.c
+++ b/sys/net/gnrc/netapi/gnrc_netapi.c
@@ -141,3 +141,41 @@ int gnrc_netapi_dispatch(gnrc_nettype_t type, uint32_t demux_ctx,
 
     return numof;
 }
+
+int gnrc_netapi_notify(gnrc_nettype_t type, uint32_t demux_ctx, netnotify_t event,
+                       void *data, size_t data_len)
+{
+    gnrc_netapi_notify_t notify;
+    msg_t cmd;
+    msg_t ack;
+
+    notify.event = event;
+    notify.data = data;
+    notify.data_len = data_len;
+
+    cmd.type = GNRC_NETAPI_MSG_TYPE_NOTIFY;
+    cmd.content.ptr = (void *)&notify;
+
+    gnrc_netreg_acquire_shared();
+
+    int numof = gnrc_netreg_num(type, demux_ctx);
+
+    if (numof != 0) {
+        /* Look up the registered threads for this message type. */
+        gnrc_netreg_entry_t *sendto = gnrc_netreg_lookup(type, demux_ctx);
+        
+        /* Dispatch to all registered threads sequentially. */
+        while (sendto) {
+            /* Need to wait for an ACK to ensure that the msg was received and that
+               there won't be any dangling pointers after the function returned. */
+            /* TODO: First send to all threads, then wait for all ACK's?*/
+            msg_send_receive(&cmd, &ack, sendto->target.pid);
+            assert(ack.type == GNRC_NETAPI_MSG_TYPE_ACK);
+            sendto = gnrc_netreg_getnext(sendto);
+        }
+    }
+
+    gnrc_netreg_release_shared();
+
+    return numof;
+}

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -172,6 +172,71 @@ static void _dispatch_next_header(gnrc_pktsnip_t *pkt, unsigned nh,
 }
 
 /**
+ * @brief   Find entry in NIB neighbor cache.
+ *
+ * @param[in] l2addr        Layer 2 address of the neighbor.
+ * @param[in] l2addr_len    Length of @p l2addr.
+ * @param[out] ipv6         IPv6 address of the neighbor or NULL.
+ *
+ * @return  True, if a neighbor with @p l2addr was found in the nc.
+ * @return  False, otherwise.
+ */
+static inline bool _find_entry_in_nc(uint8_t *l2addr, uint8_t l2addr_len, ipv6_addr_t *ipv6)
+{
+    void *state = NULL;
+    gnrc_ipv6_nib_nc_t nce;
+
+    while (gnrc_ipv6_nib_nc_iter(0, &state, &nce)) {
+        if (l2util_addr_equal(l2addr, l2addr_len, nce.l2addr, nce.l2addr_len)) {
+            *ipv6 = nce.ipv6;
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * @brief   Handle a link-layer connection-established event.
+ *
+ * @param[in] connect   Netapi connection event.
+ */
+static inline void _on_l2_connected(netnotify_l2_connec_t *connect)
+{
+    ipv6_addr_t ipv6;
+
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
+    /* Add neighbor to neighbor cache if interface represents a 6LN. */
+    gnrc_ipv6_nib_nc_try_set_6ln(connect->if_pid, connect->l2addr, connect->l2addr_len);
+#endif /* CONFIG_GNRC_IPV6_NIB_6LN */
+
+    /* Inform routing layer of new reachable neighbor. */
+    if (_find_entry_in_nc(connect->l2addr, connect->l2addr_len, &ipv6)) {
+        gnrc_netapi_notify(GNRC_NETTYPE_L3_ROUTING, GNRC_NETREG_DEMUX_CTX_ALL,
+                           NETNOTIFY_L3_DISCOVERED, &ipv6, sizeof(ipv6_addr_t));
+    }
+}
+
+/**
+ * @brief   Handle a link-layer connection-closed event.
+ *
+ * @param[in] connect   Netapi connection event.
+ */
+static inline void _on_l2_disconnected(netnotify_l2_connec_t *connect)
+{
+    ipv6_addr_t ipv6;
+
+    /* Inform routing layer of unreachable neighbor. This must be done *before* removing
+        the neighbor from the neighbor cache. */
+    if (_find_entry_in_nc(connect->l2addr, connect->l2addr_len, &ipv6)) {
+        gnrc_netapi_notify(GNRC_NETTYPE_L3_ROUTING, GNRC_NETREG_DEMUX_CTX_ALL,
+                           NETNOTIFY_L3_UNREACHABLE, &ipv6, sizeof(ipv6_addr_t));
+    }
+
+    /* Remove from neighbor cache. */
+    gnrc_ipv6_nib_nc_del_l2(connect->if_pid, connect->l2addr, connect->l2addr_len);
+}
+
+/**
  * @brief   Handles a netapi event notification.
  *
  * @param[in] notify    The type of notification.
@@ -179,20 +244,12 @@ static void _dispatch_next_header(gnrc_pktsnip_t *pkt, unsigned nh,
 static inline void _netapi_event(gnrc_netapi_notify_t *notify)
 {
 
-    netnotify_l2_connec_t *connect;
-
     switch (notify->event) {
     case NETNOTIFY_L2_CONNECTED:
-        connect = (netnotify_l2_connec_t *)notify->data;
-#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
-        /* Add node to neighbor cache if interface represents a 6LN. */
-        gnrc_ipv6_nib_nc_try_set_6ln(connect->if_pid, connect->l2addr, connect->l2addr_len);
-#endif /* CONFIG_GNRC_IPV6_NIB_6LN */
+        _on_l2_connected((netnotify_l2_connec_t *)notify->data);
         break;
     case NETNOTIFY_L2_DISCONNECTED:
-        connect = (netnotify_l2_connec_t *)notify->data;
-        /* Remove node from neighbor cache. */
-        gnrc_ipv6_nib_nc_del_l2(connect->if_pid, connect->l2addr, connect->l2addr_len);
+        _on_l2_disconnected((netnotify_l2_connec_t *)notify->data);
         break;
     default:
         break;

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -171,10 +171,43 @@ static void _dispatch_next_header(gnrc_pktsnip_t *pkt, unsigned nh,
     }
 }
 
+/**
+ * @brief   Handles a netapi event notification.
+ *
+ * @param[in] notify    The type of notification.
+ */
+static inline void _netapi_event(gnrc_netapi_notify_t *notify)
+{
+
+    netnotify_l2_connec_t *connect;
+
+    switch (notify->event) {
+    case NETNOTIFY_L2_CONNECTED:
+        connect = (netnotify_l2_connec_t *)notify->data;
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
+        /* Add node to neighbor cache if interface represents a 6LN. */
+        gnrc_ipv6_nib_nc_try_set_6ln(connect->if_pid, connect->l2addr, connect->l2addr_len);
+#endif /* CONFIG_GNRC_IPV6_NIB_6LN */
+        break;
+    case NETNOTIFY_L2_DISCONNECTED:
+        connect = (netnotify_l2_connec_t *)notify->data;
+        /* Remove node from neighbor cache. */
+        gnrc_ipv6_nib_nc_del_l2(connect->if_pid, connect->l2addr, connect->l2addr_len);
+        break;
+    default:
+        break;
+    }
+}
+
 static void *_event_loop(void *args)
 {
     msg_t msg, reply;
-    gnrc_netreg_entry_t me_reg = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+
+    /* Register entry for messages in IPv6 context. */
+    gnrc_netreg_entry_t me_ipv6_reg = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+                                                            thread_getpid());
+    /* Register entry for messages in L2 discovery context. */
+    gnrc_netreg_entry_t me_discovery_reg = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
                                                             thread_getpid());
 
     (void)args;
@@ -184,8 +217,12 @@ static void *_event_loop(void *args)
 #ifdef MODULE_GNRC_IPV6_EXT_FRAG
     gnrc_ipv6_ext_frag_init();
 #endif  /* MODULE_GNRC_IPV6_EXT_FRAG */
-    /* register interest in all IPv6 packets */
-    gnrc_netreg_register(GNRC_NETTYPE_IPV6, &me_reg);
+
+    /* Register interest in all IPv6 packets. */
+    gnrc_netreg_register(GNRC_NETTYPE_IPV6, &me_ipv6_reg);
+
+    /* Register interest in L2 neighbor discovery info. */
+    gnrc_netreg_register(GNRC_NETTYPE_L2_DISCOVERY, &me_discovery_reg);
 
     /* preinitialize ACK */
     reply.type = GNRC_NETAPI_MSG_TYPE_ACK;
@@ -210,6 +247,12 @@ static void *_event_loop(void *args)
             case GNRC_NETAPI_MSG_TYPE_SET:
                 DEBUG("ipv6: reply to unsupported get/set\n");
                 reply.content.value = -ENOTSUP;
+                msg_reply(&msg, &reply);
+                break;
+            case GNRC_NETAPI_MSG_TYPE_NOTIFY:
+                DEBUG("ipv6: GNRC_NETAPI_MSG_TYPE_NOTIFY received\n");
+                _netapi_event(msg.content.ptr);
+                reply.content.value = 0;
                 msg_reply(&msg, &reply);
                 break;
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -73,6 +73,34 @@ bool _resolve_addr_from_ipv6(const ipv6_addr_t *dst, gnrc_netif_t *netif,
     return res;
 }
 
+int _build_ll_ipv6_from_addr(gnrc_netif_t *netif, const uint8_t *l2addr, uint8_t l2addr_len,
+                             ipv6_addr_t *ipv6addr)
+{
+    *ipv6addr = ipv6_addr_unspecified;
+
+    /* Reverse of _resolve_addr_from_ipv6. */
+
+    if (netif == NULL) {
+        return -ENOENT;
+    }
+
+    /* Only supported for 6LN nodes. */
+    if (!gnrc_netif_is_6ln(netif)) {
+        return -ENOTSUP;
+    }
+
+    /* Build interface identifier based on l2 address. */
+    int res = gnrc_netif_eui64_from_addr(netif, l2addr, l2addr_len, (eui64_t *)&ipv6addr->u64[1]);
+    if (res < 0) {
+        return res;
+    }
+
+    /* Add IPv6 link-loca prefix. */
+    ipv6_addr_set_link_local_prefix(ipv6addr);
+
+    return sizeof(ipv6_addr_t);
+}
+
 uint8_t _handle_aro(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
                     const icmpv6_hdr_t *icmpv6,
                     const sixlowpan_nd_opt_ar_t *aro, const ndp_opt_t *sl2ao,

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.h
@@ -71,6 +71,27 @@ bool _resolve_addr_from_ipv6(const ipv6_addr_t *dst, gnrc_netif_t *netif,
                              gnrc_ipv6_nib_nc_t *nce);
 
 /**
+ * @brief   Build a link-local ipv6 address statically from the L2 address by
+ *          translating the hardware address to an EUI-64 and adding the link-local
+ *          IPv6 prefix.
+ *
+ * @note    Reverse of _resolve_addr_from_ipv6.
+ *
+ * @param[in] netif      The interface to @p l2addr.
+ * @param[in] l2addr     Layer 2 address.
+ * @param[in] l2addr_l2n Length of the layer 2 address.
+ * @param[out] ipv6addr  The resulting IPv6 address.
+ *
+ * @return  sizeof(ipv6_addr_t) on success.
+ * @return  `-ENOTSUP`, if the interface does not represent a 6LN or when
+ *           gnrc_netif_t::device_type of @p netif does not support IID conversion.
+ * @return  `-EINVAL`, when @p addr_len is invalid for the
+ *          gnrc_netif_t::device_type of @p netif.
+ */
+int _build_ll_ipv6_from_addr(gnrc_netif_t *netif, const uint8_t *l2addr,
+                             uint8_t l2addr_len, ipv6_addr_t *ipv6addr);
+
+/**
  * @brief   Calculates exponential backoff for RS retransmissions
  *
  * @see [RFC 6775, section 5.3](https://tools.ietf.org/html/rfc6775#section-5.3)
@@ -137,6 +158,7 @@ uint32_t _handle_6co(const icmpv6_hdr_t *icmpv6,
 #endif  /* CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C || defined(DOXYGEN) */
 #else   /* CONFIG_GNRC_IPV6_NIB_6LN || defined(DOXYGEN) */
 #define _resolve_addr_from_ipv6(dst, netif, nce)    (false)
+#define _build_ll_ipv6_from_addr(netif, l2addr, l2addr_len, ipv6addr)    (-ENOTSUP)
 /* _handle_aro() doesn't make sense without 6LR so don't even use it
  * => throw error in case it is compiled in => don't define it here as NOP macro
  */

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_nc.c
@@ -24,6 +24,9 @@
 #include "net/gnrc/ipv6/nib/nc.h"
 
 #include "_nib-internal.h"
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
+  #include "_nib-6ln.h"
+#endif /* CONFIG_GNRC_IPV6_NIB_6LN */
 
 int gnrc_ipv6_nib_nc_set(const ipv6_addr_t *ipv6, unsigned iface,
                          const uint8_t *l2addr, size_t l2addr_len)
@@ -59,6 +62,32 @@ int gnrc_ipv6_nib_nc_set(const ipv6_addr_t *ipv6, unsigned iface,
     return 0;
 }
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
+int gnrc_ipv6_nib_nc_try_set_6ln(unsigned iface, const uint8_t *l2addr, size_t l2addr_len)
+{
+    int res;
+    ipv6_addr_t ipv6addr;
+
+    gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
+
+    if (netif == NULL) {
+        return -ENOENT;
+    }
+    /* Build link-local IPv6 address based on L2-address. */
+    res = _build_ll_ipv6_from_addr(netif, l2addr, l2addr_len, &ipv6addr);
+    if (res < 0) {
+        return res;
+    }
+    /* Add as unmanaged entry to neighbor cache. */
+    res = gnrc_ipv6_nib_nc_set(&ipv6addr, netif->pid, l2addr, l2addr_len);
+    if (res < 0) {
+        return res;
+    }
+
+    return 0;
+}
+#endif
+
 void gnrc_ipv6_nib_nc_del(const ipv6_addr_t *ipv6, unsigned iface)
 {
     _nib_onl_entry_t *node = NULL;
@@ -72,6 +101,27 @@ void gnrc_ipv6_nib_nc_del(const ipv6_addr_t *ipv6, unsigned iface)
         }
     }
     _nib_release();
+}
+
+bool gnrc_ipv6_nib_nc_del_l2(unsigned iface, const uint8_t *l2addr, size_t l2addr_len)
+{
+    _nib_onl_entry_t *node = NULL;
+    bool res = false;
+
+    _nib_acquire();
+
+    /* Find and remove entry with matching l2 address.*/
+    while ((node = _nib_onl_iter(node)) != NULL) {
+        if ((_nib_onl_get_if(node) == iface) &&
+            l2util_addr_equal(l2addr, l2addr_len, node->l2addr, node->l2addr_len)) {
+            _nib_nc_remove(node);
+            res = true;
+            break;
+        }
+    }
+    _nib_release();
+
+    return res;
 }
 
 void gnrc_ipv6_nib_nc_mark_reachable(const ipv6_addr_t *ipv6)

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -58,7 +58,8 @@ static xtimer_t _lt_timer;
 static msg_t _lt_msg = { .type = GNRC_RPL_MSG_TYPE_LIFETIME_UPDATE };
 #endif
 static msg_t _msg_q[GNRC_RPL_MSG_QUEUE_SIZE];
-static gnrc_netreg_entry_t _me_reg;
+static gnrc_netreg_entry_t _me_icmpv6_reg;
+static gnrc_netreg_entry_t _me_routing_reg;
 static mutex_t _inst_id_mutex = MUTEX_INIT;
 static uint8_t _instance_id;
 
@@ -100,10 +101,15 @@ kernel_pid_t gnrc_rpl_init(kernel_pid_t if_pid)
          * queue, and registration with netreg can commence. */
         mutex_lock(&eventloop_startup);
 
-        _me_reg.demux_ctx = ICMPV6_RPL_CTRL;
-        _me_reg.target.pid = gnrc_rpl_pid;
-        /* register interest in all ICMPv6 packets */
-        gnrc_netreg_register(GNRC_NETTYPE_ICMPV6, &_me_reg);
+        /* Register interest in all ICMPv6 packets. */
+        _me_icmpv6_reg.demux_ctx = ICMPV6_RPL_CTRL;
+        _me_icmpv6_reg.target.pid = gnrc_rpl_pid;
+        gnrc_netreg_register(GNRC_NETTYPE_ICMPV6, &_me_icmpv6_reg);
+
+        /* Register interest in L3 routing info. */
+        _me_routing_reg.demux_ctx = GNRC_NETREG_DEMUX_CTX_ALL;
+        _me_routing_reg.target.pid = gnrc_rpl_pid;
+        gnrc_netreg_register(GNRC_NETTYPE_L3_ROUTING, &_me_routing_reg);
 
         gnrc_rpl_of_manager_init();
         evtimer_init_msg(&gnrc_rpl_evtimer);
@@ -273,6 +279,55 @@ static void _parent_timeout(gnrc_rpl_parent_t *parent)
     evtimer_add_msg(&gnrc_rpl_evtimer, &parent->timeout_event, gnrc_rpl_pid);
 }
 
+/**
+ * @brief   Handles the event that a new neigbor was discovered and is reachable.
+ *
+ * @param[in] addr  The address of the neigbor.
+ */
+static inline void _handle_discovered_neighbor(ipv6_addr_t *addr)
+{
+    /* Send DODAG soliciation message to node. */
+    gnrc_rpl_send_DIS(NULL, addr, NULL, 0);
+}
+
+
+/**
+ * @brief   Handles the event that a neigbor became unreachable.
+ *
+ * @param[in] addr  The address of the neigbor.
+ */
+static inline void _handle_unreachable_neighbor(ipv6_addr_t *addr)
+{
+    gnrc_rpl_parent_t *parent;
+    int idx = 0;
+
+    /* Iterate through all parents and timeout the ones with matching address.
+       There can be multiple parents with the same address because the same node
+       can be a parent in multiple different DODAGs. */
+    while ((idx = gnrc_rpl_parent_iter_by_addr(addr, &parent, idx)) >= 0) {
+        _parent_timeout(parent);
+    }
+}
+
+/**
+ * @brief   Handles a netapi event notification.
+ *
+ * @param[in] notify    The type of notification.
+ */
+static inline void _netapi_notify_event(gnrc_netapi_notify_t *notify)
+{
+    switch (notify->event) {
+    case NETNOTIFY_L3_DISCOVERED:
+        _handle_discovered_neighbor((ipv6_addr_t *)notify->data);
+        break;
+    case NETNOTIFY_L3_UNREACHABLE:
+        _handle_unreachable_neighbor((ipv6_addr_t *)notify->data);
+        break;
+    default:
+        break;
+    }
+}
+
 static void *_event_loop(void *args)
 {
     msg_t msg, reply;
@@ -340,6 +395,12 @@ static void *_event_loop(void *args)
             case GNRC_NETAPI_MSG_TYPE_SET:
                 DEBUG("RPL: reply to unsupported get/set\n");
                 reply.content.value = -ENOTSUP;
+                msg_reply(&msg, &reply);
+                break;
+            case GNRC_NETAPI_MSG_TYPE_NOTIFY:
+                DEBUG("RPL: GNRC_NETAPI_MSG_TYPE_NOTIFY received\n");
+                _netapi_notify_event(msg.content.ptr);
+                reply.content.value = 0;
                 msg_reply(&msg, &reply);
                 break;
             default:

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -196,6 +196,19 @@ void gnrc_rpl_dodag_remove_all_parents(gnrc_rpl_dodag_t *dodag)
     dodag->my_rank = GNRC_RPL_INFINITE_RANK;
 }
 
+int gnrc_rpl_parent_iter_by_addr(ipv6_addr_t *addr, gnrc_rpl_parent_t **parent, int idx)
+{
+    *parent = NULL;
+    for (uint8_t i = idx; i < GNRC_RPL_PARENTS_NUMOF; ++i) {
+        if ((gnrc_rpl_parents[i].state != 0) && ipv6_addr_equal(&gnrc_rpl_parents[i].addr, addr)) {
+            *parent = &gnrc_rpl_parents[i];
+            /* Index to continue search from. */
+            return i + 1;
+        }
+    }
+    return -ENOENT;
+}
+
 bool gnrc_rpl_parent_add_by_addr(gnrc_rpl_dodag_t *dodag, ipv6_addr_t *addr,
                                  gnrc_rpl_parent_t **parent)
 {


### PR DESCRIPTION
### Contribution description

This PR solves two issues that have been previously discussed in #21580 and #21586:
- Adding connected BLE nodes to the NIB neighbor cache 
- Notifying RPL when a BLE connection closes and the parent with matching address is unreachable.

Both issues require communication between different netapi layers and are related with each other, so I bundled them in one PR.

### Cross-layer Communication with netapi

With the current netapi it is not possible to send arbitrary data between networking threads. 
The API only allows to either dispatch **packets** to multiple threads that are registered in the netreg (`gnrc_netapi_dispatch`), or to set/get options to/from a single thread whose PID is known (`gnrc_netapi_{get,set}`).
In my use-case, however, a lower layer (BLE) wants to notify other layers higher up the stack (IPv6, RPL) of an event (e.g., connection established). Ideally, the lower layer shouldn't need to know if/ what higher layers are present, similarly to the case when packets are passed up/ down the stack. 

### netapi `notify`

To solve the above, I added a new netapi function  `gnrc_netapi_notify` that dispatches an "notification"-event  to all subscribed threads. Like in `gnrc_netapi_dispatch` the target threads are queried from netreg, but with `notify` the sending is done synchronously by blocking for an ACK. The latter is needed because contrary to the packets that get allocated in the `pktbuf`, the notify event data is stack allocated and thus blocking is needed to ensure the data was read before the function returns. This is not ideal, but I wasn't able to come up with a better solution.

### Handling BLE connection events

The `notify` event API is used:
1.  BLE -> IPv6: inform of a (dis-)connected link-layer address
    - the IPv6 thread  will add/ remove an entry to the neighbor cache, which solves https://github.com/RIOT-OS/RIOT/issues/21580#issuecomment-3051805794 (cc @mcr)
2. IPv6 -> RPL: inform of new / unreachable neighbors
   - RPL sends a DIS when a new neighbor was discovered
   - RPL times-out parents if their address became unreachable (solving #21586) 

In 2. the notification is sent from the IPv6 thread rather than from BLE because address translation from l2addr->ipv6 address is solved on that layer.


### Testing procedure

Tested on FIT IoT-Testlab with 9 nrf52dk nodes by using the `gnrc_networking` example + `nimble_rpble` module. 
The entries are added/ removed from the NIB neighbor cache as expected, and the RPL tree updates when connections between parents and children close.

### Issues/PRs references

Replaces #21586.
Part of #21574.
Related to (and might solve) #21580. 

### Additional Nodes

Happy to split up the PR in separate sub-PRs if that's easier, but as already mentioned it all kinda relates to each other.

See self-review for discussion points.

