### PR TITLE
cpu/esp32: add ESP32-C6 support

### DIFF
--- a/boards/common/esp32c6/Kconfig
+++ b/boards/common/esp32c6/Kconfig
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
+
+config BOARD_COMMON_ESP32C6
+    bool
+    select BOARD_COMMON_ESP32X
+
+source "$(RIOTBOARD)/common/esp32x/Kconfig"

--- a/boards/common/esp32c6/Makefile
+++ b/boards/common/esp32c6/Makefile
@@ -1,0 +1,5 @@
+MODULE = boards_common_esp32c6
+
+DIRS = $(RIOTBOARD)/common/esp32x
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/common/esp32c6/Makefile.dep
+++ b/boards/common/esp32c6/Makefile.dep
@@ -1,0 +1,3 @@
+USEMODULE += boards_common_esp32c6
+
+include $(RIOTBOARD)/common/esp32x/Makefile.dep

--- a/boards/common/esp32c6/Makefile.features
+++ b/boards/common/esp32c6/Makefile.features
@@ -1,0 +1,3 @@
+CPU_FAM = esp32c6
+
+include $(RIOTBOARD)/common/esp32x/Makefile.features

--- a/boards/common/esp32c6/Makefile.include
+++ b/boards/common/esp32c6/Makefile.include
@@ -1,0 +1,3 @@
+INCLUDES += -I$(RIOTBOARD)/common/esp32c6/include
+
+include $(RIOTBOARD)/common/esp32x/Makefile.include

--- a/boards/common/esp32c6/doc.md
+++ b/boards/common/esp32c6/doc.md
@@ -1,0 +1,24 @@
+<!--
+Copyright (C) 2025 Gunar Schorcht
+
+This file is subject to the terms and conditions of the GNU Lesser
+General Public License v2.1. See the file LICENSE in the top level
+directory for more details.
+-->
+
+@defgroup    boards_common_esp32c6  ESP32-C6 Common
+@ingroup     boards_common
+@ingroup     boards_esp32c6
+@brief       Definitions and configurations that are common for
+             all ESP32-C6 boards.
+
+For detailed information about the ESP32-C6, configuring and compiling RIOT
+for ESP32-C6 boards, please refer \ref esp32_riot.
+
+@defgroup    boards_esp32c6  ESP32-C6 Boards
+@ingroup     boards
+@brief       This group of boards contains the documentation of ESP32-C6 boards.
+
+@note        For detailed information about the ESP32-C6 SoC, the tool chain
+             as well as configuring and compiling RIOT for ESP32-C6 boards,
+             see \ref esp32_riot.

--- a/boards/common/esp32c6/include/board_common_esp32c6.h
+++ b/boards/common/esp32c6/include/board_common_esp32c6.h
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_common_esp32c6
+ * @brief       Board definitions that are common for all ESP32-C6 boards.
+ *
+ * This file contains board configurations that are valid for all ESP32-C6.
+ *
+ * For detailed information about the configuration of ESP32-C6 boards, see
+ * section \ref esp32_peripherals "Common Peripherals".
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !DOXYGEN
+
+/**
+ * @name    ztimer Configuration valid for all ESP32-C6 boards
+ * @{
+ */
+#if CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ == 20
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET         134
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP       139
+#elif CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ == 40
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET         33
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP       34
+#elif CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ == 80
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET         18
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP       18
+#elif CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ == 120
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET         12
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP       13
+#elif CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ == 160
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET         11
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP       10
+#else
+#  error "Invalid CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ value"
+#endif
+/** @} */
+
+#endif /* !DOXYGEN */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/** @} */

--- a/boards/common/esp32c6/include/periph_conf_common_esp32c6.h
+++ b/boards/common/esp32c6/include/periph_conf_common_esp32c6.h
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_common_esp32c6
+ * @brief       Common peripheral configurations for ESP32-C6 boards
+ *
+ * This file contains the peripheral configurations that are valid for all
+ * ESP32-C6 boards.
+ *
+ * For detailed information about the peripheral configuration for ESP32-C6
+ * boards, see section \ref esp32_peripherals "Common Peripherals".
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   UART configuration
+ * @{
+ */
+#ifndef UART0_TXD
+#  define UART0_TXD (GPIO16)  /**< TxD of UART_DEV(0) used on all ESP32-C6 boards */
+#endif
+
+#ifndef UART0_RXD
+#  define UART0_RXD (GPIO17)  /**< RxD of UART_DEV(0) used on all ESP32-C6 boards */
+#endif
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/** @} */

--- a/boards/common/esp32x/include/board_common.h
+++ b/boards/common/esp32x/include/board_common.h
@@ -35,6 +35,8 @@
 #  include "board_common_esp32.h"
 #elif defined(CPU_FAM_ESP32C3)
 #  include "board_common_esp32c3.h"
+#elif defined(CPU_FAM_ESP32C6)
+#  include "board_common_esp32c6.h"
 #elif defined(CPU_FAM_ESP32H2)
 #  include "board_common_esp32h2.h"
 #elif defined(CPU_FAM_ESP32S2)

--- a/boards/common/esp32x/include/periph_conf_common.h
+++ b/boards/common/esp32x/include/periph_conf_common.h
@@ -24,6 +24,8 @@
 #  include "periph_conf_common_esp32.h"
 #elif defined(CPU_FAM_ESP32C3)
 #  include "periph_conf_common_esp32c3.h"
+#elif defined(CPU_FAM_ESP32C6)
+#  include "periph_conf_common_esp32c6.h"
 #elif defined(CPU_FAM_ESP32H2)
 #  include "periph_conf_common_esp32h2.h"
 #elif defined(CPU_FAM_ESP32S2)

--- a/boards/esp32c6-devkit/Kconfig
+++ b/boards/esp32c6-devkit/Kconfig
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
+
+config BOARD
+    default "esp32c6-devkit" if BOARD_ESP32C6_DEVKIT
+
+config BOARD_ESP32C6_DEVKIT
+    bool
+    default y
+    select BOARD_COMMON_ESP32C6
+    select CPU_MODEL_ESP32C6_MINI_1X_X4
+
+source "$(RIOTBOARD)/common/esp32c6/Kconfig"

--- a/boards/esp32c6-devkit/Makefile
+++ b/boards/esp32c6-devkit/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/esp32c6
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/esp32c6-devkit/Makefile.dep
+++ b/boards/esp32c6-devkit/Makefile.dep
@@ -1,0 +1,5 @@
+include $(RIOTBOARD)/common/esp32c6/Makefile.dep
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/esp32c6-devkit/Makefile.features
+++ b/boards/esp32c6-devkit/Makefile.features
@@ -1,0 +1,20 @@
+CPU_MODEL = esp32c6_mini_1x_x1
+
+# common board and CPU features
+include $(RIOTBOARD)/common/esp32c6/Makefile.features
+
+# additional features provided by the board
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+
+# unique features provided by the board
+FEATURES_PROVIDED += esp_jtag
+
+FEATURES_PROVIDED += arduino_analog
+FEATURES_PROVIDED += arduino_i2c
+FEATURES_PROVIDED += arduino_pins
+FEATURES_PROVIDED += arduino_pwm
+FEATURES_PROVIDED += arduino_spi
+FEATURES_PROVIDED += arduino_uart

--- a/boards/esp32c6-devkit/Makefile.include
+++ b/boards/esp32c6-devkit/Makefile.include
@@ -1,0 +1,5 @@
+include $(RIOTBOARD)/common/esp32c6/Makefile.include
+
+# Only consider TTYs matching the following filter when auto-selecting the TTY
+# with `MOST_RECENT_PORT=1`.
+TTY_BOARD_FILTER := --driver 'cp210x' --vendor 'Silicon Labs' --model 'CP2102N USB to UART Bridge Controller'

--- a/boards/esp32c6-devkit/doc.md
+++ b/boards/esp32c6-devkit/doc.md
@@ -1,0 +1,160 @@
+<!--
+Copyright (C) 2025 Gunar Schorcht
+
+This file is subject to the terms and conditions of the GNU Lesser
+General Public License v2.1. See the file LICENSE in the top level
+directory for more details.
+-->
+
+@defgroup    boards_esp32c6_devkit ESP32-C6-DevKit Board
+@ingroup     boards_esp32c6
+@brief       Support for generic ESP32-C6 boards
+@author      Gunar Schorcht <gunar@schorcht.net>
+
+\section esp32c6_devkit ESP32-C6-DevKit
+
+## Table of Contents {#esp32c6_devkit_toc}
+
+-# [Overview](#esp32c6_devkit_overview)
+-# [Hardware](#esp32c6_devkit_hardware)
+    -# [MCU](#esp32c6_devkit_mcu)
+    -# [Board Configuration](#esp32c6_devkit_board_configuration)
+    -# [Board Pinout](#esp32c6_devkit_pinout)
+-# [Flashing the Device](#esp32c6_devkit_flashing)
+
+## Overview {#esp32c6_devkit_overview}
+
+The Espressif ESP32-C6-DevKit boards are a couple of boards that use one of
+the following modules:
+
+- ESP32-C6-MINI-1x module (ESP32-C6-DevKitM-1 board)
+- ESP32-C6-WROOM-1x module (ESP32-C6-DevKitC-1 board)
+
+Since the number of GPIOs and their possible uses on the ESP32-C6 are quite
+limited, the ESP32-C6-DevKit should also work for most other ESP32-C6 boards.
+Any modifications required for specific applications could be overridden by
+\ref esp32_application_specific_configurations "application-specific board configuration".
+
+\image html "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32c6/_images/esp32-c6-devkitm-1-v1-annotated-photo.png" "Espressif ESP32-C6-DevKitM-1" width=800px
+
+[Back to table of contents](#esp32c6_devkit_toc)
+
+## Hardware {#esp32c6_devkit_hardware}
+
+This section describes
+
+- the [MCU](#esp32c6_devkit_mcu),
+- the default [board configuration](#esp32c6_devkit_board_configuration),
+- [optional hardware configurations](#esp32c6_devkit_optional_hardware),
+- the [board pinout](#esp32c6_devkit_pinout).
+
+[Back to table of contents](#esp32c6_devkit_toc)
+
+### MCU {#esp32c6_devkit_mcu}
+
+Most features of the board are provided by the ESP32-C6 SoC. For detailed
+information about the ESP32-C6 variant (family) and ESP32x SoCs,
+see section \ref esp32_mcu_esp32 "ESP32 SoC Series".
+
+[Back to table of contents](#esp32c6_devkit_toc)
+
+### Board Configuration {#esp32c6_devkit_board_configuration}
+
+ESP32-C6-DevKit boards have no special hardware on board with the exception
+of a WS2812-compatible RGB-LED.
+
+All GPIOs are simply broken out for flexibility. Therefore, the board
+configuration is the most flexible one which provides:
+
+- 7 x ADC channels at maximum
+- 1 x SPI
+- 1 x I2C
+- 1 x UART
+- 2 x PWM with 3 channels each
+- 1 x RGB-LED WS2812-compatible
+
+Since all GPIOs are broken out, GPIOs can be used for different purposes
+in different applications. For flexibility, GPIOs can be used in multiple
+peripheral configurations, but they can only be used for one peripheral
+at a time. For example, GPIO4 and GPIO5 are defined as ADC channels
+and signals for I2C_DEV(0), GPIO7 and GPIO18 are defined as channels
+for PWM_DEV(1) and signals for SPI_DEV(0).
+
+This is possible because GPIOs are only used for a specific peripheral
+interface when either
+
+- the corresponding peripheral module is used, e.g. `periph_i2c` and
+  `periph_spi`, or
+- the corresponding init function is called, e.g. `adc_init` and
+  `pwm_init`.
+
+That is, the purpose for which a GPIO is used depends on which module
+or function is used first. For example, if module `periph_i2c` is not used,
+the GPIOs listed in I2C configuration can be used for the other purposes,
+that is, GPIO4 and GPIO5 can be used as ADC channels.
+
+The following table shows the default board configuration, which is sorted
+according to the defined functionality of GPIOs. This configuration can be
+overridden by \ref esp32_application_specific_configurations
+"application-specific configurations".
+
+<center>
+Function        | GPIOs  | Remarks |Configuration
+:---------------|:-------|:--------|:----------------------------------
+BUTTON0         | GPIO9  | | |
+ADC             | GPIO0, GPIO1, GPIO2, GPIO3, GPIO4, GPIO5, GPIO6 | | see \ref esp32_adc_channels "ADC Channels"
+PWM_DEV(0)      | GPIO19, GPIO20, GPIO21 | - | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(1)      | GPIO22, GPIO18, GPIO7  | - | \ref esp32_pwm_channels "PWM Channels"
+I2C_DEV(0):SCL  | GPIO5  | | \ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(0):SDA  | GPIO4  | | \ref esp32_i2c_interfaces "I2C Interfaces"
+RGB-LED         | GPIO8  | supported by driver module `ws281x` | |
+SPI_DEV(0):CLK  | GPIO6  | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MISO | GPIO2  | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MOSI | GPIO7  | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):CS0  | GPIO18 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+UART_DEV(0):TxD | GPIO16 | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(0):RxD | GPIO17 | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+USB D-          | GPIO12 | | |
+USB D+          | GPIO13 | | |
+</center>
+\n
+@note
+- The configuration of ADC channels contains all ESP32-C6 GPIOs that could
+  be used as ADC channels.
+- GPIO10, GPIO11 and GPIO24 to GPIO30 are used for internal flash and are not broken out.
+- GPIO0 and GPIO1 can be used to connect an external 32.678 kHz crystal.
+- GPIO15 is a strapping pin used to select the JTAG interface if
+  `JTAG_SEL_ENABLE` is burned in the eFuses.
+
+For detailed information about the peripheral configurations of ESP32-C6
+boards, see section \ref esp32_peripherals "Common Peripherals".
+
+[Back to table of contents](#esp32c6_devkit_toc)
+
+### Board Pinout {#esp32c6_devkit_pinout}
+
+The following figures show the pinouts as configured by default board
+definition.
+
+@image html https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32c6/_images/esp32-c6-devkitm-1-pin-layout.png "EPS32-C6-DevKitM-1x Pinout"
+@image html https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32c6/_images/esp32-c6-devkitc-1-pin-layout.png "EPS32-C6-DevKitC-1x Pinout"
+
+The corresponding board schematics can be found:
+
+- [ESP32-C6-DevKitM-1](https://dl.espressif.com/dl/schematics/esp32-c6-devkitm-1-schematics.pdf)
+- [ESP32-C6-DevKitC-1](https://dl.espressif.com/dl/schematics/esp32-c6-devkitc-1-schematics_v1.4.pdf)
+
+[Back to table of contents](#esp32c6_devkit_toc)
+
+## Flashing the Device {#esp32c6_devkit_flashing}
+
+Flashing RIOT is quite easy. The board has a Micro-USB connector with
+reset/boot/flash logic. Just connect the board to your host computer
+using the programming port and execute command:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BOARD=esp32c6-devkit make flash ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For detailed information about ESP32-C6 as well as configuring and compiling
+RIOT for ESP32-C6 boards, see \ref esp32_riot.
+
+[Back to table of contents](#esp32c6_devkit_toc)

--- a/boards/esp32c6-devkit/include/arduino_iomap.h
+++ b/boards/esp32c6-devkit/include/arduino_iomap.h
@@ -1,0 +1,131 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_esp32c6_devkit
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Arduino's UART devices
+ * @{
+ */
+#define ARDUINO_UART_D0D1   UART_DEV(0) /**< Default UART (fix) */
+/** @} */
+
+/**
+ * @name    Arduino's SPI buses
+ * @{
+ */
+#define ARDUINO_SPI_DEV     SPI_DEV(0)  /**< Default SPI */
+/** @} */
+
+/**
+ * @name    Arduino's I2C buses
+ * @{
+ */
+#define ARDUINO_I2C_DEV     I2C_DEV(0)  /**< Default I2C */
+/** @} */
+
+/**
+ * @name   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0       GPIO17      /**< Arduino pin 0 (RxD) */
+#define ARDUINO_PIN_1       GPIO16      /**< Arduino pin 1 (TxD) */
+#define ARDUINO_PIN_2       GPIO15      /**< Arduino pin 2 */
+#define ARDUINO_PIN_3       GPIO19      /**< Arduino pin 3 (PWM) */
+#define ARDUINO_PIN_4       GPIO9       /**< Arduino pin 4 */
+#define ARDUINO_PIN_5       GPIO20      /**< Arduino pin 5 (PWM) */
+#define ARDUINO_PIN_6       GPIO21      /**< Arduino pin 6 (PWM) */
+#define ARDUINO_PIN_7       GPIO_UNDEF  /**< Arduino pin 7 */
+#define ARDUINO_PIN_8       GPIO8       /**< Arduino pin 8 */
+#define ARDUINO_PIN_9       GPIO22      /**< Arduino pin 9 (PWM) */
+
+#define ARDUINO_PIN_10      GPIO18      /**< Arduino pin 10 (CS0 / PWM)  */
+#define ARDUINO_PIN_11      GPIO7       /**< Arduino pin 11 (MOSI / PWM) */
+#define ARDUINO_PIN_12      GPIO2       /**< Arduino pin 12 (MISO) */
+#define ARDUINO_PIN_13      GPIO6       /**< Arduino pin 13 (SCK)  */
+
+/* analog pins as digital pins: */
+#define ARDUINO_PIN_14      GPIO0       /**< Arduino pin A0 */
+#define ARDUINO_PIN_15      GPIO1       /**< Arduino pin A1 */
+#define ARDUINO_PIN_16      GPIO2       /**< Arduino pin A2 */
+#define ARDUINO_PIN_17      GPIO3       /**< Arduino pin A3 */
+
+#define ARDUINO_PIN_18      GPIO4       /**< Arduino pin A4 (SDA) */
+#define ARDUINO_PIN_19      GPIO5       /**< Arduino pin A5 (SCL) */
+
+#define ARDUINO_PIN_LAST    19
+/** @} */
+
+/**
+ * @name    Aliases for analog pins
+ * @{
+ */
+#define ARDUINO_PIN_A0      ARDUINO_PIN_14   /**< Arduino pin A0 */
+#define ARDUINO_PIN_A1      ARDUINO_PIN_15   /**< Arduino pin A1 */
+#define ARDUINO_PIN_A2      ARDUINO_PIN_16   /**< Arduino pin A2 */
+#define ARDUINO_PIN_A3      ARDUINO_PIN_17   /**< Arduino pin A3 */
+#define ARDUINO_PIN_A4      ARDUINO_PIN_18   /**< Arduino pin A4 (SDA) */
+#define ARDUINO_PIN_A5      ARDUINO_PIN_19   /**< Arduino pin A5 (SCL) */
+/** @} */
+
+/**
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
+ * @{
+ */
+#define ARDUINO_A0          ADC_LINE(0)     /**< ADC line for Arduino pin A0 */
+#define ARDUINO_A1          ADC_LINE(1)     /**< ADC line for Arduino pin A1 */
+#define ARDUINO_A2          ADC_LINE(2)     /**< ADC line for Arduino pin A2 */
+#define ARDUINO_A3          ADC_LINE(3)     /**< ADC line for Arduino pin A3 */
+#define ARDUINO_A4          ADC_LINE(4)     /**< ADC line for Arduino pin A4 */
+#define ARDUINO_A5          ADC_LINE(5)     /**< ADC line for Arduino pin A5 */
+
+#define ARDUINO_ANALOG_PIN_LAST 5
+/** @} */
+
+/**
+ * @name    Mapping of Arduino pins to RIOT PWM dev and channel pairs
+ * @{
+ */
+#define ARDUINO_PIN_3_PWM_DEV   PWM_DEV(0)  /**< PWM device for Arduino pin3 */
+#define ARDUINO_PIN_3_PWM_CHAN  0           /**< PWM channel for Arduino pin3 */
+
+#define ARDUINO_PIN_5_PWM_DEV   PWM_DEV(0)  /**< PWM device for Arduino pin5 */
+#define ARDUINO_PIN_5_PWM_CHAN  1           /**< PWM channel for Arduino pin5 */
+
+#define ARDUINO_PIN_6_PWM_DEV   PWM_DEV(0)  /**< PWM device for Arduino pin6 */
+#define ARDUINO_PIN_6_PWM_CHAN  2           /**< PWM channel for Arduino pin6 */
+
+#define ARDUINO_PIN_9_PWM_DEV   PWM_DEV(1)  /**< PWM device for Arduino pin9 */
+#define ARDUINO_PIN_9_PWM_CHAN  0           /**< PWM channel for Arduino pin9 */
+
+#define ARDUINO_PIN_10_PWM_DEV  PWM_DEV(1)  /**< PWM device for Arduino pin10 */
+#define ARDUINO_PIN_10_PWM_CHAN 1           /**< PWM channel for Arduino pin10 */
+
+#define ARDUINO_PIN_11_PWM_DEV  PWM_DEV(1)  /**< PWM device for Arduino pin11 */
+#define ARDUINO_PIN_11_PWM_CHAN 2           /**< PWM channel for Arduino pin11 */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/esp32c6-devkit/include/board.h
+++ b/boards/esp32c6-devkit/include/board.h
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_esp32c6_devkit
+ * @brief       Board definitions for ESP32-C6-DevKit boards
+ * @{
+ *
+ * The board definitions in this file are valid for Espressif
+ * ESP32-C6-DevKitx boards that use one of the following modules:
+ *
+ * - ESP32-C6-MINI-1x module (ESP32-C6-DevKitM-1 board)
+ * - ESP32-C6-WROOM-1x module (ESP32-C6-DevKitC-1 board)
+ *
+ * Since the number of GPIOs and their possible uses on the ESP32-C6 are quite
+ * limited, these board definitions can also be used for most other
+ * ESP32-C6 boards. Any modifications required for specific applications
+ * can be overridden by \ref esp32_application_specific_configurations
+ * "application-specific board configuration".
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include <stdint.h>
+
+/**
+ * @name    Button pin definitions
+ * @{
+ */
+
+/**
+ * @brief   Default button GPIO pin definition
+ *
+ * ESP32-C6-DevKit boards have a BOOT button connected to GPIO9, which can be
+ * used as button during normal operation. Since the GPIO9 pin is pulled up,
+ * the button signal is inverted, i.e., pressing the button will give a
+ * low signal.
+ */
+#define BTN0_PIN            GPIO9
+
+/**
+ * @brief   Default button GPIO mode definition
+ *
+ * Since the GPIO pin of the button needs to be pulled up for normal operation
+ * and the board does not have an external resistor connected to the GPIO pin,
+ * the mode for the GPIO pin must be set to GPIO_IN_PU.
+ */
+#define BTN0_MODE           GPIO_IN_PU
+
+/**
+ * @brief   Default interrupt flank definition for the button GPIO
+ */
+#ifndef BTN0_INT_FLANK
+#  define BTN0_INT_FLANK    GPIO_FALLING
+#endif
+
+/**
+ * @brief   Definition for compatibility with previous versions
+ */
+#define BUTTON0_PIN         BTN0_PIN
+
+/** @} */
+
+/**
+ * @name    LED (on-board) configuration
+ *
+ * ESP32-C6-DevKit boards have a SK68XXMINI-HS smart RGB-LED connected to
+ * GPIO8 on-board. The WS281x driver module `ws281x` can be used to control it.
+ * @{
+ */
+#ifndef WS281X_PARAM_PIN
+#  define WS281X_PARAM_PIN      (GPIO8)   /**< GPIO pin connected to the data pin */
+#endif
+#ifndef WS281X_PARAM_NUMOF
+#  define WS281X_PARAM_NUMOF    (1U)      /**< Number of LEDs chained */
+#endif
+/** @} */
+
+/* include common board definitions as last step */
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/** @} */

--- a/boards/esp32c6-devkit/include/gpio_params.h
+++ b/boards/esp32c6-devkit/include/gpio_params.h
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_esp32c6_devkit
+ * @brief       Board specific configuration of direct mapped GPIOs
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @{
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   LED and Button configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "BOOT",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/esp32c6-devkit/include/periph_conf.h
+++ b/boards/esp32c6-devkit/include/periph_conf.h
@@ -1,0 +1,165 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_esp32c6_devkit
+ * @brief       Peripheral configurations for ESP32-C6-DevKit boards
+ * @{
+ *
+ * The peripheral configurations in this file are valid for Espressif
+ * ESP32-C6-DevKitx boards that use one of the following modules:
+ *
+ * - ESP32-C6-MINI-1x module (ESP32-C6-DevKitM-1 board)
+ * - ESP32-C6-WROOM-1x module (ESP32-C6-DevKitC-1 board)
+ *
+ * Since the number of GPIOs and their possible uses on the ESP32-C6 are quite
+ * limited, these peripheral configurations can also be used for most other
+ * ESP32-C6 boards. Any modifications required for specific applications
+ * can be overridden by \ref esp32_application_specific_configurations
+ * "application-specific board configuration".
+ *
+ * For detailed information about the peripheral configuration for ESP32-C6
+ * boards, see section \ref esp32_peripherals "Common Peripherals".
+ *
+ * @note
+ * Most definitions can be overridden by an \ref esp32_application_specific_configurations
+ * "application-specific board configuration" if necessary.
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    ADC and DAC channel configuration
+ * @{
+ */
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ *
+ * For generic boards, all ADC pins that are broken out are declared as ADC
+ * channels.
+ *
+ * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
+ * channels with the `adc_init` function, they can be used for other
+ * purposes.
+ */
+#ifndef ADC_GPIOS
+#  define ADC_GPIOS     { GPIO0, GPIO1, GPIO2, GPIO3, GPIO4, GPIO5, GPIO6 }
+#endif
+/** @} */
+
+/**
+ * @name   I2C configuration
+ *
+ * For generic boards, only one I2C interface I2C_DEV(0) is defined.
+ *
+ * The GPIOs listed in the configuration are only initialized as I2C signals
+ * when module `periph_i2c` is used. Otherwise they are not allocated and
+ * can be used for other purposes.
+ *
+ * @{
+ */
+#ifndef I2C0_SPEED
+#  define I2C0_SPEED    I2C_SPEED_FAST  /**< I2C bus speed of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SCL
+#  define I2C0_SCL      GPIO5           /**< SCL signal of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SDA
+#  define I2C0_SDA      GPIO4           /**< SDA signal of I2C_DEV(0) */
+#endif
+/** @} */
+
+/**
+ * @name   PWM channel configuration
+ *
+ * For generic boards, two PWM devices are configured. Generally, all output
+ * pins could be used as PWM channels.
+ * @{
+ */
+
+/**
+ * @brief Declaration of the channels for device PWM_DEV(0), at maximum PWM_CHANNEL_NUM_DEV_MAX.
+ *
+ * @note PWM_DEV(0) contains only GPIOs that are not used for ADC, I2C, SPI
+ *       or UART on this board. As long as the according PWM device is not
+ *       initialized with the `pwm_init` function, the GPIOs declared for
+ *       this device can be used for the other purposes.
+ */
+#ifndef PWM0_GPIOS
+#  define PWM0_GPIOS    { GPIO19, GPIO20, GPIO21 }
+#endif
+
+/**
+ * @brief Declaration of the channels for device PWM_DEV(1), at maximum PWM_CHANNEL_NUM_DEV_MAX.
+ *
+ * @note PMW_DEV(1) contains pins that are also used for SPI_DEV(0).
+ *       However, as long as the according PWM device is not
+ *       initialized with the `pwm_init` function, the GPIOs declared for
+ *       this device can be used for SPI_DEV(0).
+ */
+#ifndef PWM1_GPIOS
+#  define PWM1_GPIOS    { GPIO22, GPIO18, GPIO7 }
+#endif
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * @note The GPIOs listed in the configuration are first initialized as SPI
+ * signals when the corresponding SPI interface is used for the first time
+ * by either calling the `spi_init_cs` function or the `spi_acquire`
+ * function. That is, they are not allocated as SPI signals before and can
+ * be used for other purposes as long as the SPI interface is not used.
+ * @{
+ */
+#ifndef SPI0_CTRL
+#  define SPI0_CTRL     FSPI    /**< FSPI is used as SPI_DEV(0) */
+#endif
+#ifndef SPI0_SCK
+#  define SPI0_SCK      GPIO6   /**< FSPI SCK (pin FSPICLK) */
+#endif
+#ifndef SPI0_MISO
+#  define SPI0_MISO     GPIO2   /**< FSPI MISO (pin FSPIQ) */
+#endif
+#ifndef SPI0_MOSI
+#  define SPI0_MOSI     GPIO7   /**< FSPI MOSI (pin FSPID) */
+#endif
+#ifndef SPI0_CS0
+#  define SPI0_CS0      GPIO18  /**< FSPI CS0 (pin FSPICS2) */
+#endif
+/** @} */
+
+/**
+ * @name   UART configuration
+ *
+ * ESP32-C6 provides 2 UART interfaces at maximum:
+ *
+ * UART_DEV(0) uses fixed standard configuration.<br>
+ * UART_DEV(1) is not used.<br>
+ *
+ * @{
+ */
+#define UART0_TXD   GPIO16  /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO17  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/* include common peripheral definitions as last step */
+#include "periph_conf_common.h"
+
+/** @} */

--- a/cpu/esp32/Kconfig
+++ b/cpu/esp32/Kconfig
@@ -41,6 +41,7 @@ config CPU_CORE
 rsource "Kconfig.esp32x"
 rsource "Kconfig.esp32"
 rsource "Kconfig.esp32c3"
+rsource "Kconfig.esp32c6"
 rsource "Kconfig.esp32h2"
 rsource "Kconfig.esp32s3"
 rsource "Kconfig.esp32s2"

--- a/cpu/esp32/Kconfig.esp32c6
+++ b/cpu/esp32/Kconfig.esp32c6
@@ -1,0 +1,113 @@
+# Copyright (c) 2025 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config CPU_FAM_ESP32C6
+    bool
+    select CPU_COMMON_ESP32X
+    select CPU_CORE_RV32IMAC
+
+config CPU_FAM
+    default "esp32c6" if CPU_FAM_ESP32C6
+
+## CPU Models
+config CPU_MODEL_ESP32C6
+    bool
+    select CPU_FAM_ESP32C6
+    help
+        ESP32-C6 CPU without internal Flash
+
+config CPU_MODEL_ESP32C6_FH4
+    bool
+    select CPU_FAM_ESP32C6
+    help
+        ESP32-C6 CPU with 4 MB Flash
+
+config CPU_MODEL_ESP32C6_FH8
+    bool
+    select CPU_FAM_ESP32C6
+    help
+        ESP32-C6 CPU with 8 MB Flash
+
+## CPU Modules
+config CPU_MODEL_ESP32C6_MINI_1X_X4
+    bool
+    select CPU_MODEL_ESP32C6
+    help
+        ESP32-C6-MINI-1-N4, ESP32-C6-MINI-1U-N4, ESP32-C6-MINI-1-H4 or
+        ESP32-C6-MINI-1U-H4 module with 4 MB Flash
+
+config CPU_MODEL_ESP32C6_WROOM_1X_X4
+    bool
+    select CPU_MODEL_ESP32C6
+    help
+        ESP32-C6-WROOM-1-N4, ESP32-C6-WROOM-1U-N4, ESP32-C6-WROOM-1-H4 or
+        ESP32-C6-WROOM-1U-H4 module with 4 MB Flash
+
+config CPU_MODEL_ESP32C6_WROOM_1X_N8
+    bool
+    select CPU_MODEL_ESP32C6
+    help
+        ESP32-C6-WROOM-1-N8 or ESP32-C6-WROOM-1U-N8 module with 8 MB Flash
+
+config CPU_MODEL_ESP32C6_WROOM_1X_N16
+    bool
+    select CPU_MODEL_ESP32C6
+    help
+        ESP32-C6-WROOM-1-N16 or ESP32-C6-WROOM-1U-N16 module with 16 MB Flash
+
+## Choice
+config CPU_MODEL
+    depends on CPU_FAM_ESP32C6
+    default "esp32c6_mini_1x_x4" if CPU_MODEL_ESP32C6_MINI_1X_X4
+    default "esp32c6_wroom_1x_x4" if CPU_MODEL_ESP32C6_WROOM_1X_X4
+    default "esp32c6_wroom_1x_n8" if CPU_MODEL_ESP32C6_WROOM_1X_N8
+    default "esp32c6_wroom_1x_n16" if CPU_MODEL_ESP32C6_WROOM_1X_N16
+    default "esp32c6" if CPU_MODEL_ESP32C6
+    default "esp32c6_fh4" if CPU_MODEL_ESP32C6_FH4
+    default "esp32c6_fh8" if CPU_MODEL_ESP32C6_FH8
+
+if CPU_FAM_ESP32C6
+
+menu "ESP32-C6 specific configurations"
+    depends on HAS_ARCH_ESP32
+
+    # define configuration menu entries for ESP32-C6 variant (family)
+
+    choice
+        bool "CPU clock frequency"
+        default ESP32C6_DEFAULT_CPU_FREQ_MHZ_80
+        help
+            CPU clock frequency used (default 80 MHz).
+            Please note that peripherals such as I2C or SPI might not work at
+            the specified clock frequency if the selected CPU clock frequency
+            is too low. These peripherals are clocked by the APB clock, which
+            has a clock rate of 40 MHz for CPU clock frequencies greater than
+            or equal to 40 MHz, but is equal to the CPU clock frequency for
+            CPU clock frequencies less than 40 MHz. Thus, for SPI, the APB
+            clock rate must be at least five times the SPI clock rate. For the
+            I2C hardware implementation, the APB clock rate must be at least
+            3 MHZ to use I2C in fast mode with a I2C clock rate of 400 kHz.
+            For the I2C software implementation, the maximum I2C clock rate
+            is 1/130 times the CPU clock rate.
+
+        config ESP32C6_DEFAULT_CPU_FREQ_MHZ_20
+            bool "20 MHz"
+        config ESP32C6_DEFAULT_CPU_FREQ_MHZ_40
+            bool "40 MHz"
+        config ESP32C6_DEFAULT_CPU_FREQ_MHZ_80
+            bool "80 MHz"
+        config ESP32C6_DEFAULT_CPU_FREQ_MHZ_120
+            bool "120 MHz"
+        config ESP32C6_DEFAULT_CPU_FREQ_MHZ_160
+            bool "160 MHz"
+    endchoice
+
+    # import configuration menu entries that are common for all ESP32x SoCs
+    rsource "Kconfig.common"
+
+endmenu
+
+endif # CPU_FAM_ESP32C6

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -34,12 +34,12 @@ ifneq (,$(filter esp_ieee802154,$(USEMODULE)))
   FEATURES_REQUIRED += esp_ieee802154
   USEMODULE += esp_idf_ieee802154
   USEMODULE += esp_idf_phy
-  USEMODULE += iolist
+  USEPKG += esp32_sdk_lib_phy
+  ifeq (esp32c6,$(CPU_FAM))
+    USEMODULE += esp_idf_nvs_flash
+  endif
   ifneq (,$(filter netdev,$(USEMODULE)))
     USEMODULE += netdev_ieee802154_submac
-  endif
-  ifeq (esp32h2,$(CPU_FAM))
-    USEPKG += esp32_sdk_lib_phy
   endif
 endif
 
@@ -162,7 +162,7 @@ ifneq (,$(filter nimble,$(USEPKG)))
   USEMODULE += nimble_host
   USEMODULE += nimble_transport_hci_h4
   USEMODULE += ztimer_msec
-  ifeq (esp32h2,$(CPU_FAM))
+  ifneq (,$(filter esp32c6 esp32h2,$(CPU_FAM)))
     # TODO for the moment, we use tinycrypt for encryption
     # USEPKG += esp32_sdk_mbedtls
     USEPKG += esp32_sdk_lib_coexist

--- a/cpu/esp32/Makefile.features
+++ b/cpu/esp32/Makefile.features
@@ -4,6 +4,9 @@ ifeq (esp32,$(CPU_FAM))
 else ifeq (esp32c3,$(CPU_FAM))
   CPU_ARCH = rv32
   CPU_CORE = rv32imc
+else ifeq (esp32c6,$(CPU_FAM))
+  CPU_ARCH = rv32
+  CPU_CORE = rv32imac
 else ifeq (esp32h2,$(CPU_FAM))
   CPU_ARCH = rv32
   CPU_CORE = rv32imac
@@ -45,7 +48,7 @@ ifneq (esp32h2,$(CPU_FAM))
   FEATURES_PROVIDED += esp_wifi_enterprise
 endif
 
-ifneq (,$(filter esp32 esp32c3 esp32h2 esp32s3,$(CPU_FAM)))
+ifneq (,$(filter esp32 esp32c3 esp32c6 esp32h2 esp32s3,$(CPU_FAM)))
   FEATURES_PROVIDED += ble_nimble
   FEATURES_PROVIDED += ble_nimble_netif
   FEATURES_PROVIDED += esp_ble
@@ -64,7 +67,7 @@ ifneq (,$(filter esp32 esp32s3,$(CPU_FAM)))
   endif
 endif
 
-ifeq (esp32h2,$(CPU_FAM))
+ifneq (,$(filter esp32c6 esp32h2,$(CPU_FAM)))
   FEATURES_PROVIDED += esp_ieee802154
 endif
 

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -14,7 +14,7 @@ ifeq (esp32,$(CPU_FAM))
   export FLASH_FREQ ?= 40m
   export FLASH_SIZE ?= 2
   BOOTLOADER_POS = 0x1000
-else ifneq (,$(filter esp32c3 esp32s3,$(CPU_FAM)))
+else ifneq (,$(filter esp32c3 esp32c6 esp32s3,$(CPU_FAM)))
   export FLASH_MODE ?= dio
   export FLASH_FREQ ?= 80m
   export FLASH_SIZE ?= 2
@@ -60,6 +60,11 @@ else ifeq (esp32c3,$(CPU_FAM))
   # used as instruction cache via the instruction bus.
   RAM_LEN = 320K
   RAM_START_ADDR = 0x3FC80000
+else ifeq (esp32c6,$(CPU_FAM))
+  # ESP32-C6 has 512 kByte RAM but the 2nd stage bootloader starts at 0x4086E610
+  # so that there are only 452.112 byte (about 441 kByte) remaining
+  RAM_LEN = 441K
+  RAM_START_ADDR = 0x40800000
 else ifeq (esp32h2,$(CPU_FAM))
   # ESP32-H2 has 320 kByte RAM but the 2nd stage bootloader starts at 0x4083EFD0
   # so that there are only 258,000 byte (about 250 kByte) remaining
@@ -173,12 +178,12 @@ ifneq (,$(filter xtensa%,$(TARGET_ARCH)))
 endif
 
 ifneq (,$(filter esp_ble,$(USEMODULE)))
-  ifneq (,$(filter esp32 esp32h2,$(CPU_FAM)))
+  ifneq (,$(filter esp32 esp32c6 esp32h2,$(CPU_FAM)))
     INCLUDES += -I$(ESP32_SDK_DIR)/components/bt/include/$(CPU_FAM)/include
   else ifneq (,$(filter esp32s3 esp32c3,$(CPU_FAM)))
     INCLUDES += -I$(ESP32_SDK_DIR)/components/bt/include/esp32c3/include
   endif
-  ifeq (esp32h2,$(CPU_FAM))
+  ifneq (,$(filter esp32c6 esp32h2,$(CPU_FAM)))
     CFLAGS += -Ddefault_RNG_defined=0
     CFLAGS += -DNIMBLE_OS_MSYS_INIT_IN_CONTROLLER=1
     CFLAGS += -DNIMBLE_G_MSYS_POOL_LIST_IN_CONTROLLER=1
@@ -323,7 +328,7 @@ ifneq (,$(filter riscv%,$(TARGET_ARCH)))
   ifeq (esp32c3,$(CPU_FAM))
     CFLAGS += -march=rv32imc_zicsr_zifencei
     LINKFLAGS += -march=rv32imc_zicsr_zifencei
-  else ifeq (esp32h2,$(CPU_FAM))
+  else ifneq (,$(filter esp32c6 esp32h2,$(CPU_FAM)))
     CFLAGS += -march=rv32imac_zicsr_zifencei
     LINKFLAGS += -march=rv32imac_zicsr_zifencei
   else
@@ -366,6 +371,12 @@ else ifeq (esp32c3,$(CPU_FAM))
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.bt_funcs.ld
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib.ld
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.eco3.ld
+else ifeq (esp32c6,$(CPU_FAM))
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.coexist.ld
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib.ld
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.pp.ld
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.phy.ld
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.net80211.ld
 else ifeq (esp32h2,$(CPU_FAM))
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib.ld
 else
@@ -404,20 +415,20 @@ ifneq (,$(filter esp_ble,$(USEMODULE)))
   ifneq (,$(filter esp32 esp32c3 esp32s3,$(CPU_FAM)))
     LINKFLAGS += -L$(ESP32_SDK_LIB_BT_DIR)/$(CPU_FAM)
     ARCHIVES += -lbtdm_app
-  else ifeq (esp32h2,$(CPU_FAM))
+  else ifneq (,$(filter esp32c6 esp32h2,$(CPU_FAM)))
     LINKFLAGS += -L$(ESP32_SDK_LIB_COEXIST_DIR)/$(CPU_FAM)
     LINKFLAGS += -L$(ESP32_SDK_LIB_BT_DIR)
     ARCHIVES += -lble_app -lcoexist
   endif
   ifeq (esp32,$(CPU_FAM))
     ARCHIVES += -lrtc
-  else ifneq (,$(filter esp32c3 esp32h2 esp32s3,$(CPU_FAM)))
+  else ifneq (,$(filter esp32c3 esp32c6 esp32h2 esp32s3,$(CPU_FAM)))
     ARCHIVES += -lbtbb
   endif
 endif
 
 ifneq (,$(filter esp_ieee802154,$(USEMODULE)))
-  ifeq (esp32h2,$(CPU_FAM))
+  ifneq (,$(filter esp32c6 esp32h2,$(CPU_FAM)))
     LINKFLAGS += -L$(ESP32_SDK_LIB_PHY_DIR)/$(CPU_FAM)
     LINKFLAGS += -L$(ESP32_SDK_LIB_BT_DIR)
     ARCHIVES += -lbtbb

--- a/cpu/esp32/bootloader/Makefile
+++ b/cpu/esp32/bootloader/Makefile
@@ -176,13 +176,29 @@ else ifeq (esp32c3,$(CPU_FAM))
     components/soc/$(CPU_FAM)/gdma_periph.c \
     components/soc/$(CPU_FAM)/temperature_sensor_periph.c \
     #
+else ifeq (esp32c6,$(CPU_FAM))
+  ESP_SDK_BOOTLOADER_SRCS += \
+    components/efuse/$(CPU_FAM)/esp_efuse_rtc_calib.c \
+    components/efuse/src/efuse_controller/keys/with_key_purposes/esp_efuse_api_key.c \
+    components/esp_hw_support/port/$(CPU_FAM)/pmu_init.c \
+    components/esp_hw_support/port/$(CPU_FAM)/pmu_param.c \
+    components/esp_hw_support/port/$(CPU_FAM)/pmu_sleep.c \
+    components/esp_rom/patches/esp_rom_hp_regi2c_$(CPU_FAM).c \
+    components/esp_rom/patches/esp_rom_systimer.c \
+    components/esp_rom/patches/esp_rom_wdt.c \
+    components/hal/cache_hal.c \
+    components/hal/wdt_hal_iram.c \
+    components/hal/lp_timer_hal.c \
+    #
+ESP_SDK_BOOTLOADER_SRCS += components/bootloader_support/src/$(CPU_FAM)/bootloader_ecdsa.c
+
 else ifeq (esp32h2,$(CPU_FAM))
   ESP_SDK_BOOTLOADER_SRCS += \
     components/efuse/$(CPU_FAM)/esp_efuse_rtc_calib.c \
     components/efuse/src/efuse_controller/keys/with_key_purposes/esp_efuse_api_key.c \
-    components/esp_hw_support/port/esp32h2/pmu_init.c \
-    components/esp_hw_support/port/esp32h2/pmu_param.c \
-    components/esp_hw_support/port/esp32h2/pmu_sleep.c \
+    components/esp_hw_support/port/$(CPU_FAM)/pmu_init.c \
+    components/esp_hw_support/port/$(CPU_FAM)/pmu_param.c \
+    components/esp_hw_support/port/$(CPU_FAM)/pmu_sleep.c \
     components/esp_rom/patches/esp_rom_regi2c_$(CPU_FAM).c \
     components/esp_rom/patches/esp_rom_systimer.c \
     components/esp_rom/patches/esp_rom_wdt.c \
@@ -260,7 +276,7 @@ ifneq (,$(filter riscv32%,$(TARGET_ARCH)))
 
   ifeq (esp32c3,$(CPU_FAM))
     CFLAGS += -march=rv32imc_zicsr_zifencei
-  else ifeq (esp32h2,$(CPU_FAM))
+  else ifneq (,$(filter esp32c6 esp32h2,$(CPU_FAM)))
     CFLAGS += -march=rv32imac_zicsr_zifencei
   else
       $(error Missing -march option for ESP32x RISC-V SoC variant: $(CPU_FAM))
@@ -352,6 +368,13 @@ else ifneq (,$(filter esp32c3,$(CPU_FAM)))
     -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.bt_funcs.ld \
     -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.eco3.ld \
     -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.eco3_bt_funcs.ld \
+    #
+else ifneq (,$(filter esp32c6,$(CPU_FAM)))
+  LINKFLAGS += -nostartfiles
+  LINKFLAGS += --specs=nosys.specs
+  ESP_SDK_BOOTLOADER_ADD_LINK_FLAGS += \
+    -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib.ld \
+    -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.version.ld \
     #
 else ifneq (,$(filter esp32h2,$(CPU_FAM)))
   LINKFLAGS += -nostartfiles

--- a/cpu/esp32/bootloader/sdkconfig.h
+++ b/cpu/esp32/bootloader/sdkconfig.h
@@ -36,6 +36,8 @@
 #  include "sdkconfig_default_esp32.h"
 #elif defined(CPU_FAM_ESP32C3)
 #  include "sdkconfig_default_esp32c3.h"
+#elif defined(CPU_FAM_ESP32C6)
+#  include "sdkconfig_default_esp32c6.h"
 #elif defined(CPU_FAM_ESP32H2)
 #  include "sdkconfig_default_esp32h2.h"
 #elif defined(CPU_FAM_ESP32S2)

--- a/cpu/esp32/bootloader/sdkconfig_default_esp32c6.h
+++ b/cpu/esp32/bootloader/sdkconfig_default_esp32c6.h
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     cpu_esp32
+ * @{
+ *
+ * @file
+ * @brief       Default SDK configuration for the ESP32-C3 SoC bootloader
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef DOXYGEN
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CONFIG_ESP32C6_REV_MIN_0            1
+#define CONFIG_ESP32C6_REV_MIN_FULL         0
+
+#ifndef CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ
+#  define CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ   80
+#endif
+
+#define CONFIG_XTAL_FREQ                    40
+
+#define CONFIG_ESP_DEBUG_OCDAWARE           1
+
+#define CONFIG_BOOTLOADER_OFFSET_IN_FLASH   0x0
+#define CONFIG_EFUSE_MAX_BLK_LEN            256
+#define CONFIG_IDF_FIRMWARE_CHIP_ID         0x000D
+#define CONFIG_MMU_PAGE_SIZE                0x8000
+
+#define CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG    1
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DOXYGEN */
+/** @} */

--- a/cpu/esp32/doc.md
+++ b/cpu/esp32/doc.md
@@ -181,7 +181,7 @@ either based on
 - Tensilica Xtensa 32-bit LX7 microprocessor (ESP32-S2, ESP32-S3), or
 - 32-bit RISC-V CPU (ESP32-C3, ESP32-C3 ESP32-H2).
 
-At the moment, ESP32, ESP32-S2, ESP32-S3, ESP32-C3 and ESP32-H2
+At the moment, ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C6 and ESP32-H2
 variants (families) are supported by RIOT-OS.
 
 @note Even if the used ESP32x SoC is a dual-core version, RIOT-OS uses only
@@ -265,6 +265,43 @@ The key features of ESP32-C3 are:
 | Crypto            | Hardware acceleration of AES, SHA-2, RSA, ECC, RNG                | no  |
 | Vcc               | 3.0 - 3.6 V                                                       | |
 | Documents         | [Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf) <br> [Technical Reference](https://www.espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf) | |
+
+</center><br>
+
+### Features of The ESP32-C6 SoC variant (family)
+
+The key features of ESP32-C6 are:
+
+<center>
+
+| MCU               | ESP32-C6                                                          | Supported by RIOT |
+| ------------------|-------------------------------------------------------------------|------------------ |
+| Vendor            | Espressif                                                         |     |
+| Cores             | 1 x 32-bit RISC-V core                                            | yes |
+| FPU               | -                                                                 | -   |
+| RAM               | 512 KiB SRAM <br> 16 KiB LP SRAM                                  | yes <br> yes |
+| ROM               | 320 KiB                                                           | yes |
+| Flash             | 16 MiB                                                            | yes |
+| Frequency         | 160 MHz, 120 MHz, **80 MHz**, 40 MHz, 20 MHz                      | yes |
+| Power Consumption | 27 mA @ 160 MHz <br> 19 mA @ 80 MHz <br> 180 uA in light sleep mode <br> 7 uA in deep sleep mode | yes <br> yes <br> yes <br> yes |
+| Timer             | 2 x 54 bit                                                        | yes |
+| ADC               | 1 x SAR-ADC with up to 7 x 12 bit channels total                  | yes |
+| DAC               | -                                                                 | -   |
+| GPIO              | 31                                                                | yes |
+| I2C               | 2                                                                 | yes |
+| SPI               | 3 (1 usable as general purpose SPI)                               | yes |
+| UART              | 3 (2 in high-power domain and 1 in low-power domain)              | yes |
+| WiFi              | IEEE 802.11 b/g/n/ax built in                                     | yes |
+| Bluetooth         | Bluetooth 5 (LE)                                                  | yes |
+| IEEE 802.15.4     | 250 Kbps data rate in 2.4 GHz band with OQPSK PHY                 | yes |
+| Ethernet          | -                                                                 | -   |
+| CAN               | version 2.0                                                       | yes |
+| IR                | up to 4 channels TX/RX                                            | -   |
+| Motor PWM         | 1 device x 6 channels                                             | no  |
+| LED PWM           | 6 channels with 20 bit resolution in 1 channel group with 4 timers| yes |
+| Crypto            | Hardware acceleration of AES, SHA-2, RSA, ECC, RNG                | no  |
+| Vcc               | 3.0 - 3.6 V                                                       |     |
+| Documents         | [Datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf) <br> [Technical Reference](https://www.espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf) | |
 
 </center><br>
 
@@ -389,6 +426,8 @@ Most common modules used by ESP32x SoC boards are:
 - [ESP32-WROVER](https://www.espressif.com/sites/default/files/documentation/esp32-wrover_datasheet_en.pdf)
 - [ESP32-C3-MINI-1](https://www.espressif.com/sites/default/files/documentation/esp32-c3-mini-1_datasheet_en.pdf)
 - [ESP32-C3-WROOM-02](https://www.espressif.com/sites/default/files/documentation/esp32-c3-wroom-02_datasheet_en.pdf)
+- [ESP32-C6-MINI-1](https://www.espressif.com/sites/default/files/documentation/esp32-c6-mini-1_datasheet_en.pdf)
+- [ESP32-C6-WROOM-1](https://www.espressif.com/sites/default/files/documentation/esp32-c6-wroom-1_datasheet_en.pdf)
 - [ESP32-H2-MINI-1](https://www.espressif.com/sites/default/files/documentation/esp32-h2-mini-1_mini-1u_datasheet_en.pdf)
 - [ESP32-S2-MINI-1](https://www.espressif.com/sites/default/files/documentation/esp32-s2-mini-1_esp32-s2-mini-1u_datasheet_en.pdf)
 - [ESP32-S2-SOLO](https://www.espressif.com/sites/default/files/documentation/esp32-s2-solo_esp32-s2-solo-u_datasheet_en.pdf)
@@ -502,7 +541,7 @@ install Espressif's precompiled versions of the following tools:
 
 - ESP32 vendor toolchain
 - GDB for ESP32x SoCs based on Xtensa or RISC-V
-- OpenOCD for ESP32 (for ESP32, ESP32-S2, ESP32-S3, ESP32-C3 and ESP32-H2)
+- OpenOCD for ESP32 (for ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C6 and ESP32-H2)
 - QEMU for ESP32x SoCs (for ESP32, ESP32-S3 and ESP32-C3)
 
 `$RIOTBASE` defines the root directory of the RIOT repository. The shell
@@ -514,7 +553,7 @@ $ dist/tools/esptools/install.sh
 Usage: install.sh <tool>
        install.sh gdb <platform>
        install.sh qemu <platform>
-<tool> = all | gdb | openocd | qemu |
+<tool> = all | esptool | gdb | openocd | qemu |
          esp8266 | esp32 | esp32c3 | esp32h2 | esp32s2 | esp32s3
 <platform> = xtensa | riscv
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -546,7 +585,7 @@ Usage: export.sh <tool>
        export.sh gdb <platform>
        export.sh qemu <platform>
 <tool> = all | gdb | openocd | qemu |
-         esp8266 | esp32 | esp32c3 | esp32h2 | esp32s2 | esp32s3
+         esp8266 | esp32 | esp32c3 | esp32c6 | esp32h2 | esp32s2 | esp32s3
 <platform> = xtensa | riscv
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -756,6 +795,7 @@ For details, see:
 
 - \ref esp32_gpio_pins_esp32 "ESP32"
 - \ref esp32_gpio_pins_esp32c3 "ESP32-C3"
+- \ref esp32_gpio_pins_esp32c6 "ESP32-C6"
 - \ref esp32_gpio_pins_esp32h2 "ESP32-H2"
 - \ref esp32_gpio_pins_esp32s2 "ESP32-S2"
 - \ref esp32_gpio_pins_esp32s3 "ESP32-S3"
@@ -771,6 +811,7 @@ details, see:
 
 - \ref esp32_adc_channels_esp32 "ESP32"
 - \ref esp32_adc_channels_esp32c3 "ESP32-C3"
+- \ref esp32_adc_channels_esp32c6 "ESP32-C6"
 - \ref esp32_adc_channels_esp32h2 "ESP32-H2"
 - \ref esp32_adc_channels_esp32s2 "ESP32-S2"
 - \ref esp32_adc_channels_esp32s3 "ESP32-S3"
@@ -893,6 +934,7 @@ on used ESP32x SoC family, for details see:
 
 - \ref esp32_i2c_interfaces_esp32 "ESP32"
 - \ref esp32_i2c_interfaces_esp32c3 "ESP32-C3"
+- \ref esp32_i2c_interfaces_esp32c6 "ESP32-C6"
 - \ref esp32_i2c_interfaces_esp32h2 "ESP32-H2"
 - \ref esp32_i2c_interfaces_esp32s2 "ESP32-S2"
 - \ref esp32_i2c_interfaces_esp32s3 "ESP32-S3"
@@ -946,6 +988,7 @@ channel depends on respective ESP32x SoC family. For details, see:
 
 - \ref esp32_pwm_channels_esp32 "ESP32"
 - \ref esp32_pwm_channels_esp32c3 "ESP32-C3"
+- \ref esp32_pwm_channels_esp32c6 "ESP32-C6"
 - \ref esp32_pwm_channels_esp32h2 "ESP32-H2"
 - \ref esp32_pwm_channels_esp32s2 "ESP32-S2"
 - \ref esp32_pwm_channels_esp32s3 "ESP32-S3"
@@ -1125,6 +1168,7 @@ on used ESP32x SoC family, for details see:
 
 - \ref esp32_spi_interfaces_esp32 "ESP32"
 - \ref esp32_spi_interfaces_esp32c3 "ESP32-C3"
+- \ref esp32_spi_interfaces_esp32c6 "ESP32-C6"
 - \ref esp32_spi_interfaces_esp32h2 "ESP32-H2"
 - \ref esp32_spi_interfaces_esp32s2 "ESP32-S2"
 - \ref esp32_spi_interfaces_esp32s3 "ESP32-S3"
@@ -1170,6 +1214,7 @@ ESP32x SoC family, for details see:
 
 - \ref esp32_timers_esp32 "ESP32"
 - \ref esp32_timers_esp32c3 "ESP32-C3"
+- \ref esp32_timers_esp32c6 "ESP32-C6"
 - \ref esp32_timers_esp32h2 "ESP32-H2"
 - \ref esp32_timers_esp32s2 "ESP32-S2"
 - \ref esp32_timers_esp32s3 "ESP32-S3"
@@ -1233,6 +1278,7 @@ on used ESP32x SoC family, for details see:
 
 - \ref esp32_uart_interfaces_esp32 "ESP32"
 - \ref esp32_uart_interfaces_esp32c3 "ESP32-C3"
+- \ref esp32_uart_interfaces_esp32c6 "ESP32-C6"
 - \ref esp32_uart_interfaces_esp32h2 "ESP32-H2"
 - \ref esp32_uart_interfaces_esp32s2 "ESP32-S2"
 - \ref esp32_uart_interfaces_esp32s3 "ESP32-S3"
@@ -1828,7 +1874,7 @@ The following ESP32x SoC variants (families) integrate a Bluetooth Link
 Controller and a Bluetooth baseband system:
 
 - ESP32 supports Bluetooth v4.2 BR/EDR and Bluetooth LE
-- ESP32-C3, ESP32-H2, ESP32-S3 support Bluetooth 5 and Bluetooth mesh
+- ESP32-C3, ESP32-C6, ESP32-H2, ESP32-S3 support Bluetooth 5 and Bluetooth mesh
 
 The Bluetooth interface can be used with the Bluetooth host implementation
 of the NimBLE package. Use one of the `nimble_*` modules for different
@@ -1839,7 +1885,7 @@ implementation. Please refer to the NimBle package documentation for details.
 
 ## IEEE 802.15.4 Network Interface {#esp32_esp_ieee802154_interface}
 
-ESP-H2 includes an IEEE 802.15.4 subsystem
+ESP32-C6 and ESP-H2 include an IEEE 802.15.4 subsystem
 that integrates PHY and MAC layer.
 
 The \ref drivers_ieee802154_hal "IEEE 802.15.4 Hardware Abstraction Layer"
@@ -2049,6 +2095,7 @@ For details, see:
 
 - \ref esp32_jtag_interface_esp32 "ESP32"
 - \ref esp32_jtag_interface_esp32c3 "ESP32-C3"
+- \ref esp32_jtag_interface_esp32c6 "ESP32-C6"
 - \ref esp32_jtag_interface_esp32h2 "ESP32-H2"
 - \ref esp32_jtag_interface_esp32s2 "ESP32-S2"
 - \ref esp32_jtag_interface_esp32s3 "ESP32-S3"
@@ -2071,6 +2118,7 @@ that can be used without additional chips. For details, see:
 
 - \ref esp32_jtag_interface_esp32 "ESP32"
 - \ref esp32_jtag_interface_esp32c3 "ESP32-C3"
+- \ref esp32_jtag_interface_esp32c6 "ESP32-C6"
 - \ref esp32_jtag_interface_esp32h2 "ESP32-H2"
 - \ref esp32_jtag_interface_esp32s2 "ESP32-S2"
 - \ref esp32_jtag_interface_esp32s3 "ESP32-S3"
@@ -2115,6 +2163,7 @@ ESP32x SoC variant (family) can be found in ESP-IDF Programming Guide:
 
 - [ESP32](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/index.html)
 - [ESP32-C3](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-guides/jtag-debugging/index.html)
+- [ESP32-C6](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c6/api-guides/jtag-debugging/index.html)
 - [ESP32-H2](https://docs.espressif.com/projects/esp-idf/en/latest/esp32h2/api-guides/jtag-debugging/index.html)
 - [ESP32-S3](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-guides/jtag-debugging/index.html)
 - [ESP32-S2](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-guides/jtag-debugging/index.html)

--- a/cpu/esp32/doc_esp32c6.doc.md
+++ b/cpu/esp32/doc_esp32c6.doc.md
@@ -1,0 +1,226 @@
+<!--
+Copyright (C) 2025 Gunar Schorcht
+
+This file is subject to the terms and conditions of the GNU Lesser
+General Public License v2.1. See the file LICENSE in the top level
+directory for more details.
+-->
+
+@defgroup   cpu_esp32_esp32c6 ESP32-C6 family
+@ingroup    cpu_esp32
+@brief      Specific properties of ESP32-C6 variant (family)
+@author     Gunar Schorcht <gunar@schorcht.net>
+
+\section esp32_riot_esp32c6  Specific properties of ESP32-C6 variant (family)
+
+## GPIO pins {#esp32_gpio_pins_esp32c6}
+
+ESP32-C6 has 19 broken-out GPIO pins, where a subset can be used as ADC channel
+and as low-power digital inputs/outputs in deep-sleep mode, the so-called
+LP GPIOs. Some of them are used by special SoC components. The following
+table gives a short overview.
+
+<center>
+
+Pin    | Type   | ADC / LP | PU / PD | Special function | Remarks
+-------|:-------|:--------:|:-------:|------------------|--------
+GPIO0  | In/Out | ADC / LP | yes     | XTAL_32K_P       | -
+GPIO1  | In/Out | ADC / LP | yes     | XTAL_32K_N       | -
+GPIO2  | In/Out | ADC / LP | yes     |                  | FSPIQ
+GPIO3  | In/Out | ADC / LP | yes     |                  | -
+GPIO4  | In/Out | ADC / LP | yes     | MTMS             | FSPIWP
+GPIO5  | In/Out | ADC / LP | yes     | MTDI             | FSPIHD
+GPIO6  | In/Out | ADC / LP | yes     | MTCK             | FSPICLK
+GPIO7  | In/Out | LP       | yes     | MTDO             | FSPID
+GPIO8  | In/Out |          | yes     |                  | Bootstrapping
+GPIO9  | In/Out |          | yes     |                  | Bootstrapping, pulled up
+GPIO10 | In/Out |          | yes     |                  | N/A on chips with in-package flash
+GPIO11 | In/Out |          | yes     |                  | N/A on chips with in-package flash
+GPIO12 | In/Out |          | yes     | USB D-           | USB Serial / JTAG interface
+GPIO13 | In/Out |          | yes     | USB D+           | USB Serial / JTAG interface
+GPIO14 | In/Out |          | yes     |                  | N/A on chips w/o in-package flash
+GPIO15 | In/Out |          | yes     |                  | Bootstrapping
+GPIO16 | In/Out |          | yes     | UART0 TX         | FSPICS0
+GPIO17 | In/Out |          | yes     | UART0 RX         | FSPICS1
+GPIO18 | In/Out |          | yes     | UART0 RX         | FSPICS2
+GPIO19 | In/Out |          | yes     |                  | FSPICS3
+GPIO20 | In/Out |          | yes     |                  | FSPICS4
+GPIO21 | In/Out |          | yes     |                  | FSPICS5
+GPIO22 | In/Out |          | yes     |                  | -
+GPIO23 | In/Out |          | yes     |                  | -
+GPIO24 | In/Out |          | yes     | SPICS0           | N/A on chips with in-package flash
+GPIO25 | In/Out |          | yes     | SPIQ             | N/A on chips with in-package flash
+GPIO26 | In/Out |          | yes     | SPIWP            | N/A on chips with in-package flash
+GPIO27 | In/Out |          | yes     | VDD_SPI          | N/A on chips with in-package flash
+GPIO28 | In/Out |          | yes     | SPIHD            | N/A on chips with in-package flash
+GPIO29 | In/Out |          | yes     | SPICLK           | N/A on chips with in-package flash
+GPIO30 | In/Out |          | yes     | SPID             | N/A on chips with in-package flash
+
+</center><br>
+
+<b>ADC:</b> these pins can be used as ADC inputs<br>
+<b>LP:</b> these pins are LP GPIOs and can be used in deep-sleep mode<br>
+<b>PU/PD:</b> these pins have software configurable pull-up/pull-down functionality.<br>
+
+GPIO8 and GPIO9 are bootstrapping pins which are used to boot
+ESP32-C6 in different modes:
+
+<center>
+
+GPIO9 | GPIO8 | Mode
+:----:|:-----:|:------------------------------------------------------------
+1     | X     | SPI Boot mode to boot the firmware from flash (default mode)
+0     | 1     | SPI Download Boot mode
+
+Other combinations are invalid.
+
+</center><br>
+
+## ADC Channels {#esp32_adc_channels_esp32c6}
+
+ESP32-C6 integrates one 12-bit ADC with 7 channels in
+total: GPIO0, GPIO1, GPIO2, GPIO3, GPIO4, GPIO5 and GPIO6
+
+The maximum number of ADC channels #ADC_NUMOF_MAX is 7.
+
+## I2C Interfaces {#esp32_i2c_interfaces_esp32c6}
+
+ESP32-C6 has two built-in I2C interfaces.
+
+The following table shows the default configuration of I2C interfaces
+used for ESP32-C6 boards. It can be overridden by
+[application-specific configurations](#esp32_application_specific_configurations).
+
+<center>
+
+Device     | Signal | Pin    | Symbol        | Remarks
+:----------|:-------|:-------|:--------------|:----------------
+I2C_DEV(0) |        |        | `I2C0_SPEED`  | default is `I2C_SPEED_FAST`
+I2C_DEV(0) | SCL    | GPIO5  | `I2C0_SCL`    | -
+I2C_DEV(0) | SDA    | GPIO4  | `I2C0_SDA`    | -
+
+</center><br>
+
+## PWM Channels {#esp32_pwm_channels_esp32c6}
+
+The ESP32-C6 LEDC module has 1 channel group with 6 channels. Each of
+these channels can be clocked by one of the 4 timers. This means that
+it is possible to define up to 4 PWM devices with different frequencies
+and resolutions and a total of 6 PWM channels.
+
+## SPI Interfaces {#esp32_spi_interfaces_esp32c6}
+
+ESP32-C6 has three SPI controllers where SPI0 and SPI1 share the same bus.
+They are used as interface for external memory and can only operate in memory
+mode:
+
+- Controller SPI0 is reserved for caching external memory like Flash
+- Controller SPI1 is reserved for external memory like PSRAM
+- Controller SPI2 can be used as general purpose SPI (also called FSPI)
+
+Thus, only SPI2 (FSPI) can be used as general purpose SPI in RIOT as
+SPI_DEV(0).
+
+The following table shows the pin configuration used for most boards, even
+though it **can vary** from board to board.
+
+<center>
+
+Device        | Signal | Pin    | Symbol      | Remarks
+:-------------|:------:|:-------|:-----------:|:---------------------------
+SPI_DEV(0)    | SCK    | GPIO6  |`SPI0_SCK`   | `SPI2_HOST` (`FSPI`)
+SPI_DEV(0)    | MOSI   | GPIO7  |`SPI0_MOSI`  | `SPI2_HOST` (`FSPI`)
+SPI_DEV(0)    | MISO   | GPIO2  |`SPI0_MISO`  | `SPI2_HOST` (`FSPI`)
+SPI_DEV(0)    | CS0    | GPIO18 |`SPI0_CS0`   | `SPI2_HOST` (`FSPI`)
+
+</center><br>
+
+## Timers {#esp32_timers_esp32c6}
+
+ESP32-C6 has two timer groups with one timer each, resulting in a total of
+two timers. Thus one timer with one channel can be used in RIOT
+as timer device TIMER_DEV(0), because the other timer is used as system timer.
+
+ESP32-C6 do not have CCOMPARE registers. The counter implementation can not
+be used.
+
+## UART Interfaces {#esp32_uart_interfaces_esp32c6}
+
+ESP32-C6 integrates three UART interfaces, two in the high-power domain and
+one in the low-power domain. The low-power UART interface is not yet supported.
+The following default pin configuration of UART interfaces as used by a most
+boards can be overridden by the application, see section
+[Application-Specific Configurations](#esp32_application_specific_configurations).
+
+<center>
+
+Device      |Signal|Pin     |Symbol      |Remarks
+:-----------|:-----|:-------|:-----------|:----------------
+UART_DEV(0) | TxD  | GPIO16 |`UART0_TXD` | cannot be changed
+UART_DEV(0) | RxD  | GPIO17 |`UART0_RXD` | cannot be changed
+UART_DEV(1) | TxD  |        |`UART1_TXD` | optional, can be configured
+UART_DEV(1) | RxD  |        |`UART1_RXD` | optional, can be configured
+
+</center><br>
+
+## JTAG Interface {#esp32_jtag_interface_esp32c6}
+
+There are two options on how to use the JTAG interface on ESP32-C6:
+
+1.  Using the built-in USB-to-JTAG bridge connected to an USB cable as follows:
+    <center>
+    USB Signal     | ESP32-C6 Pin
+    :--------------|:-----------
+    D- (white)     | GPIO12
+    D+ (green)     | GPIO13
+    V_Bus (red)    | 5V
+    Ground (black) | GND
+    </center><br>
+
+2.  Using an external JTAG adapter connected to the JTAG interface exposed
+    to GPIOs as follows:
+    <center>
+    JTAG Signal | ESP32-C6 Pin
+    :-----------|:-----------
+    TRST_N      | CHIP_PU
+    TDO         | GPIO7 (MTDO)
+    TDI         | GPIO5 (MTDI)
+    TCK         | GPIO6 (MTCK)
+    TMS         | GPIO4 (MTMS)
+    GND         | GND
+    </center><br>
+
+Using the built-in USB-to-JTAG bridge is the default option, i.e. the JTAG
+interface of the ESP32-C6 is connected to the built-in USB-to-JTAG bridge.
+To use an external JTAG adapter, the JTAG interface of the ESP32-C6 has to
+be connected to the GPIOs as shown above. For this purpose eFuses have to be
+burned with the following command:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+espefuse.py burn_efuse JTAG_SEL_ENABLE --port /dev/ttyUSB0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@warning Burning eFuses is an irreversible operation.
+
+Once the eFuses are burned with this command and option `JTAG_SEL_ENABLE`,
+GPIO15 is used as a bootstrapping pin to choose between the two options.
+If GPIO15 is HIGH when ESP32-C6 is reset, the JTAG interface is connected
+to the built-in USB to JTAG bridge and the USB cable can be used for on-chip
+debugging. Otherwise, the JTAG interface is exposed to GPIO4 ... GPIO7
+and an external JTAG adapter has to be used.
+
+Alternatively, the integrated USB-to-JTAG bridge can be permanently disabled
+with the following command:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+espefuse.py burn_efuse DIS_USB_JTAG --port /dev/ttyUSB0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@warning Burning eFuses is an irreversible operation.
+
+Once the eFuses are burned with this command and option `DIS_USB_JTAG`,
+the JTAG interface is always exposed to GPIO4 ... GPIO7 and an external
+JTAG adapter has to be used.
+
+For more information about JTAG configuration for ESP32-C6, refer to the
+section [Configure Other JTAG Interface]
+(https://docs.espressif.com/projects/esp-idf/en/latest/esp32c6/api-guides/jtag-debugging/configure-other-jtag.html)
+in the ESP-IDF documentation.

--- a/cpu/esp32/esp-idf/ble/Makefile
+++ b/cpu/esp32/esp-idf/ble/Makefile
@@ -4,7 +4,7 @@ ifeq (esp32,$(CPU_FAM))
   # source files to be compiled for this module for ESP32
   ESP32_SDK_SRC += components/bt/controller/$(CPU_FAM)/bt.c
   ESP32_SDK_SRC += components/esp_system/esp_system.c
-else ifeq (esp32h2,$(CPU_FAM))
+else ifneq (,$(filter esp32c6 esp32h2,$(CPU_FAM)))
   # source files to be compiled for this module for ESP32H2
   ESP32_SDK_SRC += components/bt/controller/$(CPU_FAM)/bt.c
   ESP32_SDK_SRC += components/bt/porting/mem/bt_osi_mem.c
@@ -18,7 +18,7 @@ else ifneq (,$(filter esp32s3 esp32c3,$(CPU_FAM)))
   ESP32_SDK_SRC += components/esp_system/esp_system.c
 endif
 
-ifeq (esp32h2,$(CPU_FAM))
+ifneq (,$(filter esp32c6 esp32h2,$(CPU_FAM)))
   # ESP-IDF npl includes have to be found before the includes of pkg/nimble
   INCLUDES := -I$(ESP32_SDK_DIR)/components/bt/porting/npl/freertos/include $(INCLUDES)
   INCLUDES += -I$(ESP32_SDK_DIR)/components/bt/porting/transport/include

--- a/cpu/esp32/esp-idf/common/Makefile
+++ b/cpu/esp32/esp-idf/common/Makefile
@@ -66,7 +66,16 @@ endif
 ifneq (,$(filter esp_idf_phy,$(USEMODULE)))
   ESP32_SDK_SRC += components/esp_phy/src/phy_common.c
   INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_phy/include
-  ifeq (esp32h2,$(CPU_FAM))
+  INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_phy/$(CPU_FAM)/include
+  ifeq (esp32c6,$(CPU_FAM))
+    ESP32_SDK_SRC += components/esp_phy/$(CPU_FAM)/phy_init_data.c
+    ESP32_SDK_SRC += components/esp_phy/src/btbb_init.c
+    ESP32_SDK_SRC += components/esp_phy/src/phy_init.c
+    ESP32_SDK_SRC += components/esp_phy/src/phy_override.c
+    INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_event/include
+    INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_netif/include
+    INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_wifi/include
+  else ifeq (esp32h2,$(CPU_FAM))
     ESP32_SDK_SRC += components/esp_phy/src/btbb_init.c
     ESP32_SDK_SRC += components/esp_phy/src/phy_init_esp32hxx.c
     ESP32_SDK_SRC += components/esp_phy/src/phy_override.c
@@ -77,7 +86,6 @@ ifneq (,$(filter esp_idf_phy,$(USEMODULE)))
     ESP32_SDK_SRC += components/soc/esp32/dport_access.c
     INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_event/include
     INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_netif/include
-    INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_phy/$(CPU_FAM)/include
     INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_wifi/include
     ifeq (,$(filter esp_idf_wifi,$(USEMODULE)))
       ESP32_SDK_SRC += components/esp_wifi/src/wifi_init.c
@@ -166,6 +174,23 @@ else ifeq (esp32c3,$(CPU_FAM))
   ESP32_SDK_SRC += components/hal/$(CPU_FAM)/rtc_cntl_hal.c
   ESP32_SDK_SRC += components/hal/cache_hal.c
   ESP32_SDK_SRC += components/hal/systimer_hal.c
+else ifeq (esp32c6,$(CPU_FAM))
+  ESP32_SDK_SRC += components/esp_rom/patches/esp_rom_hp_regi2c_$(CPU_FAM).c
+  ESP32_SDK_SRC += components/esp_hw_support/lowpower/port/$(CPU_FAM)/sleep_cpu.c
+  ESP32_SDK_SRC += components/esp_hw_support/modem_clock.c
+  ESP32_SDK_SRC += components/esp_hw_support/port/$(CPU_FAM)/ocode_init.c
+  ESP32_SDK_SRC += components/esp_hw_support/port/$(CPU_FAM)/systimer.c
+  ESP32_SDK_SRC += components/esp_hw_support/port/pau_regdma.c
+  ESP32_SDK_SRC += components/esp_hw_support/port/regdma_link.c
+  ESP32_SDK_SRC += components/esp_hw_support/sleep_console.c
+  ESP32_SDK_SRC += components/esp_pm/pm_impl.c
+  ESP32_SDK_SRC += components/esp_timer/src/esp_timer_impl_systimer.c
+  ESP32_SDK_SRC += components/hal/$(CPU_FAM)/pau_hal.c
+  ESP32_SDK_SRC += components/hal/apm_hal.c
+  ESP32_SDK_SRC += components/hal/cache_hal.c
+  ESP32_SDK_SRC += components/hal/lp_timer_hal.c
+  ESP32_SDK_SRC += components/hal/systimer_hal.c
+  ESP32_SDK_ASMSRC += components/esp_hw_support/lowpower/port/$(CPU_FAM)/sleep_cpu_asm.S
 else ifeq (esp32h2,$(CPU_FAM))
   ESP32_SDK_SRC += components/esp_rom/patches/esp_rom_regi2c_$(CPU_FAM).c
   ESP32_SDK_SRC += components/esp_hw_support/lowpower/port/$(CPU_FAM)/sleep_cpu.c

--- a/cpu/esp32/esp-idf/esp_idf.mk
+++ b/cpu/esp32/esp-idf/esp_idf.mk
@@ -28,6 +28,11 @@ ifneq (,$(filter xtensa%,$(TARGET_ARCH)))
   INCLUDES += -I$(ESP32_SDK_DIR)/components/xtensa/$(CPU_FAM)/include
 endif
 
+ifeq (esp32c6,$(CPU_FAM))
+  INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/include/esp_private
+  INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/port/$(CPU_FAM)/private_include
+endif
+
 ifeq (esp32h2,$(CPU_FAM))
   INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/include/esp_private
   INCLUDES += -I$(ESP32_SDK_DIR)/components/esp_hw_support/port/$(CPU_FAM)/private_include

--- a/cpu/esp32/esp-idf/esp_idf_cflags.mk
+++ b/cpu/esp32/esp-idf/esp_idf_cflags.mk
@@ -46,6 +46,6 @@ ifneq (,$(filter riscv32%,$(TARGET_ARCH)))
   CFLAGS += -nostartfiles
 endif
 
-ifeq (esp32h2,$(CPU_FAM))
+ifneq (,$(filter esp32c6 esp32h2,$(CPU_FAM)))
   CFLAGS += -DSOC_MMU_PAGE_SIZE=CONFIG_MMU_PAGE_SIZE
 endif

--- a/cpu/esp32/esp-idf/spi_flash/Makefile
+++ b/cpu/esp32/esp-idf/spi_flash/Makefile
@@ -23,7 +23,7 @@ ESP32_SDK_SRC = \
   components/spi_flash/spi_flash_chip_winbond.c \
   #
 
-ifneq (,$(filter esp32s2 esp32s3 esp32c3 esp32h2,$(CPU_FAM)))
+ifneq (,$(filter esp32s2 esp32s3 esp32c3 esp32c6 esp32h2,$(CPU_FAM)))
   ESP32_SDK_SRC += components/hal/spi_flash_hal_gpspi.c
 endif
 

--- a/cpu/esp32/include/cpu_conf.h
+++ b/cpu/esp32/include/cpu_conf.h
@@ -103,6 +103,8 @@ extern uint8_t _fp_mmu_start;
 #  include "cpu_conf_esp32.h"
 #elif defined(CPU_FAM_ESP32C3)
 #  include "cpu_conf_esp32c3.h"
+#elif defined(CPU_FAM_ESP32C6)
+#  include "cpu_conf_esp32c6.h"
 #elif defined(CPU_FAM_ESP32H2)
 #  include "cpu_conf_esp32h2.h"
 #elif defined(CPU_FAM_ESP32S2)

--- a/cpu/esp32/include/cpu_conf_esp32c6.h
+++ b/cpu/esp32/include/cpu_conf_esp32c6.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     cpu_esp32
+ * @ingroup     config
+ * @brief       Compile-time configuration macros for ESP32-C6 SoCs
+ * @{
+ *
+ * @file
+ * @brief       ESP32-C6 specific compile-time configuration
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ESP_ISR_STACKSIZE
+/** Stack size used in interrupt context */
+#  define ESP_ISR_STACKSIZE     (THREAD_STACKSIZE_DEFAULT)
+#endif /* ESP_ISR_STACKSIZE */
+
+/** Number of DRAM sections that can be used as heap. */
+#define NUM_HEAPS (1)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -1044,6 +1044,8 @@ typedef enum {
 #  include "periph_cpu_esp32.h"
 #elif defined(CPU_FAM_ESP32C3)
 #  include "periph_cpu_esp32c3.h"
+#elif defined(CPU_FAM_ESP32C6)
+#  include "periph_cpu_esp32c6.h"
 #elif defined(CPU_FAM_ESP32H2)
 #  include "periph_cpu_esp32h2.h"
 #elif defined(CPU_FAM_ESP32S2)

--- a/cpu/esp32/include/periph_cpu_esp32c6.h
+++ b/cpu/esp32/include/periph_cpu_esp32c6.h
@@ -1,0 +1,180 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     cpu_esp32
+ * @{
+ *
+ * @file
+ * @brief       ESP32-C6 specific peripheral configuration
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include "sdkconfig.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Mapping configured ESP32-C6 default clock to CLOCK_CORECLOCK define */
+#define CLOCK_CORECLOCK     (1000000UL * CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ)
+
+/**
+ * @brief   CPU cycles per busy wait loop
+ */
+#define CPU_CYCLES_PER_LOOP (4)
+
+/**
+ * @name   Predefined GPIO names
+ * @{
+ */
+#define GPIO0  (GPIO_PIN(PORT_GPIO, 0))  /**< GPIO0 */
+#define GPIO1  (GPIO_PIN(PORT_GPIO, 1))  /**< GPIO1 */
+#define GPIO2  (GPIO_PIN(PORT_GPIO, 2))  /**< GPIO2 */
+#define GPIO3  (GPIO_PIN(PORT_GPIO, 3))  /**< GPIO3 */
+#define GPIO4  (GPIO_PIN(PORT_GPIO, 4))  /**< GPIO4 */
+#define GPIO5  (GPIO_PIN(PORT_GPIO, 5))  /**< GPIO5 */
+#define GPIO6  (GPIO_PIN(PORT_GPIO, 6))  /**< GPIO6 */
+#define GPIO7  (GPIO_PIN(PORT_GPIO, 7))  /**< GPIO7 */
+#define GPIO8  (GPIO_PIN(PORT_GPIO, 8))  /**< GPIO8 */
+#define GPIO9  (GPIO_PIN(PORT_GPIO, 9))  /**< GPIO9 */
+#define GPIO10 (GPIO_PIN(PORT_GPIO, 10)) /**< GPIO10 is not broken out on chips with flash */
+#define GPIO11 (GPIO_PIN(PORT_GPIO, 11)) /**< GPIO11 is not broken out on chips with flash */
+#define GPIO12 (GPIO_PIN(PORT_GPIO, 12)) /**< GPIO12 */
+#define GPIO13 (GPIO_PIN(PORT_GPIO, 13)) /**< GPIO13 */
+#define GPIO14 (GPIO_PIN(PORT_GPIO, 14)) /**< GPIO14 is not usable for chips w/o flash */
+#define GPIO15 (GPIO_PIN(PORT_GPIO, 15)) /**< GPIO15 */
+#define GPIO16 (GPIO_PIN(PORT_GPIO, 16)) /**< GPIO16 */
+#define GPIO17 (GPIO_PIN(PORT_GPIO, 17)) /**< GPIO17 */
+#define GPIO18 (GPIO_PIN(PORT_GPIO, 18)) /**< GPIO18 */
+#define GPIO19 (GPIO_PIN(PORT_GPIO, 19)) /**< GPIO19 */
+#define GPIO20 (GPIO_PIN(PORT_GPIO, 20)) /**< GPIO20 */
+#define GPIO21 (GPIO_PIN(PORT_GPIO, 21)) /**< GPIO21 */
+#define GPIO22 (GPIO_PIN(PORT_GPIO, 22)) /**< GPIO22 */
+#define GPIO23 (GPIO_PIN(PORT_GPIO, 23)) /**< GPIO23 */
+#define GPIO24 (GPIO_PIN(PORT_GPIO, 24)) /**< GPIO24 */
+#define GPIO25 (GPIO_PIN(PORT_GPIO, 25)) /**< GPIO25 is not broken out on chips with flash */
+#define GPIO26 (GPIO_PIN(PORT_GPIO, 26)) /**< GPIO26 is not broken out on chips with flash */
+#define GPIO27 (GPIO_PIN(PORT_GPIO, 27)) /**< GPIO27 is not broken out on chips with flash */
+#define GPIO28 (GPIO_PIN(PORT_GPIO, 28)) /**< GPIO28 is not broken out on chips with flash */
+#define GPIO29 (GPIO_PIN(PORT_GPIO, 29)) /**< GPIO29 is not broken out on chips with flash */
+#define GPIO30 (GPIO_PIN(PORT_GPIO, 30)) /**< GPIO30 is not broken out on chips with flash */
+/** @} */
+
+/**
+ * @name   ADC configuration
+ *
+ * ESP32-C6 integrates one 12-bit ADC (ADC1) with 7 channels:
+ *
+ * GPIO0, GPIO01, GPIO2, GPIO3, GPIO4, GPIO5 and GPIO6
+ *
+ * The maximum number of ADC channels #ADC_NUMOF_MAX is 7.
+ */
+
+/**
+ * @name   I2C configuration
+ *
+ * ESP32-C6 has one built-in I2C interfaces.
+ *
+ * The following table shows the default configuration of I2C interfaces
+ * used for ESP32-C6 boards. It can be overridden by
+ * [application-specific configurations](#esp32_application_specific_configurations).
+ *
+ * <center>
+ *
+ * Device     | Signal | Pin    | Symbol        | Remarks
+ * :----------|:-------|:-------|:--------------|:----------------
+ * I2C_DEV(0) |        |        | `#I2C0_SPEED` | default is `I2C_SPEED_FAST`
+ * I2C_DEV(0) | SCL    | GPIO5  | `#I2C0_SCL`   | -
+ * I2C_DEV(0) | SDA    | GPIO4  | `#I2C0_SDA`   | -
+ *
+ * </center><br>
+ */
+
+/**
+ * @name   PWM configuration
+ *
+ * The ESP32-C6 LEDC module has 1 channel group with 6 channels. Each of
+ * these channels can be clocked by one of the 4 timers. This means that
+ * it is possible to define up to 4 PWM devices with different frequencies
+ * and resolutions and a total of 6 PWM channels.
+ */
+
+/**
+ * @name   SPI configuration
+ *
+ * ESP32-C6 has three SPI controllers where SPI0 and SPI1 share the same bus
+ * and can only operate in memory mode while SPI2 can be used as general
+ * purpose SPI:
+ *
+ * - controller SPI0 is reserved for external memories like flash and PSRAM
+ * - controller SPI1 is reserved for external memories like flash and PSRAM
+ * - controller SPI2 can be used for peripherals (also called FSPI)
+ *
+ * Thus, only SPI2 (FSPI) can be used as general purpose SPI in RIOT as
+ * SPI_DEV(0).
+ *
+ * The following table shows the pin configuration used by default, even
+ * though it **can vary** from board to board.
+ *
+ * <center>
+ *
+ * Device (Alias)          | Signal | Pin    | Symbol      | Remarks
+ * :-----------------------|:------:|:-------|:-----------:|:------------------
+ * `SPI_HOST0`/`SPI_HOST1` | SPICS0 | - | - | reserved for Flash and PSRAM
+ * `SPI_HOST0`/`SPI_HOST1` | SPICLK | - | - | reserved for Flash and PSRAM
+ * `SPI_HOST0`/`SPI_HOST1` | SPID   | - | - | reserved for Flash and PSRAM
+ * `SPI_HOST0`/`SPI_HOST1` | SPIQ   | - | - | reserved for Flash and PSRAM
+ * `SPI_HOST0`/`SPI_HOST1` | SPIHD  | - | - | reserved for Flash and PSRAM
+ * `SPI_HOST0`/`SPI_HOST1` | SPIWP  | - | - | reserved for Flash and PSRAM
+ * `SPI_HOST2` (`FSPI`)    | SCK    | GPIO6  |`#SPI0_SCK`  | can be used
+ * `SPI_HOST2` (`FSPI`)    | MOSI   | GPIO7  |`#SPI0_MOSI` | can be used
+ * `SPI_HOST2` (`FSPI`)    | MISO   | GPIO2  |`#SPI0_MISO` | can be used
+ * `SPI_HOST2` (`FSPI`)    | CS0    | GPIO18 |`#SPI0_CS0`  | can be used
+ *
+ * </center><br>
+ */
+
+/**
+ * @name   Timer configuration depending on which implementation is used
+ *
+ * ESP32-C6 has two timer groups with one channel each.
+ */
+
+#ifdef MODULE_ESP_HW_COUNTER
+#  error "Counter based timers are not supported by ESP32-C6"
+#endif
+
+/**
+ * @name   UART configuration
+ *
+ * ESP32-C6 integrates three UART interfaces, two in the high-power domain and
+ * one in the low-power domain. The low-power UART interface is not yet
+ * supported. The following default pin configuration of UART interfaces as
+ * used by a most
+ * boards can be overridden by the application, see section
+ * [Application-Specific Configurations](#esp32_application_specific_configurations).
+ *
+ * <center>
+ *
+ * Device      |Signal|Pin     |Symbol      |Remarks
+ * :-----------|:-----|:-------|:-----------|:----------------
+ * UART_DEV(0) | TxD  | GPIO16 |`#UART0_TXD`| cannot be changed
+ * UART_DEV(0) | RxD  | GPIO17 |`#UART0_RXD`| cannot be changed
+ * UART_DEV(1) | TxD  | -      |`#UART1_TXD`| optional, can be overridden (no direct I/O)
+ * UART_DEV(1) | RxD  | -      |`#UART1_RXD`| optional, can be overridden (no direct I/O)
+ *
+ * </center><br>
+ *
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/cpu/esp32/include/sdkconfig.h
+++ b/cpu/esp32/include/sdkconfig.h
@@ -311,6 +311,8 @@
 #  include "sdkconfig_esp32.h"
 #elif defined(CPU_FAM_ESP32C3)
 #  include "sdkconfig_esp32c3.h"
+#elif defined(CPU_FAM_ESP32C6)
+#  include "sdkconfig_esp32c6.h"
 #elif defined(CPU_FAM_ESP32H2)
 #  include "sdkconfig_esp32h2.h"
 #elif defined(CPU_FAM_ESP32S2)

--- a/cpu/esp32/include/sdkconfig_esp32c6.h
+++ b/cpu/esp32/include/sdkconfig_esp32c6.h
@@ -1,0 +1,178 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     cpu_esp32
+ * @{
+ *
+ * @file
+ * @brief       SDK configuration used by the ESP-IDF for ESP32-C6 SoC variant (family)
+ *
+ * The SDK configuration can be partially overridden by application-specific
+ * board configuration.
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef DOXYGEN
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name ESP32-C6 specific clock configuration
+ * @{
+ */
+
+/* external crystal frequency */
+#define CONFIG_XTAL_FREQ 32
+
+/* Mapping of Kconfig defines to the respective enumeration values */
+#if CONFIG_ESP32C6_DEFAULT_CPU_FREQ_MHZ_20
+#  define CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ       20
+#elif CONFIG_ESP32C6_DEFAULT_CPU_FREQ_MHZ_40
+#  define CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ       40
+#elif CONFIG_ESP32C6_DEFAULT_CPU_FREQ_MHZ_80
+#  define CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ       80
+#elif CONFIG_ESP32C6_DEFAULT_CPU_FREQ_MHZ_120
+#  define CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ       120
+#elif CONFIG_ESP32C6_DEFAULT_CPU_FREQ_MHZ_160
+#  define CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ       160
+#endif
+
+/**
+ * @brief Defines the CPU frequency [values = 20, 40, 80, 120, 160]
+ */
+#ifndef CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ
+#  define CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ       80
+#endif
+
+/** @} */
+
+/**
+ * ESP32-C6 MMU configuration (DO NOT CHANGE)
+ */
+#ifndef CONFIG_MMU_PAGE_SIZE
+#  define CONFIG_MMU_PAGE_SIZE_32KB             1
+#  define CONFIG_MMU_PAGE_SIZE                  0x8000
+#endif
+
+/**
+ * ESP32-C6 specific RTC clock configuration
+ */
+#define CONFIG_RTC_CLK_CAL_CYCLES               1024
+
+#ifdef MODULE_ESP_RTC_TIMER_32K
+#endif
+
+/**
+ * ESP32-C6 specific EFUSE configuration
+ */
+#define CONFIG_EFUSE_MAX_BLK_LEN                256
+#define CONFIG_ESP_EFUSE_BLOCK_REV_MIN_FULL     0
+#define CONFIG_ESP_EFUSE_BLOCK_REV_MAX_FULL     99
+
+/**
+ * ESP32-C6 specific MAC configuration
+ */
+#define CONFIG_ESP_MAC_ADDR_UNIVERSE_WIFI_STA   1
+#define CONFIG_ESP_MAC_ADDR_UNIVERSE_WIFI_AP    1
+#define CONFIG_ESP_MAC_ADDR_UNIVERSE_BT         1
+#define CONFIG_ESP_MAC_ADDR_UNIVERSE_IEEE802154 1
+#define CONFIG_ESP32C6_UNIVERSAL_MAC_ADDRESSES  2
+
+/**
+ * ESP32-C6 specific serial flasher config (DO NOT CHANGE)
+ */
+#define CONFIG_ESPTOOLPY_FLASHFREQ_64M          1
+#define CONFIG_ESPTOOLPY_FLASHFREQ              "64m"
+
+/**
+ * ESP32-C6 specific system configuration (DO NOT CHANGE)
+ */
+#define CONFIG_ESP32C6_REV_MIN_FULL             0
+#define CONFIG_ESP32C6_REV_MAX_FULL             99
+
+#define CONFIG_ESP_TIMER_IMPL_SYSTIMER          1
+#define CONFIG_ESP_TIMER_INTERRUPT_LEVEL        1
+
+#define CONFIG_ESP_DEBUG_OCDAWARE               1
+
+#define CONFIG_ESP_BROWNOUT_DET                 1
+#define CONFIG_ESP_BROWNOUT_DET_LVL             0
+
+/**
+ * ESP32-C6 specific sleep configuration (DO NOT CHANGE)
+ */
+#define CONFIG_ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB   1
+#define CONFIG_ESP_SLEEP_FLASH_LEAKAGE_WORKAROUND       1
+#define CONFIG_ESP_SLEEP_GPIO_ENABLE_INTERNAL_RESISTORS 0   /* we realize it */
+#define CONFIG_ESP_SLEEP_GPIO_RESET_WORKAROUND          1
+#define CONFIG_ESP_SLEEP_WAIT_FLASH_READY_EXTRA_DELAY   0
+#define CONFIG_PM_POWER_DOWN_CPU_IN_LIGHT_SLEEP         0
+
+/**
+ * ESP32-C6 BLE driver configuration (DO NOT CHANGE)
+ */
+#ifdef MODULE_ESP_BLE
+#  define CONFIG_BT_ALARM_MAX_NUM                           50
+#  define CONFIG_BT_CTRL_BLE_ADV_REPORT_DISCARD_THRSHOLD    20
+#  define CONFIG_BT_CTRL_BLE_ADV_REPORT_FLOW_CTRL_NUM       100
+#  define CONFIG_BT_CTRL_BLE_ADV_REPORT_FLOW_CTRL_SUPP      1
+#  define CONFIG_BT_LE_50_FEATURE_SUPPORT                   1
+#  define CONFIG_BT_LE_ACL_BUF_COUNT                        10
+#  define CONFIG_BT_LE_ACL_BUF_SIZE                         517
+#  define CONFIG_BT_LE_COEX_PHY_CODED_TX_RX_TLIM_DIS        1
+#  define CONFIG_BT_LE_COEX_PHY_CODED_TX_RX_TLIM_EFF        0
+#  define CONFIG_BT_LE_CONTROLLER_NPL_OS_PORTING_SUPPORT    1
+#  define CONFIG_BT_LE_CONTROLLER_TASK_STACK_SIZE           4096
+#  define CONFIG_BT_LE_CRYPTO_STACK_MBEDTLS                 0   /* default 1 */
+#  define CONFIG_BT_LE_DFT_TX_POWER_LEVEL_DBM_EFF           9
+#  define CONFIG_BT_LE_DFT_TX_POWER_LEVEL_P9                1
+#  define CONFIG_BT_LE_ENABLE_PERIODIC_ADV                  1
+#  define CONFIG_BT_LE_EXT_ADV_MAX_SIZE                     1650
+#  define CONFIG_BT_LE_EXT_ADV                              1
+#  define CONFIG_BT_LE_HCI_EVT_BUF_SIZE                     257
+#  define CONFIG_BT_LE_HCI_EVT_HI_BUF_COUNT                 30
+#  define CONFIG_BT_LE_HCI_EVT_LO_BUF_COUNT                 8
+#  define CONFIG_BT_LE_HCI_INTERFACE_USE_RAM                1
+#  define CONFIG_BT_LE_LL_CFG_FEAT_LE_2M_PHY                1
+#  define CONFIG_BT_LE_LL_CFG_FEAT_LE_CODED_PHY             1
+#  define CONFIG_BT_LE_LL_CFG_FEAT_LE_ENCRYPTION            1
+#  define CONFIG_BT_LE_LL_DUP_SCAN_LIST_COUNT               20
+#  define CONFIG_BT_LE_LL_RESOLV_LIST_SIZE                  4
+#  define CONFIG_BT_LE_LL_SCA                               60
+#  define CONFIG_BT_LE_LP_CLK_SRC_MAIN_XTAL                 1
+#  define CONFIG_BT_LE_MAX_CONNECTIONS                      3
+#  define CONFIG_BT_LE_MAX_EXT_ADV_INSTANCES                1
+#  define CONFIG_BT_LE_MAX_PERIODIC_ADVERTISER_LIST         5
+#  define CONFIG_BT_LE_MAX_PERIODIC_SYNCS                   1
+#  define CONFIG_BT_LE_MSYS_1_BLOCK_COUNT                   12
+#  define CONFIG_BT_LE_MSYS_1_BLOCK_SIZE                    256
+#  define CONFIG_BT_LE_MSYS_2_BLOCK_COUNT                   24
+#  define CONFIG_BT_LE_MSYS_2_BLOCK_SIZE                    320
+#  define CONFIG_BT_LE_MSYS_INIT_IN_CONTROLLER              NIMBLE_OS_MSYS_INIT_IN_CONTROLLER
+#  define CONFIG_BT_LE_PERIODIC_ADV_SYNC_TRANSFER           1
+#  define CONFIG_BT_LE_SCAN_DUPL_CACHE_REFRESH_PERIOD       0
+#  define CONFIG_BT_LE_SCAN_DUPL_TYPE                       0
+#  define CONFIG_BT_LE_SCAN_DUPL_TYPE_DEVICE                1
+#  define CONFIG_BT_LE_SCAN_DUPL                            1
+#  define CONFIG_BT_LE_SECURITY_ENABLE                      1
+#  define CONFIG_BT_LE_SM_LEGACY                            1
+#  define CONFIG_BT_LE_SM_SC                                1
+#  define CONFIG_BT_LE_USE_ESP_TIMER                        1
+#  define CONFIG_BT_LE_WHITELIST_SIZE                       12
+#  define CONFIG_BT_NIMBLE_COEX_PHY_CODED_TX_RX_TLIM_DIS    1
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DOXYGEN */
+/** @} */

--- a/cpu/esp32/irq_arch.c
+++ b/cpu/esp32/irq_arch.c
@@ -61,60 +61,69 @@ static const struct intr_handle_data_t _irq_data_table[] = {
     { ETS_TG1_T1_LEVEL_INTR_SOURCE, CPU_INUM_TIMER, 2 },
 #  endif /* SOC_TIMER_GROUP_TIMERS_PER_GROUP > 1 */
 #endif /* SOC_TIMER_GROUPS > 1 */
-#if defined(CPU_FAM_ESP32)
+#if CPU_FAM_ESP32
     { ETS_TG0_LACT_LEVEL_INTR_SOURCE, CPU_INUM_SYSTIMER, 2 },
-#elif defined(CPU_FAM_ESP32S2) || defined(CPU_FAM_ESP32S3) || \
-      defined(CPU_FAM_ESP32C3) || defined(CPU_FAM_ESP32H2)
-    { ETS_SYSTIMER_TARGET2_EDGE_INTR_SOURCE, CPU_INUM_SYSTIMER, 2 },
+#elif CPU_FAM_ESP32S2 || CPU_FAM_ESP32S3 || \
+      CPU_FAM_ESP32C3 || CPU_FAM_ESP32C6 || CPU_FAM_ESP32H2
+    { ETS_SYSTIMER_TARGET2_INTR_SOURCE, CPU_INUM_SYSTIMER, 2 },
 #else
 #  error "Platform implementation is missing"
 #endif
     { ETS_UART0_INTR_SOURCE, CPU_INUM_UART, 1 },
     { ETS_UART1_INTR_SOURCE, CPU_INUM_UART, 1 },
-#if SOC_UART_NUM > 2
+#if SOC_UART_HP_NUM > 2
     { ETS_UART2_INTR_SOURCE, CPU_INUM_UART, 1 },
 #endif
     { ETS_GPIO_INTR_SOURCE, CPU_INUM_GPIO, 1 },
     { ETS_I2C_EXT0_INTR_SOURCE, CPU_INUM_I2C, 1 },
-#if SOC_I2C_NUM > 1
+#if SOC_HP_I2C_NUM > 1
     { ETS_I2C_EXT1_INTR_SOURCE, CPU_INUM_I2C, 1 },
 #endif
-#if defined(SOC_BLE_SUPPORTED)
-#  if defined(CPU_FAM_ESP32) || defined(CPU_FAM_ESP32S3) || defined(CPU_FAM_ESP32C3)
+#if SOC_BLE_SUPPORTED
+#  if CPU_FAM_ESP32 || CPU_FAM_ESP32S3 || CPU_FAM_ESP32C3
     { ETS_RWBLE_INTR_SOURCE, CPU_INUM_BLE, 1 },
-#  elif defined(CPU_FAM_ESP32H2)
+#  elif CPU_FAM_ESP32C6
+    { ETS_LP_TIMER_INTR_SOURCE, CPU_INUM_BLE, 1 },
+    { ETS_BT_MAC_INTR_SOURCE, CPU_INUM_BT_MAC, 1 },
+#  elif CPU_FAM_ESP32H2
     { ETS_LP_BLE_TIMER_INTR_SOURCE, CPU_INUM_BLE, 1 },
     { ETS_BT_MAC_INTR_SOURCE, CPU_INUM_BT_MAC, 1 },
 #  else
 #    error "Platform implementation is missing"
 #  endif
 #endif /* SOC_BLE_SUPPORTED */
-#if defined(SOC_EMAC_SUPPORTED)
+#if SOC_EMAC_SUPPORTED
     { ETS_ETH_MAC_INTR_SOURCE, CPU_INUM_ETH, 1 },
 #endif
 #if SOC_IEEE802154_SUPPORTED
+#  if CPU_FAM_ESP32C6
+    { ETS_ZB_MAC_SOURCE, CPU_INUM_ZMAC, 3},
+#  elif CPU_FAM_ESP32H2
     { ETS_ZB_MAC_INTR_SOURCE, CPU_INUM_ZMAC, 3},
+#  else
+#    error "Platform implementation is missing"
+#  endif
 #endif
-#if defined(SOC_RMT_SUPPORTED)
+#if SOC_RMT_SUPPORTED
     { ETS_RMT_INTR_SOURCE, CPU_INUM_RMT, 1 },
 #endif
-#if defined(SOC_SDMMC_HOST_SUPPORTED)
+#if SOC_SDMMC_HOST_SUPPORTED
     { ETS_SDIO_HOST_INTR_SOURCE, CPU_INUM_SDMMC, 2 },
 #endif
-#if defined(SOC_TWAI_SUPPORTED)
-#  if defined(CPU_FAM_ESP32) || defined(CPU_FAM_ESP32S3) || \
-      defined(CPU_FAM_ESP32S2) || defined(CPU_FAM_ESP32C3)
+#if SOC_TWAI_SUPPORTED
+#  if CPU_FAM_ESP32 || CPU_FAM_ESP32S3 || \
+      CPU_FAM_ESP32S2 || CPU_FAM_ESP32C3
     { ETS_TWAI_INTR_SOURCE, CPU_INUM_CAN, 1 },
-#  elif defined(CPU_FAM_ESP32H2)
+#  elif CPU_FAM_ESP32C6 || CPU_FAM_ESP32H2
     { ETS_TWAI0_INTR_SOURCE, CPU_INUM_CAN, 1 },
 #  else
 #    error "Platform implementation is missing"
 #  endif
 #endif /* SOC_TWAI_SUPPORTED */
-#if defined(SOC_USB_OTG_SUPPORTED)
+#if SOC_USB_OTG_SUPPORTED
     { ETS_USB_INTR_SOURCE, CPU_INUM_USB, 1 },
 #endif
-#if defined(SOC_USB_SERIAL_JTAG_SUPPORTED)
+#if SOC_USB_SERIAL_JTAG_SUPPORTED
     { ETS_USB_SERIAL_JTAG_INTR_SOURCE, CPU_INUM_SERIAL_JTAG, 1 },
 #endif
 #if SOC_LCDCAM_SUPPORTED
@@ -215,6 +224,9 @@ esp_err_t esp_intr_alloc(int source, int flags, intr_handler_t handler,
     if (ret_handle) {
         *((intr_handle_t *)ret_handle) = (const intr_handle_t)&_irq_data_table[i];
     }
+
+    DEBUG("%s source=%d routed to interrupt %u\n",
+          __func__, source, _irq_data_table[i].intr);
 
     return ESP_OK;
 }

--- a/cpu/esp32/periph/adc_arch_esp32c6.c
+++ b/cpu/esp32/periph/adc_arch_esp32c6.c
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @{
+ *
+ * @file
+ * @brief       Architecture-specific ADC/DAC definitions for ESP32-C2 variant (family)
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ *
+ * @}
+ */
+
+#include "board.h"
+
+#include "adc_arch_private.h"
+#include "esp_common.h"
+#include "soc/adc_channel.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+/**
+ * @brief   ADC hardware descriptor table (for internal use only)
+ *
+ * @note    The index of entries in the table MUST correspond to the
+ *          RTCIO GPIO number.
+ */
+const _adc_hw_desc_t _adc_hw[] = {
+    /* rtcio,         gpio,                    adc_ctrl,   adc_channel,   pad_name */
+    {  RTCIO_GPIO(0), ADC1_CHANNEL_0_GPIO_NUM, ADC_UNIT_1, ADC_CHANNEL_0, "XTAL_32K_P" },
+    {  RTCIO_GPIO(1), ADC1_CHANNEL_1_GPIO_NUM, ADC_UNIT_1, ADC_CHANNEL_1, "XTAL_32K_P" },
+    {  RTCIO_GPIO(2), ADC1_CHANNEL_2_GPIO_NUM, ADC_UNIT_1, ADC_CHANNEL_2, "GPIO2" },
+    {  RTCIO_GPIO(3), ADC1_CHANNEL_3_GPIO_NUM, ADC_UNIT_1, ADC_CHANNEL_3, "GPIO3" },
+    {  RTCIO_GPIO(4), ADC1_CHANNEL_4_GPIO_NUM, ADC_UNIT_1, ADC_CHANNEL_4, "MTMS" },
+    {  RTCIO_GPIO(5), ADC1_CHANNEL_5_GPIO_NUM, ADC_UNIT_1, ADC_CHANNEL_5, "MTDI" },
+    {  RTCIO_GPIO(6), ADC1_CHANNEL_6_GPIO_NUM, ADC_UNIT_1, ADC_CHANNEL_6, "MTCK" },
+};
+
+/**
+ * @brief   GPIO to RTC IO map (for internal use only)
+ */
+const gpio_t _gpio_rtcio_map[] = {
+    RTCIO_GPIO(0),   /* GPIO0 */
+    RTCIO_GPIO(1),   /* GPIO1 */
+    RTCIO_GPIO(2),   /* GPIO2 */
+    RTCIO_GPIO(3),   /* GPIO3 */
+    RTCIO_GPIO(4),   /* GPIO4 */
+    RTCIO_GPIO(5),   /* GPIO5 */
+    RTCIO_GPIO(6),   /* GPIO6 */
+    RTCIO_NA,        /* GPIO7 */
+    RTCIO_NA,        /* GPIO8 */
+    RTCIO_NA,        /* GPIO9 */
+    RTCIO_NA,        /* GPIO10 */
+    RTCIO_NA,        /* GPIO11 */
+    RTCIO_NA,        /* GPIO12 */
+    RTCIO_NA,        /* GPIO13 */
+    RTCIO_NA,        /* GPIO14 */
+    RTCIO_NA,        /* GPIO15 */
+    RTCIO_NA,        /* GPIO16 */
+    RTCIO_NA,        /* GPIO17 */
+    RTCIO_NA,        /* GPIO18 */
+    RTCIO_NA,        /* GPIO19 */
+    RTCIO_NA,        /* GPIO20 */
+    RTCIO_NA,        /* GPIO21 */
+    RTCIO_NA,        /* GPIO22 */
+    RTCIO_NA,        /* GPIO23 */
+    RTCIO_NA,        /* GPIO24 */
+    RTCIO_NA,        /* GPIO25 */
+    RTCIO_NA,        /* GPIO26 */
+    RTCIO_NA,        /* GPIO27 */
+    RTCIO_NA,        /* GPIO28 */
+    RTCIO_NA,        /* GPIO29 */
+    RTCIO_NA,        /* GPIO30 */
+};
+
+/**
+ * @brief   Default voltage range of ADC results for different attenuations
+ *
+ * These values are used by function adc_get_vrange_min_max if software
+ * calibration doesn't work for any reason and the voltage range can't be
+ * determined by software.
+ *
+ * Table 5-6 in [ESP32-C6 Datasheet]
+ * (https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf).
+ */
+const int _adc_vrange_min_max[] = {
+    0, 1000,    /* min, max @ ADC_ATTEN_DB_0   */
+    0, 1300,    /* min, max @ ADC_ATTEN_DB_2_5 */
+    0, 1900,    /* min, max @ ADC_ATTEN_DB_6   */
+    0, 3300,    /* min, max @ ADC_ATTEN_DB_12  */
+};
+
+_Static_assert(ARRAY_SIZE(_gpio_rtcio_map) == SOC_GPIO_PIN_COUNT,
+               "size of _gpio_rtcio_map does not match SOC_GPIO_PIN_COUNT");
+_Static_assert(ARRAY_SIZE(_adc_vrange_min_max) == (SOC_ADC_ATTEN_NUM * 2),
+               "size of _adc_vrange_min_max does not match SOC_ADC_ATTEN_NUM");

--- a/cpu/esp32/periph/gpio.c
+++ b/cpu/esp32/periph/gpio.c
@@ -39,7 +39,7 @@
 #include "soc/gpio_sig_map.h"
 #include "soc/gpio_struct.h"
 #include "soc/io_mux_reg.h"
-#ifndef CPU_FAM_ESP32H2
+#if !CPU_FAM_ESP32H2 && !CPU_FAM_ESP32C6
 #include "soc/rtc_cntl_reg.h"
 #endif
 #include "soc/rtc_io_periph.h"

--- a/cpu/esp32/periph/gpio_arch_esp32c6.c
+++ b/cpu/esp32/periph/gpio_arch_esp32c6.c
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     cpu_esp32
+ * @ingroup     drivers_periph_gpio
+ * @{
+ *
+ * @file
+ * @brief       Architecture-specific GPIO definitions for ESP32-C3 variant (family)
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @}
+ */
+
+#include "gpio_arch.h"
+#include "soc/io_mux_reg.h"
+
+#if !IS_USED(MODULE_ESP_IDF_GPIO_HAL)
+
+/* GPIO to IOMUX register mapping (see Technical Reference, Section 6.13 IO MUX Functions List)
+   https://www.espressif.com/sites/default/files/documentation/esp32-h2_technical_reference_manual_en.pdf */
+
+const uint32_t _gpio_to_iomux_reg[GPIO_PIN_NUMOF] =
+{
+    PERIPHS_IO_MUX_XTAL_32K_P_U,    /* GPIO0 used for XTAL_32K_P */
+    PERIPHS_IO_MUX_XTAL_32K_N_U,    /* GPIO1 used for XTAL_32K_N*/
+    PERIPHS_IO_MUX_GPIO2_U,         /* GPIO2 */
+    PERIPHS_IO_MUX_GPIO3_U,         /* GPIO3 */
+    PERIPHS_IO_MUX_MTMS_U,          /* GPIO4 */
+    PERIPHS_IO_MUX_MTDI_U,          /* GPIO5 */
+    PERIPHS_IO_MUX_MTCK_U,          /* GPIO6 */
+    PERIPHS_IO_MUX_MTDO_U,          /* GPIO7 */
+    PERIPHS_IO_MUX_GPIO8_U,         /* GPIO8 */
+    PERIPHS_IO_MUX_GPIO9_U,         /* GPIO9 */
+    PERIPHS_IO_MUX_GPIO10_U,        /* GPIO10 not broken out on chips with in-packge flash */
+    PERIPHS_IO_MUX_GPIO11_U,        /* GPIO11 not broken out on chips with in-packge flash */
+    PERIPHS_IO_MUX_GPIO12_U,        /* GPIO12 could be used for builtin USB2JTAG bridge */
+    PERIPHS_IO_MUX_GPIO13_U,        /* GPIO13 could be used for builtin USB2JTAG bridge */
+    PERIPHS_IO_MUX_GPIO14_U,        /* GPIO14 not broken out on chips w/o in-packge flash */
+    PERIPHS_IO_MUX_GPIO15_U,        /* GPIO15 */
+    PERIPHS_IO_MUX_U0TXD_U,         /* GPIO16 */
+    PERIPHS_IO_MUX_U0RXD_U,         /* GPIO17 */
+    PERIPHS_IO_MUX_SDIO_CMD_U,      /* GPIO18 */
+    PERIPHS_IO_MUX_SDIO_CLK_U,      /* GPIO19 */
+    PERIPHS_IO_MUX_SDIO_DATA0_U,    /* GPIO20 */
+    PERIPHS_IO_MUX_SDIO_DATA1_U,    /* GPIO21 */
+    PERIPHS_IO_MUX_SDIO_DATA2_U,    /* GPIO22 */
+    PERIPHS_IO_MUX_SDIO_DATA3_U,    /* GPIO22 */
+    PERIPHS_IO_MUX_SPICS0_U,        /* GPIO24 not broken out on chips with in-packge flash */
+    PERIPHS_IO_MUX_SPIQ_U,          /* GPIO25 not broken out on chips with in-packge flash */
+    PERIPHS_IO_MUX_SPIWP_U,         /* GPIO26 not broken out on chips with in-packge flash */
+    PERIPHS_IO_MUX_VDD_SPI_U,       /* GPIO27 not broken out on chips with in-packge flash */
+    PERIPHS_IO_MUX_SPIHD_U,         /* GPIO28 not broken out on chips with in-packge flash */
+    PERIPHS_IO_MUX_SPICLK_U,        /* GPIO29 not broken out on chips with in-packge flash */
+    PERIPHS_IO_MUX_SPID_U,          /* GPIO30 not broken out on chips with in-packge flash */
+};
+
+#endif /* !IS_USED(MODULE_ESP_IDF_GPIO_HAL) */
+
+/* Table of the usage type of each GPIO pin */
+gpio_pin_usage_t _gpio_pin_usage[GPIO_PIN_NUMOF] = {
+#if MODULE_ESP_RTC_TIMER_32K
+    _NOT_EXIST,   /* GPIO0 is used for external 32K crystal */
+    _NOT_EXIST,   /* GPIO1 is used for external 32K crystal */
+#else
+    _GPIO,        /* GPIO0 */
+    _GPIO,        /* GPIO1 */
+#endif
+    _GPIO,        /* GPIO2 */
+    _GPIO,        /* GPIO3 */
+    _GPIO,        /* GPIO4 */
+    _GPIO,        /* GPIO5 */
+    _GPIO,        /* GPIO6 */
+    _GPIO,        /* GPIO7 */
+    _GPIO,        /* GPIO8 */
+    _GPIO,        /* GPIO9 */
+    _GPIO,        /* GPIO10 not broken out on chips with in-package flash */
+    _GPIO,        /* GPIO11 not broken out on chips with in-package flash */
+    _GPIO,        /* GPIO12 could be used for builtin USB2JTAG bridge */
+    _GPIO,        /* GPIO13 could be used for builtin USB2JTAG bridge */
+    _GPIO,        /* GPIO14 not broken out on chips w/o in-packge flash */
+    _GPIO,        /* GPIO15 */
+    _UART,        /* GPIO16 is used as direct I/O UART0 TxD */
+    _UART,        /* GPIO17 is used as direct I/O UART0 RxD */
+    _GPIO,        /* GPIO18 */
+    _GPIO,        /* GPIO19 */
+    _GPIO,        /* GPIO20 */
+    _GPIO,        /* GPIO21 */
+    _GPIO,        /* GPIO22 */
+    _GPIO,        /* GPIO23 */
+    _GPIO,        /* GPIO24 not broken out on chips with in-package flash */
+    _GPIO,        /* GPIO25 not broken out on chips with in-package flash */
+    _GPIO,        /* GPIO26 not broken out on chips with in-package flash */
+    _GPIO,        /* GPIO27 not broken out on chips with in-package flash */
+    _GPIO,        /* GPIO28 not broken out on chips with in-package flash */
+    _GPIO,        /* GPIO29 not broken out on chips with in-package flash */
+    _GPIO,        /* GPIO30 not broken out on chips with in-package flash */
+};

--- a/cpu/esp32/periph/pm.c
+++ b/cpu/esp32/periph/pm.c
@@ -36,7 +36,7 @@
 #include "rom/rtc.h"
 #include "rom/uart.h"
 #include "soc/rtc.h"
-#ifndef CPU_FAM_ESP32H2
+#if !CPU_FAM_ESP32H2 && !CPU_FAM_ESP32C6
 #  include "soc/rtc_cntl_reg.h"
 #endif
 

--- a/cpu/esp32/periph/pwm.c
+++ b/cpu/esp32/periph/pwm.c
@@ -43,7 +43,7 @@
 
 #if defined(PWM0_GPIOS) || defined(PWM1_GPIOS) || defined(PWM2_GPIOS) || defined(PWM3_GPIOS)
 
-/* Ensure that the SPIn_* symbols define SPI_DEV(n) */
+/* Ensure that the PWMn_* symbols define PWM_DEV(n) */
 #if defined(PWM1_GPIOS) && !defined(PWM0_GPIOS)
 #error "PWM1_GPIOS is used but PWM0_GPIOS is not defined"
 #elif defined(PWM2_GPIOS) && !defined(PWM1_GPIOS)

--- a/cpu/esp32/periph/spi.c
+++ b/cpu/esp32/periph/spi.c
@@ -373,7 +373,7 @@ void IRAM_ATTR spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t cl
                                    &_spi[bus].timing.clock_reg);
     spi_ll_apply_config(_spi[bus].periph->hw);
 
-#if defined(CPU_FAM_ESP32C3) || defined(CPU_FAM_ESP32S3) || defined(CPU_FAM_ESP32H2)
+#if CPU_FAM_ESP32C3 || CPU_FAM_ESP32C6 || CPU_FAM_ESP32H2 || CPU_FAM_ESP32S3
     /*
      * If the SPI mode has been changed, the clock signal is only set to the
      * correct level at the beginning of the transfer on the ESP32x3. However,
@@ -389,7 +389,7 @@ void IRAM_ATTR spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t cl
         spi_transfer_bytes(bus, GPIO_UNDEF, false, &temp, &temp, 1);
         _spi[bus].mode_last = mode;
     }
-#elif defined(CPU_FAM_ESP32) || defined(CPU_FAM_ESP32S2)
+#elif CPU_FAM_ESP32 || CPU_FAM_ESP32S2
     /* This workaround isn't needed on ESP32 and ESP32-S2 */
 #else
 #error Platform implementation is missing
@@ -410,6 +410,8 @@ void IRAM_ATTR spi_release(spi_t bus)
 #if defined(CPU_FAM_ESP32)
 static const char* _spi_names[] = { "CSPI/FSPI", "HSPI", "VSPI"  };
 #elif defined(CPU_FAM_ESP32C3)
+static const char* _spi_names[] = { "SPI", "FSPI"  };
+#elif defined(CPU_FAM_ESP32C6)
 static const char* _spi_names[] = { "SPI", "FSPI"  };
 #elif defined(CPU_FAM_ESP32H2)
 static const char* _spi_names[] = { "SPI", "FSPI"  };

--- a/cpu/esp32/startup.c
+++ b/cpu/esp32/startup.c
@@ -57,7 +57,7 @@
 #include "rom/rtc.h"
 #include "rom/uart.h"
 #include "soc/rtc.h"
-#ifndef CPU_FAM_ESP32H2
+#if !CPU_FAM_ESP32H2 && !CPU_FAM_ESP32C6
 #  include "soc/rtc_cntl_reg.h"
 #  include "soc/rtc_cntl_struct.h"
 #  include "soc/syscon_reg.h"

--- a/cpu/esp32/syscalls.c
+++ b/cpu/esp32/syscalls.c
@@ -44,7 +44,7 @@
 #include "rom/libc_stubs.h"
 #include "soc/periph_defs.h"
 #include "soc/rtc.h"
-#ifndef CPU_FAM_ESP32H2
+#if !CPU_FAM_ESP32H2 && !CPU_FAM_ESP32C6
 #  include "soc/rtc_cntl_reg.h"
 #  include "soc/rtc_cntl_struct.h"
 #endif

--- a/cpu/esp32/vendor/ld/esp32c6/memory.ld.in
+++ b/cpu/esp32/vendor/ld/esp32c6/memory.ld.in
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ *                    ESP32-C6 Linker Script Memory Layout
+ * This file describes the memory layout (memory blocks) by virtual memory addresses.
+ * This linker script is passed through the C preprocessor to include configuration options.
+ * Please use preprocessor features sparingly!
+ * Restrict to simple macros with numeric values, and/or #if/#endif blocks.
+ */
+
+#include "sdkconfig.h"
+#include "ld.common"
+
+#define SRAM_SEG_START     0x40800000
+#define SRAM_SEG_END       0x4086E610  /* 2nd stage bootloader iram_loader_seg start address */
+#define SRAM_SEG_SIZE      SRAM_SEG_END - SRAM_SEG_START
+
+#if CONFIG_APP_BUILD_USE_FLASH_SECTIONS
+/*
+ * IDRAM0_2_SEG_SIZE_DEFAULT is used when page size is 64KB
+ */
+#define IDRAM0_2_SEG_SIZE   (CONFIG_MMU_PAGE_SIZE << 8)
+#endif
+
+MEMORY
+{
+  /**
+   *  All these values assume the flash cache is on, and have the blocks this uses subtracted from the length
+   *  of the various regions. The 'data access port' dram/drom regions map to the same iram/irom regions but
+   *  are connected to the data port of the CPU and eg allow byte-wise access.
+   */
+
+#if CONFIG_APP_BUILD_USE_FLASH_SECTIONS
+  /* Flash mapped instruction data */
+  irom_seg (RX) :                    org = 0x42000020, len = IDRAM0_2_SEG_SIZE - 0x20
+
+  /**
+   * (0x20 offset above is a convenience for the app binary image generation.
+   * Flash cache has 64KB pages. The .bin file which is flashed to the chip
+   * has a 0x18 byte file header, and each segment has a 0x08 byte segment
+   * header. Setting this offset makes it simple to meet the flash cache MMU's
+   * constraint that (paddr % 64KB == vaddr % 64KB).)
+   */
+#endif // CONFIG_APP_BUILD_USE_FLASH_SECTIONS
+
+  /**
+   * Shared data RAM, excluding memory reserved for ROM bss/data/stack.
+   * Enabling Bluetooth & Trace Memory features in menuconfig will decrease the amount of RAM available.
+   */
+  sram_seg (RWX) :                   org = SRAM_SEG_START, len = SRAM_SEG_SIZE
+
+#if CONFIG_APP_BUILD_USE_FLASH_SECTIONS
+  /* Flash mapped constant data */
+  drom_seg (R) :                     org = 0x42000020, len = IDRAM0_2_SEG_SIZE - 0x20
+
+  /* (See irom_seg for meaning of 0x20 offset in the above.) */
+#endif // CONFIG_APP_BUILD_USE_FLASH_SECTIONS
+
+  /**
+   * lp ram memory (RWX). Persists over deep sleep. // TODO: IDF-5667
+   */
+#if CONFIG_ULP_COPROC_ENABLED
+  lp_ram_seg(RW)  :                 org = 0x50000000 + CONFIG_ULP_COPROC_RESERVE_MEM,
+                                    len = 0x4000 - CONFIG_ULP_COPROC_RESERVE_MEM - RESERVE_RTC_MEM
+#else
+  lp_ram_seg(RW)  :                 org = 0x50000000, len = 0x4000 - RESERVE_RTC_MEM
+#endif // CONFIG_ULP_COPROC_ENABLED
+
+  /* We reduced the size of lp_ram_seg by RESERVE_RTC_MEM value.
+     It reserves the amount of LP memory that we use for this memory segment.
+     This segment is intended for keeping:
+       - (lower addr) rtc timer data (s_rtc_timer_retain_mem, see esp_clk.c files).
+       - (higher addr) bootloader rtc data (s_bootloader_retain_mem, when a Kconfig option is on).
+     The aim of this is to keep data that will not be moved around and have a fixed address.
+  */
+  lp_reserved_seg(RW) :        org = 0x50000000 + 0x4000 - RESERVE_RTC_MEM, len = RESERVE_RTC_MEM
+}
+
+/* Heap ends at top of sram_seg */
+_heap_end = 0x40000000;
+
+_data_seg_org = ORIGIN(rtc_data_seg);
+
+/**
+ *  The lines below define location alias for .rtc.data section
+ *  C6 has no distinguished LP(RTC) fast and slow memory sections, instead, there is a unified LP_RAM section
+ *  Thus, the following region segments are not configurable like on other targets
+ */
+REGION_ALIAS("rtc_iram_seg", lp_ram_seg );
+REGION_ALIAS("rtc_data_seg", rtc_iram_seg );
+REGION_ALIAS("rtc_slow_seg", rtc_iram_seg );
+REGION_ALIAS("rtc_data_location", rtc_iram_seg );
+REGION_ALIAS("rtc_reserved_seg", lp_reserved_seg );
+
+#if CONFIG_APP_BUILD_USE_FLASH_SECTIONS
+  REGION_ALIAS("default_code_seg", irom_seg);
+#else
+  REGION_ALIAS("default_code_seg", sram_seg);
+#endif // CONFIG_APP_BUILD_USE_FLASH_SECTIONS
+
+#if CONFIG_APP_BUILD_USE_FLASH_SECTIONS
+  REGION_ALIAS("default_rodata_seg", drom_seg);
+#else
+  REGION_ALIAS("default_rodata_seg", sram_seg);
+#endif // CONFIG_APP_BUILD_USE_FLASH_SECTIONS
+
+/**
+ *  If rodata default segment is placed in `drom_seg`, then flash's first rodata section must
+ *  also be first in the segment.
+ */
+#if CONFIG_APP_BUILD_USE_FLASH_SECTIONS
+  ASSERT(_flash_rodata_dummy_start == ORIGIN(default_rodata_seg),
+         ".flash_rodata_dummy section must be placed at the beginning of the rodata segment.")
+#endif
+
+#if CONFIG_ESP_SYSTEM_USE_EH_FRAME
+    ASSERT ((__eh_frame_end > __eh_frame), "Error: eh_frame size is null!");
+    ASSERT ((__eh_frame_hdr_end > __eh_frame_hdr), "Error: eh_frame_hdr size is null!");
+#endif

--- a/cpu/esp32/vendor/ld/esp32c6/sections.ld.in
+++ b/cpu/esp32/vendor/ld/esp32c6/sections.ld.in
@@ -1,0 +1,784 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "ld.common"
+
+/* Default entry point */
+ENTRY(call_start_cpu0);
+
+SECTIONS
+{
+  /**
+   * RTC fast memory holds RTC wake stub code,
+   * including from any source file named rtc_wake_stub*.c
+   */
+  .rtc.text :
+  {
+    /* Align the start of RTC code region as per PMP granularity
+     * this ensures we do not overwrite the permissions for the previous
+     * region (ULP mem) regardless of its end alignment
+     */
+    ALIGNED_SYMBOL(_esp_pmp_align_size, _rtc_fast_start)
+    ALIGNED_SYMBOL(_esp_pmp_align_size, _rtc_text_start)
+
+    *(.rtc.entry.text)
+
+    *(.rtc.literal .rtc.text .rtc.text.*)
+
+    *rtc_wake_stub*.*(.text .text.*)
+    *(.rtc_text_end_test)
+
+    /* Align the end of RTC code region as per PMP granularity */
+    . = ALIGN(_esp_pmp_align_size);
+
+    _rtc_text_end = ABSOLUTE(.);
+  } > lp_ram_seg
+
+  /**
+   * This section located in RTC FAST Memory area.
+   * It holds data marked with RTC_FAST_ATTR attribute.
+   * See the file "esp_attr.h" for more information.
+   */
+  .rtc.force_fast :
+  {
+    ALIGNED_SYMBOL(4, _rtc_force_fast_start)
+
+    _coredump_rtc_fast_start = ABSOLUTE(.);
+    *(.rtc.fast.coredump .rtc.fast.coredump.*)
+    _coredump_rtc_fast_end = ABSOLUTE(.);
+
+    *(.rtc.force_fast .rtc.force_fast.*)
+
+    ALIGNED_SYMBOL(4, _rtc_force_fast_end)
+  } > lp_ram_seg
+
+  /**
+   * RTC data section holds RTC wake stub
+   * data/rodata, including from any source file
+   * named rtc_wake_stub*.c and the data marked with
+   * RTC_DATA_ATTR, RTC_RODATA_ATTR attributes.
+   */
+  .rtc.data :
+  {
+    _rtc_data_start = ABSOLUTE(.);
+
+    _coredump_rtc_start = ABSOLUTE(.);
+    *(.rtc.coredump .rtc.coredump.*)
+    _coredump_rtc_end = ABSOLUTE(.);
+    *(.rtc.data .rtc.data.*)
+    *(.rtc.rodata .rtc.rodata.*)
+
+    *rtc_wake_stub*.*(.data .rodata .data.* .rodata.* .srodata.*)
+
+    _rtc_data_end = ABSOLUTE(.);
+  } > lp_ram_seg
+
+  /* RTC bss, from any source file named rtc_wake_stub*.c */
+  .rtc.bss (NOLOAD) :
+  {
+    _rtc_bss_start = ABSOLUTE(.);
+
+    *rtc_wake_stub*.*(.bss .bss.* .sbss .sbss.*)
+    *rtc_wake_stub*.*(COMMON)
+
+    _rtc_bss_end = ABSOLUTE(.);
+    /* part that saves some data for rtc periph module, this part is
+       only initialized at power on reset */
+    _rtc_bss_rtc_start = ABSOLUTE(.);
+    *(.rtc.bss .rtc.bss.*)
+    _rtc_bss_rtc_end = ABSOLUTE(.);
+  } > lp_ram_seg
+
+  /**
+   * This section holds data that should not be initialized at power up
+   * and will be retained during deep sleep.
+   * User data marked with RTC_NOINIT_ATTR will be placed
+   * into this section. See the file "esp_attr.h" for more information.
+   */
+  .rtc_noinit (NOLOAD):
+  {
+    ALIGNED_SYMBOL(4, _rtc_noinit_start)
+
+    *(.rtc_noinit .rtc_noinit.*)
+
+    ALIGNED_SYMBOL(4, _rtc_noinit_end)
+  } > lp_ram_seg
+
+  /**
+   * This section located in RTC SLOW Memory area.
+   * It holds data marked with RTC_SLOW_ATTR attribute.
+   * See the file "esp_attr.h" for more information.
+   */
+  .rtc.force_slow :
+  {
+    ALIGNED_SYMBOL(4, _rtc_force_slow_start)
+
+    *(.rtc.force_slow .rtc.force_slow.*)
+
+    ALIGNED_SYMBOL(4, _rtc_force_slow_end)
+  } > lp_ram_seg
+
+  /**
+   * This section holds RTC data that should have fixed addresses.
+   * The data are not initialized at power-up and are retained during deep
+   * sleep.
+   */
+  .rtc_reserved (NOLOAD):
+  {
+    ALIGNED_SYMBOL(4, _rtc_reserved_start)
+
+    /**
+     * New data can only be added here to ensure existing data are not moved.
+     * Because data have adhered to the end of the segment and code is relied
+     * on it.
+     * >> put new data here <<
+     */
+
+    *(.rtc_timer_data_in_rtc_mem .rtc_timer_data_in_rtc_mem.*)
+    KEEP(*(.bootloader_data_rtc_mem .bootloader_data_rtc_mem.*))
+
+    _rtc_reserved_end = ABSOLUTE(.);
+  } > rtc_reserved_seg
+
+  _rtc_reserved_length = _rtc_reserved_end - _rtc_reserved_start;
+  ASSERT((_rtc_reserved_length <= LENGTH(rtc_reserved_seg)),
+          "RTC reserved segment data does not fit.")
+
+  /* Get size of rtc slow data based on rtc_data_location alias */
+  _rtc_slow_length = (ORIGIN(rtc_slow_seg) == ORIGIN(rtc_data_location))
+                        ? (_rtc_force_slow_end - _rtc_data_start)
+                        : (_rtc_force_slow_end - _rtc_force_slow_start);
+
+  _rtc_fast_length = (ORIGIN(rtc_slow_seg) == ORIGIN(rtc_data_location))
+                        ? (_rtc_force_fast_end - _rtc_fast_start)
+                        : (_rtc_noinit_end - _rtc_fast_start);
+
+  ASSERT((_rtc_slow_length <= LENGTH(rtc_slow_seg)),
+          "RTC_SLOW segment data does not fit.")
+
+  ASSERT((_rtc_fast_length <= LENGTH(rtc_data_seg)),
+          "RTC_FAST segment data does not fit.")
+
+  .iram0.text :
+  {
+    _iram_start = ABSOLUTE(.);
+
+#if CONFIG_ESP_DEBUG_INCLUDE_OCD_STUB_BINS
+    /* Do not move this block! OpenOCD expects this to be at the beginning of IRAM. */
+    KEEP(*(.ocd_stub.code));
+    KEEP(*(.ocd_stub.tramp));
+    . = ALIGN(0x800);
+    KEEP(*(.ocd_stub.data));
+    KEEP(*(.ocd_stub.bss));
+    KEEP(*(.ocd_stub.stack));
+    KEEP(*(.ocd_stub.params));
+    . = ALIGN(0x1000);
+    KEEP(*(.ocd_stub.scratchmem));
+    ASSERT(ABSOLUTE(.) == _iram_start + 0x2000, "openocd stub memory must be ended at _iram_start + 0x2000");
+#endif
+
+    /* Vectors go to start of IRAM */
+    ASSERT(ABSOLUTE(.) % 0x100 == 0, "vector address must be 256 byte aligned");
+    KEEP(*(.exception_vectors_table.text));
+    KEEP(*(.exception_vectors.text));
+
+    ALIGNED_SYMBOL(4, _invalid_pc_placeholder)
+
+    /* Code marked as running out of IRAM */
+    _iram_text_start = ABSOLUTE(.);
+
+    *(.iram1 .iram1.*)
+
+    /* parts of RIOT that should run in IRAM */
+    *core/*(.literal .text .literal.* .text.*)
+    *core_lib/*(.literal .text .literal.* .text.*)
+    *esp_common_periph/flash.*(.literal .text .literal.* .text.*)
+    *esp_common/thread_arch.*(.literal .text .literal.* .text.*)
+    *esp_freertos_common/*(.literal .text .literal.* .text.*)
+    *isrpipe/*(.literal .text .literal.* .text.*)
+    *stdio/stdio.*(.literal .text .literal.* .text.*) 
+    *stdio_*/stdio*(.literal .text .literal.* .text.*) 
+    *syscalls.*(.literal .text .literal.* .text.*)
+    *tsrb/*(.literal .text .literal.* .text.*)
+
+    /* parts of ESP-IDF that should run in IRAM */
+    /* find components/ -type f -name linker.lf -exec grep "(noflash)" {} \; -print */
+    /* find components/ -type f -name linker.lf -exec grep "(noflash_text)" {} \; -print */
+    *components/app_trace/app_trace.*(.literal .literal.* .text .text.*)
+    *components/app_trace/app_trace_util.*(.literal .literal.* .text .text.*)
+    *components/app_trace/port/port_uart.*(.literal .literal.* .text .text.*)
+    *components/esp_driver_gptimer/src/gptimer.*(.literal.gptimer_default_isr .text.gptimer_default_isr)
+    *components/esp_event/default_event_loop.*(.literal.esp_event_isr_post .text.esp_event_isr_post)
+    *components/esp_event/esp_event.*(.literal.esp_event_isr_post_to .text.esp_event_isr_post_to)
+    *components/esp_hw_support/cpu.*(.literal.esp_cpu_compare_and_set .text.esp_cpu_compare_and_set)
+    *components/esp_hw_support/cpu.*(.literal.esp_cpu_reset .text.esp_cpu_reset)
+    *components/esp_hw_support/cpu.*(.literal.esp_cpu_stall .text.esp_cpu_stall)
+    *components/esp_hw_support/cpu.*(.literal.esp_cpu_unstall .text.esp_cpu_unstall)
+    *components/esp_hw_support/cpu.*(.literal.esp_cpu_wait_for_intr .text.esp_cpu_wait_for_intr)
+    *components/esp_hw_support/esp_memory_utils.*(.literal .literal.* .text .text.*)
+    *components/esp_hw_support/gdma.*(.literal.gdma_append .text.gdma_append)
+    *components/esp_hw_support/gdma.*(.literal.gdma_default_rx_isr .text.gdma_default_rx_isr)
+    *components/esp_hw_support/gdma.*(.literal.gdma_default_tx_isr .text.gdma_default_tx_isr)
+    *components/esp_hw_support/gdma.*(.literal.gdma_reset .text.gdma_reset)
+    *components/esp_hw_support/gdma.*(.literal.gdma_start .text.gdma_start)
+    *components/esp_hw_support/gdma.*(.literal.gdma_stop .text.gdma_stop)
+    *components/esp_hw_support/mspi_timing_tuning.*(.literal .literal.* .text .text.*)
+    *components/esp_hw_support/periph_ctrl.*(.literal.periph_module_reset .text.periph_module_reset)
+    *components/esp_hw_support/periph_ctrl.*(.literal.wifi_module_disable .text.wifi_module_disable)
+    *components/esp_hw_support/periph_ctrl.*(.literal.wifi_module_enable .text.wifi_module_enable)
+    *components/esp_hw_support/*/pmu_sleep.*(.literal .literal.* .text .text.*)
+    *components/esp_hw_support/*/rtc_clk.*(.literal .literal.* .text .text.*)
+    *components/esp_hw_support/*/rtc_time.*(.literal .literal.* .text .text.*)
+    *components/esp_hw_support/*/sar_periph_ctrl.*(.literal.sar_periph_ctrl_power_enable .text.sar_periph_ctrl_power_enable)
+    *components/esp_hw_support/sleep_console.*(.literal .literal.* .text .text.*)
+    *components/esp_hw_support/*/systimer.*(.literal .literal.* .text .text.*)
+    *components/esp_mm/esp_cache.*(.literal .literal.* .text .text.*)
+    *components/esp_phy/*/phy_init.*(.literal.esp_phy_disable .text.esp_phy_disable)
+    *components/esp_phy/*/phy_init.*(.literal.esp_phy_enable .text.esp_phy_enable)
+    *components/esp_phy/*/phy_init.*(.literal.esp_wifi_bt_power_domain_off .text.esp_wifi_bt_power_domain_off)
+    *components/esp_ringbuf/*(.literal .literal.* .text .text.*)
+    *components/esp_rom/patches/esp_rom_print.*(.literal .literal.* .text .text.*)
+    *components/esp_rom/patches/esp_rom_spiflash.*(.literal .literal.* .text .text.*)
+    *components/esp_rom/patches/esp_rom_sys.*(.literal .literal.* .text .text.*)
+    *components/esp_rom/patches/esp_rom_systimer.*(.literal .literal.* .text .text.*)
+    *components/esp_rom/patches/esp_rom_tlsf.*(.literal .literal.* .text .text.*)
+    *components/esp_rom/patches/esp_rom_wdt.*(.literal .literal.* .text .text.*)
+    *components/esp_system/esp_err.*(.literal .literal.* .text .text.*)
+    *components/esp_system/esp_system_chip.*(.literal.esp_system_abort .text.esp_system_abort)
+    *components/esp_system/image_process.*(.literal .literal.* .text .text.*)
+    *components/esp_system/ubsan.*(.literal .literal.* .text .text.*)
+    *components/esp_wifi/*/esp_adapter.*(.literal.coex_pti_get_wrapper .text.coex_pti_get_wrapper)
+    *components/esp_wifi/*/esp_adapter.*(.literal.wifi_clock_disable_wrapper .text.wifi_clock_disable_wrapper)
+    *components/esp_wifi/*/esp_adapter.*(.literal.wifi_clock_enable_wrapper .text.wifi_clock_enable_wrapper)
+    *components/esp_wifi/src/wifi_netif.*(.literal.wifi_sta_receive .text.wifi_sta_receive)
+    *components/esp_wifi/src/wifi_netif.*(.literal.wifi_transmit_wrap .text.wifi_transmit_wrap)
+
+    *libclang_rt.builtins.a:_divsf3.*(.literal .literal.* .text .text.*)
+    *libclang_rt.builtins.a:restore.*(.literal .literal.* .text .text.*)
+    *libclang_rt.builtins.a:save.*(.literal .literal.* .text .text.*)
+    *libcoexist.a:(.coexiram .coexiram.*)
+    *libcoexist.a:(.coexsleepiram .coexsleepiram.*)
+    *libgcc.a:_divsf3.*(.literal .literal.* .text .text.*)
+    *libgcc.a:lib2funcs.*(.literal .literal.* .text .text.*)
+    *libgcc.a:save-restore.*(.literal .literal.* .text .text.*)
+    *libgcov.a:(.literal .literal.* .text .text.*)
+
+    *components/hal/cache_hal.*(.literal .literal.* .text .text.*)
+    *components/hal/gdma_hal_ahb_v1.*(.literal.gdma_ahb_hal_append .text.gdma_ahb_hal_append)
+    *components/hal/gdma_hal_ahb_v1.*(.literal.gdma_ahb_hal_clear_intr .text.gdma_ahb_hal_clear_intr)
+    *components/hal/gdma_hal_ahb_v1.*(.literal.gdma_ahb_hal_get_eof_desc_addr .text.gdma_ahb_hal_get_eof_desc_addr)
+    *components/hal/gdma_hal_ahb_v1.*(.literal.gdma_ahb_hal_read_intr_status .text.gdma_ahb_hal_read_intr_status)
+    *components/hal/gdma_hal_ahb_v1.*(.literal.gdma_ahb_hal_reset .text.gdma_ahb_hal_reset)
+    *components/hal/gdma_hal_ahb_v1.*(.literal.gdma_ahb_hal_start_with_desc .text.gdma_ahb_hal_start_with_desc)
+    *components/hal/gdma_hal_ahb_v1.*(.literal.gdma_ahb_hal_stop .text.gdma_ahb_hal_stop)
+    *components/hal/gdma_hal_top.*(.literal.gdma_hal_append .text.gdma_hal_append)
+    *components/hal/gdma_hal_top.*(.literal.gdma_hal_clear_intr .text.gdma_hal_clear_intr)
+    *components/hal/gdma_hal_top.*(.literal.gdma_hal_get_eof_desc_addr .text.gdma_hal_get_eof_desc_addr)
+    *components/hal/gdma_hal_top.*(.literal.gdma_hal_read_intr_status .text.gdma_hal_read_intr_status)
+    *components/hal/gdma_hal_top.*(.literal.gdma_hal_reset .text.gdma_hal_reset)
+    *components/hal/gdma_hal_top.*(.literal.gdma_hal_start_with_desc .text.gdma_hal_start_with_desc)
+    *components/hal/gdma_hal_top.*(.literal.gdma_hal_stop .text.gdma_hal_stop)
+    *components/hal/gpio_hal.*(.literal.gpio_hal_isolate_in_sleep .text.gpio_hal_isolate_in_sleep)
+    *components/hal/i2c_hal_iram.*(.literal .literal.* .text .text.*)
+    *components/hal/ledc_hal_iram.*(.literal .literal.* .text .text.*)
+    *components/hal/mmu_hal.*(.literal .literal.* .text .text.*)
+    *components/hal/pmu_hal.*(.literal .literal.* .text .text.*)
+    *components/hal/spi_flash_encrypt_hal_iram.*(.literal .literal.* .text .text.*)
+    *components/hal/spi_flash_hal_gpspi.*(.literal .literal.* .text .text.*)
+    *components/hal/spi_flash_hal_iram.*(.literal .literal.* .text .text.*)
+    *components/hal/spi_hal_iram.*(.literal .literal.* .text .text.*)
+    *components/hal/spi_slave_hal_iram.*(.literal .literal.* .text .text.*)
+    *components/hal/timer_hal.*(.literal.timer_hal_capture_and_get_counter_value .text.timer_hal_capture_and_get_counter_value)
+    *components/heap/multi_heap.*(.literal._multi_heap_lock .text._multi_heap_lock)
+    *components/heap/multi_heap.*(.literal._multi_heap_unlock .text._multi_heap_unlock)
+    *components/heap/multi_heap.*(.literal.multi_heap_aligned_alloc_offs .text.multi_heap_aligned_alloc_offs)
+    *components/heap/multi_heap.*(.literal.multi_heap_in_rom_init .text.multi_heap_in_rom_init)
+
+    *libnet80211.a:(.wifi0iram .wifi0iram.*)
+    *libnet80211.a:(.wifiextrairam .wifiextrairam.*)
+    *libnet80211.a:(.wifirxiram .wifirxiram.*)
+    *libnet80211.a:(.wifislpiram .wifislpiram.*)
+    *libnet80211.a:(.wifislprxiram .wifislprxiram.*)
+
+    *libieee802154.a:esp_ieee802154_ack.*(.literal.ieee802154_ack_config_pending_bit .text.ieee802154_ack_config_pending_bit)
+    *libieee802154.a:esp_ieee802154_dev.*(.literal.ieee802154_isr .text.ieee802154_isr)
+    *libieee802154.a:esp_ieee802154_dev.*(.literal.ieee802154_rx_frame_info_update .text.ieee802154_rx_frame_info_update)
+    *libieee802154.a:esp_ieee802154_event.*(.literal.ieee802154_inner_energy_detect_done .text.ieee802154_inner_energy_detect_done)
+    *libieee802154.a:esp_ieee802154_event.*(.literal.ieee802154_inner_enh_ack_generator .text.ieee802154_inner_enh_ack_generator)
+    *libieee802154.a:esp_ieee802154_event.*(.literal.ieee802154_inner_receive_done .text.ieee802154_inner_receive_done)
+    *libieee802154.a:esp_ieee802154_event.*(.literal.ieee802154_inner_receive_sfd_done .text.ieee802154_inner_receive_sfd_done)
+    *libieee802154.a:esp_ieee802154_event.*(.literal.ieee802154_inner_transmit_done .text.ieee802154_inner_transmit_done)
+    *libieee802154.a:esp_ieee802154_event.*(.literal.ieee802154_inner_transmit_failed .text.ieee802154_inner_transmit_failed)
+    *libieee802154.a:esp_ieee802154_event.*(.literal.ieee802154_inner_transmit_sfd_done .text.ieee802154_inner_transmit_sfd_done)
+    *libieee802154.a:esp_ieee802154_frame.*(.literal.ieee802154_frame_get_security_field_len .text.ieee802154_frame_get_security_field_len)
+    *libieee802154.a:esp_ieee802154_frame.*(.literal.ieee802154_frame_get_security_payload_offset .text.ieee802154_frame_get_security_payload_offset)
+    *libieee802154.a:esp_ieee802154_frame.*(.literal.ieee802154_frame_get_src_addr .text.ieee802154_frame_get_src_addr)
+    *libieee802154.a:esp_ieee802154_frame.*(.literal.ieee802154_frame_security_header_offset .text.ieee802154_frame_security_header_offset)
+    *libieee802154.a:esp_ieee802154_frame.*(.literal.is_dst_panid_present .text.is_dst_panid_present)
+    *libieee802154.a:esp_ieee802154_frame.*(.literal.is_src_panid_present .text.is_src_panid_present)
+    *libieee802154.a:esp_ieee802154_pib.*(.literal.ieee802154_pib_get_pending_mode .text.ieee802154_pib_get_pending_mode)
+    *libieee802154.a:esp_ieee802154_pib.*(.literal.ieee802154_pib_get_rx_when_idle .text.ieee802154_pib_get_rx_when_idle)
+    *libieee802154.a:esp_ieee802154_sec.*(.literal.ieee802154_sec_update .text.ieee802154_sec_update)
+    *libieee802154.a:esp_ieee802154_sec.*(.literal.ieee802154_transmit_security_config .text.ieee802154_transmit_security_config)
+    *libieee802154.a:esp_ieee802154_timer.*(.literal.ieee802154_timer0_set_threshold .text.ieee802154_timer0_set_threshold)
+    *libieee802154.a:esp_ieee802154_timer.*(.literal.ieee802154_timer0_start .text.ieee802154_timer0_start)
+    *libieee802154.a:esp_ieee802154_timer.*(.literal.ieee802154_timer0_stop .text.ieee802154_timer0_stop)
+    *libieee802154.a:esp_ieee802154_timer.*(.literal.ieee802154_timer1_set_threshold .text.ieee802154_timer1_set_threshold)
+    *libieee802154.a:esp_ieee802154_timer.*(.literal.ieee802154_timer1_start .text.ieee802154_timer1_start)
+    *libieee802154.a:esp_ieee802154_timer.*(.literal.ieee802154_timer1_stop .text.ieee802154_timer1_stop)
+    *libieee802154.a:esp_ieee802154_util.*(.literal.ieee802154_etm_channel_clear .text.ieee802154_etm_channel_clear)
+
+    *components/log/*/log_lock.*(.literal .literal.* .text .text.*)
+    *components/log/*/log_timestamp.*(.literal.esp_log_early_timestamp .text.esp_log_early_timestamp)
+    *components/log/*/log_timestamp.*(.literal.esp_log_timestamp .text.esp_log_timestamp)
+    *components/log/*/log_write.*(.literal.esp_log_write .text.esp_log_write)
+    *components/newlib/abort.*(.literal .literal.* .text .text.*)
+    *components/newlib/assert.*(.literal .literal.* .text .text.*)
+    *components/newlib/heap.*(.literal .literal.* .text .text.*)
+    *components/newlib/stdatomic.*(.literal .literal.* .text .text.*)
+
+    *libpp.a:(.wifi0iram .wifi0iram.*)
+    *libpp.a:(.wifiextrairam .wifiextrairam.*)
+    *libpp.a:(.wifiorslpiram .wifiorslpiram.*)
+    *libpp.a:(.wifirxiram .wifirxiram.*)
+    *libpp.a:(.wifislpiram .wifislpiram.*)
+    *libpp.a:(.wifislprxiram .wifislprxiram.*)
+
+    *components/riscv/interrupt.*(.text .text._global_interrupt_handler .text.intr_get_item .text.intr_handler_get_arg)
+    *components/riscv/vectors.*(.literal .literal.* .text .text.*)
+
+    *librtc.a:(.literal .literal.* .text .text.*)
+
+    *components/soc/lldesc.*(.literal .literal.* .text .text.*)
+    *components/spi_flash/flash_brownout_hook.*(.literal .literal.* .text .text.*)
+    *components/spi_flash/memspi_host_driver.*(.literal .literal.* .text .text.*)
+    *components/spi_flash/spi_flash_chip_boya.*(.literal .literal.* .text .text.*)
+    *components/spi_flash/spi_flash_chip_gd.*(.literal .literal.* .text .text.*)
+    *components/spi_flash/spi_flash_chip_generic.*(.literal .literal.* .text .text.*)
+    *components/spi_flash/spi_flash_chip_issi.*(.literal .literal.* .text .text.*)
+    *components/spi_flash/spi_flash_chip_mxic.*(.literal .literal.* .text .text.*)
+    *components/spi_flash/spi_flash_chip_mxic_opi.*(.literal .literal.* .text .text.*)
+    *components/spi_flash/spi_flash_chip_th.*(.literal .literal.* .text .text.*)
+    *components/spi_flash/spi_flash_chip_winbond.*(.literal .literal.* .text .text.*)
+    *components/spi_flash/spi_flash_wrap.*(.literal .literal.* .text .text.*)
+
+  } > sram_seg
+
+  /* Marks the end of IRAM code segment */
+  .iram0.text_end (NOLOAD) :
+  {
+    /* Align the end of code region as per PMP region granularity */
+    . = ALIGN(_esp_pmp_align_size);
+
+    ALIGNED_SYMBOL(4, _iram_text_end)
+  } > sram_seg
+
+  .iram0.data :
+  {
+    ALIGNED_SYMBOL(16, _iram_data_start)
+
+    *(.iram.data .iram.data.*)
+    _coredump_iram_start = ABSOLUTE(.);
+    *(.iram2.coredump .iram2.coredump.*)
+    _coredump_iram_end = ABSOLUTE(.);
+
+    _iram_data_end = ABSOLUTE(.);
+  } > sram_seg
+
+  .iram0.bss (NOLOAD) :
+  {
+    ALIGNED_SYMBOL(16, _iram_bss_start)
+
+    *(.iram.bss .iram.bss.*)
+
+    _iram_bss_end = ABSOLUTE(.);
+
+    ALIGNED_SYMBOL(16, _iram_end)
+  } > sram_seg
+
+  .dram0.data :
+  {
+    _data_start = ABSOLUTE(.);
+    *(.gnu.linkonce.d.*)
+    *(.data1)
+    __global_pointer$ = . + 0x800;
+    *(.sdata)
+    *(.sdata.*)
+    KEEP (*(SORT(.xfa.*)))
+    *(.gnu.linkonce.s.*)
+    *(.gnu.linkonce.s2.*)
+    *(.jcr)
+
+    *(EXCLUDE_FILE(*libble_app.a *libbt.a) .data EXCLUDE_FILE(*libble_app.a *libbt.a) .data.*)
+    *(.dram1 .dram1.*)
+    _coredump_dram_start = ABSOLUTE(.);
+    *(.dram2.coredump .dram2.coredump.*)
+    _coredump_dram_end = ABSOLUTE(.);
+    *components/app_trace/app_trace.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/app_trace/app_trace_util.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/app_trace/port_uart.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+
+    . = ALIGN(4);
+    _bt_controller_data_start = ABSOLUTE(.);
+    *libble_app.a:(.data .data.*)
+    . = ALIGN(4);
+    _bt_controller_data_end = ABSOLUTE(.);
+    . = ALIGN(4);
+    _bt_data_start = ABSOLUTE(.);
+    *libbt.a:(.data .data.*)
+    . = ALIGN(4);
+    _bt_data_end = ABSOLUTE(.);
+
+    *components/esp_hw_support/esp_memory_utils.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/esp_hw_support/mspi_timing_tuning.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/esp_hw_support/*/pmu_sleep.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/esp_hw_support/*/rtc_clk.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/esp_hw_support/sleep_console.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/esp_hw_support/*/systimer.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/esp_mm/esp_cache.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/esp_rom/patches/esp_rom_print.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/esp_rom/patches/esp_rom_spiflash.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/esp_rom/patches/esp_rom_sys.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/esp_rom/patches/esp_rom_systimer.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/esp_rom/patches/esp_rom_tlsf.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/esp_rom/patches/esp_rom_wdt.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/esp_system/esp_err.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/esp_system/port/image_process.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/esp_system/ubsan.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+
+    *libclang_rt.builtins.a:_divsf3.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libclang_rt.builtins.a:restore.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libclang_rt.builtins.a:save.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libgcc.a:_divsf3.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libgcc.a:save-restore.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libgcov.a:(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *libg_nano.a:libc_a-mem*(.literal .literal.* .text .text.*)
+
+    *components/hal/cache_hal.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/hal/i2c_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/hal/ledc_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/hal/mmu_hal.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/hal/pmu_hal.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/hal/spi_flash_encrypt_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/hal/spi_flash_hal_gpspi.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/hal/spi_flash_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/hal/spi_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/hal/spi_slave_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/log/*/log_lock.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+
+    *components/newlib/abort.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/newlib/assert.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/newlib/heap.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/newlib/stdatomic.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+
+    _nimble_data_start = ABSOLUTE(.);
+    *libnimble.a:(.data .data.*)
+    . = ALIGN(4);
+    _nimble_data_end = ABSOLUTE(.);
+
+    *libphy.a:(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+
+    *components/soc/lldesc.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/spi_flash/flash_brownout_hook.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/spi_flash/memspi_host_driver.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/spi_flash/spi_flash_chip_boya.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/spi_flash/spi_flash_chip_gd.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/spi_flash/spi_flash_chip_generic.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/spi_flash/spi_flash_chip_issi.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/spi_flash/spi_flash_chip_mxic.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/spi_flash/spi_flash_chip_mxic_opi.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/spi_flash/spi_flash_chip_th.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/spi_flash/spi_flash_chip_winbond.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/spi_flash/spi_flash_wrap.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+
+    _data_end = ABSOLUTE(.);
+  } > sram_seg
+
+  /**
+   * This section holds data that should not be initialized at power up.
+   * The section located in Internal SRAM memory region. The macro _NOINIT
+   * can be used as attribute to place data into this section.
+   * See the "esp_attr.h" file for more information.
+   */
+  .noinit (NOLOAD):
+  {
+    ALIGNED_SYMBOL(4, _noinit_start)
+
+    *(.noinit .noinit.*)
+
+    ALIGNED_SYMBOL(4, _noinit_end)
+  } > sram_seg
+
+  /* Shared RAM */
+  .dram0.bss (NOLOAD) :
+  {
+    ALIGNED_SYMBOL(8, _bss_start)
+
+    /**
+     * ldgen places all bss-related data to mapping[dram0_bss]
+     * (See components/esp_system/app.lf).
+     */
+    *(EXCLUDE_FILE(*libble_app.a *libbt.a) .bss EXCLUDE_FILE(*libble_app.a *libbt.a) .bss.*)
+    *(.dynbss .dynsbss .gnu.linkonce.b .gnu.linkonce.b.* .gnu.linkonce.sb .gnu.linkonce.sb.* .gnu.linkonce.sb2 .gnu.linkonce.sb2.* .sbss .sbss.* .sbss2 .sbss2.* .scommon .share.mem)
+    *(.ext_ram.bss .ext_ram.bss.*)
+    *(EXCLUDE_FILE(*libble_app.a *libbt.a) COMMON)
+    . = ALIGN(4);
+    _bt_controller_bss_start = ABSOLUTE(.);
+    *libble_app.a:(.bss .bss.*)
+    . = ALIGN(4);
+    _bt_controller_bss_end = ABSOLUTE(.);
+    . = ALIGN(4);
+    _bt_controller_common_start = ABSOLUTE(.);
+    *libble_app.a:(COMMON)
+    . = ALIGN(4);
+    _bt_controller_common_end = ABSOLUTE(.);
+    . = ALIGN(4);
+    _bt_bss_start = ABSOLUTE(.);
+    *libbt.a:(.bss .bss.*)
+    . = ALIGN(4);
+    _bt_bss_end = ABSOLUTE(.);
+    . = ALIGN(4);
+    _bt_common_start = ABSOLUTE(.);
+    *libbt.a:(COMMON)
+    . = ALIGN(4);
+    _bt_common_end = ABSOLUTE(.);
+
+    ALIGNED_SYMBOL(8, _bss_end)
+  } > sram_seg
+
+  .flash.text :
+  {
+    _stext = .;
+    /**
+     * Mark the start of flash.text.
+     * This can be used by the MMU driver to maintain the virtual address.
+     */
+    _instruction_reserved_start = ABSOLUTE(.);
+    _text_start = ABSOLUTE(.);
+
+    *(.literal .literal.* .text .text.*)
+    *(.wifi0iram .wifi0iram.*)
+    *(.wifiextrairam .wifiextrairam.*)
+    *(.wifiorslpiram .wifiorslpiram.*)
+    *(.wifirxiram .wifirxiram.*)
+    *(.wifislpiram .wifislpiram.*)
+    *(.wifislprxiram .wifislprxiram.*)
+
+    *(.stub)
+    *(.gnu.linkonce.t.*)
+    *(.gnu.warning)
+    *(.irom0.text) /* catch stray ICACHE_RODATA_ATTR */
+
+    /**
+     * CPU will try to prefetch up to 16 bytes of of instructions.
+     * This means that any configuration (e.g. MMU, PMS) must allow
+     * safe access to up to 16 bytes after the last real instruction, add
+     * dummy bytes to ensure this
+     */
+    . += _esp_flash_mmap_prefetch_pad_size;
+
+    _text_end = ABSOLUTE(.);
+    /**
+     * Mark the flash.text end.
+     * This can be used for MMU driver to maintain virtual address.
+     */
+    _instruction_reserved_end = ABSOLUTE(.);
+    _etext = .;
+
+    /**
+     * Similar to _iram_start, this symbol goes here so it is
+     * resolved by addr2line in preference to the first symbol in
+     * the flash.text segment.
+     */
+    _flash_cache_start = ABSOLUTE(0);
+  } > default_code_seg
+
+  /**
+   * Dummy section represents the .flash.text section but in default_rodata_seg.
+   * Thus, it must have its alignment and (at least) its size.
+   */
+  .flash_rodata_dummy (NOLOAD):
+  {
+    _flash_rodata_dummy_start = .;
+
+    . = ALIGN(ALIGNOF(.flash.text)) + SIZEOF(.flash.text);
+
+    /* Add alignment of MMU page size + 0x20 bytes for the mapping header. */
+    . = ALIGN(_esp_mmu_page_size) + 0x20;
+  } > default_rodata_seg
+
+  .flash.appdesc : ALIGN(0x10)
+  {
+    /**
+     * Mark flash.rodata start.
+     * This can be used for mmu driver to maintain virtual address
+     */
+    _rodata_reserved_start = ABSOLUTE(.);
+    _rodata_start = ABSOLUTE(.);
+
+    /* !DO NOT PUT ANYTHING BEFORE THIS! */
+
+    /* Should be the first.  App version info. */
+    *(.rodata_desc .rodata_desc.*)
+    /* Should be the second. Custom app version info. */
+    *(.rodata_custom_desc .rodata_custom_desc.*)
+
+    /**
+     * Create an empty gap within this section. Thanks to this, the end of this
+     * section will match .flash.rodata's begin address. Thus, both sections
+     * will be merged when creating the final bin image.
+     */
+    . = ALIGN(ALIGNOF(.flash.rodata));
+  } > default_rodata_seg
+  ASSERT_SECTIONS_GAP(.flash.appdesc, .flash.rodata)
+
+  .flash.rodata : ALIGN(0x10)
+  {
+    _flash_rodata_start = ABSOLUTE(.);
+
+    *(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *(.rodata_wlog_error .rodata_wlog_error.*)
+    *(.rodata_wlog_info .rodata_wlog_info.*)
+    *(.rodata_wlog_warning .rodata_wlog_warning.*)
+    *(.rodata_wlog_debug .rodata_wlog_debug.*)
+    *(.rodata_wlog_verbose .rodata_wlog_verbose.*)
+
+    KEEP (*(SORT(.roxfa.*)))
+
+    *(.irom1.text) /* catch stray ICACHE_RODATA_ATTR */
+    *(.gnu.linkonce.r.*)
+    *(.rodata1)
+    *(.gcc_except_table .gcc_except_table.*)
+    *(.gnu.linkonce.e.*)
+    /**
+     * C++ constructor tables.
+     *
+     * Excluding crtbegin.o/crtend.o since IDF doesn't use the toolchain crt.
+     *
+     * RISC-V gcc is configured with --enable-initfini-array so it emits
+     * .init_array section instead. But the init_priority sections will be
+     * sorted for iteration in ascending order during startup.
+     * The rest of the init_array sections is sorted for iteration in descending
+     * order during startup, however. Hence a different section is generated for
+     * the init_priority functions which is iterated in ascending order during
+     * startup. The corresponding code can be found in startup.c.
+     */
+    ALIGNED_SYMBOL(4, __init_priority_array_start)
+    KEEP (*(EXCLUDE_FILE (*crtend.* *crtbegin.*) .init_array.*))
+    __init_priority_array_end = ABSOLUTE(.);
+
+    ALIGNED_SYMBOL(4, __init_array_start)
+    KEEP (*(EXCLUDE_FILE (*crtend.* *crtbegin.*) .init_array))
+    __init_array_end = ABSOLUTE(.);
+
+    /* Addresses of memory regions reserved via SOC_RESERVE_MEMORY_REGION() */
+    ALIGNED_SYMBOL(4, soc_reserved_memory_region_start)
+    KEEP (*(.reserved_memory_address))
+    soc_reserved_memory_region_end = ABSOLUTE(.);
+
+    /* System init functions registered via ESP_SYSTEM_INIT_FN */
+    ALIGNED_SYMBOL(4, _esp_system_init_fn_array_start)
+    KEEP (*(SORT_BY_INIT_PRIORITY(.esp_system_init_fn.*)))
+    _esp_system_init_fn_array_end = ABSOLUTE(.);
+
+    _rodata_end = ABSOLUTE(.);
+    . = ALIGN(ALIGNOF(.eh_frame_hdr));
+  } > default_rodata_seg
+  ASSERT_SECTIONS_GAP(.flash.rodata, .eh_frame_hdr)
+
+  .eh_frame_hdr :
+  {
+#if CONFIG_COMPILER_CXX_EXCEPTIONS || CONFIG_ESP_SYSTEM_USE_EH_FRAME
+    ALIGNED_SYMBOL(4, __eh_frame_hdr)
+
+    KEEP (*(.eh_frame_hdr))
+
+    __eh_frame_hdr_end = ABSOLUTE(.);
+#endif // CONFIG_COMPILER_CXX_EXCEPTIONS || CONFIG_ESP_SYSTEM_USE_EH_FRAME
+
+    . = ALIGN(ALIGNOF(.eh_frame));
+  } > default_rodata_seg
+  ASSERT_SECTIONS_GAP(.eh_frame_hdr, .eh_frame)
+
+  .eh_frame :
+  {
+#if CONFIG_COMPILER_CXX_EXCEPTIONS || CONFIG_ESP_SYSTEM_USE_EH_FRAME
+    ALIGNED_SYMBOL(4, __eh_frame)
+
+    KEEP (*(.eh_frame))
+    /**
+     * As we are not linking with crtend.o, which includes the CIE terminator
+     * (see __FRAME_END__ in libgcc sources), it is manually provided here.
+     */
+    LONG(0);
+
+    __eh_frame_end = ABSOLUTE(.);
+#endif // CONFIG_COMPILER_CXX_EXCEPTIONS || CONFIG_ESP_SYSTEM_USE_EH_FRAME
+
+    . = ALIGN(ALIGNOF(.flash.tdata));
+  } > default_rodata_seg
+  ASSERT_SECTIONS_GAP(.eh_frame, .flash.tdata)
+
+  .flash.tdata :
+  {
+    _thread_local_data_start = ABSOLUTE(.);
+
+    *(.tdata .tdata.* .gnu.linkonce.td.*)
+
+    . = ALIGN(ALIGNOF(.flash.tbss));
+    _thread_local_data_end = ABSOLUTE(.);
+  } > default_rodata_seg
+  ASSERT_SECTIONS_GAP(.flash.tdata, .flash.tbss)
+
+  .flash.tbss (NOLOAD) :
+  {
+    _thread_local_bss_start = ABSOLUTE(.);
+
+    *(.tbss .tbss.* .gnu.linkonce.tb.*)
+    *(.tcommon .tcommon.*)
+
+    _thread_local_bss_end = ABSOLUTE(.);
+  } > default_rodata_seg
+
+  /**
+   * This section contains all the rodata that is not used
+   * at runtime, helping to avoid an increase in binary size.
+   */
+  .flash.rodata_noload (NOLOAD) :
+  {
+    /**
+     * This symbol marks the end of flash.rodata. It can be utilized by the MMU
+     * driver to maintain the virtual address.
+     * NOLOAD rodata may not be included in this section.
+     */
+    _rodata_reserved_end = ADDR(.flash.tbss);
+
+    . = ALIGN(CONFIG_MMU_PAGE_SIZE);
+    _fp_mmu_start = .;
+    _fp_mmu_end = . + CONFIG_ESP_FLASHPAGE_CAPACITY;
+
+    _fp_mem_start = . ;
+    KEEP(*(SORT(.flash_writable.*)))
+    _fp_mem_end = . ;
+    . = ALIGN(4096);
+    _end_fw = . ;
+
+    *(.rodata_wlog_debug .rodata_wlog_debug.*)
+    *(.rodata_wlog_verbose .rodata_wlog_verbose.*)
+  } > default_rodata_seg
+
+  /* Marks the end of data, bss and possibly rodata */
+  .dram0.heap_start (NOLOAD) :
+  {
+    ALIGNED_SYMBOL(16, _heap_start)
+    _sheap = ABSOLUTE(.);
+  } > sram_seg
+
+  . = ORIGIN(sram_seg) + LENGTH(sram_seg);
+  _eheap = ABSOLUTE(.);
+
+#include "elf_misc.ld.in"
+}

--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -53,7 +53,7 @@ ifneq (,$(filter netdev_default,$(USEMODULE)))
     endif
   else
     # otherwise use esp_now as default netdev if no other netdev is enabled
-    ifeq (,$(filter esp_wifi esp_eth nimble_netif nimble_netif_ext,$(USEMODULE)))
+    ifeq (,$(filter esp_wifi esp_eth esp_ieee802154 nimble_netif nimble_netif_ext,$(USEMODULE)))
       USEMODULE += esp_now
     endif
   endif

--- a/cpu/esp_common/periph/i2c_sw.c
+++ b/cpu/esp_common/periph/i2c_sw.c
@@ -60,13 +60,13 @@
 
 /* gpio access macros */
 #if defined(CPU_FAM_ESP32) || defined(CPU_FAM_ESP32S2) || defined(CPU_FAM_ESP32S3)
-#define GPIO_SET(lo, hi, b) if (b < 32) { GPIO.lo =  BIT(b); } else { GPIO.hi.val =  BIT(b-32); }
-#define GPIO_GET(lo, hi, b) ((b < 32) ? GPIO.lo & BIT(b) : GPIO.hi.val & BIT(b-32))
-#elif defined(CPU_FAM_ESP32C3) || defined(CPU_FAM_ESP32H2)
-#define GPIO_SET(lo, hi, b) GPIO.lo.val = BIT(b)
-#define GPIO_GET(lo, hi, b) GPIO.lo.val & BIT(b)
+#  define GPIO_SET(lo, hi, b) if (b < 32) { GPIO.lo =  BIT(b); } else { GPIO.hi.val =  BIT(b-32); }
+#  define GPIO_GET(lo, hi, b) ((b < 32) ? GPIO.lo & BIT(b) : GPIO.hi.val & BIT(b-32))
+#elif defined(CPU_FAM_ESP32C3) || defined(CPU_FAM_ESP32C6) || defined(CPU_FAM_ESP32H2)
+#  define GPIO_SET(lo, hi, b) GPIO.lo.val = BIT(b)
+#  define GPIO_GET(lo, hi, b) GPIO.lo.val & BIT(b)
 #else
-#error "Platform implementation is missing"
+#  error "Platform implementation is missing"
 #endif
 
 #else /* CPU_ESP8266 */
@@ -83,7 +83,7 @@
  */
 #ifndef I2C_CLOCK_STRETCH
 /* max clock stretching counter (ca. 10 ms) */
-#define I2C_CLOCK_STRETCH 40000
+#  define I2C_CLOCK_STRETCH 40000
 #endif /* I2C_CLOCK_STRETCH */
 
 /* following functions have to be declared as extern since it is not possible */
@@ -116,19 +116,21 @@ static _i2c_bus_t _i2c_bus[I2C_NUMOF] = {};
 #pragma GCC optimize ("O2")
 
 #if defined(CPU_FAM_ESP32)
-#define I2C_CLK_CAL     62      /* clock calibration offset */
+#  define I2C_CLK_CAL   62      /* clock calibration offset */
 #elif defined(CPU_FAM_ESP32C3)
-#define I2C_CLK_CAL     32      /* clock calibration offset */
+#  define I2C_CLK_CAL   32      /* clock calibration offset */
+#elif defined(CPU_FAM_ESP32C6)
+#  define I2C_CLK_CAL   32      /* clock calibration offset */
 #elif defined(CPU_FAM_ESP32H2)
-#define I2C_CLK_CAL     24      /* clock calibration offset */
+#  define I2C_CLK_CAL   24      /* clock calibration offset */
 #elif defined(CPU_FAM_ESP32S2)
-#define I2C_CLK_CAL     82      /* clock calibration offset */
+#  define I2C_CLK_CAL   82      /* clock calibration offset */
 #elif defined(CPU_FAM_ESP32S3)
-#define I2C_CLK_CAL     82      /* clock calibration offset */
+#  define I2C_CLK_CAL   82      /* clock calibration offset */
 #elif defined(CPU_ESP8266)
-#define I2C_CLK_CAL     47      /* clock calibration offset */
+#  define I2C_CLK_CAL   47      /* clock calibration offset */
 #else
-#error "Platform implementation is missing"
+#  error "Platform implementation is missing"
 #endif
 
 static const uint32_t _i2c_clocks[] = {

--- a/cpu/esp_common/periph/uart.c
+++ b/cpu/esp_common/periph/uart.c
@@ -83,11 +83,13 @@
  * For lower CPU clock frequencies, the APB clock corresponds to the CPU clock
  * frequency. Therefore, we need to determine the actual UART clock frequency
  * from the actual APB clock frequency. */
-#define UART_CLK_FREQ   rtc_clk_apb_freq_get() /* APB_CLK is used */
+#  define UART_CLK_FREQ rtc_clk_apb_freq_get() /* APB_CLK is used */
+#elif CPU_FAM_ESP32C6
+#  define UART_CLK_FREQ (CLK_LL_PLL_80M_FREQ_MHZ * MHZ)  /* PLL_F80M_CLK is used */
 #elif CPU_FAM_ESP32H2
-#define UART_CLK_FREQ   (CLK_LL_PLL_48M_FREQ_MHZ * MHZ)  /* PLL_F48M_CLK is used */
+#  define UART_CLK_FREQ (CLK_LL_PLL_48M_FREQ_MHZ * MHZ)  /* PLL_F48M_CLK is used */
 #else
-#error "Platform implementation is missing"
+#  error "Platform implementation is missing"
 #endif
 
 #endif /* defined(CPU_ESP8266) */

--- a/dist/tools/esptools/export.sh
+++ b/dist/tools/esptools/export.sh
@@ -26,7 +26,7 @@ export_arch()
             TARGET_ARCH="xtensa-esp-elf"
             ESP_GCC_RELEASE="${ESP32_GCC_RELEASE}"
             ;;
-        esp32c3|esp32h2)
+        esp32c3|esp32c6|esp32h2)
             TARGET_ARCH="riscv32-esp-elf"
             ESP_GCC_RELEASE="${ESP32_GCC_RELEASE}"
             ;;
@@ -147,10 +147,10 @@ if [ -z "$1" ]; then
     echo "       export.sh gdb <platform>"
     echo "       export.sh qemu <platform>"
     echo "<tool> = all | gdb | openocd | qemu |"
-    echo "         esp8266 | esp32 | esp32c3 | esp32h2 | esp32s2 | esp32s3"
+    echo "         esp8266 | esp32 | esp32c3 | esp32c6 | esp32h2 | esp32s2 | esp32s3"
     echo "<platform> = xtensa | riscv"
 elif [ "$1" = "all" ]; then
-    ARCH_ALL="esp8266 esp32 esp32c3 esp32h2 esp32s2 esp32s3"
+    ARCH_ALL="esp8266 esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3"
     for arch in ${ARCH_ALL}; do
         export_arch "$arch"
     done

--- a/dist/tools/esptools/install.sh
+++ b/dist/tools/esptools/install.sh
@@ -98,7 +98,7 @@ install_arch()
             TARGET_ARCH="xtensa-esp-elf"
             ESP_GCC_RELEASE="${ESP32_GCC_RELEASE}"
             ;;
-        esp32c3|esp32h2)
+        esp32c3|esp32c6|esp32h2)
             TARGET_ARCH="riscv32-esp-elf"
             ESP_GCC_RELEASE="${ESP32_GCC_RELEASE}"
             ;;
@@ -236,11 +236,11 @@ if [ -z "$1" ]; then
     echo "       install.sh gdb <platform>"
     echo "       install.sh qemu <platform>"
     echo "<tool> = all | esptool | gdb | openocd | qemu |"
-    echo "         esp8266 | esp32 | esp32c3 | esp32h2 | esp32s2 | esp32s3"
+    echo "         esp8266 | esp32 | esp32c3 | esp32c6 | esp32h2 | esp32s2 | esp32s3"
     echo "<platform> = xtensa | riscv"
     exit 1
 elif [ "$1" = "all" ]; then
-    ARCH_ALL="esp8266 esp32 esp32c3 esp32h2 esp32s2 esp32s3"
+    ARCH_ALL="esp8266 esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3"
     for arch in ${ARCH_ALL}; do
         install_arch "$arch"
     done

--- a/pkg/esp32_sdk/patches/0037-bootloader-changes-for-esp32c6-to-compile-in-RIOT-OS.patch
+++ b/pkg/esp32_sdk/patches/0037-bootloader-changes-for-esp32c6-to-compile-in-RIOT-OS.patch
@@ -1,0 +1,84 @@
+From c055591e5f9576d6af1ce42f74414fdf78e6266a Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Sun, 20 Apr 2025 16:05:04 +0200
+Subject: [PATCH 37/37] bootloader: changes for esp32c6 to compile in RIOT-OS
+
+---
+ .../subproject/main/ld/esp32c6/bootloader.ld  | 58 +++++++++----------
+ 1 file changed, 28 insertions(+), 30 deletions(-)
+
+diff --git a/components/bootloader/subproject/main/ld/esp32c6/bootloader.ld b/components/bootloader/subproject/main/ld/esp32c6/bootloader.ld
+index a9eb54247c..9a7207dfe4 100644
+--- a/components/bootloader/subproject/main/ld/esp32c6/bootloader.ld
++++ b/components/bootloader/subproject/main/ld/esp32c6/bootloader.ld
+@@ -59,39 +59,37 @@ SECTIONS
+     _loader_text_start = ABSOLUTE(.);
+     *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+     *(.iram1 .iram1.*) /* catch stray IRAM_ATTR */
+-    *liblog.a:(.literal .text .literal.* .text.*)
++    *components/log/*(.literal .text .literal.* .text.*)
+     /* we use either libgcc or compiler-rt, so put similar entries for them here */
+     *libgcc.a:(.literal .text .literal.* .text.*)
+     *libclang_rt.builtins.a:(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_clock_loader.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_common_loader.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_flash.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_random.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_random*.*(.literal.bootloader_random_disable .text.bootloader_random_disable)
+-    *libbootloader_support.a:bootloader_random*.*(.literal.bootloader_random_enable .text.bootloader_random_enable)
+-    *libbootloader_support.a:bootloader_efuse.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_utility.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_sha.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_console_loader.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_panic.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:bootloader_soc.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:esp_image_format.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:flash_encrypt.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:flash_encryption_secure_features.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:flash_partitions.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:secure_boot.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:secure_boot_secure_features.*(.literal .text .literal.* .text.*)
+-    *libbootloader_support.a:secure_boot_signatures_bootloader.*(.literal .text .literal.* .text.*)
+-    *libmicro-ecc.a:*.*(.literal .text .literal.* .text.*)
+-    *libspi_flash.a:*.*(.literal .text .literal.* .text.*)
+-    *libhal.a:wdt_hal_iram.*(.literal .text .literal.* .text.*)
+-    *libhal.a:mmu_hal.*(.literal .text .literal.* .text.*)
+-    *libhal.a:cache_hal.*(.literal .text .literal.* .text.*)
+-    *libhal.a:efuse_hal.*(.literal .text .literal.* .text.*)
+-    *libesp_hw_support.a:rtc_clk.*(.literal .text .literal.* .text.*)
+-    *libesp_hw_support.a:rtc_time.*(.literal .text .literal.* .text.*)
+-    *libesp_hw_support.a:regi2c_ctrl.*(.literal .text .literal.* .text.*)
+-    *libefuse.a:*.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_clock_loader.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_common_loader.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_flash.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_random.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_efuse.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_utility.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_sha.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_console_loader.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_panic.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/bootloader_soc.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/esp_image_format.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/flash_encrypt.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/flash_encryption_secure_features.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/flash_partitions.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/secure_boot.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/secure_boot_secure_features.*(.literal .text .literal.* .text.*)
++    *components/bootloader_support/*/secure_boot_signatures_bootloader.*(.literal .text .literal.* .text.*)
++    *components/*/micro-ecc/*(.literal .text .literal.* .text.*)
++    *components/spi_flash/*(.literal .text .literal.* .text.*)
++    *components/hal/wdt_hal_iram.*(.literal .text .literal.* .text.*)
++    *components/hal/mmu_hal.*(.literal .text .literal.* .text.*)
++    *components/hal/cache_hal.*(.literal .text .literal.* .text.*)
++    *components/hal/efuse_hal.*(.literal .text .literal.* .text.*)
++    *components/esp_hw_support/*/rtc_clk.*(.literal .text .literal.* .text.*)
++    *components/esp_hw_support/*/rtc_time.*(.literal .text .literal.* .text.*)
++    *components/esp_hw_support/regi2c_ctrl.*(.literal .text .literal.* .text.*)
++    *components/efuse/*(.literal .text .literal.* .text.*)
+     *(.fini.literal)
+     *(.fini)
+     *(.gnu.version)
+-- 
+2.34.1
+

--- a/pkg/esp32_sdk/patches/0038-hal-esp32c6-gspi_flash_ll-fix-signed-unsigned-compar.patch
+++ b/pkg/esp32_sdk/patches/0038-hal-esp32c6-gspi_flash_ll-fix-signed-unsigned-compar.patch
@@ -1,0 +1,26 @@
+From 686ebb0788c6a4e35d2296211010b4caccf290d7 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Mon, 21 Apr 2025 00:07:42 +0200
+Subject: [PATCH 38/40] hal/esp32c6/gspi_flash_ll: fix signed/unsigned
+ comparison
+
+---
+ components/hal/esp32c6/include/hal/gpspi_flash_ll.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/components/hal/esp32c6/include/hal/gpspi_flash_ll.h b/components/hal/esp32c6/include/hal/gpspi_flash_ll.h
+index 73d64db653..3345eb2de2 100644
+--- a/components/hal/esp32c6/include/hal/gpspi_flash_ll.h
++++ b/components/hal/esp32c6/include/hal/gpspi_flash_ll.h
+@@ -85,7 +85,7 @@ static inline void gpspi_flash_ll_get_buffer_data(spi_dev_t *dev, void *buffer,
+     } else {
+         // Otherwise, slow(er) path copies word by word
+         int copy_len = read_len;
+-        for (int i = 0; i < (read_len + 3) / 4; i++) {
++        for (unsigned i = 0; i < (read_len + 3) / 4; i++) {
+             int word_len = MIN(sizeof(uint32_t), copy_len);
+             uint32_t word = dev->data_buf[i].buf;
+             memcpy(buffer, &word, word_len);
+-- 
+2.34.1
+

--- a/pkg/esp32_sdk/patches/0039-hal-esp32c6-spimem_flash_ll-fix-signed-unsigned-comp.patch
+++ b/pkg/esp32_sdk/patches/0039-hal-esp32c6-spimem_flash_ll-fix-signed-unsigned-comp.patch
@@ -1,0 +1,26 @@
+From 5d979a80acb0ef4d6af26793300639bc51d24480 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Mon, 21 Apr 2025 00:08:06 +0200
+Subject: [PATCH 39/40] hal/esp32c6/spimem_flash_ll: fix signed/unsigned
+ comparison
+
+---
+ components/hal/esp32c6/include/hal/spimem_flash_ll.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/components/hal/esp32c6/include/hal/spimem_flash_ll.h b/components/hal/esp32c6/include/hal/spimem_flash_ll.h
+index ba68cc3bc7..e5c067ac25 100644
+--- a/components/hal/esp32c6/include/hal/spimem_flash_ll.h
++++ b/components/hal/esp32c6/include/hal/spimem_flash_ll.h
+@@ -333,7 +333,7 @@ static inline void spimem_flash_ll_get_buffer_data(spi_mem_dev_t *dev, void *buf
+     } else {
+         // Otherwise, slow(er) path copies word by word
+         int copy_len = read_len;
+-        for (int i = 0; i < (read_len + 3) / 4; i++) {
++        for (unsigned i = 0; i < (read_len + 3) / 4; i++) {
+             int word_len = MIN(sizeof(uint32_t), copy_len);
+             uint32_t word = dev->data_buf[i];
+             memcpy(buffer, &word, word_len);
+-- 
+2.34.1
+

--- a/pkg/esp32_sdk/patches/0040-esp_wifi-esp32c6-esp_adapter-fix-missing-include.patch
+++ b/pkg/esp32_sdk/patches/0040-esp_wifi-esp32c6-esp_adapter-fix-missing-include.patch
@@ -1,0 +1,24 @@
+From 358072c5129a8149fa66452f5ab7c69d60fce4e4 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Mon, 21 Apr 2025 00:08:50 +0200
+Subject: [PATCH 40/40] esp_wifi/esp32c6/esp_adapter: fix missing include
+
+---
+ components/esp_wifi/esp32c6/esp_adapter.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/components/esp_wifi/esp32c6/esp_adapter.c b/components/esp_wifi/esp32c6/esp_adapter.c
+index 1cefee5e36..c4b37a1802 100644
+--- a/components/esp_wifi/esp32c6/esp_adapter.c
++++ b/components/esp_wifi/esp32c6/esp_adapter.c
+@@ -28,6 +28,7 @@
+ #include "esp_log.h"
+ #include "esp_event.h"
+ #include "esp_heap_caps.h"
++#include "esp_system.h"
+ #include "esp_timer.h"
+ #include "esp_private/esp_modem_clock.h"
+ #include "esp_private/wifi_os_adapter.h"
+-- 
+2.34.1
+

--- a/pkg/esp32_sdk/patches/0041-bt-controller-fix-include-path-for-esp32c6.patch
+++ b/pkg/esp32_sdk/patches/0041-bt-controller-fix-include-path-for-esp32c6.patch
@@ -1,0 +1,25 @@
+From e49f756645d74b19af06647ee5b48b2526844c7b Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Mon, 21 Apr 2025 01:26:45 +0200
+Subject: [PATCH 41/41] bt/controller: fix include path for esp32c6
+
+---
+ components/bt/include/esp32c6/include/esp_bt.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/components/bt/include/esp32c6/include/esp_bt.h b/components/bt/include/esp32c6/include/esp_bt.h
+index 663e025f9f..e2a6e37d62 100644
+--- a/components/bt/include/esp32c6/include/esp_bt.h
++++ b/components/bt/include/esp32c6/include/esp_bt.h
+@@ -14,7 +14,7 @@
+ #include "esp_task.h"
+ 
+ #include "nimble/nimble_npl.h"
+-#include "../../../../controller/esp32c6/esp_bt_cfg.h"
++#include "../../../controller/esp32c6/esp_bt_cfg.h"
+ #include "hal/efuse_hal.h"
+ #include "esp_private/esp_modem_clock.h"
+ 
+-- 
+2.34.1
+

--- a/pkg/esp32_sdk/patches/0042-esp_system-cpu_start-keep-PLL-running-for-lower-CPU-.patch
+++ b/pkg/esp32_sdk/patches/0042-esp_system-cpu_start-keep-PLL-running-for-lower-CPU-.patch
@@ -1,0 +1,30 @@
+From feb43f45f9ee6723c293ae5caad90a68415784f2 Mon Sep 17 00:00:00 2001
+From: Gunar Schorcht <gunar@schorcht.net>
+Date: Tue, 22 Apr 2025 01:48:09 +0200
+Subject: [PATCH 42/42] esp_system/cpu_start: keep PLL running for lower CPU
+ freqencies
+
+---
+ components/esp_system/port/cpu_start.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/components/esp_system/port/cpu_start.c b/components/esp_system/port/cpu_start.c
+index cad5d291ac..09c4a7cd5b 100644
+--- a/components/esp_system/port/cpu_start.c
++++ b/components/esp_system/port/cpu_start.c
+@@ -716,6 +716,12 @@ void IRAM_ATTR call_start_cpu0(void)
+     trax_start_trace(TRAX_DOWNCOUNT_WORDS);
+ #endif // CONFIG_ESP32_TRAX || CONFIG_ESP32S2_TRAX || CONFIG_ESP32S3_TRAX
+ 
++#if (CPU_FAM_ESP32C6 && (CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ <= 40)) || \
++    (CPU_FAM_ESP32H2 && (CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ <= 32))
++    /* add a consumer for PLL480M to keep the PLL running on clock change */
++    rtc_clk_bbpll_add_consumer();
++#endif
++
+     esp_clk_init();
+     esp_perip_clk_init();
+ 
+-- 
+2.34.1
+

--- a/pkg/esp32_sdk_lib_bt_esp32c6/Makefile
+++ b/pkg/esp32_sdk_lib_bt_esp32c6/Makefile
@@ -1,0 +1,10 @@
+PKG_NAME=esp32_sdk_lib_bt_esp32c6
+PKG_URL=https://github.com/espressif/esp32c6-bt-lib
+# This is a version in the v5.4 release branch
+PKG_VERSION=2c3b919de82278768a98f66c02c63a148026a613
+PKG_LICENSE=Apache-2.0
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+# there is nothing to compile
+all:

--- a/pkg/esp32_sdk_lib_bt_esp32c6/Makefile.dep
+++ b/pkg/esp32_sdk_lib_bt_esp32c6/Makefile.dep
@@ -1,0 +1,3 @@
+# This package can only be used with the ESP32 CPU
+FEATURES_REQUIRED += arch_esp32
+FEATURES_REQUIRED += esp_ble

--- a/pkg/esp32_sdk_lib_bt_esp32c6/Makefile.include
+++ b/pkg/esp32_sdk_lib_bt_esp32c6/Makefile.include
@@ -1,0 +1,3 @@
+export ESP32_SDK_LIB_BT_DIR ?= $(PKGDIRBASE)/esp32_sdk_lib_bt_esp32c6/$(CPU_FAM)
+
+PSEUDOMODULES += esp32_sdk_lib_bt_esp32c6

--- a/pkg/esp32_sdk_lib_bt_esp32c6/doc.md
+++ b/pkg/esp32_sdk_lib_bt_esp32c6/doc.md
@@ -1,0 +1,4 @@
+@defgroup pkg_esp32_sdk_lib_bt_esp32c6  ESP32 SDK Bluetooth library for the ESP32-C6 SoC
+@ingroup  pkg_esp32_sdk
+@brief    Vendor SDK Bluetooth library for ESP32-C6 SoC by Espressif
+@see      https://github.com/espressif/esp32c6-bt-lib

--- a/tests/build_system/external_board_dirs/esp-ci-boards/esp32c6-ci/Kconfig
+++ b/tests/build_system/external_board_dirs/esp-ci-boards/esp32c6-ci/Kconfig
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
+
+config BOARD
+    default "esp32c6-ci" if BOARD_ESP32C6_CI
+
+config BOARD_ESP32C6_CI
+    bool
+    default y
+    select BOARD_COMMON_ESP32C6
+    select CPU_MODEL_ESP32C6_MINI_1X_X4
+
+source "$(RIOTBOARD)/common/esp32c6/Kconfig"

--- a/tests/build_system/external_board_dirs/esp-ci-boards/esp32c6-ci/Makefile
+++ b/tests/build_system/external_board_dirs/esp-ci-boards/esp32c6-ci/Makefile
@@ -1,0 +1,6 @@
+# This must be a different name than 'board' as it is implemented by 'esp32c6-devkit'
+MODULE = board_esp32c6-ci
+
+DIRS += $(RIOTBOARD)/esp32c6-devkit
+
+include $(RIOTBASE)/Makefile.base

--- a/tests/build_system/external_board_dirs/esp-ci-boards/esp32c6-ci/Makefile.dep
+++ b/tests/build_system/external_board_dirs/esp-ci-boards/esp32c6-ci/Makefile.dep
@@ -1,0 +1,29 @@
+# This must be a different name than 'board' as it is implemented by 'esp32c6-devkit'
+USEMODULE += board_esp32c6-ci
+
+USEMODULE += esp_idf_heap
+USEMODULE += esp_jtag
+USEMODULE += esp_log_startup
+USEMODULE += esp_log_tagged
+
+ifneq (,$(filter periph_i2c,$(USEMODULE)))
+  USEMODULE += esp_i2c_hw
+endif
+
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  # if netdev_default is used, we use gnrc modules that are enabled
+  # in different examples to use different esp_wifi modules
+  ifneq (,$(filter gnrc_netif_single,$(USEMODULE)))
+    # if gnrc_netif_single module is enabled, esp_wifi_enterprise is used
+    USEMODULE += esp_wifi_enterprise
+  else
+    # in all other case esp_wifi_ap is enabled
+    USEMODULE += esp_wifi_ap
+  endif
+endif
+
+ifneq (,$(filter ws281x,$(USEMODULE)))
+  USEMODULE += ws281x_esp32_sw
+endif
+
+include $(RIOTBOARD)/esp32c6-devkit/Makefile.dep

--- a/tests/build_system/external_board_dirs/esp-ci-boards/esp32c6-ci/Makefile.features
+++ b/tests/build_system/external_board_dirs/esp-ci-boards/esp32c6-ci/Makefile.features
@@ -1,0 +1,3 @@
+FEATURES_PROVIDED += esp_rtc_timer_32k
+
+include $(RIOTBOARD)/esp32c6-devkit/Makefile.features

--- a/tests/build_system/external_board_dirs/esp-ci-boards/esp32c6-ci/Makefile.include
+++ b/tests/build_system/external_board_dirs/esp-ci-boards/esp32c6-ci/Makefile.include
@@ -1,0 +1,10 @@
+# We must duplicate the include done by $(RIOTBASE)/Makefile.include
+# to also include the main board header
+INCLUDES += $(addprefix -I,$(wildcard $(RIOTBOARD)/esp32c6-devkit/include))
+
+# WIFI_EAP_USER and WIFI_EAP_PASS have to be defined to compile the
+# optional module esp_wifi_enterprise in CI
+CFLAGS += -DWIFI_EAP_USER=\"riot@riot-os.org\"
+CFLAGS += -DWIFI_EAP_PASS=\"riot\"
+
+include $(RIOTBOARD)/esp32c6-devkit/Makefile.include


### PR DESCRIPTION
### Contribution description

This PR adds the support for the ESP32-C6 variant, a RISC-V based ESP32x SoC with WiFi, IEEE802.15.4 and Bluetooth 5 (LE). It includes a board definition for the Espressif development board [ESP32-C6-DevKitM-1](https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32c6/esp32-c6-devkitm-1/user_guide.html).

### Testing procedure

Basic tests for peripherals and ESP-specific modules have to work. Following peripherals and modules have been tested successfully:

Module                   | esp32c6
-------------------------|--------
shell                    |   OK
periph/adc               |   OK
periph/can               |   OK
periph/cpuid             |   OK
periph/dac               |   -
periph/flash             |   OK
periph/flashpage         |   OK
periph/gpio              |   OK
periph/gpio_ll           |   OK
periph/gpio_ll_irq       |   OK
periph/hwrng             |   OK
periph/i2c_sw            |   OK
periph/i2c_hw            |   OK
periph/pm                |   OK
periph/pwm               |   OK
periph/rtt_sys           |   OK
periph/rtt_hw            |   OK
periph/sdmmc             |   -
periph/spi               |   OK
periph/timer             |   OK
esp_hw_counter           |   -
esp_ble_nimble           |   OK
esp_ble_nimble + esp_wifi|   
esp_eth                  |   -
esp_idf_gpio_hal         |   OK
esp_idf_usb              |   -
esp_idf_heap             |   OK
esp_ieee802154           |   OK
esp_now                  |   OK
esp_spi_ram              |   -
esp_wifi                 |   OK
esp_wifi_ap              |   OK
esp_wifi_enterprise      |   

[-] not supported by ESP32-H2

### Issues/PRs references