### PR TITLE
unittests/unicoap: statically allocate option buffers [backport 2025.07]

### DIFF
--- a/sys/include/net/unicoap/options.h
+++ b/sys/include/net/unicoap/options.h
@@ -177,10 +177,12 @@ static inline void unicoap_options_clear(unicoap_options_t* options)
  * @{
  */
 #ifndef DOXYGEN
-#  define _UNICOAP_OPTIONS_ALLOC(_buf, _name, capacity) \
-      uint8_t _buf[capacity];                           \
-      unicoap_options_t _name;                          \
-      unicoap_options_init(&_name, _buf, capacity);
+#  define _UNICOAP_OPTIONS_ALLOC(_buf, _name, capacity, _static)    \
+    _static uint8_t _buf[capacity];                                 \
+    _static unicoap_options_t _name = {                             \
+        .entries = { { .data = _buf } },                            \
+        .storage_capacity = capacity,                               \
+    };
 #endif
 
 /**
@@ -190,10 +192,28 @@ static inline void unicoap_options_clear(unicoap_options_t* options)
  * @param capacity Storage buffer capacity in bytes
  *
  * Allocates a new @ref unicoap_options_t container and a storage buffer with
- * the given capacity, then calls @ref unicoap_options_t::unicoap_options_init.
+ * the given capacity, and initializes it. No need to call
+ * @ref unicoap_options_t::unicoap_options_init afterwards.
+ *
+ * See @ref UNICOAP_OPTIONS_ALLOC_STATIC for static allocation
  */
 #define UNICOAP_OPTIONS_ALLOC(name, capacity) \
-    _UNICOAP_OPTIONS_ALLOC(_CONCAT3(name, _storage, __LINE__), name, capacity)
+    _UNICOAP_OPTIONS_ALLOC(_CONCAT3(name, _storage, __LINE__), name, capacity,)
+
+/**
+ * @brief Statically allocates options with buffer capacity
+ *
+ * @param name Name of the variable storing the options structure
+ * @param capacity Static storage buffer capacity in bytes
+ *
+ * Statically allocates a new @ref unicoap_options_t container and a storage
+ * buffer with the given capacity, and initializes it. No need to call
+ * @ref unicoap_options_t::unicoap_options_init afterwards.
+ *
+ * See @ref UNICOAP_OPTIONS_ALLOC for non-static allocation
+ */
+#define UNICOAP_OPTIONS_ALLOC_STATIC(name, capacity) \
+    _UNICOAP_OPTIONS_ALLOC(_CONCAT3(name, _storage, __LINE__), name, capacity, static)
 
 /**
  * @brief Allocates options with default capacity
@@ -201,11 +221,27 @@ static inline void unicoap_options_clear(unicoap_options_t* options)
  * @param name Name of the variable storing the options structure
  *
  * Allocates a new @ref unicoap_options_t container and a storage buffer with
- * @ref CONFIG_UNICOAP_OPTIONS_BUFFER_DEFAULT_CAPACITY,
- * then calls @ref unicoap_options_t::unicoap_options_init.
+ * @ref CONFIG_UNICOAP_OPTIONS_BUFFER_DEFAULT_CAPACITY, and initializes it.
+ * No need to call @ref unicoap_options_t::unicoap_options_init afterwards.
+ *
+ * See @ref UNICOAP_OPTIONS_ALLOC_STATIC_DEFAULT for static allocation
  */
 #define UNICOAP_OPTIONS_ALLOC_DEFAULT(name) \
     UNICOAP_OPTIONS_ALLOC(name, CONFIG_UNICOAP_OPTIONS_BUFFER_DEFAULT_CAPACITY)
+
+/**
+ * @brief Statically allocates options with default capacity
+ *
+ * @param name Name of the variable storing the options structure
+ *
+ * Statically allocates a new @ref unicoap_options_t container and a storage buffer
+ * with @ref CONFIG_UNICOAP_OPTIONS_BUFFER_DEFAULT_CAPACITY, and initializes it.
+ * No need to call @ref unicoap_options_t::unicoap_options_init afterwards.
+ *
+ * See @ref UNICOAP_OPTIONS_ALLOC_DEFAULT for non-static allocation
+ */
+#define UNICOAP_OPTIONS_ALLOC_STATIC_DEFAULT(name) \
+    UNICOAP_OPTIONS_ALLOC_STATIC(name, CONFIG_UNICOAP_OPTIONS_BUFFER_DEFAULT_CAPACITY)
 /** @} */
 
 /* MARK: - Option characteristics */

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -79,6 +79,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     pba-d-01-kw2x \
     remote-pa \
     remote-reva \
+    remote-revb \
     samd10-xmini \
     samd20-xpro \
     samd21-xpro \

--- a/tests/unittests/tests-unicoap/tests-unicoap-options.c
+++ b/tests/unittests/tests-unicoap/tests-unicoap-options.c
@@ -59,7 +59,7 @@ static void assert_options_data(const unicoap_options_t* options)
 
 static void test_in_order(void)
 {
-    UNICOAP_OPTIONS_ALLOC(options, 100);
+    UNICOAP_OPTIONS_ALLOC_STATIC(options, 100);
     TEST_ASSERT_EQUAL_INT(unicoap_options_add_uri_path_component_string(&options, "actuators"), 0);
     TEST_ASSERT_EQUAL_INT(unicoap_options_add_uri_path_component_string(&options, "leds"), 0);
     TEST_ASSERT_EQUAL_INT(unicoap_options_set_content_format(&options, UNICOAP_FORMAT_JSON), 0);
@@ -71,7 +71,7 @@ static void test_in_order(void)
 
 static void test_out_of_order(void)
 {
-    UNICOAP_OPTIONS_ALLOC(options, 100);
+    UNICOAP_OPTIONS_ALLOC_STATIC(options, 100);
     TEST_ASSERT_EQUAL_INT(unicoap_options_set_accept(&options, UNICOAP_FORMAT_JSON), 0);
     TEST_ASSERT_EQUAL_INT(unicoap_options_add_uri_path_component_string(&options, "actuators"), 0);
     TEST_ASSERT_EQUAL_INT(unicoap_options_add_uri_query_string(&options, "color=g"), 0);
@@ -83,7 +83,7 @@ static void test_out_of_order(void)
 
 static void test_idempotent(void)
 {
-    UNICOAP_OPTIONS_ALLOC(options, 100);
+    UNICOAP_OPTIONS_ALLOC_STATIC(options, 100);
     TEST_ASSERT_EQUAL_INT(unicoap_options_set_accept(&options, UNICOAP_FORMAT_JSON), 0);
     TEST_ASSERT_EQUAL_INT(unicoap_options_set_accept(&options, UNICOAP_FORMAT_JSON), 0);
     TEST_ASSERT_EQUAL_INT(unicoap_options_add_uri_path_component_string(&options, "actuators"), 0);
@@ -112,7 +112,7 @@ static void _populate(unicoap_options_t* options)
 
 static void test_extended_uint_shifts(void)
 {
-    UNICOAP_OPTIONS_ALLOC(options, 900);
+    UNICOAP_OPTIONS_ALLOC_STATIC(options, 900);
     _populate(&options);
 
     /* options blob, from nanoCoAP */
@@ -180,7 +180,7 @@ static void test_extended_uint_shifts(void)
 
 static void test_remove_leading(void)
 {
-    UNICOAP_OPTIONS_ALLOC(options, 900);
+    UNICOAP_OPTIONS_ALLOC_STATIC(options, 900);
     _populate(&options);
 
     TEST_ASSERT_EQUAL_INT(unicoap_options_remove(&options, 1), 0);
@@ -250,7 +250,7 @@ static void test_remove_leading(void)
 
 static void test_remove_trailing(void)
 {
-    UNICOAP_OPTIONS_ALLOC(options, 900);
+    UNICOAP_OPTIONS_ALLOC_STATIC(options, 900);
     _populate(&options);
 
     TEST_ASSERT_EQUAL_INT(unicoap_options_remove(&options, 70), 0);
@@ -320,7 +320,7 @@ static void test_remove_trailing(void)
 
 static void test_remove_multiple(void)
 {
-    UNICOAP_OPTIONS_ALLOC(options, 900);
+    UNICOAP_OPTIONS_ALLOC_STATIC(options, 900);
     _populate(&options);
 
     TEST_ASSERT_EQUAL_INT(unicoap_options_remove(&options, 12), 0);

--- a/tests/unittests/tests-unicoap/tests-unicoap-options.c
+++ b/tests/unittests/tests-unicoap/tests-unicoap-options.c
@@ -112,7 +112,7 @@ static void _populate(unicoap_options_t* options)
 
 static void test_extended_uint_shifts(void)
 {
-    UNICOAP_OPTIONS_ALLOC(options, 2100);
+    UNICOAP_OPTIONS_ALLOC(options, 900);
     _populate(&options);
 
     /* options blob, from nanoCoAP */
@@ -180,7 +180,7 @@ static void test_extended_uint_shifts(void)
 
 static void test_remove_leading(void)
 {
-    UNICOAP_OPTIONS_ALLOC(options, 2100);
+    UNICOAP_OPTIONS_ALLOC(options, 900);
     _populate(&options);
 
     TEST_ASSERT_EQUAL_INT(unicoap_options_remove(&options, 1), 0);
@@ -250,7 +250,7 @@ static void test_remove_leading(void)
 
 static void test_remove_trailing(void)
 {
-    UNICOAP_OPTIONS_ALLOC(options, 2100);
+    UNICOAP_OPTIONS_ALLOC(options, 900);
     _populate(&options);
 
     TEST_ASSERT_EQUAL_INT(unicoap_options_remove(&options, 70), 0);
@@ -320,7 +320,7 @@ static void test_remove_trailing(void)
 
 static void test_remove_multiple(void)
 {
-    UNICOAP_OPTIONS_ALLOC(options, 2100);
+    UNICOAP_OPTIONS_ALLOC(options, 900);
     _populate(&options);
 
     TEST_ASSERT_EQUAL_INT(unicoap_options_remove(&options, 12), 0);


### PR DESCRIPTION
# Backport of #21610

### Contribution description

unicoap unittests would currently fail due to stack overflow on most hardware. They indeed allocate much more memory than needed.

The default unittest stacksize is set to THREAD_STACKSIZE_LARGE which is 2048 for cortexm_common, so 900 bytes will largely fit. However, some other architectures (e.g., atmega8) define much smaller stack sizes per default, where the reduced buffer would not fit. Should we rather make them static so they work for all architectures? We then wouldn't be able to use the convenience macro anymore.

EDIT: Changed to statically allocated buffers now using a new convenience macro `UNICOAP_OPTIONS_ALLOC_STATIC`.


### Testing procedure

`make -C tests/unittests BOARD=nrf52840dk tests-unicoap flash term`

on `master`:
```
Welcome to pyterm!
Type '/exit' to exit.
r
2025-07-17 14:28:14,931 # READY
s
2025-07-17 14:28:16,637 # START
2025-07-17 14:28:16,643 # main(): This is RIOT! (Version: 2025.07-devel-571-gd06b6)
2025-07-17 14:28:16,648 # Help: Press s to start test, r to print it is ready
```

with this PR:
```
Welcome to pyterm!
Type '/exit' to exit.
r
2025-07-17 14:26:48,657 # READY
s
2025-07-17 14:26:49,469 # START
2025-07-17 14:26:49,471 # ................
2025-07-17 14:26:49,473 # OK (16 tests)
```


### Issues/PRs references

Found while testing #21582 
