### PR TITLE
nimble/netif: use `netdev_legacy_api` module

### DIFF
--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -146,6 +146,7 @@ ifneq (,$(filter nimble_netif,$(USEMODULE)))
   USEMODULE += random
   USEMODULE += l2util
   USEMODULE += bluetil_addr
+  USEMODULE += netdev_legacy_api
   ifneq (,$(filter gnrc_ipv6_%,$(USEMODULE)))
     USEMODULE += nimble_svc_ipss
   endif


### PR DESCRIPTION
### Contribution description

Nimble still implements the legacy netdev API, where a sent packet isn't confirmed by the network device.
It should therefore enable the `netdev_legacy_api` module (see #18426). This PR adds it to the nimble `Makefile.dep`.

Without the fix, sending packets via BLE fails as soon the `netdev_new_api` is enabled (e.g., because a second network driver is present that uses the new API). The reason is that when the new API is enabled, `gnrc_netif` expects the driver to confirm a sent packets, which nimble doesn't do.

### Testing procedure

1. Run on one node (`A`) the `gnrc_border_router` example with `UPLINK=cdc-ecm`, `DOWNLINK=ble` and `PREFIX_CONF=static` (board must support CDC-ECM and BLE; I used the `adafruit-feather-nrf52840-sense`). The node should autoconfigure its IP address and RPL, and announce itself as RPL root.
2. On a second node (`B`) run the `gnrc_networking` example + `nimble_rpble` module (I used `nrf52dk` board)

Without the fix, RPL doesn't work properly (i.e., `B` never receives any rpl messages and `rpl show` on `B` prints an empty tree) and `gnrc_netif: can't queue packet for sending, drop it` error messages are printed on `A`. 

With the fix, RPL works as expected, and `rpl show` on `B` prints the rpl tree.


### Issues/PRs references

This was fixed for other network drivers in #18426. I assume nimble was simply forgotten?

cc @maribu as author of #18426,
