### PR TITLE
boards: move licenses from headers to SPDX format (part2)

### DIFF
--- a/boards/acd52832/Kconfig
+++ b/boards/acd52832/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "acd52832" if BOARD_ACD52832

--- a/boards/acd52832/include/board.h
+++ b/boards/acd52832/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/acd52832/include/gpio_params.h
+++ b/boards/acd52832/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/acd52832/include/periph_conf.h
+++ b/boards/acd52832/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016-2017 Freie Universität Berlin
- *                    2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-clue/Kconfig
+++ b/boards/adafruit-clue/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "adafruit-clue" if BOARD_ADAFRUIT_CLUE

--- a/boards/adafruit-clue/board.c
+++ b/boards/adafruit-clue/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/adafruit-clue/include/board.h
+++ b/boards/adafruit-clue/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-clue/include/gpio_params.h
+++ b/boards/adafruit-clue/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-clue/include/periph_conf.h
+++ b/boards/adafruit-clue/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-feather-nrf52840-express/Kconfig
+++ b/boards/adafruit-feather-nrf52840-express/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "adafruit-feather-nrf52840-express" if BOARD_ADAFRUIT_FEATHER_NRF52840_EXPRESS

--- a/boards/adafruit-feather-nrf52840-express/bat_voltage.c
+++ b/boards/adafruit-feather-nrf52840-express/bat_voltage.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/adafruit-feather-nrf52840-express/include/bat_voltage_params.h
+++ b/boards/adafruit-feather-nrf52840-express/include/bat_voltage_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-feather-nrf52840-express/include/board.h
+++ b/boards/adafruit-feather-nrf52840-express/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-feather-nrf52840-express/include/gpio_params.h
+++ b/boards/adafruit-feather-nrf52840-express/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-feather-nrf52840-express/include/periph_conf.h
+++ b/boards/adafruit-feather-nrf52840-express/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-feather-nrf52840-express/mtd.c
+++ b/boards/adafruit-feather-nrf52840-express/mtd.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/adafruit-feather-nrf52840-sense/Kconfig
+++ b/boards/adafruit-feather-nrf52840-sense/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2023 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2023 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "adafruit-feather-nrf52840-sense" if BOARD_ADAFRUIT_FEATHER_NRF52840_SENSE

--- a/boards/adafruit-feather-nrf52840-sense/bat_voltage.c
+++ b/boards/adafruit-feather-nrf52840-sense/bat_voltage.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/adafruit-feather-nrf52840-sense/include/bat_voltage_params.h
+++ b/boards/adafruit-feather-nrf52840-sense/include/bat_voltage_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-feather-nrf52840-sense/include/board.h
+++ b/boards/adafruit-feather-nrf52840-sense/include/board.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
- * Copyright (C) 2023 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2023 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-feather-nrf52840-sense/include/gpio_params.h
+++ b/boards/adafruit-feather-nrf52840-sense/include/gpio_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
- * Copyright (C) 2023 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2023 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-feather-nrf52840-sense/include/periph_conf.h
+++ b/boards/adafruit-feather-nrf52840-sense/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
- * Copyright (C) 2023 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2023 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-feather-nrf52840-sense/mtd.c
+++ b/boards/adafruit-feather-nrf52840-sense/mtd.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/adafruit-grand-central-m4-express/Kconfig
+++ b/boards/adafruit-grand-central-m4-express/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (C) 2023 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2023 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "adafruit-grand-central-m4-express" if BOARD_ADAFRUIT_GRAND_CENTRAL_M4_EXPRESS

--- a/boards/adafruit-grand-central-m4-express/board.c
+++ b/boards/adafruit-grand-central-m4-express/board.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *               2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/adafruit-grand-central-m4-express/include/arduino_iomap.h
+++ b/boards/adafruit-grand-central-m4-express/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-grand-central-m4-express/include/board.h
+++ b/boards/adafruit-grand-central-m4-express/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-grand-central-m4-express/include/gpio_params.h
+++ b/boards/adafruit-grand-central-m4-express/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-grand-central-m4-express/include/periph_conf.h
+++ b/boards/adafruit-grand-central-m4-express/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *               2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-itsybitsy-m4/Kconfig
+++ b/boards/adafruit-itsybitsy-m4/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2021 ML!PA Consulting GmbH
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "adafruit-itsybitsy-m4" if BOARD_ADAFRUIT_ITSYBITSY_M4

--- a/boards/adafruit-itsybitsy-m4/board.c
+++ b/boards/adafruit-itsybitsy-m4/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/adafruit-itsybitsy-m4/include/board.h
+++ b/boards/adafruit-itsybitsy-m4/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-itsybitsy-m4/include/gpio_params.h
+++ b/boards/adafruit-itsybitsy-m4/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-itsybitsy-m4/include/periph_conf.h
+++ b/boards/adafruit-itsybitsy-m4/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-itsybitsy-nrf52/Kconfig
+++ b/boards/adafruit-itsybitsy-nrf52/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "adafruit-itsybitsy-nrf52" if BOARD_ADAFRUIT_ITSYBITSY_NRF52

--- a/boards/adafruit-itsybitsy-nrf52/include/board.h
+++ b/boards/adafruit-itsybitsy-nrf52/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2020 Bruno Chianca <brunobcf@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Bruno Chianca <brunobcf@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-itsybitsy-nrf52/include/gpio_params.h
+++ b/boards/adafruit-itsybitsy-nrf52/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Bruno Chianca <brunobcf@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Bruno Chianca <brunobcf@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-itsybitsy-nrf52/include/periph_conf.h
+++ b/boards/adafruit-itsybitsy-nrf52/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Bruno Chianca <brunobcf@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Bruno Chianca <brunobcf@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-metro-m4-express/Kconfig
+++ b/boards/adafruit-metro-m4-express/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (C) 2024 ML!PA Consulting GmbH
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2024 ML!PA Consulting GmbH
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "adafruit-metro-m4-express" if BOARD_ADAFRUIT_METRO_M4_EXPRESS

--- a/boards/adafruit-metro-m4-express/board.c
+++ b/boards/adafruit-metro-m4-express/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/adafruit-metro-m4-express/include/arduino_iomap.h
+++ b/boards/adafruit-metro-m4-express/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-metro-m4-express/include/board.h
+++ b/boards/adafruit-metro-m4-express/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-metro-m4-express/include/gpio_params.h
+++ b/boards/adafruit-metro-m4-express/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-metro-m4-express/include/periph_conf.h
+++ b/boards/adafruit-metro-m4-express/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-pybadge/Kconfig
+++ b/boards/adafruit-pybadge/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "adafruit-pybadge" if BOARD_ADAFRUIT_PYBADGE

--- a/boards/adafruit-pybadge/board.c
+++ b/boards/adafruit-pybadge/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/adafruit-pybadge/include/board.h
+++ b/boards/adafruit-pybadge/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-pybadge/include/gpio_params.h
+++ b/boards/adafruit-pybadge/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/adafruit-pybadge/include/periph_conf.h
+++ b/boards/adafruit-pybadge/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/airfy-beacon/Kconfig
+++ b/boards/airfy-beacon/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "airfy-beacon" if BOARD_AIRFY_BEACON

--- a/boards/airfy-beacon/include/board.h
+++ b/boards/airfy-beacon/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Christian Mehlis <mehlis@inf.fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Christian Mehlis <mehlis@inf.fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/airfy-beacon/include/periph_conf.h
+++ b/boards/airfy-beacon/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Christian Mehlis <mehlis@inf.fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Christian Mehlis <mehlis@inf.fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/alientek-pandora/Kconfig
+++ b/boards/alientek-pandora/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (C) 2021 Luo Jia (HUST IoT Security Lab)
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Luo Jia (HUST IoT Security Lab)
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "alientek-pandora" if BOARD_ALIENTEK_PANDORA

--- a/boards/alientek-pandora/include/board.h
+++ b/boards/alientek-pandora/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Luo Jia (HUST IoT Security Lab)
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Luo Jia (HUST IoT Security Lab)
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/alientek-pandora/include/gpio_params.h
+++ b/boards/alientek-pandora/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Luo Jia (HUST IoT Security Lab)
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Luo Jia (HUST IoT Security Lab)
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/alientek-pandora/include/periph_conf.h
+++ b/boards/alientek-pandora/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Luo Jia (HUST IoT Security Lab)
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Luo Jia (HUST IoT Security Lab)
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-due/Kconfig
+++ b/boards/arduino-due/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "arduino-due" if BOARD_ARDUINO_DUE

--- a/boards/arduino-duemilanove/Kconfig
+++ b/boards/arduino-duemilanove/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_ARDUINO_DUEMILANOVE
     bool

--- a/boards/arduino-duemilanove/include/board.h
+++ b/boards/arduino-duemilanove/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017   Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-leonardo/Kconfig
+++ b/boards/arduino-leonardo/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "arduino-leonardo" if BOARD_ARDUINO_LEONARDO

--- a/boards/arduino-leonardo/board.c
+++ b/boards/arduino-leonardo/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2017 Thomas Perrot <thomas.perrot@tupi.fr>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Thomas Perrot <thomas.perrot@tupi.fr>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/arduino-leonardo/include/board.h
+++ b/boards/arduino-leonardo/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017   Thomas Perrot <thomas.perrot@tupi.fr>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Thomas Perrot <thomas.perrot@tupi.fr>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-mega2560/Kconfig
+++ b/boards/arduino-mega2560/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "arduino-mega2560" if BOARD_ARDUINO_MEGA2560

--- a/boards/arduino-mega2560/include/board.h
+++ b/boards/arduino-mega2560/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017   Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-mkr1000/Kconfig
+++ b/boards/arduino-mkr1000/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "arduino-mkr1000" if BOARD_ARDUINO_MKR1000

--- a/boards/arduino-mkr1000/include/board.h
+++ b/boards/arduino-mkr1000/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-mkrfox1200/Kconfig
+++ b/boards/arduino-mkrfox1200/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "arduino-mkrfox1200" if BOARD_ARDUINO_MKRFOX1200

--- a/boards/arduino-mkrfox1200/include/board.h
+++ b/boards/arduino-mkrfox1200/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-mkrwan1300/Kconfig
+++ b/boards/arduino-mkrwan1300/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "arduino-mkrwan1300" if BOARD_ARDUINO_MKRWAN1300

--- a/boards/arduino-mkrwan1300/include/board.h
+++ b/boards/arduino-mkrwan1300/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-mkrwan1300/include/periph_conf.h
+++ b/boards/arduino-mkrwan1300/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C)  2016 Freie Universität Berlin
- *                2016-2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016-2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-mkrzero/Kconfig
+++ b/boards/arduino-mkrzero/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "arduino-mkrzero" if BOARD_ARDUINO_MKRZERO

--- a/boards/arduino-mkrzero/include/board.h
+++ b/boards/arduino-mkrzero/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-nano-33-ble-sense/Kconfig
+++ b/boards/arduino-nano-33-ble-sense/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2024 Méwen Berthelot
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2024 Méwen Berthelot
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "arduino-nano-33-ble-sense" if BOARD_ARDUINO_NANO_33_BLE_SENSE

--- a/boards/arduino-nano-33-ble-sense/board.c
+++ b/boards/arduino-nano-33-ble-sense/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2024 Méwen Berthelot
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 Méwen Berthelot
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/arduino-nano-33-ble-sense/include/board.h
+++ b/boards/arduino-nano-33-ble-sense/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 Méwen Berthelot
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 Méwen Berthelot
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-nano-33-ble-sense/include/gpio_params.h
+++ b/boards/arduino-nano-33-ble-sense/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-nano-33-ble-sense/include/periph_conf.h
+++ b/boards/arduino-nano-33-ble-sense/include/periph_conf.h
@@ -1,8 +1,6 @@
 /*
- * Copyright (C) 2024 Méwen Berthelot
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 Méwen Berthelot
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-nano-33-ble-sense/reset.c
+++ b/boards/arduino-nano-33-ble-sense/reset.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/arduino-nano-33-ble/Kconfig
+++ b/boards/arduino-nano-33-ble/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "arduino-nano-33-ble" if BOARD_ARDUINO_NANO_33_BLE

--- a/boards/arduino-nano-33-ble/include/board.h
+++ b/boards/arduino-nano-33-ble/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-nano-33-ble/include/gpio_params.h
+++ b/boards/arduino-nano-33-ble/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-nano-33-ble/include/periph_conf.h
+++ b/boards/arduino-nano-33-ble/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-nano-33-ble/reset.c
+++ b/boards/arduino-nano-33-ble/reset.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/arduino-nano-33-iot/Kconfig
+++ b/boards/arduino-nano-33-iot/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "arduino-nano-33-iot" if BOARD_ARDUINO_NANO_33_IOT

--- a/boards/arduino-nano-33-iot/include/board.h
+++ b/boards/arduino-nano-33-iot/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-nano-33-iot/include/gpio_params.h
+++ b/boards/arduino-nano-33-iot/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-nano-33-iot/include/periph_conf.h
+++ b/boards/arduino-nano-33-iot/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-nano/Kconfig
+++ b/boards/arduino-nano/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_ARDUINO_NANO
     bool

--- a/boards/arduino-nano/include/board.h
+++ b/boards/arduino-nano/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017   Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-uno/Kconfig
+++ b/boards/arduino-uno/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_ARDUINO_UNO
     bool

--- a/boards/arduino-uno/include/board.h
+++ b/boards/arduino-uno/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017   Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/arduino-zero/Kconfig
+++ b/boards/arduino-zero/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "arduino-zero" if BOARD_ARDUINO_ZERO

--- a/boards/atmega1284p/Kconfig
+++ b/boards/atmega1284p/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "atmega1284p" if BOARD_ATMEGA1284P

--- a/boards/atmega1284p/include/board.h
+++ b/boards/atmega1284p/include/board.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
- *               2016 Laurent Navet <laurent.navet@gmail.com>
- *               2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ * SPDX-FileCopyrightText: 2016 Laurent Navet <laurent.navet@gmail.com>
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atmega1284p/include/periph_conf.h
+++ b/boards/atmega1284p/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atmega256rfr2-xpro/Kconfig
+++ b/boards/atmega256rfr2-xpro/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "atmega256rfr2-xpro" if BOARD_ATMEGA256RFR2_XPRO

--- a/boards/atmega256rfr2-xpro/include/board.h
+++ b/boards/atmega256rfr2-xpro/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atmega256rfr2-xpro/include/gpio_params.h
+++ b/boards/atmega256rfr2-xpro/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atmega256rfr2-xpro/include/periph_conf.h
+++ b/boards/atmega256rfr2-xpro/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atmega328p-xplained-mini/Kconfig
+++ b/boards/atmega328p-xplained-mini/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-# Copyright (c) 2021-2023 Gerson Fernando Budke
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2021-2023 Gerson Fernando Budke
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "atmega328p-xplained-mini" if BOARD_ATMEGA328P_XPLAINED_MINI

--- a/boards/atmega328p-xplained-mini/include/board.h
+++ b/boards/atmega328p-xplained-mini/include/board.h
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
- *               2016 Laurent Navet <laurent.navet@gmail.com>
- *               2019 Otto-von-Guericke-Universität Magdeburg
- *               2021-2123 Gerson Fernando Budke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ * SPDX-FileCopyrightText: 2016 Laurent Navet <laurent.navet@gmail.com>
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-FileCopyrightText: 2021-2023 Gerson Fernando Budke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atmega328p-xplained-mini/include/gpio_params.h
+++ b/boards/atmega328p-xplained-mini/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gerson Fernando Budke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gerson Fernando Budke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atmega328p-xplained-mini/include/periph_conf.h
+++ b/boards/atmega328p-xplained-mini/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *               2021 Gerson Fernando Budke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-FileCopyrightText: 2021 Gerson Fernando Budke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atmega328p/Kconfig
+++ b/boards/atmega328p/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "atmega328p" if BOARD_ATMEGA328P

--- a/boards/atmega328p/include/board.h
+++ b/boards/atmega328p/include/board.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
- *               2016 Laurent Navet <laurent.navet@gmail.com>
- *               2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ * SPDX-FileCopyrightText: 2016 Laurent Navet <laurent.navet@gmail.com>
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atmega328p/include/periph_conf.h
+++ b/boards/atmega328p/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atmega8/Kconfig
+++ b/boards/atmega8/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "atmega8" if BOARD_ATMEGA8

--- a/boards/atmega8/include/board.h
+++ b/boards/atmega8/include/board.h
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
- *               2016 Laurent Navet <laurent.navet@gmail.com>
- *               2019 Otto-von-Guericke-Universität Magdeburg
- *               2023 Hugues Larrive
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ * SPDX-FileCopyrightText: 2016 Laurent Navet <laurent.navet@gmail.com>
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-FileCopyrightText: 2023 Hugues Larrive
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atmega8/include/periph_conf.h
+++ b/boards/atmega8/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *               2023 Hugues Larrive
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-FileCopyrightText: 2023 Hugues Larrive
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atxmega-a1-xplained/Kconfig
+++ b/boards/atxmega-a1-xplained/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-# Copyright (c) 2021 Gerson Fernando Budle
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2021 Gerson Fernando Budke
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "atxmega-a1-xplained" if BOARD_ATXMEGA_A1_XPLAINED

--- a/boards/atxmega-a1-xplained/include/board.h
+++ b/boards/atxmega-a1-xplained/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gerson Fernando Budke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gerson Fernando Budke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atxmega-a1-xplained/include/gpio_params.h
+++ b/boards/atxmega-a1-xplained/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gerson Fernando Budke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gerson Fernando Budke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atxmega-a1-xplained/include/periph_conf.h
+++ b/boards/atxmega-a1-xplained/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gerson Fernando Budke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gerson Fernando Budke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atxmega-a1u-xpro/Kconfig
+++ b/boards/atxmega-a1u-xpro/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-# Copyright (c) 2021 Gerson Fernando Budle
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2021 Gerson Fernando Budke
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "atxmega-a1u-xpro" if BOARD_ATXMEGA_A1U_XPRO

--- a/boards/atxmega-a1u-xpro/include/board.h
+++ b/boards/atxmega-a1u-xpro/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gerson Fernando Budke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gerson Fernando Budke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atxmega-a1u-xpro/include/gpio_params.h
+++ b/boards/atxmega-a1u-xpro/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gerson Fernando Budke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gerson Fernando Budke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atxmega-a1u-xpro/include/periph_conf.h
+++ b/boards/atxmega-a1u-xpro/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gerson Fernando Budke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gerson Fernando Budke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atxmega-a3bu-xplained/Kconfig
+++ b/boards/atxmega-a3bu-xplained/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-# Copyright (c) 2021 Gerson Fernando Budle
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2021 Gerson Fernando Budke
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "atxmega-a3bu-xplained" if BOARD_ATXMEGA_A3BU_XPLAINED

--- a/boards/atxmega-a3bu-xplained/include/board.h
+++ b/boards/atxmega-a3bu-xplained/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gerson Fernando Budke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gerson Fernando Budke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atxmega-a3bu-xplained/include/gpio_params.h
+++ b/boards/atxmega-a3bu-xplained/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gerson Fernando Budke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gerson Fernando Budke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/atxmega-a3bu-xplained/include/periph_conf.h
+++ b/boards/atxmega-a3bu-xplained/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gerson Fernando Budke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gerson Fernando Budke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/avr-rss2/Kconfig
+++ b/boards/avr-rss2/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "avr-rss2" if BOARD_AVR_RSS2

--- a/boards/avr-rss2/include/board.h
+++ b/boards/avr-rss2/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Robert Olsson <roolss@kth.se>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Robert Olsson <roolss@kth.se>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/avr-rss2/include/eui_provider_params.h
+++ b/boards/avr-rss2/include/eui_provider_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/avr-rss2/include/gpio_params.h
+++ b/boards/avr-rss2/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Robert Olsson <roolss@kth.se>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Robert Olsson <roolss@kth.se>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/avr-rss2/include/periph_conf.h
+++ b/boards/avr-rss2/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Robert Olsson <roolss@kth.se>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Robert Olsson <roolss@kth.se>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/avr-rss2/led_init.c
+++ b/boards/avr-rss2/led_init.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Robert Olsson <roolss@kth.se>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Robert Olsson <roolss@kth.se>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/avsextrem/Kconfig
+++ b/boards/avsextrem/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "avsextrem" if BOARD_AVSEXTREM

--- a/boards/avsextrem/board_init.c
+++ b/boards/avsextrem/board_init.c
@@ -1,10 +1,6 @@
 /*
- * board_init.c - initialization of the AVSEXTREM-BOARD.
- * Copyright (C) 2013 Heiko Will <hwill@inf.fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Heiko Will <hwill@inf.fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/avsextrem/include/board.h
+++ b/boards/avsextrem/include/board.h
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2013 Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2013 Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/avsextrem/include/periph_conf.h
+++ b/boards/avsextrem/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/b-l072z-lrwan1/Kconfig
+++ b/boards/b-l072z-lrwan1/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "b-l072z-lrwan1" if BOARD_B_L072Z_LRWAN1

--- a/boards/b-l072z-lrwan1/board.c
+++ b/boards/b-l072z-lrwan1/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/b-l072z-lrwan1/include/board.h
+++ b/boards/b-l072z-lrwan1/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/b-l072z-lrwan1/include/gpio_params.h
+++ b/boards/b-l072z-lrwan1/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) Inria 2016
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/b-l072z-lrwan1/include/periph_conf.h
+++ b/boards/b-l072z-lrwan1/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/b-l475e-iot01a/Kconfig
+++ b/boards/b-l475e-iot01a/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "b-l475e-iot01a" if BOARD_B_L475E_IOT01A

--- a/boards/b-l475e-iot01a/include/board.h
+++ b/boards/b-l475e-iot01a/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/b-l475e-iot01a/include/gpio_params.h
+++ b/boards/b-l475e-iot01a/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) Inria 2017
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/b-l475e-iot01a/include/periph_conf.h
+++ b/boards/b-l475e-iot01a/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/b-u585i-iot02a/Kconfig
+++ b/boards/b-u585i-iot02a/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "b-u585i-iot02a" if BOARD_B_U585I_IOT02A

--- a/boards/b-u585i-iot02a/board.c
+++ b/boards/b-u585i-iot02a/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/b-u585i-iot02a/include/board.h
+++ b/boards/b-u585i-iot02a/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/b-u585i-iot02a/include/gpio_params.h
+++ b/boards/b-u585i-iot02a/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) Inria 2021
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/b-u585i-iot02a/include/periph_conf.h
+++ b/boards/b-u585i-iot02a/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/bastwan/Kconfig
+++ b/boards/bastwan/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "bastwan" if BOARD_BASTWAN

--- a/boards/bastwan/board.c
+++ b/boards/bastwan/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021  Lokotius Filzer
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Lokotius Filzer
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/bastwan/include/board.h
+++ b/boards/bastwan/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021  Lokotius Filzer
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Lokotius Filzer
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/bastwan/include/gpio_params.h
+++ b/boards/bastwan/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021  Lokotius Filzer
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Lokotius Filzer
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/bastwan/include/periph_conf.h
+++ b/boards/bastwan/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019  Lokotius Filzer
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Lokotius Filzer
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/blackpill-stm32f103c8/Kconfig
+++ b/boards/blackpill-stm32f103c8/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "blackpill-stm32f103c8" if BOARD_BLACKPILL_STM32F103C8

--- a/boards/blackpill-stm32f103c8/include/board.h
+++ b/boards/blackpill-stm32f103c8/include/board.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2015 TriaGnoSys GmbH
- *               2017 Alexander Kurth, Sören Tempel, Tristan Bruns
- *               2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 TriaGnoSys GmbH
+ * SPDX-FileCopyrightText: 2017 Alexander Kurth, Sören Tempel, Tristan Bruns
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/blackpill-stm32f103cb/Kconfig
+++ b/boards/blackpill-stm32f103cb/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "blackpill-stm32f103cb" if BOARD_BLACKPILL_STM32F103CB

--- a/boards/blackpill-stm32f103cb/include/board.h
+++ b/boards/blackpill-stm32f103cb/include/board.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2015 TriaGnoSys GmbH
- *               2017 Alexander Kurth, Sören Tempel, Tristan Bruns
- *               2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 TriaGnoSys GmbH
+ * SPDX-FileCopyrightText: 2017 Alexander Kurth, Sören Tempel, Tristan Bruns
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/bluepill-stm32f030c8/Kconfig
+++ b/boards/bluepill-stm32f030c8/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Benjamin Valentin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Benjamin Valentin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "bluepill-stm32f030c8" if BOARD_BLUEPILL_STM32F030C8

--- a/boards/bluepill-stm32f030c8/include/board.h
+++ b/boards/bluepill-stm32f030c8/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/bluepill-stm32f030c8/include/gpio_params.h
+++ b/boards/bluepill-stm32f030c8/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/bluepill-stm32f030c8/include/periph_conf.h
+++ b/boards/bluepill-stm32f030c8/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/bluepill-stm32f103c8/Kconfig
+++ b/boards/bluepill-stm32f103c8/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "bluepill-stm32f103c8" if BOARD_BLUEPILL_STM32F103C8

--- a/boards/bluepill-stm32f103c8/include/board.h
+++ b/boards/bluepill-stm32f103c8/include/board.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 TriaGnoSys GmbH
- *               2017 Alexander Kurth, Sören Tempel, Tristan Bruns
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 TriaGnoSys GmbH
+ * SPDX-FileCopyrightText: 2017 Alexander Kurth, Sören Tempel, Tristan Bruns
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/bluepill-stm32f103cb/Kconfig
+++ b/boards/bluepill-stm32f103cb/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "bluepill-stm32f103cb" if BOARD_BLUEPILL_STM32F103CB

--- a/boards/bluepill-stm32f103cb/include/board.h
+++ b/boards/bluepill-stm32f103cb/include/board.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 TriaGnoSys GmbH
- *               2017 Alexander Kurth, Sören Tempel, Tristan Bruns
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 TriaGnoSys GmbH
+ * SPDX-FileCopyrightText: 2017 Alexander Kurth, Sören Tempel, Tristan Bruns
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/calliope-mini/Kconfig
+++ b/boards/calliope-mini/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "calliope-mini" if BOARD_CALLIOPE_MINI

--- a/boards/calliope-mini/include/board.h
+++ b/boards/calliope-mini/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/calliope-mini/include/gpio_params.h
+++ b/boards/calliope-mini/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/calliope-mini/include/periph_conf.h
+++ b/boards/calliope-mini/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc1312-launchpad/Kconfig
+++ b/boards/cc1312-launchpad/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Locha Inc
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Locha Inc
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "cc1312-launchpad" if BOARD_CC1312_LAUNCHPAD

--- a/boards/cc1312-launchpad/include/board.h
+++ b/boards/cc1312-launchpad/include/board.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C)    2016 Nicholas Jackson
- *                  2017 Sebastian Meiling
- *                  2018 Anton Gerasimov
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 Nicholas Jackson
+ * SPDX-FileCopyrightText: 2017 Sebastian Meiling
+ * SPDX-FileCopyrightText: 2018 Anton Gerasimov
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc1312-launchpad/include/gpio_params.h
+++ b/boards/cc1312-launchpad/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Jean Pierre Dudey
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Jean Pierre Dudey
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc1312-launchpad/include/periph_conf.h
+++ b/boards/cc1312-launchpad/include/periph_conf.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C)    2016 Nicholas Jackson
- *                  2017 HAW Hamburg
- *                  2020 Locha Inc
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Nicholas Jackson
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-FileCopyrightText: 2020 Locha Inc
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc1350-launchpad/Kconfig
+++ b/boards/cc1350-launchpad/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Locha Inc
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Locha Inc
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "cc1350-launchpad" if BOARD_CC1350_LAUNCHPAD

--- a/boards/cc1350-launchpad/include/board.h
+++ b/boards/cc1350-launchpad/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)    2021 Jean Pierre Dudey
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2021 Jean Pierre Dudey
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc1350-launchpad/include/gpio_params.h
+++ b/boards/cc1350-launchpad/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Jean Pierre Dudey
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Jean Pierre Dudey
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc1350-launchpad/include/periph_conf.h
+++ b/boards/cc1350-launchpad/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)    2021 Jean Pierre Dudey
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Jean Pierre Dudey
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc1352-launchpad/Kconfig
+++ b/boards/cc1352-launchpad/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Locha Inc
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Locha Inc
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "cc1352-launchpad" if BOARD_CC1352_LAUNCHPAD

--- a/boards/cc1352-launchpad/include/board.h
+++ b/boards/cc1352-launchpad/include/board.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C)    2016 Nicholas Jackson
- *                  2017 Sebastian Meiling
- *                  2018 Anton Gerasimov
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 Nicholas Jackson
+ * SPDX-FileCopyrightText: 2017 Sebastian Meiling
+ * SPDX-FileCopyrightText: 2018 Anton Gerasimov
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc1352-launchpad/include/gpio_params.h
+++ b/boards/cc1352-launchpad/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc1352-launchpad/include/periph_conf.h
+++ b/boards/cc1352-launchpad/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C)    2016 Nicholas Jackson
- *                  2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Nicholas Jackson
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc1352p-launchpad/Kconfig
+++ b/boards/cc1352p-launchpad/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Locha Inc
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Locha Inc
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "cc1352p-launchpad" if BOARD_CC1352P_LAUNCHPAD

--- a/boards/cc1352p-launchpad/include/board.h
+++ b/boards/cc1352p-launchpad/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)    2020 Locha Inc
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Locha Inc
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc1352p-launchpad/include/gpio_params.h
+++ b/boards/cc1352p-launchpad/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc1352p-launchpad/include/periph_conf.h
+++ b/boards/cc1352p-launchpad/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)    2020 Locha Inc
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Locha Inc
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc2538dk/Kconfig
+++ b/boards/cc2538dk/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "cc2538dk" if BOARD_CC2538DK

--- a/boards/cc2538dk/include/board.h
+++ b/boards/cc2538dk/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Loci Controls Inc.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Loci Controls Inc.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Loci Controls Inc.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Loci Controls Inc.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc2650-launchpad/Kconfig
+++ b/boards/cc2650-launchpad/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Locha Inc
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Locha Inc
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "cc2650-launchpad" if BOARD_CC2650_LAUNCHPAD

--- a/boards/cc2650-launchpad/include/board.h
+++ b/boards/cc2650-launchpad/include/board.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C)    2016 Nicholas Jackson
- *                  2017 Sebastian Meiling
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 Nicholas Jackson
+ * SPDX-FileCopyrightText: 2017 Sebastian Meiling
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc2650-launchpad/include/gpio_params.h
+++ b/boards/cc2650-launchpad/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Jean Pierre Dudey
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Jean Pierre Dudey
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc2650-launchpad/include/periph_conf.h
+++ b/boards/cc2650-launchpad/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C)    2016 Nicholas Jackson
- *                  2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Nicholas Jackson
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc2650stk/Kconfig
+++ b/boards/cc2650stk/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Locha Inc
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Locha Inc
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "cc2650stk" if BOARD_CC2650STK

--- a/boards/cc2650stk/include/board.h
+++ b/boards/cc2650stk/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Leon George
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Leon George
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc2650stk/include/gpio_params.h
+++ b/boards/cc2650stk/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017   HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/cc2650stk/include/periph_conf.h
+++ b/boards/cc2650stk/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Leon George
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Leon George
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/adafruit-nrf52-bootloader/reset.c
+++ b/boards/common/adafruit-nrf52-bootloader/reset.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/arduino-atmega/Kconfig
+++ b/boards/common/arduino-atmega/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_ARDUINO_ATMEGA
     bool

--- a/boards/common/arduino-atmega/include/arduino_iomap.h
+++ b/boards/common/arduino-atmega/include/arduino_iomap.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *               2016 Laurent Navet <laurent.navet@gmail.com>
- *               2017 Thomas Perrot <thomas.perrot@tupi.fr>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016 Laurent Navet <laurent.navet@gmail.com>
+ * SPDX-FileCopyrightText: 2017 Thomas Perrot <thomas.perrot@tupi.fr>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/arduino-atmega/include/board_common.h
+++ b/boards/common/arduino-atmega/include/board_common.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
- *               2016 Laurent Navet <laurent.navet@gmail.com>
- *               2017 Thomas Perrot <thomas.perrot@tupi.fr>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ * SPDX-FileCopyrightText: 2016 Laurent Navet <laurent.navet@gmail.com>
+ * SPDX-FileCopyrightText: 2017 Thomas Perrot <thomas.perrot@tupi.fr>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/arduino-atmega/include/gpio_params.h
+++ b/boards/common/arduino-atmega/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/arduino-atmega/include/periph_conf.h
+++ b/boards/common/arduino-atmega/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/arduino-due/Kconfig
+++ b/boards/common/arduino-due/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_ARDUINO_DUE
     bool

--- a/boards/common/arduino-due/include/arduino_iomap.h
+++ b/boards/common/arduino-due/include/arduino_iomap.h
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 2015,2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/arduino-due/include/board.h
+++ b/boards/common/arduino-due/include/board.h
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 2014,2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/arduino-due/include/gpio_params.h
+++ b/boards/common/arduino-due/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/arduino-due/include/periph_conf.h
+++ b/boards/common/arduino-due/include/periph_conf.h
@@ -1,12 +1,10 @@
-#pragma once
-
- /*
- * Copyright (C) 2014-2015,2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+/*
+ * SPDX-FileCopyrightText: 2014-2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
+#pragma once
 
 /**
  * @ingroup     boards_common_arduino_due

--- a/boards/common/arduino-due/include/sdcard_spi_params.h
+++ b/boards/common/arduino-due/include/sdcard_spi_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
- *               2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/arduino-mkr/Kconfig
+++ b/boards/common/arduino-mkr/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_ARDUINO_MKR
     bool

--- a/boards/common/arduino-mkr/include/arduino_iomap.h
+++ b/boards/common/arduino-mkr/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2016-2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/arduino-mkr/include/board_common.h
+++ b/boards/common/arduino-mkr/include/board_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/arduino-mkr/include/gpio_params.h
+++ b/boards/common/arduino-mkr/include/gpio_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C)  2016-2017 Inria
- *                2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2017 Inria
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/arduino-mkr/include/periph_conf.h
+++ b/boards/common/arduino-mkr/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C)  2016 Freie Universität Berlin
- *                2016-2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016-2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/arduino-mkr/include/periph_conf_common.h
+++ b/boards/common/arduino-mkr/include/periph_conf_common.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C)  2016 Freie Universität Berlin
- *                2016-2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016-2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/arduino-zero/Kconfig
+++ b/boards/common/arduino-zero/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_ARDUINO_ZERO
     bool

--- a/boards/common/arduino-zero/include/arduino_iomap.h
+++ b/boards/common/arduino-zero/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/arduino-zero/include/board.h
+++ b/boards/common/arduino-zero/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/arduino-zero/include/gpio_params.h
+++ b/boards/common/arduino-zero/include/gpio_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C)  2016 Freie Universität Berlin
- *                2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/arduino-zero/include/periph_conf.h
+++ b/boards/common/arduino-zero/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C)  2016 Freie Universität Berlin
- *                2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/atmega/include/periph_conf_atmega_common.h
+++ b/boards/common/atmega/include/periph_conf_atmega_common.h
@@ -1,16 +1,13 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
- *               2016 Laurent Navet <laurent.navet@gmail.com>
- *               2016 RWTH Aachen, Josua Arndt
- *               2016 INRIA, Francisco Acosta
- *               2017 HAW Hamburg, Dimitri Nahm
- *               2018 Matthew Blue <matthew.blue.neuro@gmail.com>
- *               2019 Otto-von-Guericke-Universität Magdeburg
- *               2023 Hugues Larrive
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ * SPDX-FileCopyrightText: 2016 Laurent Navet <laurent.navet@gmail.com>
+ * SPDX-FileCopyrightText: 2016 RWTH Aachen, Josua Arndt
+ * SPDX-FileCopyrightText: 2016 INRIA, Francisco Acosta
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg, Dimitri Nahm
+ * SPDX-FileCopyrightText: 2018 Matthew Blue <matthew.blue.neuro@gmail.com>
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-FileCopyrightText: 2023 Hugues Larrive
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/atxmega/include/periph_conf_common.h
+++ b/boards/common/atxmega/include/periph_conf_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gerson Fernando Budke <nandojve@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gerson Fernando Budke <nandojve@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/blxxxpill/Kconfig
+++ b/boards/common/blxxxpill/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_BLXXXPILL
     bool

--- a/boards/common/blxxxpill/include/board_common.h
+++ b/boards/common/blxxxpill/include/board_common.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 TriaGnoSys GmbH
- *               2017 Alexander Kurth, Sören Tempel, Tristan Bruns
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 TriaGnoSys GmbH
+ * SPDX-FileCopyrightText: 2017 Alexander Kurth, Sören Tempel, Tristan Bruns
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/blxxxpill/include/gpio_params.h
+++ b/boards/common/blxxxpill/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/blxxxpill/include/periph_conf.h
+++ b/boards/common/blxxxpill/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 TriaGnoSys GmbH
- *               2017 Alexander Kurth, Sören Tempel, Tristan Bruns
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 TriaGnoSys GmbH
+ * SPDX-FileCopyrightText: 2017 Alexander Kurth, Sören Tempel, Tristan Bruns
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/cc2538/include/cfg_clk_default.h
+++ b/boards/common/cc2538/include/cfg_clk_default.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *               2015 Zolertia SL
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Zolertia SL
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/cc2538/include/cfg_timer_default.h
+++ b/boards/common/cc2538/include/cfg_timer_default.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *               2015 Zolertia SL
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Zolertia SL
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/e104-bt50xxa-tb/Kconfig
+++ b/boards/common/e104-bt50xxa-tb/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 Benjamin Valentin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 Benjamin Valentin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_E104_BT50XXA_TB
     bool

--- a/boards/common/e104-bt50xxa-tb/board.c
+++ b/boards/common/e104-bt50xxa-tb/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/e104-bt50xxa-tb/include/board.h
+++ b/boards/common/e104-bt50xxa-tb/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/e104-bt50xxa-tb/include/gpio_params.h
+++ b/boards/common/e104-bt50xxa-tb/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/e104-bt50xxa-tb/include/periph_conf.h
+++ b/boards/common/e104-bt50xxa-tb/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/esp32/Kconfig
+++ b/boards/common/esp32/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_ESP32
     bool

--- a/boards/common/esp32/include/board_common_esp32.h
+++ b/boards/common/esp32/include/board_common_esp32.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/esp32/include/periph_conf_common_esp32.h
+++ b/boards/common/esp32/include/periph_conf_common_esp32.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/esp32c3/Kconfig
+++ b/boards/common/esp32c3/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-#               2022 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2022 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_ESP32C3
     bool

--- a/boards/common/esp32c3/include/board_common_esp32c3.h
+++ b/boards/common/esp32c3/include/board_common_esp32c3.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/esp32c3/include/periph_conf_common_esp32c3.h
+++ b/boards/common/esp32c3/include/periph_conf_common_esp32c3.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/esp32h2/Kconfig
+++ b/boards/common/esp32h2/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2025 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2025 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_ESP32H2
     bool

--- a/boards/common/esp32h2/include/board_common_esp32h2.h
+++ b/boards/common/esp32h2/include/board_common_esp32h2.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/esp32h2/include/periph_conf_common_esp32h2.h
+++ b/boards/common/esp32h2/include/periph_conf_common_esp32h2.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/esp32s2/Kconfig
+++ b/boards/common/esp32s2/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-#               2022 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2022 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_ESP32S2
     bool

--- a/boards/common/esp32s2/include/board_common_esp32s2.h
+++ b/boards/common/esp32s2/include/board_common_esp32s2.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/esp32s2/include/periph_conf_common_esp32s2.h
+++ b/boards/common/esp32s2/include/periph_conf_common_esp32s2.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/esp32s3/Kconfig
+++ b/boards/common/esp32s3/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-#               2022 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2022 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_ESP32S3
     bool

--- a/boards/common/esp32s3/include/board_common_esp32s3.h
+++ b/boards/common/esp32s3/include/board_common_esp32s3.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/esp32s3/include/periph_conf_common_esp32s3.h
+++ b/boards/common/esp32s3/include/periph_conf_common_esp32s3.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/esp32x/Kconfig
+++ b/boards/common/esp32x/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_ESP32X
     bool

--- a/boards/common/esp32x/board_common.c
+++ b/boards/common/esp32x/board_common.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/esp32x/include/board_common.h
+++ b/boards/common/esp32x/include/board_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/esp32x/include/periph_conf_common.h
+++ b/boards/common/esp32x/include/periph_conf_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/esp8266/Kconfig
+++ b/boards/common/esp8266/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_ESP8266
     bool

--- a/boards/common/esp8266/board_common.c
+++ b/boards/common/esp8266/board_common.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/esp8266/include/board_common.h
+++ b/boards/common/esp8266/include/board_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/esp8266/include/board_modules.h
+++ b/boards/common/esp8266/include/board_modules.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/esp8266/include/periph_conf_common.h
+++ b/boards/common/esp8266/include/periph_conf_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/gd32v/Kconfig
+++ b/boards/common/gd32v/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2023 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2023 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_HAS_HXTAL
     bool

--- a/boards/common/gd32v/include/board_common.h
+++ b/boards/common/gd32v/include/board_common.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
- *               2023 Gunar Schorcht <gunar@schorcht.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht <gunar@schorcht.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/gd32v/include/cfg_i2c_default.h
+++ b/boards/common/gd32v/include/cfg_i2c_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht <gunar@schorcht.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht <gunar@schorcht.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/gd32v/include/cfg_spi_default.h
+++ b/boards/common/gd32v/include/cfg_spi_default.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
- *               2023 Gunar Schorcht <gunar@schorcht.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht <gunar@schorcht.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/gd32v/include/cfg_timer_default.h
+++ b/boards/common/gd32v/include/cfg_timer_default.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
- *               2023 Gunar Schorcht <gunar@schorcht.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht <gunar@schorcht.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/gd32v/include/cfg_uart_default.h
+++ b/boards/common/gd32v/include/cfg_uart_default.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
- *               2023 Gunar Schorcht <gunar@schorcht.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht <gunar@schorcht.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/gd32v/include/cfg_usbdev_default.h
+++ b/boards/common/gd32v/include/cfg_usbdev_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht <gunar@schorcht.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht <gunar@schorcht.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/gd32v/include/periph_common_conf.h
+++ b/boards/common/gd32v/include/periph_common_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
- *               2023 Gunar Schorcht <gunar@schorcht.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht <gunar@schorcht.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/init/board_common.c
+++ b/boards/common/init/board_common.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/iotlab/Kconfig
+++ b/boards/common/iotlab/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_IOTLAB
     bool

--- a/boards/common/iotlab/include/board_common.h
+++ b/boards/common/iotlab/include/board_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014-2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/iotlab/include/gpio_params.h
+++ b/boards/common/iotlab/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/iotlab/include/openwsn_defs.h
+++ b/boards/common/iotlab/include/openwsn_defs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/iotlab/include/periph_conf_common.h
+++ b/boards/common/iotlab/include/periph_conf_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/kw41z/Kconfig
+++ b/boards/common/kw41z/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_KW41Z
     bool

--- a/boards/common/kw41z/include/board_common.h
+++ b/boards/common/kw41z/include/board_common.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Eistec AB
- *               2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Eistec AB
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/kw41z/include/cfg_i2c_default.h
+++ b/boards/common/kw41z/include/cfg_i2c_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/kw41z/include/periph_conf_common.h
+++ b/boards/common/kw41z/include/periph_conf_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/microbit/include/microbit.h
+++ b/boards/common/microbit/include/microbit.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/microbit/microbit.c
+++ b/boards/common/microbit/microbit.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/msb-430/Kconfig
+++ b/boards/common/msb-430/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_MSB_430
     bool

--- a/boards/common/msb-430/board_init.c
+++ b/boards/common/msb-430/board_init.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 INRIA
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 INRIA
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/msb-430/include/board_common.h
+++ b/boards/common/msb-430/include/board_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/msp430/include/cfg_timer_a_smclk_b_aclk.h
+++ b/boards/common/msp430/include/cfg_timer_a_smclk_b_aclk.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/native/board_init.c
+++ b/boards/common/native/board_init.c
@@ -1,11 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 /**
  * Native Board board_init implementation
- *
- * Copyright (C) 2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
  *
  * @ingroup boards_common_native
  * @{

--- a/boards/common/native/drivers/native-led.c
+++ b/boards/common/native/drivers/native-led.c
@@ -1,13 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 /**
  * Native Board LED implementation
  *
  * Only prints function calls at the moment.
- *
- * Copyright (C) 2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
  *
  * @ingroup boards_common_native
  * @{

--- a/boards/common/native/drivers/native-qdec.c
+++ b/boards/common/native/drivers/native-qdec.c
@@ -1,18 +1,19 @@
-/**
+/*
+ * SPDX-FileCopyrightText: 2018 Gilles DOFFE <g.doffe@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/*
  * Native Board board implementation
- *
- * Copyright (C) 2018 Gilles DOFFE <g.doffe@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
  *
  * @ingroup boards_common_native
  * @{
  * @file
  * @author  Gilles DOFFE <g.doffe@gmail.com>
  * @}
+ *
  */
+
 #include <inttypes.h>
 #include <stdio.h>
 

--- a/boards/common/native/include/board.h
+++ b/boards/common/native/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/native/include/board_internal.h
+++ b/boards/common/native/include/board_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013, 2014 Ludwig Knüpfer
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013-2014 Ludwig Knüpfer
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/native/include/eui_provider_params.h
+++ b/boards/common/native/include/eui_provider_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nrf51/Kconfig
+++ b/boards/common/nrf51/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_NRF51
     bool

--- a/boards/common/nrf51/include/board_common.h
+++ b/boards/common/nrf51/include/board_common.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *               2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nrf51/include/cfg_clock_16_0.h
+++ b/boards/common/nrf51/include/cfg_clock_16_0.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nrf51/include/cfg_clock_16_1.h
+++ b/boards/common/nrf51/include/cfg_clock_16_1.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nrf51/include/cfg_rtt_default.h
+++ b/boards/common/nrf51/include/cfg_rtt_default.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Inria
- *               2019 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nrf51/include/cfg_timer_01.h
+++ b/boards/common/nrf51/include/cfg_timer_01.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Inria
- *               2019 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nrf51/include/cfg_timer_012.h
+++ b/boards/common/nrf51/include/cfg_timer_012.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Inria
- *               2019 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nrf52/Kconfig
+++ b/boards/common/nrf52/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_NRF52
     bool

--- a/boards/common/nrf52/include/board_common.h
+++ b/boards/common/nrf52/include/board_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nrf52/include/cfg_clock_32_0.h
+++ b/boards/common/nrf52/include/cfg_clock_32_0.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nrf52/include/cfg_clock_32_1.h
+++ b/boards/common/nrf52/include/cfg_clock_32_1.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nrf52/include/cfg_i2c_default.h
+++ b/boards/common/nrf52/include/cfg_i2c_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nrf52/include/cfg_rtt_default.h
+++ b/boards/common/nrf52/include/cfg_rtt_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nrf52/include/cfg_spi_default.h
+++ b/boards/common/nrf52/include/cfg_spi_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nrf52/include/cfg_timer_default.h
+++ b/boards/common/nrf52/include/cfg_timer_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nrf52xxxdk/Kconfig
+++ b/boards/common/nrf52xxxdk/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARDS_COMMON_NRF52XXXDK
     bool

--- a/boards/common/nrf52xxxdk/include/gpio_params.h
+++ b/boards/common/nrf52xxxdk/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nrf52xxxdk/include/periph_conf_common.h
+++ b/boards/common/nrf52xxxdk/include/periph_conf_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nrf52xxxdk/include/pwm_params.h
+++ b/boards/common/nrf52xxxdk/include/pwm_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nucleo/Kconfig
+++ b/boards/common/nucleo/Kconfig
@@ -1,8 +1,4 @@
-# Copyright (c) 2021 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource "../stm32/Kconfig"

--- a/boards/common/nucleo/include/board_nucleo.h
+++ b/boards/common/nucleo/include/board_nucleo.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nucleo144/Kconfig
+++ b/boards/common/nucleo144/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_NUCLEO144
     bool

--- a/boards/common/nucleo144/include/arduino_iomap.h
+++ b/boards/common/nucleo144/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nucleo144/include/board.h
+++ b/boards/common/nucleo144/include/board.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2017 Inria
- *               2017 OTAKeys
- *               2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2017 OTAKeys
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nucleo144/include/gpio_params.h
+++ b/boards/common/nucleo144/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nucleo32/Kconfig
+++ b/boards/common/nucleo32/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_NUCLEO32
     bool

--- a/boards/common/nucleo32/include/arduino_iomap.h
+++ b/boards/common/nucleo32/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nucleo32/include/board.h
+++ b/boards/common/nucleo32/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nucleo32/include/gpio_params.h
+++ b/boards/common/nucleo32/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nucleo64/Kconfig
+++ b/boards/common/nucleo64/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_NUCLEO64
     bool

--- a/boards/common/nucleo64/include/arduino_iomap.h
+++ b/boards/common/nucleo64/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/nucleo64/include/board.h
+++ b/boards/common/nucleo64/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/particle-mesh/Kconfig
+++ b/boards/common/particle-mesh/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_PARTICLE_MESH
     bool

--- a/boards/common/particle-mesh/bat_voltage.c
+++ b/boards/common/particle-mesh/bat_voltage.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/particle-mesh/board.c
+++ b/boards/common/particle-mesh/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/particle-mesh/bootloader.c
+++ b/boards/common/particle-mesh/bootloader.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/particle-mesh/include/bat_voltage_params.h
+++ b/boards/common/particle-mesh/include/bat_voltage_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/particle-mesh/include/board.h
+++ b/boards/common/particle-mesh/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/particle-mesh/include/gpio_params.h
+++ b/boards/common/particle-mesh/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/particle-mesh/include/periph_conf_common.h
+++ b/boards/common/particle-mesh/include/periph_conf_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/particle-mesh/include/pwm_params.h
+++ b/boards/common/particle-mesh/include/pwm_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Christian Amsüss <chrysn@fsfe.org>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Christian Amsüss <chrysn@fsfe.org>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/particle-mesh/reset.c
+++ b/boards/common/particle-mesh/reset.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2020 Christian Amsüss
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Christian Amsüss
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/qn908x/Kconfig
+++ b/boards/common/qn908x/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 iosabi
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 iosabi
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_QN908X
     bool

--- a/boards/common/remote/Kconfig
+++ b/boards/common/remote/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_REMOTE
     bool

--- a/boards/common/remote/include/board_common.h
+++ b/boards/common/remote/include/board_common.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- * Copyright (C) 2015 Zolertia SL
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Zolertia SL
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/remote/include/cfg_adc_default.h
+++ b/boards/common/remote/include/cfg_adc_default.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *               2015 Zolertia SL
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Zolertia SL
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/remote/include/cfg_i2c_default.h
+++ b/boards/common/remote/include/cfg_i2c_default.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *               2015 Zolertia SL
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Zolertia SL
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/remote/include/cfg_spi_default.h
+++ b/boards/common/remote/include/cfg_spi_default.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *               2015 Zolertia SL
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Zolertia SL
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/remote/include/cfg_uart_default.h
+++ b/boards/common/remote/include/cfg_uart_default.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *               2015 Zolertia SL
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Zolertia SL
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/remote/include/fancy_leds.h
+++ b/boards/common/remote/include/fancy_leds.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- * Copyright (C) 2015 Zolertia SL
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Zolertia SL
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/samdx1-arduino-bootloader/reset.c
+++ b/boards/common/samdx1-arduino-bootloader/reset.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C)  2019 Inria
- *                2019 Kees Bakker, SODAQ
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-FileCopyrightText: 2019 Kees Bakker, SODAQ
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/saml1x/Kconfig
+++ b/boards/common/saml1x/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_SAML1X
     bool

--- a/boards/common/saml1x/include/board.h
+++ b/boards/common/saml1x/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/saml1x/include/gpio_params.h
+++ b/boards/common/saml1x/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/seeedstudio-xiao-nrf52840/include/arduino_iomap.h
+++ b/boards/common/seeedstudio-xiao-nrf52840/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/seeedstudio-xiao-nrf52840/include/board.h
+++ b/boards/common/seeedstudio-xiao-nrf52840/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/seeedstudio-xiao-nrf52840/include/gpio_params.h
+++ b/boards/common/seeedstudio-xiao-nrf52840/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/seeedstudio-xiao-nrf52840/include/periph_conf.h
+++ b/boards/common/seeedstudio-xiao-nrf52840/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/seeedstudio-xiao-nrf52840/mtd.c
+++ b/boards/common/seeedstudio-xiao-nrf52840/mtd.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/silabs/Kconfig
+++ b/boards/common/silabs/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_SILABS
     bool

--- a/boards/common/silabs/board_common.c
+++ b/boards/common/silabs/board_common.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/silabs/drivers/aem/aem.c
+++ b/boards/common/silabs/drivers/aem/aem.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/silabs/drivers/bc/bc.c
+++ b/boards/common/silabs/drivers/bc/bc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/silabs/drivers/include/aem.h
+++ b/boards/common/silabs/drivers/include/aem.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/silabs/drivers/include/bc.h
+++ b/boards/common/silabs/drivers/include/bc.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/silabs/drivers/include/pic.h
+++ b/boards/common/silabs/drivers/include/pic.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/silabs/drivers/pic/pic.c
+++ b/boards/common/silabs/drivers/pic/pic.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/silabs/include/arduino_iomap.h
+++ b/boards/common/silabs/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2018 Federico Pellegrin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Federico Pellegrin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/silabs/include/board_common.h
+++ b/boards/common/silabs/include/board_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/silabs/include/usbdev_cfg_otg_fs.h
+++ b/boards/common/silabs/include/usbdev_cfg_otg_fs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/slwstk6000b/Kconfig
+++ b/boards/common/slwstk6000b/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_SLWSTK6000B
     bool

--- a/boards/common/slwstk6000b/board.c
+++ b/boards/common/slwstk6000b/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/slwstk6000b/include/board.h
+++ b/boards/common/slwstk6000b/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015-2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/slwstk6000b/include/gpio_params.h
+++ b/boards/common/slwstk6000b/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2017 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2017 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/slwstk6000b/include/periph_conf.h
+++ b/boards/common/slwstk6000b/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015-2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/slwstk6000b/modules/slwrb4150a/include/board_module.h
+++ b/boards/common/slwstk6000b/modules/slwrb4150a/include/board_module.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/slwstk6000b/modules/slwrb4162a/include/board_module.h
+++ b/boards/common/slwstk6000b/modules/slwrb4162a/include/board_module.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/sodaq/Kconfig
+++ b/boards/common/sodaq/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_SODAQ
     bool

--- a/boards/common/sodaq/include/board_common.h
+++ b/boards/common/sodaq/include/board_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Kees Bakker, SODAQ
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kees Bakker, SODAQ
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/sodaq/include/cfg_clock_default.h
+++ b/boards/common/sodaq/include/cfg_clock_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Kees Bakker, SODAQ
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kees Bakker, SODAQ
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/sodaq/include/cfg_rtc_default.h
+++ b/boards/common/sodaq/include/cfg_rtc_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Kees Bakker, SODAQ
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kees Bakker, SODAQ
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/sodaq/include/cfg_rtt_default.h
+++ b/boards/common/sodaq/include/cfg_rtt_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Kees Bakker, SODAQ
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kees Bakker, SODAQ
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/sodaq/include/cfg_spi_default.h
+++ b/boards/common/sodaq/include/cfg_spi_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Kees Bakker, SODAQ
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kees Bakker, SODAQ
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/sodaq/include/cfg_timer_default.h
+++ b/boards/common/sodaq/include/cfg_timer_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Kees Bakker, SODAQ
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kees Bakker, SODAQ
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/sodaq/include/cfg_usbdev_default.h
+++ b/boards/common/sodaq/include/cfg_usbdev_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Kees Bakker, SODAQ
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kees Bakker, SODAQ
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/stm32/Kconfig
+++ b/boards/common/stm32/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_HAS_HSE
     bool

--- a/boards/common/stm32/include/cfg_i2c1_pb6_pb7.h
+++ b/boards/common/stm32/include/cfg_i2c1_pb6_pb7.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/stm32/include/cfg_i2c1_pb8_pb9.h
+++ b/boards/common/stm32/include/cfg_i2c1_pb8_pb9.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/stm32/include/cfg_rtt_default.h
+++ b/boards/common/stm32/include/cfg_rtt_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/stm32/include/cfg_timer_tim2.h
+++ b/boards/common/stm32/include/cfg_timer_tim2.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/stm32/include/cfg_timer_tim2_tim15_tim16.h
+++ b/boards/common/stm32/include/cfg_timer_tim2_tim15_tim16.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/stm32/include/cfg_timer_tim5.h
+++ b/boards/common/stm32/include/cfg_timer_tim5.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/stm32/include/cfg_timer_tim5_and_tim2.h
+++ b/boards/common/stm32/include/cfg_timer_tim5_and_tim2.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/stm32/include/cfg_usb_otg_fs.h
+++ b/boards/common/stm32/include/cfg_usb_otg_fs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/stm32/include/cfg_usb_otg_fs_u5.h
+++ b/boards/common/stm32/include/cfg_usb_otg_fs_u5.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *               2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/stm32/include/cfg_usb_otg_hs_phy_fs.h
+++ b/boards/common/stm32/include/cfg_usb_otg_hs_phy_fs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/stm32/include/cfg_usb_otg_hs_phy_utmi.h
+++ b/boards/common/stm32/include/cfg_usb_otg_hs_phy_utmi.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *               2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/stm32/include/stm32_leds.h
+++ b/boards/common/stm32/include/stm32_leds.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/weact-f4x1cx/Kconfig
+++ b/boards/common/weact-f4x1cx/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Benjamin Valentin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Benjamin Valentin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD_COMMON_WEACT_F4X1CX
     bool

--- a/boards/common/weact-f4x1cx/board.c
+++ b/boards/common/weact-f4x1cx/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/common/weact-f4x1cx/include/board.h
+++ b/boards/common/weact-f4x1cx/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/weact-f4x1cx/include/gpio_params.h
+++ b/boards/common/weact-f4x1cx/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/common/weact-f4x1cx/include/periph_conf.h
+++ b/boards/common/weact-f4x1cx/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once


### PR DESCRIPTION
### Contribution description

This PR moves license information from headers to SPDX format for boards which names starts with letter `a` to `c` (including).

Except detection of missing Copyright keyword [see](https://github.com/RIOT-OS/RIOT/issues/21515#issuecomment-3058941739) and some strange [issues](https://github.com/RIOT-OS/RIOT/issues/21515#issuecomment-3083187003), which was fixed manually, other work is done automatically using scripts described in PR https://github.com/RIOT-OS/RIOT/issues/21515.

### Testing procedure

Review changed files.

### Issues/PRs references

Track PR #21515