### PR TITLE
examples: fix typos in refs to gnrc_border_router

### DIFF
--- a/examples/advanced/suit_update/README.hardware.md
+++ b/examples/advanced/suit_update/README.hardware.md
@@ -84,10 +84,10 @@ your make commands with it (for the BR as well as the device), e.g.:
      $ USEMODULE+=nimble_autoconn_ipsp make BOARD=<BR board>
 
 Plug the BR board on the computer and flash the
-[gnrc_border_router](https://github.com/RIOT-OS/RIOT/tree/master/examples/networking/gnrc_borader_router)
+[gnrc_border_router](https://github.com/RIOT-OS/RIOT/tree/master/examples/networking/gnrc_border_router)
 application on it:
 
-    $ make BOARD=<BR board> -C examples/networking/gnrc_borader_router flash
+    $ make BOARD=<BR board> -C examples/networking/gnrc_border_router flash
 
 In on terminal, start the network (assuming on the host the virtual port of the
 board is `/dev/ttyACM0`):

--- a/examples/networking/coap/gcoap/README-slip.md
+++ b/examples/networking/coap/gcoap/README-slip.md
@@ -64,4 +64,4 @@ Ping the TUN interface from the router mote, via the BR:
 
     ping bbbb::1
 
-[1]: https://github.com/RIOT-OS/RIOT/tree/master/examples/networking/gnrc_borader_router    "SLIP instructions"
+[1]: https://github.com/RIOT-OS/RIOT/tree/master/examples/networking/gnrc_border_router    "SLIP instructions"

--- a/examples/networking/misc/lwm2m/README.md
+++ b/examples/networking/misc/lwm2m/README.md
@@ -89,7 +89,7 @@ The server address is set by the application, during the instantiation of the Se
 It can be set via `menuconfig` or the environmental variable `LWM2M_SERVER_URI`. It should be
 reachable from the node, e.g. either running on native with a tap interface or as a mote connected
 to a
-[border router](https://github.com/RIOT-OS/RIOT/tree/master/examples/networking/gnrc_borader_router).
+[border router](https://github.com/RIOT-OS/RIOT/tree/master/examples/networking/gnrc_border_router).
 
 Also, if a bootstrap server is being used, it should be configured in the application via
 `menuconfig` or setting the environmental variable `LWM2M_SERVER_BOOTSTRAP` to 1. This information


### PR DESCRIPTION
### Contribution description

As the title says.


### Testing procedure

Carefully look at the diff :eyes: 
