### PR TITLE
tools/suit/manifest-generator: drop misleading 'Installing' section

### DIFF
--- a/dist/tools/suit/suit-manifest-generator/README.md
+++ b/dist/tools/suit/suit-manifest-generator/README.md
@@ -2,21 +2,6 @@
 
 This repository contains a tool to generate manifests following the specification in https://tools.ietf.org/html/draft-ietf-suit-manifest-09.
 
-# Installing
-
-First clone this repo:
-
-```
-$ git clone https://github.com/ARMmbed/suit-manifest-generator.git
-```
-
-Next, use pip to install the repo:
-
-```
-$ cd suit-manifest-generator
-$ python3 -m pip install --user --upgrade .
-```
-
 # Input File Description
 
 The input file is organised into four high-level elements:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The 'Installing' section point to the upstream version of `suit-manifest-generator`, this has since been updated to generate manifests according to a newer SUIT draft version than the one that is implemented in RIOT.

Such manifests are not compatible with the RIOT implementation, the section is therefore very misleading. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
