### PR TITLE
pkg/esp32_sdk: unshallow repository before getting tag/branch name

### DIFF
--- a/pkg/esp32_sdk/Makefile
+++ b/pkg/esp32_sdk/Makefile
@@ -7,12 +7,17 @@ PKG_LICENSE=Apache-2.0
 include $(RIOTBASE)/pkg/pkg.mk
 
 ESP32_SDK_VER_FILE = $(PKG_SOURCE_DIR)/components/esp_idf_ver.h
-ESP32_SDK_VER_CMD = $(shell git -C $(PKG_SOURCE_DIR) describe --tags $(PKG_VERSION))
 
 all: $(ESP32_SDK_VER_FILE)
 
 $(PKG_PREPARED): $(ESP32_SDK_VER_FILE)
 
 # Set the SDK version from the SDK hash/tag. For example "v4.4-98-geb3797dc3ff".
+# When not using `git-clone`, a shallow repository will be created that
+# lacks the commit history, from which the SDK version is derived.
+# It therefore has to be unshallowed first.
 $(ESP32_SDK_VER_FILE): $(PKG_PATCHED)
-	$(Q)echo "#define IDF_VER \"$(ESP32_SDK_VER_CMD)\"" > $@
+	$(Q)if $$(git -C $(PKG_SOURCE_DIR) rev-parse --is-shallow-repository); then \
+	    git -C $(PKG_SOURCE_DIR) fetch $(GIT_QUIET) --no-recurse-submodules --unshallow; \
+	fi; \
+	echo "#define IDF_VER \"`git -C $(PKG_SOURCE_DIR) describe --tags $(PKG_VERSION)`\"" > $@


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `pkg/pkg.mk` script does a shallow clone (`--depth=1`) of the package repository to save bandwidth if the repository is not in the `git-cache`.

When not using `git-cache`, this led to an error in the `pkg/esp32_sdk` Makefile, which tried to recover the version string from the tag/branch name of the repository. This does not work for shallow repositories, as `git describe` accesses the repositories history (which is missing in a shallow repository).

Therefore, this PR checks if the repository is indeed shallow and if it is, it unshallows it (yes, that's really called like that).

I could not use the `ESP32_SDK_VER_CMD` variable because make resolves these variables on entering the recipe. Therefore the `git describe` was called before the repository was unshallowed.

### Testing procedure

Start with a fresh repository or run `make distclean -j`.

Compile an application of your choice for an ESP32 board of your choice. I chose `tests/minimal` and the `esp32h2-devkit`.

With the current `master`, you'll see the following error message:
```
cbuec@W11nMate:~/RIOTstuff/riot-esp32c6/RIOT$ BOARD=esp32h2-devkit make -C tests/minimal
make: Entering directory '/home/cbuec/RIOTstuff/riot-esp32c6/RIOT/tests/minimal'
Building application "tests_minimal" for "esp32h2-devkit" with CPU "esp32".

fatal: No tags can describe 'c8bb53292d08d6449a09823cf554e62ac839cd8c'.
Try --always, or create some tags.
"make" -C /home/cbuec/RIOTstuff/riot-esp32c6/RIOT/pkg/esp32_sdk/
"make" -C /home/cbuec/RIOTstuff/riot-esp32c6/RIOT/boards
```
Also, the `build/pkg/esp32_sdk/components/esp32_idf_ver.h` file has an invalid value:
```
cbuec@W11nMate:~/RIOTstuff/riot-esp32c6/RIOT$ cat build/pkg/esp32_sdk/components/esp_idf_ver.h
#define IDF_VER ""
```

With this PR, the error message is no longer present:
```
cbuec@W11nMate:~/RIOTstuff/riot-esp32c6/RIOT$ BOARD=esp32h2-devkit make -C tests/minimal
make: Entering directory '/home/cbuec/RIOTstuff/riot-esp32c6/RIOT/tests/minimal'
Building application "tests_minimal" for "esp32h2-devkit" with CPU "esp32".

"make" -C /home/cbuec/RIOTstuff/riot-esp32c6/RIOT/pkg/esp32_sdk/
"make" -C /home/cbuec/RIOTstuff/riot-esp32c6/RIOT/boards
"make" -C /home/cbuec/RIOTstuff/riot-esp32c6/RIOT/boards/common/init
"make" -C /home/cbuec/RIOTstuff/riot-esp32c6/RIOT/boards/esp32h2-devkit
...
```
and the file has the right value:
```
cbuec@W11nMate:~/RIOTstuff/riot-esp32c6/RIOT$ cat build/pkg/esp32_sdk/components/esp_idf_ver.h
#define IDF_VER "v5.4-300-gc8bb53292d"
```

Also, with `git-cache` enabled, no error message shows up with this PR:
```
cbuec@W11nMate:~/RIOTstuff/riot-esp32c6/RIOT$ BOARD=esp32h2-devkit make -C tests/minimal
make: Entering directory '/home/cbuec/RIOTstuff/riot-esp32c6/RIOT/tests/minimal'
Building application "tests_minimal" for "esp32h2-devkit" with CPU "esp32".

git-cache: cloning from cache. tag=commitc8bb53292d08d6449a09823cf554e62ac839cd8c-1183329
"make" -C /home/cbuec/RIOTstuff/riot-esp32c6/RIOT/pkg/esp32_sdk/
"make" -C /home/cbuec/RIOTstuff/riot-esp32c6/RIOT/boards
"make" -C /home/cbuec/RIOTstuff/riot-esp32c6/RIOT/boards/common/init
"make" -C /home/cbuec/RIOTstuff/riot-esp32c6/RIOT/boards/esp32h2-devkit
...
```

And of course, the file has the right content.
```
cbuec@W11nMate:~/RIOTstuff/riot-esp32c6/RIOT$ cat build/pkg/esp32_sdk/components/esp_idf_ver.h
#define IDF_VER "v5.4-300-gc8bb53292d"
```



<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

See https://github.com/RIOT-OS/RIOT/pull/21616#issuecomment-3117701362 ff

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
