### PR TITLE
sys/psa_crypto: Extend mac API

### DIFF
--- a/pkg/driver_cryptocell_310/psa_cryptocell_310/hmac.c
+++ b/pkg/driver_cryptocell_310/psa_cryptocell_310/hmac.c
@@ -63,3 +63,90 @@ psa_status_t psa_mac_compute_hmac_sha256(const psa_key_attributes_t *attributes,
     (void)mac_size;
     return PSA_SUCCESS;
 }
+
+psa_status_t psa_mac_verify_hmac_sha256(const psa_key_attributes_t *attributes,
+                                        const uint8_t *key_buffer,
+                                        size_t key_buffer_size,
+                                        const uint8_t *input,
+                                        size_t input_length,
+                                        const uint8_t *mac,
+                                        size_t mac_length)
+{
+    (void)attributes;
+    (void)key_buffer;
+    (void)key_buffer_size;
+    (void)input;
+    (void)input_length;
+    (void)mac;
+    (void)mac_length;
+
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+psa_status_t psa_mac_sign_setup_hmac_sha256(psa_mac_operation_t *operation,
+                                            const psa_key_attributes_t *attributes,
+                                            const uint8_t *key_buffer,
+                                            size_t key_buffer_size)
+{
+    (void)operation;
+    (void)attributes;
+    (void)key_buffer;
+    (void)key_buffer_size;
+
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+psa_status_t psa_mac_verify_setup_hmac_sha256(psa_mac_operation_t *operation,
+                                              const psa_key_attributes_t *attributes,
+                                              const uint8_t *key_buffer,
+                                              size_t key_buffer_size)
+{
+    (void)operation;
+    (void)attributes;
+    (void)key_buffer;
+    (void)key_buffer_size;
+
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+psa_status_t psa_mac_update_hmac_sha256(psa_mac_operation_t *operation,
+                                        const uint8_t *input,
+                                        size_t input_length)
+{
+    (void)operation;
+    (void)input;
+    (void)input_length;
+
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+psa_status_t psa_mac_sign_finish_hmac_sha256(psa_mac_operation_t *operation,
+                                             uint8_t *mac,
+                                             size_t mac_size,
+                                             size_t *mac_length)
+{
+    (void)operation;
+    (void)mac;
+    (void)mac_size;
+    (void)mac_length;
+
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+psa_status_t psa_mac_verify_finish_hmac_sha256(psa_mac_operation_t *operation,
+                                               const uint8_t *mac,
+                                               size_t mac_length)
+{
+    (void)operation;
+    (void)mac;
+    (void)mac_length;
+
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+psa_status_t psa_mac_abort_hmac_sha256(psa_mac_operation_t *operation)
+{
+    (void)operation;
+
+    return PSA_ERROR_NOT_SUPPORTED;
+}

--- a/sys/hashes/psa_riot_hashes/hmac_sha256.c
+++ b/sys/hashes/psa_riot_hashes/hmac_sha256.c
@@ -36,3 +36,90 @@ psa_status_t psa_mac_compute_hmac_sha256(const psa_key_attributes_t *attributes,
     (void)attributes;
     return PSA_SUCCESS;
 }
+
+psa_status_t psa_mac_verify_hmac_sha256(const psa_key_attributes_t *attributes,
+                                        const uint8_t *key_buffer,
+                                        size_t key_buffer_size,
+                                        const uint8_t *input,
+                                        size_t input_length,
+                                        const uint8_t *mac,
+                                        size_t mac_length)
+{
+    (void)attributes;
+    (void)key_buffer;
+    (void)key_buffer_size;
+    (void)input;
+    (void)input_length;
+    (void)mac;
+    (void)mac_length;
+
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+psa_status_t psa_mac_sign_setup_hmac_sha256(psa_mac_operation_t *operation,
+                                            const psa_key_attributes_t *attributes,
+                                            const uint8_t *key_buffer,
+                                            size_t key_buffer_size)
+{
+    (void)operation;
+    (void)attributes;
+    (void)key_buffer;
+    (void)key_buffer_size;
+
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+psa_status_t psa_mac_verify_setup_hmac_sha256(psa_mac_operation_t *operation,
+                                              const psa_key_attributes_t *attributes,
+                                              const uint8_t *key_buffer,
+                                              size_t key_buffer_size)
+{
+    (void)operation;
+    (void)attributes;
+    (void)key_buffer;
+    (void)key_buffer_size;
+
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+psa_status_t psa_mac_update_hmac_sha256(psa_mac_operation_t *operation,
+                                        const uint8_t *input,
+                                        size_t input_length)
+{
+    (void)operation;
+    (void)input;
+    (void)input_length;
+
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+psa_status_t psa_mac_sign_finish_hmac_sha256(psa_mac_operation_t *operation,
+                                             uint8_t *mac,
+                                             size_t mac_size,
+                                             size_t *mac_length)
+{
+    (void)operation;
+    (void)mac;
+    (void)mac_size;
+    (void)mac_length;
+
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+psa_status_t psa_mac_verify_finish_hmac_sha256(psa_mac_operation_t *operation,
+                                               const uint8_t *mac,
+                                               size_t mac_length)
+{
+    (void)operation;
+    (void)mac;
+    (void)mac_length;
+
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+psa_status_t psa_mac_abort_hmac_sha256(psa_mac_operation_t *operation)
+{
+    (void)operation;
+
+    return PSA_ERROR_NOT_SUPPORTED;
+}

--- a/sys/include/psa_crypto/psa/mac/types.h
+++ b/sys/include/psa_crypto/psa/mac/types.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include "psa/algorithm.h"
+
 /**
  * @ingroup     sys_psa_crypto
  * @{
@@ -26,12 +28,10 @@ extern "C" {
 #endif
 
 /**
- * @brief   Structure storing a MAC operation context
- *
- * @note    Not yet implemented
+ * @brief   Structure containing a MAC operation context
  */
 struct psa_mac_operation_s {
-    int dummy;  /**< Not yet implemented */
+    psa_algorithm_t alg;    /**< MAC algorithm used for multi-part MAC operations */
 };
 
 /**

--- a/sys/psa_crypto/include/psa_crypto_algorithm_dispatch.h
+++ b/sys/psa_crypto/include/psa_crypto_algorithm_dispatch.h
@@ -189,6 +189,7 @@ psa_status_t psa_algorithm_dispatch_aead_decrypt(   const psa_key_attributes_t *
                                                     size_t plaintext_size,
                                                     size_t *plaintext_length);
 #endif /* MODULE_PSA_AEAD */
+
 #if IS_USED(MODULE_PSA_MAC)
 /**
  * @brief   Dispatch a mac computation function to a specific backend.
@@ -202,7 +203,68 @@ psa_status_t psa_algorithm_dispatch_mac_compute(const psa_key_attributes_t *attr
                                                 uint8_t *mac,
                                                 size_t mac_size,
                                                 size_t *mac_length);
-#endif
+
+/**
+ * @brief   Dispatch a mac verification function to a specific backend.
+ *          See @ref psa_mac_verify()
+ */
+psa_status_t psa_algorithm_dispatch_mac_verify(const psa_key_attributes_t *attributes,
+                                               psa_algorithm_t alg,
+                                               const psa_key_slot_t *slot,
+                                               const uint8_t *input,
+                                               size_t input_length,
+                                               const uint8_t *mac,
+                                               size_t mac_length);
+
+/**
+ * @brief   Dispatch call of a mac sign setup function to a specific backend.
+ *          See @ref psa_mac_sign_setup()
+ */
+psa_status_t psa_algorithm_dispatch_mac_sign_setup(psa_mac_operation_t *operation,
+                                                   const psa_key_attributes_t *attributes,
+                                                   const psa_key_slot_t *slot,
+                                                   psa_algorithm_t alg);
+
+/**
+ * @brief   Dispatch call of a mac verify setup function to a specific backend.
+ *          See @ref psa_mac_verify_setup()
+ */
+psa_status_t psa_algorithm_dispatch_mac_verify_setup(psa_mac_operation_t *operation,
+                                                     const psa_key_attributes_t *attributes,
+                                                     const psa_key_slot_t *slot,
+                                                     psa_algorithm_t alg);
+
+/**
+ * @brief   Dispatch call of a mac update function to a specific backend.
+ *          See @ref psa_mac_update()
+ */
+psa_status_t psa_algorithm_dispatch_mac_update(psa_mac_operation_t *operation,
+                                               const uint8_t *input,
+                                               size_t input_length);
+
+/**
+ * @brief   Dispatch call of a mac sign finish function to a specific backend.
+ *          See @ref psa_mac_sign_finish()
+ */
+psa_status_t psa_algorithm_dispatch_mac_sign_finish(psa_mac_operation_t *operation,
+                                                    uint8_t *mac,
+                                                    size_t mac_size,
+                                                    size_t *mac_length);
+
+/**
+ * @brief   Dispatch call of a mac verify finish function to a specific backend.
+ *          See @ref psa_mac_verify_finish()
+ */
+psa_status_t psa_algorithm_dispatch_mac_verify_finish(psa_mac_operation_t *operation,
+                                                      const uint8_t *mac,
+                                                      size_t mac_length);
+
+/**
+ * @brief   Dispatch call of a mac abort function to a specific backend.
+ *          See @ref psa_mac_abort()
+ */
+psa_status_t psa_algorithm_dispatch_mac_abort(psa_mac_operation_t *operation);
+#endif /* MODULE_PSA_MAC */
 
 #ifdef __cplusplus
 }

--- a/sys/psa_crypto/include/psa_crypto_location_dispatch.h
+++ b/sys/psa_crypto/include/psa_crypto_location_dispatch.h
@@ -81,8 +81,8 @@ psa_status_t psa_location_dispatch_verify_message(const psa_key_attributes_t *at
 
 #if IS_USED(MODULE_PSA_MAC)
 /**
- * @brief   Dispatch call of a mac computation function to a location specific backend.
- *          See psa_mac_compute()
+ * @brief   Dispatch call of a mac computation function to a location-specific backend.
+ *          See @ref psa_mac_compute()
  */
 psa_status_t psa_location_dispatch_mac_compute(const psa_key_attributes_t *attributes,
                                                psa_algorithm_t alg,
@@ -92,7 +92,68 @@ psa_status_t psa_location_dispatch_mac_compute(const psa_key_attributes_t *attri
                                                uint8_t *mac,
                                                size_t mac_size,
                                                size_t *mac_length);
-#endif
+
+/**
+ * @brief   Dispatch call of a mac verification function to a location-specific backend.
+ *          See @ref psa_mac_verify()
+ */
+psa_status_t psa_location_dispatch_mac_verify(const psa_key_attributes_t *attributes,
+                                              psa_algorithm_t alg,
+                                              const psa_key_slot_t *slot,
+                                              const uint8_t *input,
+                                              size_t input_length,
+                                              const uint8_t *mac,
+                                              size_t mac_length);
+
+/**
+ * @brief   Dispatch call of a mac sign setup function to a location-specific backend.
+ *          See @ref psa_mac_sign_setup()
+ */
+psa_status_t psa_location_dispatch_mac_sign_setup(psa_mac_operation_t *operation,
+                                                  const psa_key_attributes_t *attributes,
+                                                  const psa_key_slot_t *slot,
+                                                  psa_algorithm_t alg);
+
+/**
+ * @brief   Dispatch call of a mac verify setup function to a location-specific backend.
+ *          See @ref psa_mac_verify_setup()
+ */
+psa_status_t psa_location_dispatch_mac_verify_setup(psa_mac_operation_t *operation,
+                                                    const psa_key_attributes_t *attributes,
+                                                    const psa_key_slot_t *slot,
+                                                    psa_algorithm_t alg);
+
+/**
+ * @brief   Dispatch call of a mac update function to a location-specific backend.
+ *          See @ref psa_mac_update()
+ */
+psa_status_t psa_location_dispatch_mac_update(psa_mac_operation_t *operation,
+                                              const uint8_t *input,
+                                              size_t input_length);
+
+/**
+ * @brief   Dispatch call of a mac sign finish function to a location-specific backend.
+ *          See @ref psa_mac_sign_finish()
+ */
+psa_status_t psa_location_dispatch_mac_sign_finish(psa_mac_operation_t *operation,
+                                                   uint8_t *mac,
+                                                   size_t mac_size,
+                                                   size_t *mac_length);
+
+/**
+ * @brief   Dispatch call of a mac verify finish function to a location-specific backend.
+ *          See @ref psa_mac_verify_finish()
+ */
+psa_status_t psa_location_dispatch_mac_verify_finish(psa_mac_operation_t *operation,
+                                                     const uint8_t *mac,
+                                                     size_t mac_length);
+
+/**
+ * @brief   Dispatch call of a mac abort function to a location-specific backend.
+ *          See @ref psa_mac_abort()
+ */
+psa_status_t psa_location_dispatch_mac_abort(psa_mac_operation_t *operation);
+#endif /* MODULE_PSA_MAC */
 
 #if IS_USED(MODULE_PSA_KEY_MANAGEMENT)
 /**

--- a/sys/psa_crypto/include/psa_mac.h
+++ b/sys/psa_crypto/include/psa_mac.h
@@ -17,6 +17,7 @@
  * @brief       Function declarations for low level wrapper functions for MAC operations.
  *
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
+ * @author      Armin Wolf <armin.wolf@mailbox.tu-dresden.de>
  *
  */
 
@@ -26,20 +27,690 @@ extern "C" {
 
 #include "kernel_defines.h"
 #include "psa/crypto.h"
-#include "psa/crypto_contexts.h"
+
+#if IS_USED(MODULE_PSA_MAC_HMAC_MD5) || defined(DOXYGEN)
+/**
+ * @brief   Low level wrapper function to call a driver for a HMAC MD5 computation
+ *          See @ref psa_mac_compute()
+ */
+psa_status_t psa_mac_compute_hmac_md5(const psa_key_attributes_t *attributes,
+                                      const uint8_t *key_buffer,
+                                      size_t key_buffer_size,
+                                      const uint8_t *input,
+                                      size_t input_length,
+                                      uint8_t *mac,
+                                      size_t mac_size,
+                                      size_t *mac_length);
 
 /**
- * @brief   Low level wrapper function to call a driver for a HMAC SHA256 computation
- *          See psa_mac_compute()
+ * @brief   Low level wrapper function to call a driver for a HMAC MD5 verification
+ *          See @ref psa_mac_verify()
  */
-psa_status_t psa_mac_compute_hmac_sha256(   const psa_key_attributes_t *attributes,
+psa_status_t psa_mac_verify_hmac_md5(const psa_key_attributes_t *attributes,
+                                     const uint8_t *key_buffer,
+                                     size_t key_buffer_size,
+                                     const uint8_t *input,
+                                     size_t input_length,
+                                     const uint8_t *mac,
+                                     size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC MD5 computation
+ *          See @ref psa_mac_sign_setup()
+ */
+psa_status_t psa_mac_sign_setup_hmac_md5(psa_mac_operation_t *operation,
+                                         const psa_key_attributes_t *attributes,
+                                         const uint8_t *key_buffer,
+                                         size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC MD5 verification
+ *          See @ref psa_mac_verify_setup()
+ */
+psa_status_t psa_mac_verify_setup_hmac_md5(psa_mac_operation_t *operation,
+                                           const psa_key_attributes_t *attributes,
+                                           const uint8_t *key_buffer,
+                                           size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for updating a HMAC MD5 calculation
+ *          See @ref psa_mac_update()
+ */
+psa_status_t psa_mac_update_hmac_md5(psa_mac_operation_t *operation,
+                                     const uint8_t *input,
+                                     size_t input_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC MD5 computation
+ *          See @ref psa_mac_sign_finish()
+ */
+psa_status_t psa_mac_sign_finish_hmac_md5(psa_mac_operation_t *operation,
+                                          uint8_t *mac,
+                                          size_t mac_size,
+                                          size_t *mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC MD5 verification
+ *          See @ref psa_mac_verify_finish()
+ */
+psa_status_t psa_mac_verify_finish_hmac_md5(psa_mac_operation_t *operation,
+                                            const uint8_t *mac,
+                                            size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for aborting a HMAC MD5 operation
+ *          See @ref psa_mac_abort()
+ */
+psa_status_t psa_mac_abort_hmac_md5(psa_mac_operation_t *operation);
+#endif /* MODULE_PSA_MAC_HMAC_MD5 */
+
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_1) || defined(DOXYGEN)
+/**
+ * @brief   Low level wrapper function to call a driver for a HMAC SHA1 computation
+ *          See @ref psa_mac_compute()
+ */
+psa_status_t psa_mac_compute_hmac_sha1(const psa_key_attributes_t *attributes,
+                                       const uint8_t *key_buffer,
+                                       size_t key_buffer_size,
+                                       const uint8_t *input,
+                                       size_t input_length,
+                                       uint8_t *mac,
+                                       size_t mac_size,
+                                       size_t *mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for a HMAC SHA1 verification
+ *          See @ref psa_mac_verify()
+ */
+psa_status_t psa_mac_verify_hmac_sha1(const psa_key_attributes_t *attributes,
+                                      const uint8_t *key_buffer,
+                                      size_t key_buffer_size,
+                                      const uint8_t *input,
+                                      size_t input_length,
+                                      const uint8_t *mac,
+                                      size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC SHA1 computation
+ *          See @ref psa_mac_sign_setup()
+ */
+psa_status_t psa_mac_sign_setup_hmac_sha1(psa_mac_operation_t *operation,
+                                          const psa_key_attributes_t *attributes,
+                                          const uint8_t *key_buffer,
+                                          size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC SHA1 verification
+ *          See @ref psa_mac_verify_setup()
+ */
+psa_status_t psa_mac_verify_setup_hmac_sha1(psa_mac_operation_t *operation,
+                                            const psa_key_attributes_t *attributes,
                                             const uint8_t *key_buffer,
-                                            size_t key_buffer_size,
-                                            const uint8_t *input,
-                                            size_t input_length,
-                                            uint8_t *mac,
-                                            size_t mac_size,
-                                            size_t *mac_length);
+                                            size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for updating a HMAC SHA1 calculation
+ *          See @ref psa_mac_update()
+ */
+psa_status_t psa_mac_update_hmac_sha1(psa_mac_operation_t *operation,
+                                      const uint8_t *input,
+                                      size_t input_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC SHA1 computation
+ *          See @ref psa_mac_sign_finish()
+ */
+psa_status_t psa_mac_sign_finish_hmac_sha1(psa_mac_operation_t *operation,
+                                           uint8_t *mac,
+                                           size_t mac_size,
+                                           size_t *mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC SHA1 verification
+ *          See @ref psa_mac_verify_finish()
+ */
+psa_status_t psa_mac_verify_finish_hmac_sha1(psa_mac_operation_t *operation,
+                                             const uint8_t *mac,
+                                             size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for aborting a HMAC SHA1 operation
+ *          See @ref psa_mac_abort()
+ */
+psa_status_t psa_mac_abort_hmac_sha1(psa_mac_operation_t *operation);
+#endif /* MODULE_PSA_MAC_HMAC_SHA_1 */
+
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_224) || defined(DOXYGEN)
+/**
+ * @brief   Low level wrapper function to call a driver for a HMAC SHA224 computation
+ *          See @ref psa_mac_compute()
+ */
+psa_status_t psa_mac_compute_hmac_sha224(const psa_key_attributes_t *attributes,
+                                         const uint8_t *key_buffer,
+                                         size_t key_buffer_size,
+                                         const uint8_t *input,
+                                         size_t input_length,
+                                         uint8_t *mac,
+                                         size_t mac_size,
+                                         size_t *mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for a HMAC SHA224 verification
+ *          See @ref psa_mac_verify()
+ */
+psa_status_t psa_mac_verify_hmac_sha224(const psa_key_attributes_t *attributes,
+                                        const uint8_t *key_buffer,
+                                        size_t key_buffer_size,
+                                        const uint8_t *input,
+                                        size_t input_length,
+                                        const uint8_t *mac,
+                                        size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC SHA224 computation
+ *          See @ref psa_mac_sign_setup()
+ */
+psa_status_t psa_mac_sign_setup_hmac_sha224(psa_mac_operation_t *operation,
+                                            const psa_key_attributes_t *attributes,
+                                            const uint8_t *key_buffer,
+                                            size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC SHA224 verification
+ *          See @ref psa_mac_verify_setup()
+ */
+psa_status_t psa_mac_verify_setup_hmac_sha224(psa_mac_operation_t *operation,
+                                              const psa_key_attributes_t *attributes,
+                                              const uint8_t *key_buffer,
+                                              size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for updating a HMAC SHA224 calculation
+ *          See @ref psa_mac_update()
+ */
+psa_status_t psa_mac_update_hmac_sha224(psa_mac_operation_t *operation,
+                                        const uint8_t *input,
+                                        size_t input_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC SHA224 computation
+ *          See @ref psa_mac_sign_finish()
+ */
+psa_status_t psa_mac_sign_finish_hmac_sha224(psa_mac_operation_t *operation,
+                                             uint8_t *mac,
+                                             size_t mac_size,
+                                             size_t *mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC SHA224 verification
+ *          See @ref psa_mac_verify_finish()
+ */
+psa_status_t psa_mac_verify_finish_hmac_sha224(psa_mac_operation_t *operation,
+                                               const uint8_t *mac,
+                                               size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for aborting a HMAC SHA224 operation
+ *          See @ref psa_mac_abort()
+ */
+psa_status_t psa_mac_abort_hmac_sha224(psa_mac_operation_t *operation);
+#endif /* MODULE_PSA_MAC_HMAC_SHA_224 */
+
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_256) || defined(DOXYGEN)
+/**
+ * @brief   Low level wrapper function to call a driver for a HMAC SHA256 computation
+ *          See @ref psa_mac_compute()
+ */
+psa_status_t psa_mac_compute_hmac_sha256(const psa_key_attributes_t *attributes,
+                                         const uint8_t *key_buffer,
+                                         size_t key_buffer_size,
+                                         const uint8_t *input,
+                                         size_t input_length,
+                                         uint8_t *mac,
+                                         size_t mac_size,
+                                         size_t *mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for a HMAC SHA256 verification
+ *          See @ref psa_mac_verify()
+ */
+psa_status_t psa_mac_verify_hmac_sha256(const psa_key_attributes_t *attributes,
+                                        const uint8_t *key_buffer,
+                                        size_t key_buffer_size,
+                                        const uint8_t *input,
+                                        size_t input_length,
+                                        const uint8_t *mac,
+                                        size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC SHA256 computation
+ *          See @ref psa_mac_sign_setup()
+ */
+psa_status_t psa_mac_sign_setup_hmac_sha256(psa_mac_operation_t *operation,
+                                            const psa_key_attributes_t *attributes,
+                                            const uint8_t *key_buffer,
+                                            size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC SHA256 verification
+ *          See @ref psa_mac_verify_setup()
+ */
+psa_status_t psa_mac_verify_setup_hmac_sha256(psa_mac_operation_t *operation,
+                                              const psa_key_attributes_t *attributes,
+                                              const uint8_t *key_buffer,
+                                              size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for updating a HMAC SHA256 calculation
+ *          See @ref psa_mac_update()
+ */
+psa_status_t psa_mac_update_hmac_sha256(psa_mac_operation_t *operation,
+                                        const uint8_t *input,
+                                        size_t input_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC SHA256 computation
+ *          See @ref psa_mac_sign_finish()
+ */
+psa_status_t psa_mac_sign_finish_hmac_sha256(psa_mac_operation_t *operation,
+                                             uint8_t *mac,
+                                             size_t mac_size,
+                                             size_t *mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC SHA256 verification
+ *          See @ref psa_mac_verify_finish()
+ */
+psa_status_t psa_mac_verify_finish_hmac_sha256(psa_mac_operation_t *operation,
+                                               const uint8_t *mac,
+                                               size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for aborting a HMAC SHA256 operation
+ *          See @ref psa_mac_abort()
+ */
+psa_status_t psa_mac_abort_hmac_sha256(psa_mac_operation_t *operation);
+#endif /* MODULE_PSA_MAC_HMAC_SHA_256 */
+
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_384) || defined(DOXYGEN)
+/**
+ * @brief   Low level wrapper function to call a driver for a HMAC SHA384 computation
+ *          See @ref psa_mac_compute()
+ */
+psa_status_t psa_mac_compute_hmac_sha384(const psa_key_attributes_t *attributes,
+                                         const uint8_t *key_buffer,
+                                         size_t key_buffer_size,
+                                         const uint8_t *input,
+                                         size_t input_length,
+                                         uint8_t *mac,
+                                         size_t mac_size,
+                                         size_t *mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for a HMAC SHA384 verification
+ *          See @ref psa_mac_verify()
+ */
+psa_status_t psa_mac_verify_hmac_sha384(const psa_key_attributes_t *attributes,
+                                        const uint8_t *key_buffer,
+                                        size_t key_buffer_size,
+                                        const uint8_t *input,
+                                        size_t input_length,
+                                        const uint8_t *mac,
+                                        size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC SHA384 computation
+ *          See @ref psa_mac_sign_setup()
+ */
+psa_status_t psa_mac_sign_setup_hmac_sha384(psa_mac_operation_t *operation,
+                                            const psa_key_attributes_t *attributes,
+                                            const uint8_t *key_buffer,
+                                            size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC SHA384 verification
+ *          See @ref psa_mac_verify_setup()
+ */
+psa_status_t psa_mac_verify_setup_hmac_sha384(psa_mac_operation_t *operation,
+                                              const psa_key_attributes_t *attributes,
+                                              const uint8_t *key_buffer,
+                                              size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for updating a HMAC SHA384 calculation
+ *          See @ref psa_mac_update()
+ */
+psa_status_t psa_mac_update_hmac_sha384(psa_mac_operation_t *operation,
+                                        const uint8_t *input,
+                                        size_t input_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC SHA384 computation
+ *          See @ref psa_mac_sign_finish()
+ */
+psa_status_t psa_mac_sign_finish_hmac_sha384(psa_mac_operation_t *operation,
+                                             uint8_t *mac,
+                                             size_t mac_size,
+                                             size_t *mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC SHA384 verification
+ *          See @ref psa_mac_verify_finish()
+ */
+psa_status_t psa_mac_verify_finish_hmac_sha384(psa_mac_operation_t *operation,
+                                               const uint8_t *mac,
+                                               size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for aborting a HMAC SHA384 operation
+ *          See @ref psa_mac_abort()
+ */
+psa_status_t psa_mac_abort_hmac_sha384(psa_mac_operation_t *operation);
+#endif /* MODULE_PSA_MAC_HMAC_SHA_384 */
+
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_512) || defined(DOXYGEN)
+/**
+ * @brief   Low level wrapper function to call a driver for a HMAC SHA512 computation
+ *          See @ref psa_mac_compute()
+ */
+psa_status_t psa_mac_compute_hmac_sha512(const psa_key_attributes_t *attributes,
+                                         const uint8_t *key_buffer,
+                                         size_t key_buffer_size,
+                                         const uint8_t *input,
+                                         size_t input_length,
+                                         uint8_t *mac,
+                                         size_t mac_size,
+                                         size_t *mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for a HMAC SHA512 verification
+ *          See @ref psa_mac_verify()
+ */
+psa_status_t psa_mac_verify_hmac_sha512(const psa_key_attributes_t *attributes,
+                                        const uint8_t *key_buffer,
+                                        size_t key_buffer_size,
+                                        const uint8_t *input,
+                                        size_t input_length,
+                                        const uint8_t *mac,
+                                        size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC SHA512 computation
+ *          See @ref psa_mac_sign_setup()
+ */
+psa_status_t psa_mac_sign_setup_hmac_sha512(psa_mac_operation_t *operation,
+                                            const psa_key_attributes_t *attributes,
+                                            const uint8_t *key_buffer,
+                                            size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC SHA512 verification
+ *          See @ref psa_mac_verify_setup()
+ */
+psa_status_t psa_mac_verify_setup_hmac_sha512(psa_mac_operation_t *operation,
+                                              const psa_key_attributes_t *attributes,
+                                              const uint8_t *key_buffer,
+                                              size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for updating a HMAC SHA512 calculation
+ *          See @ref psa_mac_update()
+ */
+psa_status_t psa_mac_update_hmac_sha512(psa_mac_operation_t *operation,
+                                        const uint8_t *input,
+                                        size_t input_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC SHA512 computation
+ *          See @ref psa_mac_sign_finish()
+ */
+psa_status_t psa_mac_sign_finish_hmac_sha512(psa_mac_operation_t *operation,
+                                             uint8_t *mac,
+                                             size_t mac_size,
+                                             size_t *mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC SHA512 verification
+ *          See @ref psa_mac_verify_finish()
+ */
+psa_status_t psa_mac_verify_finish_hmac_sha512(psa_mac_operation_t *operation,
+                                               const uint8_t *mac,
+                                               size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for aborting a HMAC SHA512 operation
+ *          See @ref psa_mac_abort()
+ */
+psa_status_t psa_mac_abort_hmac_sha512(psa_mac_operation_t *operation);
+#endif /* MODULE_PSA_MAC_HMAC_SHA_512 */
+
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_256) || defined(DOXYGEN)
+/**
+ * @brief   Low level wrapper function to call a driver for a HMAC SHA3-256 computation
+ *          See @ref psa_mac_compute()
+ */
+psa_status_t psa_mac_compute_hmac_sha3_256(const psa_key_attributes_t *attributes,
+                                           const uint8_t *key_buffer,
+                                           size_t key_buffer_size,
+                                           const uint8_t *input,
+                                           size_t input_length,
+                                           uint8_t *mac,
+                                           size_t mac_size,
+                                           size_t *mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for a HMAC SHA3-256 verification
+ *          See @ref psa_mac_verify()
+ */
+psa_status_t psa_mac_verify_hmac_sha3_256(const psa_key_attributes_t *attributes,
+                                          const uint8_t *key_buffer,
+                                          size_t key_buffer_size,
+                                          const uint8_t *input,
+                                          size_t input_length,
+                                          const uint8_t *mac,
+                                          size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC SHA3-256 computation
+ *          See @ref psa_mac_sign_setup()
+ */
+psa_status_t psa_mac_sign_setup_hmac_sha3_256(psa_mac_operation_t *operation,
+                                              const psa_key_attributes_t *attributes,
+                                              const uint8_t *key_buffer,
+                                              size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC SHA3-256 verification
+ *          See @ref psa_mac_verify_setup()
+ */
+psa_status_t psa_mac_verify_setup_hmac_sha3_256(psa_mac_operation_t *operation,
+                                                const psa_key_attributes_t *attributes,
+                                                const uint8_t *key_buffer,
+                                                size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for updating a HMAC SHA3-256 calculation
+ *          See @ref psa_mac_update()
+ */
+psa_status_t psa_mac_update_hmac_sha3_256(psa_mac_operation_t *operation,
+                                          const uint8_t *input,
+                                          size_t input_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC SHA3-256 computation
+ *          See @ref psa_mac_sign_finish()
+ */
+psa_status_t psa_mac_sign_finish_hmac_sha3_256(psa_mac_operation_t *operation,
+                                               uint8_t *mac,
+                                               size_t mac_size,
+                                               size_t *mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC SHA3-256 verification
+ *          See @ref psa_mac_verify_finish()
+ */
+psa_status_t psa_mac_verify_finish_hmac_sha3_256(psa_mac_operation_t *operation,
+                                                 const uint8_t *mac,
+                                                 size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for aborting a HMAC SHA3-256 operation
+ *          See @ref psa_mac_abort()
+ */
+psa_status_t psa_mac_abort_hmac_sha3_256(psa_mac_operation_t *operation);
+#endif /* MODULE_PSA_MAC_HMAC_SHA3_256 */
+
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_384) || defined(DOXYGEN)
+/**
+ * @brief   Low level wrapper function to call a driver for a HMAC SHA3-384 computation
+ *          See @ref psa_mac_compute()
+ */
+psa_status_t psa_mac_compute_hmac_sha3_384(const psa_key_attributes_t *attributes,
+                                           const uint8_t *key_buffer,
+                                           size_t key_buffer_size,
+                                           const uint8_t *input,
+                                           size_t input_length,
+                                           uint8_t *mac,
+                                           size_t mac_size,
+                                           size_t *mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for a HMAC SHA3-384 verification
+ *          See @ref psa_mac_verify()
+ */
+psa_status_t psa_mac_verify_hmac_sha3_384(const psa_key_attributes_t *attributes,
+                                          const uint8_t *key_buffer,
+                                          size_t key_buffer_size,
+                                          const uint8_t *input,
+                                          size_t input_length,
+                                          const uint8_t *mac,
+                                          size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC SHA3-384 computation
+ *          See @ref psa_mac_sign_setup()
+ */
+psa_status_t psa_mac_sign_setup_hmac_sha3_384(psa_mac_operation_t *operation,
+                                              const psa_key_attributes_t *attributes,
+                                              const uint8_t *key_buffer,
+                                              size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC SHA3-384 verification
+ *          See @ref psa_mac_verify_setup()
+ */
+psa_status_t psa_mac_verify_setup_hmac_sha3_384(psa_mac_operation_t *operation,
+                                                const psa_key_attributes_t *attributes,
+                                                const uint8_t *key_buffer,
+                                                size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for updating a HMAC SHA3-384 calculation
+ *          See @ref psa_mac_update()
+ */
+psa_status_t psa_mac_update_hmac_sha3_384(psa_mac_operation_t *operation,
+                                          const uint8_t *input,
+                                          size_t input_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC SHA3-384 computation
+ *          See @ref psa_mac_sign_finish()
+ */
+psa_status_t psa_mac_sign_finish_hmac_sha3_384(psa_mac_operation_t *operation,
+                                               uint8_t *mac,
+                                               size_t mac_size,
+                                               size_t *mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC SHA3-384 verification
+ *          See @ref psa_mac_verify_finish()
+ */
+psa_status_t psa_mac_verify_finish_hmac_sha3_384(psa_mac_operation_t *operation,
+                                                 const uint8_t *mac,
+                                                 size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for aborting a HMAC SHA3-384 operation
+ *          See @ref psa_mac_abort()
+ */
+psa_status_t psa_mac_abort_hmac_sha3_384(psa_mac_operation_t *operation);
+#endif /* MODULE_PSA_MAC_HMAC_SHA3_384 */
+
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_512) || defined(DOXYGEN)
+/**
+ * @brief   Low level wrapper function to call a driver for a HMAC SHA3-512 computation
+ *          See @ref psa_mac_compute()
+ */
+psa_status_t psa_mac_compute_hmac_sha3_512(const psa_key_attributes_t *attributes,
+                                           const uint8_t *key_buffer,
+                                           size_t key_buffer_size,
+                                           const uint8_t *input,
+                                           size_t input_length,
+                                           uint8_t *mac,
+                                           size_t mac_size,
+                                           size_t *mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for a HMAC SHA3-512 verification
+ *          See @ref psa_mac_verify()
+ */
+psa_status_t psa_mac_verify_hmac_sha3_512(const psa_key_attributes_t *attributes,
+                                          const uint8_t *key_buffer,
+                                          size_t key_buffer_size,
+                                          const uint8_t *input,
+                                          size_t input_length,
+                                          const uint8_t *mac,
+                                          size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC SHA3-512 computation
+ *          See @ref psa_mac_sign_setup()
+ */
+psa_status_t psa_mac_sign_setup_hmac_sha3_512(psa_mac_operation_t *operation,
+                                              const psa_key_attributes_t *attributes,
+                                              const uint8_t *key_buffer,
+                                              size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for setting up a HMAC SHA3-512 verification
+ *          See @ref psa_mac_verify_setup()
+ */
+psa_status_t psa_mac_verify_setup_hmac_sha3_512(psa_mac_operation_t *operation,
+                                                const psa_key_attributes_t *attributes,
+                                                const uint8_t *key_buffer,
+                                                size_t key_buffer_size);
+
+/**
+ * @brief   Low level wrapper function to call a driver for updating a HMAC SHA3-512 calculation
+ *          See @ref psa_mac_update()
+ */
+psa_status_t psa_mac_update_hmac_sha3_512(psa_mac_operation_t *operation,
+                                          const uint8_t *input,
+                                          size_t input_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC SHA3-512 computation
+ *          See @ref psa_mac_sign_finish()
+ */
+psa_status_t psa_mac_sign_finish_hmac_sha3_512(psa_mac_operation_t *operation,
+                                               uint8_t *mac,
+                                               size_t mac_size,
+                                               size_t *mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for finishing a HMAC SHA3-512 verification
+ *          See @ref psa_mac_verify_finish()
+ */
+psa_status_t psa_mac_verify_finish_hmac_sha3_512(psa_mac_operation_t *operation,
+                                                 const uint8_t *mac,
+                                                 size_t mac_length);
+
+/**
+ * @brief   Low level wrapper function to call a driver for aborting a HMAC SHA3-512 operation
+ *          See @ref psa_mac_abort()
+ */
+psa_status_t psa_mac_abort_hmac_sha3_512(psa_mac_operation_t *operation);
+#endif /* MODULE_PSA_MAC_HMAC_SHA3_512 */
 
 #ifdef __cplusplus
 }

--- a/sys/psa_crypto/psa_crypto_algorithm_dispatch.c
+++ b/sys/psa_crypto/psa_crypto_algorithm_dispatch.c
@@ -887,33 +887,541 @@ psa_status_t psa_algorithm_dispatch_mac_compute(const psa_key_attributes_t *attr
                                                 size_t mac_size,
                                                 size_t *mac_length)
 {
+    uint8_t *key_data = NULL;
+    size_t *key_bytes = NULL;
+
+    psa_get_key_data_from_key_slot(slot, &key_data, &key_bytes);
+
+    if (!key_data || !key_bytes) {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    switch (alg) {
+#if IS_USED(MODULE_PSA_MAC_HMAC_MD5)
+    case PSA_ALG_HMAC(PSA_ALG_MD5):
+        return psa_mac_compute_hmac_md5(attributes, key_data, *key_bytes, input, input_length,
+                                        mac, mac_size, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_1)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_1):
+        return psa_mac_compute_hmac_sha1(attributes, key_data, *key_bytes, input, input_length,
+                                         mac, mac_size, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_224)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_224):
+        return psa_mac_compute_hmac_sha224(attributes, key_data, *key_bytes, input, input_length,
+                                           mac, mac_size, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_256)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_256):
+        return psa_mac_compute_hmac_sha256(attributes, key_data, *key_bytes, input, input_length,
+                                           mac, mac_size, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_384)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_384):
+        return psa_mac_compute_hmac_sha384(attributes, key_data, *key_bytes, input, input_length,
+                                           mac, mac_size, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_512)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_512):
+        return psa_mac_compute_hmac_sha512(attributes, key_data, *key_bytes, input, input_length,
+                                           mac, mac_size, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_256)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_256):
+        return psa_mac_compute_hmac_sha3_256(attributes, key_data, *key_bytes, input, input_length,
+                                             mac, mac_size, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_384)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_384):
+        return psa_mac_compute_hmac_sha3_384(attributes, key_data, *key_bytes, input, input_length,
+                                             mac, mac_size, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_512)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_512):
+        return psa_mac_compute_hmac_sha3_512(attributes, key_data, *key_bytes, input, input_length,
+                                             mac, mac_size, mac_length);
+#endif
+    default:
+        (void)attributes;
+        (void)slot;
+        (void)input;
+        (void)input_length;
+        (void)mac;
+        (void)mac_size;
+        (void)mac_length;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
+}
+
+psa_status_t psa_algorithm_dispatch_mac_verify(const psa_key_attributes_t *attributes,
+                                               psa_algorithm_t alg,
+                                               const psa_key_slot_t *slot,
+                                               const uint8_t *input,
+                                               size_t input_length,
+                                               const uint8_t *mac,
+                                               size_t mac_length)
+{
+    uint8_t *key_data = NULL;
+    size_t *key_bytes = NULL;
+
+    psa_get_key_data_from_key_slot(slot, &key_data, &key_bytes);
+
+    if (!key_data || !key_bytes) {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    switch (alg) {
+#if IS_USED(MODULE_PSA_MAC_HMAC_MD5)
+    case PSA_ALG_HMAC(PSA_ALG_MD5):
+        return psa_mac_verify_hmac_md5(attributes, key_data, *key_bytes, input, input_length,
+                                       mac, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_1)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_1):
+        return psa_mac_verify_hmac_sha1(attributes, key_data, *key_bytes, input, input_length,
+                                        mac, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_224)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_224):
+        return psa_mac_verify_hmac_sha224(attributes, key_data, *key_bytes, input, input_length,
+                                          mac, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_256)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_256):
+        return psa_mac_verify_hmac_sha256(attributes, key_data, *key_bytes, input, input_length,
+                                          mac, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_384)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_384):
+        return psa_mac_verify_hmac_sha384(attributes, key_data, *key_bytes, input, input_length,
+                                          mac, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_512)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_512):
+        return psa_mac_verify_hmac_sha512(attributes, key_data, *key_bytes, input, input_length,
+                                          mac, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_256)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_256):
+        return psa_mac_verify_hmac_sha3_256(attributes, key_data, *key_bytes, input, input_length,
+                                            mac, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_384)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_384):
+        return psa_mac_verify_hmac_sha3_384(attributes, key_data, *key_bytes, input, input_length,
+                                            mac, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_512)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_512):
+        return psa_mac_verify_hmac_sha3_512(attributes, key_data, *key_bytes, input, input_length,
+                                            mac, mac_length);
+#endif
+    default:
+        (void)attributes;
+        (void)slot;
+        (void)input;
+        (void)input_length;
+        (void)mac;
+        (void)mac_length;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
+}
+
+psa_status_t psa_algorithm_dispatch_mac_sign_setup(psa_mac_operation_t *operation,
+                                                   const psa_key_attributes_t *attributes,
+                                                   const psa_key_slot_t *slot,
+                                                   psa_algorithm_t alg)
+{
     psa_status_t status = PSA_ERROR_NOT_SUPPORTED;
     uint8_t *key_data = NULL;
     size_t *key_bytes = NULL;
 
     psa_get_key_data_from_key_slot(slot, &key_data, &key_bytes);
 
+    if (!key_data || !key_bytes) {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
     switch (alg) {
-    #if IS_USED(MODULE_PSA_MAC_HMAC_SHA_256)
-    case PSA_ALG_HMAC(PSA_ALG_SHA_256):
-        status = psa_mac_compute_hmac_sha256(attributes, key_data, *key_bytes, input, input_length,
-                                             mac, mac_size, mac_length);
+#if IS_USED(MODULE_PSA_MAC_HMAC_MD5)
+    case PSA_ALG_HMAC(PSA_ALG_MD5):
+        status = psa_mac_sign_setup_hmac_md5(operation, attributes, key_data, *key_bytes);
         if (status != PSA_SUCCESS) {
             return status;
         }
         break;
-    #endif
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_1)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_1):
+        status = psa_mac_sign_setup_hmac_sha1(operation, attributes, key_data, *key_bytes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        break;
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_224)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_224):
+        status = psa_mac_sign_setup_hmac_sha224(operation, attributes, key_data, *key_bytes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        break;
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_256)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_256):
+        status = psa_mac_sign_setup_hmac_sha256(operation, attributes, key_data, *key_bytes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        break;
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_384)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_384):
+        status = psa_mac_sign_setup_hmac_sha384(operation, attributes, key_data, *key_bytes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        break;
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_512)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_512):
+        status = psa_mac_sign_setup_hmac_sha512(operation, attributes, key_data, *key_bytes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        break;
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_256)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_256):
+        status = psa_mac_sign_setup_hmac_sha3_256(operation, attributes, key_data, *key_bytes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        break;
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_384)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_384):
+        status = psa_mac_sign_setup_hmac_sha3_384(operation, attributes, key_data, *key_bytes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        break;
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_512)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_512):
+        status = psa_mac_sign_setup_hmac_sha3_512(operation, attributes, key_data, *key_bytes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        break;
+#endif
     default:
-        (void)status;
-        return PSA_ERROR_NOT_SUPPORTED;
+        (void)attributes;
+        (void)operation;
+        (void)alg;
+        return status;
     }
 
-    (void)attributes;
-    (void)input;
-    (void)input_length;
-    (void)mac;
-    (void)mac_size;
-    (void)mac_length;
+    operation->alg = alg;
+
     return PSA_SUCCESS;
+}
+
+psa_status_t psa_algorithm_dispatch_mac_verify_setup(psa_mac_operation_t *operation,
+                                                     const psa_key_attributes_t *attributes,
+                                                     const psa_key_slot_t *slot,
+                                                     psa_algorithm_t alg)
+{
+    psa_status_t status = PSA_ERROR_NOT_SUPPORTED;
+    uint8_t *key_data = NULL;
+    size_t *key_bytes = NULL;
+
+    psa_get_key_data_from_key_slot(slot, &key_data, &key_bytes);
+
+    if (!key_data || !key_bytes) {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    switch (alg) {
+#if IS_USED(MODULE_PSA_MAC_HMAC_MD5)
+    case PSA_ALG_HMAC(PSA_ALG_MD5):
+        status = psa_mac_verify_setup_hmac_md5(operation, attributes, key_data, *key_bytes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        break;
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_1)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_1):
+        status = psa_mac_verify_setup_hmac_sha1(operation, attributes, key_data, *key_bytes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        break;
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_224)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_224):
+        status = psa_mac_verify_setup_hmac_sha224(operation, attributes, key_data, *key_bytes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        break;
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_256)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_256):
+        status = psa_mac_verify_setup_hmac_sha256(operation, attributes, key_data, *key_bytes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        break;
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_384)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_384):
+        status = psa_mac_verify_setup_hmac_sha384(operation, attributes, key_data, *key_bytes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        break;
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_512)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_512):
+        status = psa_mac_verify_setup_hmac_sha512(operation, attributes, key_data, *key_bytes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        break;
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_256)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_256):
+        status = psa_mac_verify_setup_hmac_sha3_256(operation, attributes, key_data, *key_bytes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        break;
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_384)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_384):
+        status = psa_mac_verify_setup_hmac_sha3_384(operation, attributes, key_data, *key_bytes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        break;
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_512)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_512):
+        status = psa_mac_verify_setup_hmac_sha3_512(operation, attributes, key_data, *key_bytes);
+        if (status != PSA_SUCCESS) {
+            return status;
+        }
+        break;
+#endif
+    default:
+        (void)attributes;
+        (void)operation;
+        (void)alg;
+        return status;
+    }
+
+    operation->alg = alg;
+
+    return PSA_SUCCESS;
+}
+
+psa_status_t psa_algorithm_dispatch_mac_update(psa_mac_operation_t *operation,
+                                               const uint8_t *input,
+                                               size_t input_length)
+{
+    switch (operation->alg) {
+#if IS_USED(MODULE_PSA_MAC_HMAC_MD5)
+    case PSA_ALG_HMAC(PSA_ALG_MD5):
+        return psa_mac_update_hmac_md5(operation, input, input_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_1)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_1):
+        return psa_mac_update_hmac_sha1(operation, input, input_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_224)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_224):
+        return psa_mac_update_hmac_sha224(operation, input, input_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_256)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_256):
+        return psa_mac_update_hmac_sha256(operation, input, input_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_384)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_384):
+        return psa_mac_update_hmac_sha384(operation, input, input_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_512)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_512):
+        return psa_mac_update_hmac_sha512(operation, input, input_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_256)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_256):
+        return psa_mac_update_hmac_sha3_256(operation, input, input_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_384)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_384):
+        return psa_mac_update_hmac_sha3_384(operation, input, input_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_512)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_512):
+        return psa_mac_update_hmac_sha3_512(operation, input, input_length);
+#endif
+    default:
+        (void)operation;
+        (void)input;
+        (void)input_length;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
+}
+
+psa_status_t psa_algorithm_dispatch_mac_sign_finish(psa_mac_operation_t *operation,
+                                                    uint8_t *mac,
+                                                    size_t mac_size,
+                                                    size_t *mac_length)
+{
+    switch (operation->alg) {
+#if IS_USED(MODULE_PSA_MAC_HMAC_MD5)
+    case PSA_ALG_HMAC(PSA_ALG_MD5):
+        return psa_mac_sign_finish_hmac_md5(operation, mac, mac_size, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_1)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_1):
+        return psa_mac_sign_finish_hmac_sha1(operation, mac, mac_size, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_224)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_224):
+        return psa_mac_sign_finish_hmac_sha224(operation, mac, mac_size, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_256)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_256):
+        return psa_mac_sign_finish_hmac_sha256(operation, mac, mac_size, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_384)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_384):
+        return psa_mac_sign_finish_hmac_sha384(operation, mac, mac_size, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_512)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_512):
+        return psa_mac_sign_finish_hmac_sha512(operation, mac, mac_size, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_256)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_256):
+        return psa_mac_sign_finish_hmac_sha3_256(operation, mac, mac_size, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_384)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_384):
+        return psa_mac_sign_finish_hmac_sha3_384(operation, mac, mac_size, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_512)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_512):
+        return psa_mac_sign_finish_hmac_sha3_512(operation, mac, mac_size, mac_length);
+#endif
+    default:
+        (void)operation;
+        (void)mac;
+        (void)mac_size;
+        (void)mac_length;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
+}
+
+psa_status_t psa_algorithm_dispatch_mac_verify_finish(psa_mac_operation_t *operation,
+                                                      const uint8_t *mac,
+                                                      size_t mac_length)
+{
+    switch (operation->alg) {
+#if IS_USED(MODULE_PSA_MAC_HMAC_MD5)
+    case PSA_ALG_HMAC(PSA_ALG_MD5):
+        return psa_mac_verify_finish_hmac_md5(operation, mac, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_1)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_1):
+        return psa_mac_verify_finish_hmac_sha1(operation, mac, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_224)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_224):
+        return psa_mac_verify_finish_hmac_sha224(operation, mac, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_256)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_256):
+        return psa_mac_verify_finish_hmac_sha256(operation, mac, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_384)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_384):
+        return psa_mac_verify_finish_hmac_sha384(operation, mac, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_512)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_512):
+        return psa_mac_verify_finish_hmac_sha512(operation, mac, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_256)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_256):
+        return psa_mac_verify_finish_hmac_sha3_256(operation, mac, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_384)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_384):
+        return psa_mac_verify_finish_hmac_sha3_384(operation, mac, mac_length);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_512)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_512):
+        return psa_mac_verify_finish_hmac_sha3_512(operation, mac, mac_length);
+#endif
+    default:
+        (void)operation;
+        (void)mac;
+        (void)mac_length;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
+}
+
+psa_status_t psa_algorithm_dispatch_mac_abort(psa_mac_operation_t *operation)
+{
+    switch (operation->alg) {
+#if IS_USED(MODULE_PSA_MAC_HMAC_MD5)
+    case PSA_ALG_HMAC(PSA_ALG_MD5):
+        return psa_mac_abort_hmac_md5(operation);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_1)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_1):
+        return psa_mac_abort_hmac_sha1(operation);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_224)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_224):
+        return psa_mac_abort_hmac_sha224(operation);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_256)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_256):
+        return psa_mac_abort_hmac_sha256(operation);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_384)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_384):
+        return psa_mac_abort_hmac_sha384(operation);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA_512)
+    case PSA_ALG_HMAC(PSA_ALG_SHA_512):
+        return psa_mac_abort_hmac_sha512(operation);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_256)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_256):
+        return psa_mac_abort_hmac_sha3_256(operation);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_384)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_384):
+        return psa_mac_abort_hmac_sha3_384(operation);
+#endif
+#if IS_USED(MODULE_PSA_MAC_HMAC_SHA3_512)
+    case PSA_ALG_HMAC(PSA_ALG_SHA3_512):
+        return psa_mac_abort_hmac_sha3_512(operation);
+#endif
+    case PSA_ALG_NONE:
+        /* Calling psa_mac_abort() on a fresh psa_mac_operation_t is valid */
+        return PSA_SUCCESS;
+    default:
+        (void)operation;
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
 }
 #endif /* MODULE_PSA_MAC */

--- a/sys/psa_crypto/psa_crypto_location_dispatch.c
+++ b/sys/psa_crypto/psa_crypto_location_dispatch.c
@@ -506,6 +506,80 @@ psa_status_t psa_location_dispatch_mac_compute(const psa_key_attributes_t *attri
     return psa_algorithm_dispatch_mac_compute(attributes, alg, slot, input, input_length, mac,
                                               mac_size, mac_length);
 }
+
+psa_status_t psa_location_dispatch_mac_verify(const psa_key_attributes_t *attributes,
+                                              psa_algorithm_t alg,
+                                              const psa_key_slot_t *slot,
+                                              const uint8_t *input,
+                                              size_t input_length,
+                                              const uint8_t *mac,
+                                              size_t mac_length)
+{
+#if IS_USED(MODULE_PSA_SECURE_ELEMENT)
+    psa_key_slot_number_t *slot_number = psa_key_slot_get_slot_number(slot);
+    psa_drv_se_context_t *drv_context;
+    uint8_t *key_data = NULL;
+    size_t *key_bytes = NULL;
+    const psa_drv_se_t *drv;
+
+    psa_get_key_data_from_key_slot(slot, &key_data, &key_bytes);
+
+    if (psa_get_se_driver(attributes->lifetime, &drv, &drv_context)) {
+        if (drv->mac == NULL || drv->mac->p_mac_verify == NULL) {
+            return PSA_ERROR_NOT_SUPPORTED;
+        }
+
+        return drv->mac->p_mac_verify(drv_context, input, input_length, *slot_number, alg, mac,
+                                      mac_length);
+    }
+#endif /* CONFIG_PSA_SECURE_ELEMENT */
+
+    return psa_algorithm_dispatch_mac_verify(attributes, alg, slot, input, input_length, mac,
+                                             mac_length);
+}
+
+psa_status_t psa_location_dispatch_mac_sign_setup(psa_mac_operation_t *operation,
+                                                  const psa_key_attributes_t *attributes,
+                                                  const psa_key_slot_t *slot,
+                                                  psa_algorithm_t alg)
+{
+    return psa_algorithm_dispatch_mac_sign_setup(operation, attributes, slot, alg);
+}
+
+psa_status_t psa_location_dispatch_mac_verify_setup(psa_mac_operation_t *operation,
+                                                    const psa_key_attributes_t *attributes,
+                                                    const psa_key_slot_t *slot,
+                                                    psa_algorithm_t alg)
+{
+    return psa_algorithm_dispatch_mac_verify_setup(operation, attributes, slot, alg);
+}
+
+psa_status_t psa_location_dispatch_mac_update(psa_mac_operation_t *operation,
+                                              const uint8_t *input,
+                                              size_t input_length)
+{
+    return psa_algorithm_dispatch_mac_update(operation, input, input_length);
+}
+
+psa_status_t psa_location_dispatch_mac_sign_finish(psa_mac_operation_t *operation,
+                                                   uint8_t *mac,
+                                                   size_t mac_size,
+                                                   size_t *mac_length)
+{
+    return psa_algorithm_dispatch_mac_sign_finish(operation, mac, mac_size, mac_length);
+}
+
+psa_status_t psa_location_dispatch_mac_verify_finish(psa_mac_operation_t *operation,
+                                                     const uint8_t *mac,
+                                                     size_t mac_length)
+{
+    return psa_algorithm_dispatch_mac_verify_finish(operation, mac, mac_length);
+}
+
+psa_status_t psa_location_dispatch_mac_abort(psa_mac_operation_t *operation)
+{
+    return psa_algorithm_dispatch_mac_abort(operation);
+}
 #endif /* MODULE_PSA_MAC */
 
 psa_status_t psa_location_dispatch_generate_random(uint8_t *output,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Currently PSA mac backends can only implement psa_mac_compute() from the PSA crypto API, but not psa_mac_verify() and the associated multi-part functions.

Extend the location and algorithm dispatchers to connect the above PSA API functions to suitable backends. Also extend the MAC backend API to allow backends to implement those additional functions. Due to a design issue with the SE backend API (context size is dynamic, thus requiring a memory allocation) only psa_mac_verify() can be accelerated by SE backends.

Currently no backend implements the additional functions, but this will change in the future.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

I successfully compiled and executed the PSA-related tests.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Prerequisite for #20758.
