### PR TITLE
dist/tools: improve the `esptools`, enhance documentation

### DIFF
--- a/cpu/esp32/doc.md
+++ b/cpu/esp32/doc.md
@@ -535,9 +535,13 @@ if you have already used ESP-IDF directly.
 
 Once the ESP32x tools are installed in the directory specified by the
 environment variable `$IDF_TOOLS_PATH`, the shell script
-`$RIOTBASE/dist/tools/esptools/install.sh` can be sourced to export the
+`$RIOTBASE/dist/tools/esptools/export.sh` can be sourced to export the
 paths of the installed tools using again the environment variable
 `$IDF_TOOLS_PATH`.
+By writing `.` followed by a space in front of the script, the script
+runs in the same environment as the current shell and sets the local
+environment variables, which would otherwise be lost on termination
+of the script.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 $ . dist/tools/esptools/export.sh

--- a/dist/tools/esptools/export.sh
+++ b/dist/tools/esptools/export.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# If the script is not sourced, the exported variables are not saved
+# in the environment.
+if [ "$(basename -- "$0")" = "export.sh" ]; then
+    echo "Please run the script prefixed with a '.' followed by a space to source it." 1>&2
+    exit 1
+fi
+
 ESP32_GCC_RELEASE="esp-14.2.0_20241119"
 ESP8266_GCC_RELEASE="esp-5.2.0_20191018"
 
@@ -14,6 +21,49 @@ if [ -z "${IDF_TOOLS_PATH}" ]; then
 fi
 
 TOOLS_PATH="${IDF_TOOLS_PATH}/tools"
+
+# this function expects the parameters $TOOL, $TOOLS_DIR and $*_VERSION
+export_checks()
+{
+    TOOL="$1"
+    TOOLS_DIR_INT="$2" # internal TOOLS_DIR
+    TOOLS_VERSION="$3"
+
+    # create the wildcard expression from the TOOLS_DIR
+    TOOLS_DIR_BASE=$(echo "$TOOLS_DIR_INT/bin" | sed "s|/$TOOLS_VERSION/|/[^/]*/|")
+    TOOLS_DIR_IN_PATH=$(echo "$PATH" | grep "${TOOLS_DIR_INT}")
+
+    if [ ! -e "${TOOLS_DIR_INT}" ]; then
+        echo "${TOOLS_DIR_INT} does not exist - please run"
+        echo "\${RIOTBASE}/dist/tools/esptools/install.sh $TOOL"
+        return 1
+    fi
+
+    echo "$PATH" | tr ':' '\n' | while read -r entry; do
+        if echo "$entry" | grep -q "^${TOOLS_DIR_BASE}$"; then
+            if [ "$entry" != "${TOOLS_DIR_INT}/bin" ]; then
+                echo "Warning: PATH contains outdated entry: \"$entry\"." \
+                     "Please check your ~/.bashrc or ~/.profile.">&2
+            fi
+	fi
+    done
+    unset entry
+
+    if [ -e "${TOOLS_DIR_INT}" ] && [ -z "${TOOLS_DIR_IN_PATH}" ]; then
+        echo "Extending PATH by ${TOOLS_DIR_INT}/bin"
+        export PATH="${TOOLS_DIR_INT}/bin:${PATH}"
+
+        echo "To make this permanent, add this line to your ~/.bashrc or ~/.profile:"
+        echo PATH="\$PATH:${TOOLS_DIR_INT}/bin"
+    fi
+
+    unset TOOL
+    unset TOOLS_DIR_INT
+    unset TOOLS_VERSION
+    unset TOOLS_DIR_IN_PATH
+
+    return 0
+}
 
 export_arch()
 {
@@ -36,35 +86,18 @@ export_arch()
     esac
 
     TOOLS_DIR="${TOOLS_PATH}/${TARGET_ARCH}/${ESP_GCC_RELEASE}/${TARGET_ARCH}"
-    TOOLS_DIR_IN_PATH=$(echo "$PATH" | grep "${TOOLS_DIR}")
-
-    if [ ! -e "${TOOLS_DIR}" ]; then
-        echo "${TOOLS_DIR} does not exist - please run"
-        echo "\${RIOTBASE}/dist/tools/esptools/install.sh $1"
-        return
-    fi
-
-    if [ -e "${TOOLS_DIR}" ] && [ -z "${TOOLS_DIR_IN_PATH}" ]; then
-        echo "Extending PATH by ${TOOLS_DIR}/bin"
-        export PATH="${TOOLS_DIR}/bin:${PATH}"
-    fi
-
-    echo "To make this permanent, add this line to your ~/.bashrc or ~/.profile:"
-    echo PATH="\$PATH:${TOOLS_DIR}/bin"
-
+    export_checks "$1" "$TOOLS_DIR" "$ESP_GCC_RELEASE"
     unset TOOLS_DIR
 }
 
 export_openocd()
 {
     TOOLS_DIR="${TOOLS_PATH}/openocd-esp32/${ESP32_OPENOCD_VERSION}"
-    TOOLS_DIR_IN_PATH=$(echo "$PATH" | grep "${TOOLS_DIR}")
     OPENOCD_DIR="${TOOLS_DIR}/openocd-esp32"
 
-    if [ -e "${OPENOCD_DIR}" ] && [ -z "${TOOLS_DIR_IN_PATH}" ]; then
-        echo "Extending PATH by ${TOOLS_DIR}/bin"
-        export PATH="${OPENOCD_DIR}/bin:${PATH}"
-        export OPENOCD="${OPENOCD_DIR}/bin/openocd -s ${OPENOCD_DIR}/share/openocd/scripts"
+    export_checks "openocd" "$OPENOCD_DIR" "$ESP32_OPENOCD_VERSION"
+    if [ $? -eq 0 ]; then
+       export OPENOCD="${OPENOCD_DIR}/bin/openocd -s ${OPENOCD_DIR}/share/openocd/scripts"
     fi
 
     unset TOOLS_DIR
@@ -107,13 +140,7 @@ export_qemu()
     fi
 
     TOOLS_DIR="${TOOLS_PATH}/${QEMU_ARCH}/${ESP32_QEMU_VERSION}/qemu"
-    TOOLS_DIR_IN_PATH=$(echo "$PATH" | grep "${TOOLS_DIR}")
-
-    if [ -e "${TOOLS_DIR}" ] && [ -z "${TOOLS_DIR_IN_PATH}" ]; then
-        echo "Extending PATH by ${TOOLS_DIR}/bin"
-        export PATH="${TOOLS_DIR}/bin:${PATH}"
-    fi
-
+    export_checks "qemu $1" "$TOOLS_DIR" "$ESP32_QEMU_VERSION"
     unset TOOLS_DIR
 }
 
@@ -132,13 +159,7 @@ export_gdb()
     esac
 
     TOOLS_DIR="${TOOLS_PATH}/${GDB_ARCH}/${GDB_VERSION}/${GDB_ARCH}"
-    TOOLS_DIR_IN_PATH=$(echo "$PATH" | grep "${TOOLS_DIR}")
-
-    if [ -e "${TOOLS_DIR}" ] && [ -z "${TOOLS_DIR_IN_PATH}" ]; then
-        echo "Extending PATH by ${TOOLS_DIR}/bin"
-        export PATH="${TOOLS_DIR}/bin:${PATH}"
-    fi
-
+    export_checks "gdb $1" "$TOOLS_DIR" "$GDB_VERSION"
     unset TOOLS_DIR
 }
 
@@ -170,7 +191,7 @@ elif [ "$1" = "gdb" ]; then
 elif [ "$1" = "openocd" ]; then
     export_openocd
 elif [ "$1" = "qemu" ]; then
-    export_qemu $2
+    export_qemu "$2"
 else
     export_arch "$1"
 fi

--- a/dist/tools/esptools/install.sh
+++ b/dist/tools/esptools/install.sh
@@ -264,4 +264,4 @@ else
 fi
 
 echo "Use following command to extend the PATH variable:"
-echo ". $(dirname "$0")/export.sh $1"
+echo ". $(dirname "$0")/export.sh $1 $2"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The esptools/export.sh script has to be sourced, otherwise the exported variables are not persistent in the environment, rendering the script useless. The commit adds a check to the script that it runs in the correct environment and enhances the documentation to make it clearer that the "source" prefix command is important.

The documentation mentioned that, but I did not understand what "sourcing a script" means and I did not pay attention to the dot in front of the script. Sorry @gschorcht for not reading the documentation well enough 👀 


***Open for discussion:*** Should the script terminate before doing anything (as it does now) or should it print out the warning instead of the `Extending PATH by ...` message?

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure: Sourcing

Pre: Make sure your PATH variable does not contain the latest ESP SDK version yet.

Current situation on `master`: Calling the `dist/tools/esptools/export.sh` script without a `.` or `source` command in the front suggests to be adding the SDK path to the PATH variable, while it actually doesn't (well it does, but to the environment of the script, which is lost after the script terminates):
```
cbuec@W11nMate:~/RIOTstuff/riot-esp32c6/RIOT$ dist/tools/esptools/export.sh esp32h2
Extending PATH by /home/cbuec/.espressif/tools/riscv32-esp-elf/esp-14.2.0_20241119/riscv32-esp-elf/bin
To make this permanent, add this line to your ~/.bashrc or ~/.profile:
PATH=$PATH:/home/cbuec/.espressif/tools/riscv32-esp-elf/esp-14.2.0_20241119/riscv32-esp-elf/bin

cbuec@W11nMate:~/RIOTstuff/riot-esp32c6/RIOT$ dist/tools/esptools/export.sh esp32h2
Extending PATH by /home/cbuec/.espressif/tools/riscv32-esp-elf/esp-14.2.0_20241119/riscv32-esp-elf/bin
To make this permanent, add this line to your ~/.bashrc or ~/.profile:
PATH=$PATH:/home/cbuec/.espressif/tools/riscv32-esp-elf/esp-14.2.0_20241119/riscv32-esp-elf/bin
```

With this PR, an error message is printed:
```
cbuec@W11nMate:~/RIOTstuff/riot-esp32c6/RIOT$ dist/tools/esptools/export.sh esp32h2
Please run the script prefixed with the 'source' command.

cbuec@W11nMate:~/RIOTstuff/riot-esp32c6/RIOT$ source dist/tools/esptools/export.sh esp32h2
Extending PATH by /home/cbuec/.espressif/tools/riscv32-esp-elf/esp-14.2.0_20241119/riscv32-esp-elf/bin
To make this permanent, add this line to your ~/.bashrc or ~/.profile:
PATH=$PATH:/home/cbuec/.espressif/tools/riscv32-esp-elf/esp-14.2.0_20241119/riscv32-esp-elf/bin

cbuec@W11nMate:~/RIOTstuff/riot-esp32c6/RIOT$ source dist/tools/esptools/export.sh esp32h2
To make this permanent, add this line to your ~/.bashrc or ~/.profile:
PATH=$PATH:/home/cbuec/.espressif/tools/riscv32-esp-elf/esp-14.2.0_20241119/riscv32-esp-elf/bin
```

### Testing Procedure: Version Check

Testing procedure:

1) Make sure there is nothing related to the ESP-SDK in your PATH:
```
cbuec@W11nMate:~/RIOTstuff/riot-esp32c6/RIOT$ echo $PATH
/home/cbuec/.local/bin:/home/cbuec/.cargo/bin:/home/cbuec/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/wsl/lib
```

2) Export a platform of your choice:
```
cbuec@W11nMate:~/RIOTstuff/riot-esp32c6/RIOT$ . ./dist/tools/esptools/export.sh esp32s3
Extending PATH by /home/cbuec/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/bin
To make this permanent, add this line to your ~/.bashrc or ~/.profile:
PATH=$PATH:/home/cbuec/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/bin

cbuec@W11nMate:~/RIOTstuff/riot-esp32c6/RIOT$ echo $PATH
/home/cbuec/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/bin:/home/cbuec/.local/bin:/home/cbuec/.cargo/bin:/home/cbuec/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/wsl/lib
```

3) Manipulate the PATH so that the version number is older (or newer, doesn't matter).
```
cbuec@W11nMate:~/RIOTstuff/riot-esp32c6/RIOT$ PATH="/home/cbuec/.espressif/tools/xtensa-esp-elf/esp-12.0.0_2
0241119/xtensa-esp-elf/bin:/home/cbuec/.local/bin:/home/cbuec/.cargo/bin:/home/cbuec/.local/bin:/usr/local/s
bin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/wsl/lib"
```

4) Run the export script again and observe the warning message.
```
cbuec@W11nMate:~/RIOTstuff/riot-esp32c6/RIOT$ . ./dist/tools/esptools/export.sh esp32s3
Warning: PATH contains outdated entry: "/home/cbuec/.espressif/tools/xtensa-esp-elf/esp-12.0.0_20241119/xtensa-esp-elf/bin". Please check your ~/.bashrc or ~/.profile.
Extending PATH by /home/cbuec/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/bin
To make this permanent, add this line to your ~/.bashrc or ~/.profile:
PATH=$PATH:/home/cbuec/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/bin
```

5) Repeat with QEMU and GDB.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Came up in https://github.com/RIOT-OS/RIOT/pull/21616#issuecomment-3117189747

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
