### PR TITLE
unittests/unicoap: reduce buffer size to fit on stack

### DIFF
--- a/tests/unittests/tests-unicoap/tests-unicoap-options.c
+++ b/tests/unittests/tests-unicoap/tests-unicoap-options.c
@@ -112,7 +112,7 @@ static void _populate(unicoap_options_t* options)
 
 static void test_extended_uint_shifts(void)
 {
-    UNICOAP_OPTIONS_ALLOC(options, 2100);
+    UNICOAP_OPTIONS_ALLOC(options, 900);
     _populate(&options);
 
     /* options blob, from nanoCoAP */
@@ -180,7 +180,7 @@ static void test_extended_uint_shifts(void)
 
 static void test_remove_leading(void)
 {
-    UNICOAP_OPTIONS_ALLOC(options, 2100);
+    UNICOAP_OPTIONS_ALLOC(options, 900);
     _populate(&options);
 
     TEST_ASSERT_EQUAL_INT(unicoap_options_remove(&options, 1), 0);
@@ -250,7 +250,7 @@ static void test_remove_leading(void)
 
 static void test_remove_trailing(void)
 {
-    UNICOAP_OPTIONS_ALLOC(options, 2100);
+    UNICOAP_OPTIONS_ALLOC(options, 900);
     _populate(&options);
 
     TEST_ASSERT_EQUAL_INT(unicoap_options_remove(&options, 70), 0);
@@ -320,7 +320,7 @@ static void test_remove_trailing(void)
 
 static void test_remove_multiple(void)
 {
-    UNICOAP_OPTIONS_ALLOC(options, 2100);
+    UNICOAP_OPTIONS_ALLOC(options, 900);
     _populate(&options);
 
     TEST_ASSERT_EQUAL_INT(unicoap_options_remove(&options, 12), 0);


### PR DESCRIPTION
### Contribution description

unicoap unittests would currently fail due to stack overflow on most hardware. They indeed allocate much more memory than needed.

The default unittest stacksize is set to THREAD_STACKSIZE_LARGE which is 2048 for cortexm_common, so 900 bytes will largely fit. However, some other architectures (e.g., atmega8) define much smaller stack sizes per default, where the reduced buffer would not fit. Should we rather make them static so they work for all architectures? We then wouldn't be able to use the convenience macro anymore.


### Testing procedure

`make -C tests/unittests BOARD=nrf52840dk tests-unicoap flash term`

on `master`:
```
Welcome to pyterm!
Type '/exit' to exit.
r
2025-07-17 14:28:14,931 # READY
s
2025-07-17 14:28:16,637 # START
2025-07-17 14:28:16,643 # main(): This is RIOT! (Version: 2025.07-devel-571-gd06b6)
2025-07-17 14:28:16,648 # Help: Press s to start test, r to print it is ready
```

with this PR:
```
Welcome to pyterm!
Type '/exit' to exit.
r
2025-07-17 14:26:48,657 # READY
s
2025-07-17 14:26:49,469 # START
2025-07-17 14:26:49,471 # ................
2025-07-17 14:26:49,473 # OK (16 tests)
```


### Issues/PRs references

Found while testing #21582 
