### PR TITLE
boards/lora-e5-dev: set OpenOCD _TARGETNAME variable to fix flashing

### DIFF
--- a/boards/lora-e5-dev/dist/openocd.cfg
+++ b/boards/lora-e5-dev/dist/openocd.cfg
@@ -1,3 +1,3 @@
 source [find target/stm32wlx.cfg]
 reset_config trst_only
-$_TARGETNAME configure -rtos auto
+$_CHIPNAME.cpu0 configure -rtos auto


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This patch fixes an issue in the OpenOCD STM32WLX target config (`target/stm32wlx.cfg`) where the `_TARGETNAME` variable is not defined after creating the CPU target. 

Board configs relying on `_TARGETNAME` fail with `can't read "_TARGETNAME": no such variable` during flashing or debugging.

Per the [OpenOCD Config File Guidelines](https://openocd.org/doc/html/Config-File-Guidelines.html), `_TARGETNAME` should be set in the target config, but it was removed in a previous commit ([diff](https://review.openocd.org/c/openocd/+/6050/8/tcl/target/stm32wlx.cfg#b44)).

This patch sets `_TARGETNAME` explicitly in the `openocd.cfg` for `lora-e5-dev` to point to the main CPU target (`$_CHIPNAME.cpu0`), restoring expected behavior.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
With this fix, flashing the `examples/basic/hello-world` example now works correctly.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
#21614 