### PR TITLE
boards: move licenses from headers to SPDX format (part3)

### DIFF
--- a/boards/derfmega128/Kconfig
+++ b/boards/derfmega128/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "derfmega128" if BOARD_DERFMEGA128

--- a/boards/derfmega128/include/board.h
+++ b/boards/derfmega128/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Alexander Chudov <chudov@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Alexander Chudov <chudov@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/derfmega128/include/periph_conf.h
+++ b/boards/derfmega128/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Alexander Chudov <chudov@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Alexander Chudov <chudov@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/derfmega256/Kconfig
+++ b/boards/derfmega256/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "derfmega256" if BOARD_DERFMEGA256

--- a/boards/derfmega256/include/board.h
+++ b/boards/derfmega256/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Alexander Chudov <chudov@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Alexander Chudov <chudov@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/derfmega256/include/eui_provider_params.h
+++ b/boards/derfmega256/include/eui_provider_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/derfmega256/include/periph_conf.h
+++ b/boards/derfmega256/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Alexander Chudov <chudov@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Alexander Chudov <chudov@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/dwm1001/Kconfig
+++ b/boards/dwm1001/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "dwm1001" if BOARD_DWM1001

--- a/boards/dwm1001/include/board.h
+++ b/boards/dwm1001/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/dwm1001/include/gpio_params.h
+++ b/boards/dwm1001/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Gregory Holder <gregory.holder@orange.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gregory Holder <gregory.holder@orange.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/dwm1001/include/periph_conf.h
+++ b/boards/dwm1001/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/e104-bt5010a-tb/Kconfig
+++ b/boards/e104-bt5010a-tb/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 Benjamin Valentin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 Benjamin Valentin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "e104-bt5010a-tb" if BOARD_E104_BT5010A_TB

--- a/boards/e104-bt5011a-tb/Kconfig
+++ b/boards/e104-bt5011a-tb/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 Benjamin Valentin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 Benjamin Valentin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "e104-bt5011a-tb" if BOARD_E104_BT5011A_TB

--- a/boards/e180-zg120b-tb/Kconfig
+++ b/boards/e180-zg120b-tb/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "e180-zg120b-tb" if BOARD_E180_ZG120B_TB

--- a/boards/e180-zg120b-tb/board.c
+++ b/boards/e180-zg120b-tb/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015-2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/e180-zg120b-tb/include/board.h
+++ b/boards/e180-zg120b-tb/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015-2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/e180-zg120b-tb/include/gpio_params.h
+++ b/boards/e180-zg120b-tb/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2020 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2020 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/e180-zg120b-tb/include/periph_conf.h
+++ b/boards/e180-zg120b-tb/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015-2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/ek-lm4f120xl/Kconfig
+++ b/boards/ek-lm4f120xl/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "ek-lm4f120xl" if BOARD_EK_LM4F120XL

--- a/boards/ek-lm4f120xl/include/board.h
+++ b/boards/ek-lm4f120xl/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Rakendra Thapa <rakendrathapa@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2015 Rakendra Thapa <rakendrathapa@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/ek-lm4f120xl/include/gpio_params.h
+++ b/boards/ek-lm4f120xl/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Benjamin Valentin <benpicco@googlemail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Benjamin Valentin <benpicco@googlemail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/ek-lm4f120xl/include/periph_conf.h
+++ b/boards/ek-lm4f120xl/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Rakendra Thapa <rakendrathapa@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2015 Rakendra Thapa <rakendrathapa@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-ethernet-kit-v1_0/Kconfig
+++ b/boards/esp32-ethernet-kit-v1_0/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-# Copyright (c) 2020 Google LLC
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2020 Google LLC
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32-ethernet-kit-v1_0" if BOARD_ESP32_ETHERNET_KIT_V1_0

--- a/boards/esp32-ethernet-kit-v1_0/include/board.h
+++ b/boards/esp32-ethernet-kit-v1_0/include/board.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- * Copyright (C) 2020 Google LLC
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-FileCopyrightText: 2020 Google LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-ethernet-kit-v1_0/include/gpio_params.h
+++ b/boards/esp32-ethernet-kit-v1_0/include/gpio_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- * Copyright (C) 2020 Google LLC
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-FileCopyrightText: 2020 Google LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-ethernet-kit-v1_0/include/periph_conf.h
+++ b/boards/esp32-ethernet-kit-v1_0/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- * Copyright (C) 2020 Google LLC
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-FileCopyrightText: 2020 Google LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-ethernet-kit-v1_1/Kconfig
+++ b/boards/esp32-ethernet-kit-v1_1/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-# Copyright (c) 2020 Google LLC
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2020 Google LLC
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32-ethernet-kit-v1_1" if BOARD_ESP32_ETHERNET_KIT_V1_1

--- a/boards/esp32-ethernet-kit-v1_2/Kconfig
+++ b/boards/esp32-ethernet-kit-v1_2/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-# Copyright (c) 2020 Google LLC
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2020 Google LLC
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32-ethernet-kit-v1_2" if BOARD_ESP32_ETHERNET_KIT_V1_2

--- a/boards/esp32-heltec-lora32-v2/Kconfig
+++ b/boards/esp32-heltec-lora32-v2/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32-heltec-lora32-v2" if BOARD_ESP32_HELTEC_LORA32_V2

--- a/boards/esp32-heltec-lora32-v2/include/arduino_iomap.h
+++ b/boards/esp32-heltec-lora32-v2/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2019 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-heltec-lora32-v2/include/board.h
+++ b/boards/esp32-heltec-lora32-v2/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-heltec-lora32-v2/include/gpio_params.h
+++ b/boards/esp32-heltec-lora32-v2/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-heltec-lora32-v2/include/periph_conf.h
+++ b/boards/esp32-heltec-lora32-v2/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-mh-et-live-minikit/Kconfig
+++ b/boards/esp32-mh-et-live-minikit/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32-mh-et-live-minikit" if BOARD_ESP32_MH_ET_LIVE_MINIKIT

--- a/boards/esp32-mh-et-live-minikit/include/arduino_iomap.h
+++ b/boards/esp32-mh-et-live-minikit/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-mh-et-live-minikit/include/board.h
+++ b/boards/esp32-mh-et-live-minikit/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-mh-et-live-minikit/include/board_modules.h
+++ b/boards/esp32-mh-et-live-minikit/include/board_modules.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-mh-et-live-minikit/include/gpio_params.h
+++ b/boards/esp32-mh-et-live-minikit/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-mh-et-live-minikit/include/periph_conf.h
+++ b/boards/esp32-mh-et-live-minikit/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-olimex-evb/Kconfig
+++ b/boards/esp32-olimex-evb/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32-olimex-evb" if BOARD_ESP32_OLIMEX_EVB

--- a/boards/esp32-olimex-evb/include/arduino_iomap.h
+++ b/boards/esp32-olimex-evb/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-olimex-evb/include/board.h
+++ b/boards/esp32-olimex-evb/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-olimex-evb/include/gpio_params.h
+++ b/boards/esp32-olimex-evb/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-olimex-evb/include/periph_conf.h
+++ b/boards/esp32-olimex-evb/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-ttgo-t-beam/Kconfig
+++ b/boards/esp32-ttgo-t-beam/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32-ttgo-t-beam" if BOARD_ESP32_TTGO_T_BEAM

--- a/boards/esp32-ttgo-t-beam/board.c
+++ b/boards/esp32-ttgo-t-beam/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/esp32-ttgo-t-beam/include/arduino_iomap.h
+++ b/boards/esp32-ttgo-t-beam/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Yegor Yefremov
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Yegor Yefremov
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-ttgo-t-beam/include/board.h
+++ b/boards/esp32-ttgo-t-beam/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Yegor Yefremov
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Yegor Yefremov
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-ttgo-t-beam/include/gpio_params.h
+++ b/boards/esp32-ttgo-t-beam/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Yegor Yefremov
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Yegor Yefremov
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-ttgo-t-beam/include/periph_conf.h
+++ b/boards/esp32-ttgo-t-beam/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Yegor Yefremov
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Yegor Yefremov
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-wemos-d1-r32/Kconfig
+++ b/boards/esp32-wemos-d1-r32/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (C) 2025 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2025 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32-wemos-d1-r2" if BOARD_ESP32_WEMOS_D1_R32

--- a/boards/esp32-wemos-d1-r32/include/arduino_iomap.h
+++ b/boards/esp32-wemos-d1-r32/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2025 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-wemos-d1-r32/include/board.h
+++ b/boards/esp32-wemos-d1-r32/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-wemos-d1-r32/include/gpio_params.h
+++ b/boards/esp32-wemos-d1-r32/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-wemos-d1-r32/include/periph_conf.h
+++ b/boards/esp32-wemos-d1-r32/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-wemos-lolin-d32-pro/Kconfig
+++ b/boards/esp32-wemos-lolin-d32-pro/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32-wemos-lolin-d32-pro" if BOARD_ESP32_WEMOS_LOLIN_D32_PRO

--- a/boards/esp32-wemos-lolin-d32-pro/include/arduino_iomap.h
+++ b/boards/esp32-wemos-lolin-d32-pro/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-wemos-lolin-d32-pro/include/board.h
+++ b/boards/esp32-wemos-lolin-d32-pro/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-wemos-lolin-d32-pro/include/gpio_params.h
+++ b/boards/esp32-wemos-lolin-d32-pro/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-wemos-lolin-d32-pro/include/periph_conf.h
+++ b/boards/esp32-wemos-lolin-d32-pro/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-wroom-32/Kconfig
+++ b/boards/esp32-wroom-32/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32-wroom-32" if BOARD_ESP32_WROOM_32

--- a/boards/esp32-wroom-32/include/arduino_iomap.h
+++ b/boards/esp32-wroom-32/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-wroom-32/include/board.h
+++ b/boards/esp32-wroom-32/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-wroom-32/include/gpio_params.h
+++ b/boards/esp32-wroom-32/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-wroom-32/include/periph_conf.h
+++ b/boards/esp32-wroom-32/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-wrover-kit/Kconfig
+++ b/boards/esp32-wrover-kit/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32-wrover-kit" if BOARD_ESP32_WROVER_KIT

--- a/boards/esp32-wrover-kit/board.c
+++ b/boards/esp32-wrover-kit/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/esp32-wrover-kit/include/arduino_iomap.h
+++ b/boards/esp32-wrover-kit/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-wrover-kit/include/board.h
+++ b/boards/esp32-wrover-kit/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-wrover-kit/include/gpio_params.h
+++ b/boards/esp32-wrover-kit/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32-wrover-kit/include/periph_conf.h
+++ b/boards/esp32-wrover-kit/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32c3-devkit/Kconfig
+++ b/boards/esp32c3-devkit/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-#               2022 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2022 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32c3-devkit" if BOARD_ESP32C3_DEVKIT

--- a/boards/esp32c3-devkit/include/arduino_iomap.h
+++ b/boards/esp32c3-devkit/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32c3-devkit/include/board.h
+++ b/boards/esp32c3-devkit/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32c3-devkit/include/gpio_params.h
+++ b/boards/esp32c3-devkit/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32c3-devkit/include/periph_conf.h
+++ b/boards/esp32c3-devkit/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32c3-wemos-mini/Kconfig
+++ b/boards/esp32c3-wemos-mini/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-#               2022 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2022 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32c3-wemos-mini" if BOARD_ESP32C3_WEMOS_MINI

--- a/boards/esp32c3-wemos-mini/include/arduino_iomap.h
+++ b/boards/esp32c3-wemos-mini/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32c3-wemos-mini/include/board.h
+++ b/boards/esp32c3-wemos-mini/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32c3-wemos-mini/include/gpio_params.h
+++ b/boards/esp32c3-wemos-mini/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32c3-wemos-mini/include/periph_conf.h
+++ b/boards/esp32c3-wemos-mini/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32h2-devkit/Kconfig
+++ b/boards/esp32h2-devkit/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2025 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2025 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32h2-devkit" if BOARD_ESP32H2_DEVKIT

--- a/boards/esp32h2-devkit/include/arduino_iomap.h
+++ b/boards/esp32h2-devkit/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2025 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32h2-devkit/include/board.h
+++ b/boards/esp32h2-devkit/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32h2-devkit/include/gpio_params.h
+++ b/boards/esp32h2-devkit/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32h2-devkit/include/periph_conf.h
+++ b/boards/esp32h2-devkit/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s2-devkit/Kconfig
+++ b/boards/esp32s2-devkit/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-#               2022 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2022 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32s2-devkit" if BOARD_ESP32S2_DEVKIT

--- a/boards/esp32s2-devkit/include/arduino_iomap.h
+++ b/boards/esp32s2-devkit/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s2-devkit/include/board.h
+++ b/boards/esp32s2-devkit/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s2-devkit/include/gpio_params.h
+++ b/boards/esp32s2-devkit/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s2-devkit/include/periph_conf.h
+++ b/boards/esp32s2-devkit/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s2-lilygo-ttgo-t8/Kconfig
+++ b/boards/esp32s2-lilygo-ttgo-t8/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-#               2022 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2022 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32s2-lilygo-ttgo-t8" if BOARD_ESP32S2_LILYGO_TTGO_T8

--- a/boards/esp32s2-lilygo-ttgo-t8/board.c
+++ b/boards/esp32s2-lilygo-ttgo-t8/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/esp32s2-lilygo-ttgo-t8/include/arduino_iomap.h
+++ b/boards/esp32s2-lilygo-ttgo-t8/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s2-lilygo-ttgo-t8/include/board.h
+++ b/boards/esp32s2-lilygo-ttgo-t8/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s2-lilygo-ttgo-t8/include/gpio_params.h
+++ b/boards/esp32s2-lilygo-ttgo-t8/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s2-lilygo-ttgo-t8/include/periph_conf.h
+++ b/boards/esp32s2-lilygo-ttgo-t8/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s2-wemos-mini/Kconfig
+++ b/boards/esp32s2-wemos-mini/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2022 Benjamin Valentin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2022 Benjamin Valentin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32s2-wemos-mini" if BOARD_ESP32S2_WEMOS_MINI

--- a/boards/esp32s2-wemos-mini/include/board.h
+++ b/boards/esp32s2-wemos-mini/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s2-wemos-mini/include/gpio_params.h
+++ b/boards/esp32s2-wemos-mini/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s2-wemos-mini/include/periph_conf.h
+++ b/boards/esp32s2-wemos-mini/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s3-box/Kconfig
+++ b/boards/esp32s3-box/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-#               2023 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2023 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32s3-box" if BOARD_ESP32S3_BOX

--- a/boards/esp32s3-box/board.c
+++ b/boards/esp32s3-box/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/esp32s3-box/include/board.h
+++ b/boards/esp32s3-box/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s3-box/include/gpio_params.h
+++ b/boards/esp32s3-box/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s3-box/include/periph_conf.h
+++ b/boards/esp32s3-box/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s3-devkit/Kconfig
+++ b/boards/esp32s3-devkit/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-#               2022 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2022 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32s3-devkit" if BOARD_ESP32S3_DEVKIT

--- a/boards/esp32s3-devkit/include/arduino_iomap.h
+++ b/boards/esp32s3-devkit/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s3-devkit/include/board.h
+++ b/boards/esp32s3-devkit/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s3-devkit/include/gpio_params.h
+++ b/boards/esp32s3-devkit/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s3-devkit/include/periph_conf.h
+++ b/boards/esp32s3-devkit/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s3-pros3/Kconfig
+++ b/boards/esp32s3-pros3/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-#               2023 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2023 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32s3-pros3" if BOARD_ESP32S3_PROS3

--- a/boards/esp32s3-pros3/include/arduino_iomap.h
+++ b/boards/esp32s3-pros3/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s3-pros3/include/board.h
+++ b/boards/esp32s3-pros3/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s3-pros3/include/gpio_params.h
+++ b/boards/esp32s3-pros3/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s3-pros3/include/periph_conf.h
+++ b/boards/esp32s3-pros3/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s3-usb-otg/Kconfig
+++ b/boards/esp32s3-usb-otg/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-#               2022 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2022 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32s3-usb-otg" if BOARD_ESP32S3_USB_OTG

--- a/boards/esp32s3-usb-otg/board.c
+++ b/boards/esp32s3-usb-otg/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/esp32s3-usb-otg/include/board.h
+++ b/boards/esp32s3-usb-otg/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s3-usb-otg/include/gpio_params.h
+++ b/boards/esp32s3-usb-otg/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s3-usb-otg/include/periph_conf.h
+++ b/boards/esp32s3-usb-otg/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s3-wt32-sc01-plus/Kconfig
+++ b/boards/esp32s3-wt32-sc01-plus/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-#               2023 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2023 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp32s3-wt32-sc01-plus" if BOARD_ESP32S3_WT32_SC01_PLUS

--- a/boards/esp32s3-wt32-sc01-plus/board.c
+++ b/boards/esp32s3-wt32-sc01-plus/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/esp32s3-wt32-sc01-plus/include/board.h
+++ b/boards/esp32s3-wt32-sc01-plus/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s3-wt32-sc01-plus/include/gpio_params.h
+++ b/boards/esp32s3-wt32-sc01-plus/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp32s3-wt32-sc01-plus/include/periph_conf.h
+++ b/boards/esp32s3-wt32-sc01-plus/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp8266-esp-12x/Kconfig
+++ b/boards/esp8266-esp-12x/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp8266-esp-12x" if BOARD_ESP8266_ESP_12X

--- a/boards/esp8266-esp-12x/include/arduino_iomap.h
+++ b/boards/esp8266-esp-12x/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp8266-esp-12x/include/board.h
+++ b/boards/esp8266-esp-12x/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp8266-esp-12x/include/gpio_params.h
+++ b/boards/esp8266-esp-12x/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp8266-esp-12x/include/periph_conf.h
+++ b/boards/esp8266-esp-12x/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp8266-olimex-mod/Kconfig
+++ b/boards/esp8266-olimex-mod/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp8266-olimex-mod" if BOARD_ESP8266_OLIMEX_MOD

--- a/boards/esp8266-olimex-mod/include/arduino_iomap.h
+++ b/boards/esp8266-olimex-mod/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp8266-olimex-mod/include/board.h
+++ b/boards/esp8266-olimex-mod/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp8266-olimex-mod/include/gpio_params.h
+++ b/boards/esp8266-olimex-mod/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp8266-olimex-mod/include/periph_conf.h
+++ b/boards/esp8266-olimex-mod/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp8266-sparkfun-thing/Kconfig
+++ b/boards/esp8266-sparkfun-thing/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "esp8266-sparkfun-thing" if BOARD_ESP8266_SPARKFUN_THING

--- a/boards/esp8266-sparkfun-thing/include/arduino_iomap.h
+++ b/boards/esp8266-sparkfun-thing/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp8266-sparkfun-thing/include/board.h
+++ b/boards/esp8266-sparkfun-thing/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp8266-sparkfun-thing/include/gpio_params.h
+++ b/boards/esp8266-sparkfun-thing/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/esp8266-sparkfun-thing/include/periph_conf.h
+++ b/boards/esp8266-sparkfun-thing/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/f4vi1/Kconfig
+++ b/boards/f4vi1/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "f4vi1" if BOARD_F4VI1

--- a/boards/f4vi1/include/board.h
+++ b/boards/f4vi1/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/f4vi1/include/periph_conf.h
+++ b/boards/f4vi1/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/feather-m0-lora/Kconfig
+++ b/boards/feather-m0-lora/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "feather-m0-lora" if BOARD_FEATHER_M0_LORA

--- a/boards/feather-m0-wifi/Kconfig
+++ b/boards/feather-m0-wifi/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "feather-m0-wifi" if BOARD_FEATHER_M0_WIFI

--- a/boards/feather-m0/Kconfig
+++ b/boards/feather-m0/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "feather-m0" if BOARD_FEATHER_M0

--- a/boards/feather-m0/include/arduino_iomap.h
+++ b/boards/feather-m0/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 J. David Ibáñez <jdavid.ibp@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 J. David Ibáñez <jdavid.ibp@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/feather-m0/include/board.h
+++ b/boards/feather-m0/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/feather-m0/include/gpio_params.h
+++ b/boards/feather-m0/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/feather-m0/include/sdcard_spi_params.h
+++ b/boards/feather-m0/include/sdcard_spi_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/firefly/Kconfig
+++ b/boards/firefly/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "firefly" if BOARD_FIREFLY

--- a/boards/firefly/include/adc_params.h
+++ b/boards/firefly/include/adc_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/firefly/include/board.h
+++ b/boards/firefly/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 DAI Labor Technische Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 DAI Labor Technische Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/firefly/include/gpio_params.h
+++ b/boards/firefly/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 DAI Labor Technische Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 DAI Labor Technische Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/firefly/include/periph_conf.h
+++ b/boards/firefly/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 DAI Labor Technische Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 DAI Labor Technische Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/frdm-k22f/Kconfig
+++ b/boards/frdm-k22f/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "frdm-k22f" if BOARD_FRDM_K22F

--- a/boards/frdm-k22f/include/adc_params.h
+++ b/boards/frdm-k22f/include/adc_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/frdm-k22f/include/board.h
+++ b/boards/frdm-k22f/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/frdm-k22f/include/gpio_params.h
+++ b/boards/frdm-k22f/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/frdm-k22f/include/periph_conf.h
+++ b/boards/frdm-k22f/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Eistec AB
- *               2021-2023 Hugues Larrive
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Eistec AB
+ * SPDX-FileCopyrightText: 2021-2023 Hugues Larrive
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/frdm-k64f/Kconfig
+++ b/boards/frdm-k64f/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "frdm-k64f" if BOARD_FRDM_K64F

--- a/boards/frdm-k64f/board.c
+++ b/boards/frdm-k64f/board.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- * Copyright (C) 2014 PHYTEC Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2014 PHYTEC Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/frdm-k64f/include/adc_params.h
+++ b/boards/frdm-k64f/include/adc_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/frdm-k64f/include/board.h
+++ b/boards/frdm-k64f/include/board.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- * Copyright (C) 2015 PHYTEC Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 PHYTEC Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *               2015 PHYTEC Messtechnik GmbH
- *               2023 Hugues Larrive
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 PHYTEC Messtechnik GmbH
+ * SPDX-FileCopyrightText: 2023 Hugues Larrive
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/frdm-kl43z/Kconfig
+++ b/boards/frdm-kl43z/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 Benjamin Valentin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 Benjamin Valentin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "frdm-kl43z" if BOARD_FRDM_KL43Z

--- a/boards/frdm-kl43z/include/adc_params.h
+++ b/boards/frdm-kl43z/include/adc_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2018 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/frdm-kl43z/include/board.h
+++ b/boards/frdm-kl43z/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2018 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/frdm-kl43z/include/gpio_params.h
+++ b/boards/frdm-kl43z/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2018 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/frdm-kl43z/include/periph_conf.h
+++ b/boards/frdm-kl43z/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2018 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/frdm-kw41z/Kconfig
+++ b/boards/frdm-kw41z/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "frdm-kw41z" if BOARD_FRDM_KW41Z

--- a/boards/frdm-kw41z/include/adc_params.h
+++ b/boards/frdm-kw41z/include/adc_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/frdm-kw41z/include/board.h
+++ b/boards/frdm-kw41z/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/frdm-kw41z/include/gpio_params.h
+++ b/boards/frdm-kw41z/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 SKF AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 SKF AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/frdm-kw41z/include/periph_conf.h
+++ b/boards/frdm-kw41z/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/gba_cartridge/Kconfig
+++ b/boards/gba_cartridge/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2023 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2023 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "gba" if BOARD_GBA

--- a/boards/gba_cartridge/include/board.h
+++ b/boards/gba_cartridge/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Bennet Blischke <bennet.blischke@haw-hamburg.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2023 Bennet Blischke <bennet.blischke@haw-hamburg.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/gba_cartridge/include/periph_conf.h
+++ b/boards/gba_cartridge/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Bennet Blischke <bennet.blischke@haw-hamburg.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2023 Bennet Blischke <bennet.blischke@haw-hamburg.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/gd32vf103c-start/include/arduino_iomap.h
+++ b/boards/gd32vf103c-start/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/gd32vf103c-start/include/board.h
+++ b/boards/gd32vf103c-start/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/gd32vf103c-start/include/gpio_params.h
+++ b/boards/gd32vf103c-start/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/gd32vf103c-start/include/periph_conf.h
+++ b/boards/gd32vf103c-start/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht <gunar@schorcht.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht <gunar@schorcht.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/generic-cc2538-cc2592-dk/Kconfig
+++ b/boards/generic-cc2538-cc2592-dk/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "generic-cc2538-cc2592-dk" if BOARD_GENERIC_CC2538_CC2592_DK

--- a/boards/generic-cc2538-cc2592-dk/include/board.h
+++ b/boards/generic-cc2538-cc2592-dk/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/generic-cc2538-cc2592-dk/include/gpio_params.h
+++ b/boards/generic-cc2538-cc2592-dk/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/generic-cc2538-cc2592-dk/include/periph_conf.h
+++ b/boards/generic-cc2538-cc2592-dk/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/hamilton/Kconfig
+++ b/boards/hamilton/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "hamilton" if BOARD_HAMILTON

--- a/boards/hamilton/include/board.h
+++ b/boards/hamilton/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 UC Berkeley
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 UC Berkeley
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/hamilton/include/gpio_params.h
+++ b/boards/hamilton/include/gpio_params.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *               2015 Kaspar Schleiser <kaspar@schleiser.de>
- *               2016 UC Berkeley
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2016 UC Berkeley
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014-2015 Freie Universität Berlin
- *               2016 UC Berkeley
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016 UC Berkeley
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/hifive1/Kconfig
+++ b/boards/hifive1/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "hifive1" if BOARD_HIFIVE1

--- a/boards/hifive1/include/board.h
+++ b/boards/hifive1/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Ken Rabold
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Ken Rabold
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/hifive1/include/periph_conf.h
+++ b/boards/hifive1/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Ken Rabold
- *               2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Ken Rabold
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/hifive1b/Kconfig
+++ b/boards/hifive1b/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "hifive1b" if BOARD_HIFIVE1B

--- a/boards/hifive1b/include/arduino_iomap.h
+++ b/boards/hifive1b/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/hifive1b/include/board.h
+++ b/boards/hifive1b/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Ken Rabold
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Ken Rabold
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/hifive1b/include/periph_conf.h
+++ b/boards/hifive1b/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2019 Ken Rabold
- *               2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2019 Ken Rabold
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/hip-badge/Kconfig
+++ b/boards/hip-badge/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2023 Benjamin Valentin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2023 Benjamin Valentin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "hip-badge" if BOARD_HIP_BADGE

--- a/boards/hip-badge/include/board.h
+++ b/boards/hip-badge/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/hip-badge/include/gpio_params.h
+++ b/boards/hip-badge/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/hip-badge/include/periph_conf.h
+++ b/boards/hip-badge/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/i-nucleo-lrwan1/Kconfig
+++ b/boards/i-nucleo-lrwan1/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "i-nucleo-lrwan1" if BOARD_I_NUCLEO_LRWAN1

--- a/boards/i-nucleo-lrwan1/include/board.h
+++ b/boards/i-nucleo-lrwan1/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/i-nucleo-lrwan1/include/periph_conf.h
+++ b/boards/i-nucleo-lrwan1/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/ikea-tradfri/Kconfig
+++ b/boards/ikea-tradfri/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "ikea-tradfri" if BOARD_IKEA_TRADFRI

--- a/boards/ikea-tradfri/board.c
+++ b/boards/ikea-tradfri/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017-2020 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017-2020 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/ikea-tradfri/include/board.h
+++ b/boards/ikea-tradfri/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017-2020 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017-2020 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/ikea-tradfri/include/gpio_params.h
+++ b/boards/ikea-tradfri/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017-2020 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017-2020 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017-2020 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017-2020 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/im880b/Kconfig
+++ b/boards/im880b/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "im880b" if BOARD_IM880B

--- a/boards/im880b/include/board.h
+++ b/boards/im880b/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/im880b/include/periph_conf.h
+++ b/boards/im880b/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/iotlab-a8-m3/Kconfig
+++ b/boards/iotlab-a8-m3/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "iotlab-a8-m3" if BOARD_IOTLAB_A8_M3

--- a/boards/iotlab-a8-m3/include/board.h
+++ b/boards/iotlab-a8-m3/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014-2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/iotlab-a8-m3/include/periph_conf.h
+++ b/boards/iotlab-a8-m3/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/iotlab-m3/Kconfig
+++ b/boards/iotlab-m3/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "iotlab-m3" if BOARD_IOTLAB_M3

--- a/boards/iotlab-m3/include/board.h
+++ b/boards/iotlab-m3/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014-2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/iotlab-m3/include/periph_conf.h
+++ b/boards/iotlab-m3/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/iotlab-m3/mtd.c
+++ b/boards/iotlab-m3/mtd.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/limifrog-v1/Kconfig
+++ b/boards/limifrog-v1/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "limifrog-v1" if BOARD_LIMIFROG_V1

--- a/boards/limifrog-v1/include/board.h
+++ b/boards/limifrog-v1/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Hamburg University of Applied Sciences
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2015 Hamburg University of Applied Sciences
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/limifrog-v1/include/periph_conf.h
+++ b/boards/limifrog-v1/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Hamburg University of Applied Sciences
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2015 Hamburg University of Applied Sciences
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/lobaro-lorabox/Kconfig
+++ b/boards/lobaro-lorabox/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "lobaro-lorabox" if BOARD_LOBARO_LORABOX

--- a/boards/lobaro-lorabox/board.c
+++ b/boards/lobaro-lorabox/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/lobaro-lorabox/include/board.h
+++ b/boards/lobaro-lorabox/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/lobaro-lorabox/include/gpio_params.h
+++ b/boards/lobaro-lorabox/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/lobaro-lorabox/include/periph_conf.h
+++ b/boards/lobaro-lorabox/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *               2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/lora-e5-dev/Kconfig
+++ b/boards/lora-e5-dev/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "lora-e5-dev" if BOARD_LORA_E5_DEV

--- a/boards/lora-e5-dev/board.c
+++ b/boards/lora-e5-dev/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/lora-e5-dev/include/arduino_iomap.h
+++ b/boards/lora-e5-dev/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 J. David Ibáñez <jdavid.ibp@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 J. David Ibáñez <jdavid.ibp@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/lora-e5-dev/include/board.h
+++ b/boards/lora-e5-dev/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/lora-e5-dev/include/gpio_params.h
+++ b/boards/lora-e5-dev/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/lora-e5-dev/include/periph_conf.h
+++ b/boards/lora-e5-dev/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/lsn50/Kconfig
+++ b/boards/lsn50/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "lsn50" if BOARD_LSN50

--- a/boards/lsn50/include/board.h
+++ b/boards/lsn50/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/lsn50/include/periph_conf.h
+++ b/boards/lsn50/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/maple-mini/Kconfig
+++ b/boards/maple-mini/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "maple-mini" if BOARD_MAPLE_MINI

--- a/boards/maple-mini/include/board.h
+++ b/boards/maple-mini/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Frits Kuipers
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 Frits Kuipers
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/maple-mini/include/gpio_params.h
+++ b/boards/maple-mini/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Frits Kuipers
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Frits Kuipers
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/maple-mini/include/periph_conf.h
+++ b/boards/maple-mini/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Frits Kuipers
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Frits Kuipers
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/mbed_lpc1768/Kconfig
+++ b/boards/mbed_lpc1768/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "mbed_lpc1768" if BOARD_MBED_LPC1768

--- a/boards/mbed_lpc1768/board.c
+++ b/boards/mbed_lpc1768/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/mbed_lpc1768/include/board.h
+++ b/boards/mbed_lpc1768/include/board.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 INRIA
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 INRIA
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/mbed_lpc1768/include/gpio_params.h
+++ b/boards/mbed_lpc1768/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/mbed_lpc1768/include/periph_conf.h
+++ b/boards/mbed_lpc1768/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/mcb2388/Kconfig
+++ b/boards/mcb2388/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "mcb2388" if BOARD_MCB2388

--- a/boards/mcb2388/board_init.c
+++ b/boards/mcb2388/board_init.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Beuth Hochschule für Technik Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Beuth Hochschule für Technik Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/mcb2388/include/adc_params.h
+++ b/boards/mcb2388/include/adc_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Beuth Hochschule für Technik Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Beuth Hochschule für Technik Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/mcb2388/include/board.h
+++ b/boards/mcb2388/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Beuth Hochschule für Technik Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Beuth Hochschule für Technik Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/mcb2388/include/gpio_params.h
+++ b/boards/mcb2388/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Beuth Hochschule für Technik Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Beuth Hochschule für Technik Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/mcb2388/include/periph_conf.h
+++ b/boards/mcb2388/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Beuth Hochschule für Technik Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2019 Beuth Hochschule für Technik Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/mega-xplained/Kconfig
+++ b/boards/mega-xplained/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "mega-xplained" if BOARD_MEGA_XPLAINED

--- a/boards/mega-xplained/include/adc_params.h
+++ b/boards/mega-xplained/include/adc_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *               2018 Matthew Blue <matthew.blue.neuro@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-FileCopyrightText: 2018 Matthew Blue <matthew.blue.neuro@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/mega-xplained/include/board.h
+++ b/boards/mega-xplained/include/board.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
- *               2016 Laurent Navet <laurent.navet@gmail.com>
- *               2018 Matthew Blue <matthew.blue.neuro@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ * SPDX-FileCopyrightText: 2016 Laurent Navet <laurent.navet@gmail.com>
+ * SPDX-FileCopyrightText: 2018 Matthew Blue <matthew.blue.neuro@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/mega-xplained/include/gpio_params.h
+++ b/boards/mega-xplained/include/gpio_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2018 Matthew Blue <matthew.blue.neuro@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 Matthew Blue <matthew.blue.neuro@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/mega-xplained/include/mega-xplained_pinmap.h
+++ b/boards/mega-xplained/include/mega-xplained_pinmap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Matthew Blue <matthew.blue.neuro@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Matthew Blue <matthew.blue.neuro@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/mega-xplained/include/periph_conf.h
+++ b/boards/mega-xplained/include/periph_conf.h
@@ -1,13 +1,10 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
- *               2016 Laurent Navet <laurent.navet@gmail.com>
- *               2017 HAW Hamburg, Dimitri Nahm
- *               2018 Matthew Blue <matthew.blue.neuro@gmail.com>
- *               2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ * SPDX-FileCopyrightText: 2016 Laurent Navet <laurent.navet@gmail.com>
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg, Dimitri Nahm
+ * SPDX-FileCopyrightText: 2018 Matthew Blue <matthew.blue.neuro@gmail.com>
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/microbit-v2/Kconfig
+++ b/boards/microbit-v2/Kconfig
@@ -1,4 +1,5 @@
-# Copyright (c) 2021 Inria
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level

--- a/boards/microbit-v2/include/board.h
+++ b/boards/microbit-v2/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/microbit-v2/include/gpio_params.h
+++ b/boards/microbit-v2/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/microbit-v2/include/periph_conf.h
+++ b/boards/microbit-v2/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/microbit/Kconfig
+++ b/boards/microbit/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "microbit" if BOARD_MICROBIT

--- a/boards/microbit/include/board.h
+++ b/boards/microbit/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/microbit/include/gpio_params.h
+++ b/boards/microbit/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/microbit/include/periph_conf.h
+++ b/boards/microbit/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/microduino-corerf/Kconfig
+++ b/boards/microduino-corerf/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 
 config BOARD

--- a/boards/microduino-corerf/include/board.h
+++ b/boards/microduino-corerf/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/microduino-corerf/include/periph_conf.h
+++ b/boards/microduino-corerf/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/msb-430/Kconfig
+++ b/boards/msb-430/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "msb-430" if BOARD_MSB_430

--- a/boards/msb-430/include/board.h
+++ b/boards/msb-430/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright 2009, Freie Universitaet Berlin (FUB). All rights reserved.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2009 Freie Universitaet Berlin (FUB)
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/msb-430/include/periph_conf.h
+++ b/boards/msb-430/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 INRIA
- *               2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 INRIA
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/msb-430h/Kconfig
+++ b/boards/msb-430h/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "msb-430h" if BOARD_MSB_430H

--- a/boards/msb-430h/include/board.h
+++ b/boards/msb-430h/include/board.h
@@ -1,9 +1,7 @@
 /*
- * Copyright 2009, 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2009 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/msb-430h/include/periph_conf.h
+++ b/boards/msb-430h/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 INRIA
- *               2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 INRIA
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/msba2/Kconfig
+++ b/boards/msba2/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "msba2" if BOARD_MSBA2

--- a/boards/msba2/board_init.c
+++ b/boards/msba2/board_init.c
@@ -1,10 +1,6 @@
 /*
- * main.c - Main function of the SRF02 ultrasonic sensor project.
- * Copyright (C) 2013 Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/msba2/include/board.h
+++ b/boards/msba2/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/msba2/include/periph_conf.h
+++ b/boards/msba2/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/msbiot/Kconfig
+++ b/boards/msbiot/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "msbiot" if BOARD_MSBIOT

--- a/boards/msbiot/board.c
+++ b/boards/msbiot/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/msbiot/include/gpio_params.h
+++ b/boards/msbiot/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/mulle/Kconfig
+++ b/boards/mulle/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "mulle" if BOARD_MULLE

--- a/boards/mulle/board.c
+++ b/boards/mulle/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2017 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014-2017 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/mulle/include/adc_params.h
+++ b/boards/mulle/include/adc_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/mulle/include/board.h
+++ b/boards/mulle/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/mulle/include/gpio_params.h
+++ b/boards/mulle/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/mulle/include/mulle-nvram.h
+++ b/boards/mulle/include/mulle-nvram.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2015 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Eistec AB
- *               2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2015 Eistec AB
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/native32/Kconfig
+++ b/boards/native32/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "native32" if BOARD_NATIVE32

--- a/boards/native64/Kconfig
+++ b/boards/native64/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "native64" if BOARD_NATIVE64

--- a/boards/nrf51dk/Kconfig
+++ b/boards/nrf51dk/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nrf51dk" if BOARD_NRF51DK

--- a/boards/nrf51dk/include/arduino_iomap.h
+++ b/boards/nrf51dk/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf51dk/include/board.h
+++ b/boards/nrf51dk/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf51dk/include/gpio_params.h
+++ b/boards/nrf51dk/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf51dk/include/periph_conf.h
+++ b/boards/nrf51dk/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf51dongle/Kconfig
+++ b/boards/nrf51dongle/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nrf51dongle" if BOARD_NRF51DONGLE

--- a/boards/nrf51dongle/include/board.h
+++ b/boards/nrf51dongle/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf51dongle/include/periph_conf.h
+++ b/boards/nrf51dongle/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52832-mdk/Kconfig
+++ b/boards/nrf52832-mdk/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nrf52832-mdk" if BOARD_NRF52832_MDK

--- a/boards/nrf52832-mdk/include/board.h
+++ b/boards/nrf52832-mdk/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52832-mdk/include/gpio_params.h
+++ b/boards/nrf52832-mdk/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52832-mdk/include/periph_conf.h
+++ b/boards/nrf52832-mdk/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52840-mdk-dongle/Kconfig
+++ b/boards/nrf52840-mdk-dongle/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nrf52840-mdk-dongle" if BOARD_NRF52840_MDK_DONGLE

--- a/boards/nrf52840-mdk-dongle/include/board.h
+++ b/boards/nrf52840-mdk-dongle/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52840-mdk-dongle/include/gpio_params.h
+++ b/boards/nrf52840-mdk-dongle/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52840-mdk-dongle/include/periph_conf.h
+++ b/boards/nrf52840-mdk-dongle/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52840-mdk-dongle/include/pwm_params.h
+++ b/boards/nrf52840-mdk-dongle/include/pwm_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52840-mdk-dongle/reset.c
+++ b/boards/nrf52840-mdk-dongle/reset.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/nrf52840-mdk/Kconfig
+++ b/boards/nrf52840-mdk/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nrf52840-mdk" if BOARD_NRF52840_MDK

--- a/boards/nrf52840-mdk/include/board.h
+++ b/boards/nrf52840-mdk/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52840-mdk/include/gpio_params.h
+++ b/boards/nrf52840-mdk/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52840-mdk/include/periph_conf.h
+++ b/boards/nrf52840-mdk/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52840dk/Kconfig
+++ b/boards/nrf52840dk/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nrf52840dk" if BOARD_NRF52840DK

--- a/boards/nrf52840dk/include/arduino_iomap.h
+++ b/boards/nrf52840dk/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52840dk/include/board.h
+++ b/boards/nrf52840dk/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52840dk/include/periph_conf.h
+++ b/boards/nrf52840dk/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52840dk/mtd.c
+++ b/boards/nrf52840dk/mtd.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/nrf52840dongle/Kconfig
+++ b/boards/nrf52840dongle/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nrf52840dongle" if BOARD_NRF52840DONGLE

--- a/boards/nrf52840dongle/include/board.h
+++ b/boards/nrf52840dongle/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Christian Amsüss <chrysn@fsfe.org>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Christian Amsüss <chrysn@fsfe.org>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52840dongle/include/gpio_params.h
+++ b/boards/nrf52840dongle/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Christian Amsüss <chrysn@fsfe.org>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Christian Amsüss <chrysn@fsfe.org>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52840dongle/include/periph_conf.h
+++ b/boards/nrf52840dongle/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2019 Christian Amsüss <chrysn@fsfe.org>
- *               2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Christian Amsüss <chrysn@fsfe.org>
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52840dongle/include/pwm_params.h
+++ b/boards/nrf52840dongle/include/pwm_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Christian Amsüss <chrysn@fsfe.org>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Christian Amsüss <chrysn@fsfe.org>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52840dongle/reset.c
+++ b/boards/nrf52840dongle/reset.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/nrf52dk/Kconfig
+++ b/boards/nrf52dk/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nrf52dk" if BOARD_NRF52DK

--- a/boards/nrf52dk/include/arduino_iomap.h
+++ b/boards/nrf52dk/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2024 Christian Amsüss <chrysn@fsfe.org>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 Christian Amsüss <chrysn@fsfe.org>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52dk/include/board.h
+++ b/boards/nrf52dk/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf52dk/include/periph_conf.h
+++ b/boards/nrf52dk/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016-2018 Freie Universität Berlin
- *               2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2018 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf5340dk-app/Kconfig
+++ b/boards/nrf5340dk-app/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2023 Mesotic SAS
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2023 Mesotic SAS
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nrf5340dk-app" if BOARD_NRF5340DK_APP

--- a/boards/nrf5340dk-app/board.c
+++ b/boards/nrf5340dk-app/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/nrf5340dk-app/include/board.h
+++ b/boards/nrf5340dk-app/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf5340dk-app/include/periph_conf.h
+++ b/boards/nrf5340dk-app/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf9160dk/Kconfig
+++ b/boards/nrf9160dk/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2021 Mesotic SAS
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2021 Mesotic SAS
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nrf9160dk" if BOARD_NRF9160DK

--- a/boards/nrf9160dk/include/board.h
+++ b/boards/nrf9160dk/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nrf9160dk/include/periph_conf.h
+++ b/boards/nrf9160dk/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nz32-sc151/Kconfig
+++ b/boards/nz32-sc151/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "nz32-sc151" if BOARD_NZ32_SC151

--- a/boards/nz32-sc151/include/board.h
+++ b/boards/nz32-sc151/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Fundacion Inria Chile
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 Fundacion Inria Chile
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nz32-sc151/include/gpio_params.h
+++ b/boards/nz32-sc151/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nz32-sc151/include/periph_conf.h
+++ b/boards/nz32-sc151/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Fundacion Inria Chile
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 Fundacion Inria Chile
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/nz32-sc151/include/sx127x_params.h
+++ b/boards/nz32-sc151/include/sx127x_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria Chile
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria Chile
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/olimex-msp430-h1611/Kconfig
+++ b/boards/olimex-msp430-h1611/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "olimex-msp430-h1611" if BOARD_OLIMEX_MSP430_H1611

--- a/boards/olimex-msp430-h1611/include/board.h
+++ b/boards/olimex-msp430-h1611/include/board.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2013, 2014 INRIA
- *               2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013-2014 INRIA
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/olimex-msp430-h1611/include/periph_conf.h
+++ b/boards/olimex-msp430-h1611/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 INRIA
- *               2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 INRIA
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/olimex-msp430-h2618/Kconfig
+++ b/boards/olimex-msp430-h2618/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "olimex-msp430-h2618" if BOARD_OLIMEX_MSP430_H2618

--- a/boards/olimex-msp430-h2618/include/board.h
+++ b/boards/olimex-msp430-h2618/include/board.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2013, 2014 INRIA
- *               2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013-2014 INRIA
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/olimex-msp430-h2618/include/periph_conf.h
+++ b/boards/olimex-msp430-h2618/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 INRIA
- *               2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 INRIA
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/olimexino-stm32/Kconfig
+++ b/boards/olimexino-stm32/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "olimexino-stm32" if BOARD_OLIMEXINO_STM32

--- a/boards/olimexino-stm32/include/board.h
+++ b/boards/olimexino-stm32/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Scallog
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Scallog
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/olimexino-stm32/include/gpio_params.h
+++ b/boards/olimexino-stm32/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Scallog
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Scallog
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/olimexino-stm32/include/periph_conf.h
+++ b/boards/olimexino-stm32/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Scallog
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Scallog
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/omote/Kconfig
+++ b/boards/omote/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (C) 2020 Oppila Microsystems - http://www.oppila.in
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 Oppila Microsystems - http://www.oppila.in
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "omote" if BOARD_OMOTE

--- a/boards/omote/board.c
+++ b/boards/omote/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Oppila Microsystems - http://www.oppila.in
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Oppila Microsystems - http://www.oppila.in
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/omote/include/adc_params.h
+++ b/boards/omote/include/adc_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Eistec AB
- * Copyright (C) 2020 Oppila Microsystems - http://www.oppila.in
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-FileCopyrightText: 2020 Oppila Microsystems - http://www.oppila.in
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/omote/include/board.h
+++ b/boards/omote/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Oppila Microsystems - http://www.oppila.in
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Oppila Microsystems - http://www.oppila.in
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/omote/include/gpio_params.h
+++ b/boards/omote/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Oppila Microsystems -  http://www.oppila.in
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Oppila Microsystems -  http://www.oppila.in
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/omote/include/periph_conf.h
+++ b/boards/omote/include/periph_conf.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- * Copyright (C) 2017 HAW Hamburg
- *               2020 Oppila Microsystems -  http://www.oppila.in
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-FileCopyrightText: 2020 Oppila Microsystems -  http://www.oppila.in
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/opencm904/Kconfig
+++ b/boards/opencm904/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "opencm904" if BOARD_OPENCM904

--- a/boards/opencm904/board.c
+++ b/boards/opencm904/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 INRIA
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 INRIA
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/opencm904/include/board.h
+++ b/boards/opencm904/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 INRIA
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 INRIA
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/opencm904/include/periph_conf.h
+++ b/boards/opencm904/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 INRIA
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 INRIA
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/openlabs-kw41z-mini-256kib/Kconfig
+++ b/boards/openlabs-kw41z-mini-256kib/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "openlabs-kw41z-mini-256kib" if BOARD_OPENLABS_KW41Z_MINI_256KIB

--- a/boards/openlabs-kw41z-mini/Kconfig
+++ b/boards/openlabs-kw41z-mini/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "openlabs-kw41z-mini" if BOARD_OPENLABS_KW41Z_MINI

--- a/boards/openlabs-kw41z-mini/board.c
+++ b/boards/openlabs-kw41z-mini/board.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Thomas Stilwell <stilwellt@openlabs.co>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Thomas Stilwell <stilwellt@openlabs.co>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/openlabs-kw41z-mini/include/adc_params.h
+++ b/boards/openlabs-kw41z-mini/include/adc_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Thomas Stilwell <stilwellt@openlabs.co>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Thomas Stilwell <stilwellt@openlabs.co>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/openlabs-kw41z-mini/include/board.h
+++ b/boards/openlabs-kw41z-mini/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Thomas Stilwell <stilwellt@openlabs.co>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Thomas Stilwell <stilwellt@openlabs.co>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/openlabs-kw41z-mini/include/gpio_params.h
+++ b/boards/openlabs-kw41z-mini/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Thomas Stilwell <stilwellt@openlabs.co>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Thomas Stilwell <stilwellt@openlabs.co>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/openlabs-kw41z-mini/include/periph_conf.h
+++ b/boards/openlabs-kw41z-mini/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Thomas Stilwell <stilwellt@openlabs.co>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Thomas Stilwell <stilwellt@openlabs.co>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/openmote-b/Kconfig
+++ b/boards/openmote-b/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "openmote-b" if BOARD_OPENMOTE_B

--- a/boards/openmote-b/board.c
+++ b/boards/openmote-b/board.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- * Copyright (C) 2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/openmote-b/include/board.h
+++ b/boards/openmote-b/include/board.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- * Copyright (C) 2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/openmote-b/include/gpio_params.h
+++ b/boards/openmote-b/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/openmote-b/include/periph_conf.h
+++ b/boards/openmote-b/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- * Copyright (C) 2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/openmote-cc2538/Kconfig
+++ b/boards/openmote-cc2538/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "openmote-cc2538" if BOARD_OPENMOTE_CC2538

--- a/boards/openmote-cc2538/include/board.h
+++ b/boards/openmote-cc2538/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/p-l496g-cell02/Kconfig
+++ b/boards/p-l496g-cell02/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "p-l496g-cell02" if BOARD_P_L496G_CELL02

--- a/boards/p-l496g-cell02/include/board.h
+++ b/boards/p-l496g-cell02/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/p-l496g-cell02/include/gpio_params.h
+++ b/boards/p-l496g-cell02/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/p-l496g-cell02/include/periph_conf.h
+++ b/boards/p-l496g-cell02/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/p-nucleo-wb55/Kconfig
+++ b/boards/p-nucleo-wb55/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "p-nucleo-wb55" if BOARD_P_NUCLEO_WB55

--- a/boards/p-nucleo-wb55/include/arduino_iomap.h
+++ b/boards/p-nucleo-wb55/include/arduino_iomap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)  2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/p-nucleo-wb55/include/board.h
+++ b/boards/p-nucleo-wb55/include/board.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/p-nucleo-wb55/include/gpio_params.h
+++ b/boards/p-nucleo-wb55/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/p-nucleo-wb55/include/periph_conf.h
+++ b/boards/p-nucleo-wb55/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/pba-d-01-kw2x/Kconfig
+++ b/boards/pba-d-01-kw2x/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "pba-d-01-kw2x" if BOARD_PBA_D_01_KW2X

--- a/boards/pba-d-01-kw2x/board.c
+++ b/boards/pba-d-01-kw2x/board.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- * Copyright (C) 2014 PHYTEC Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2014 PHYTEC Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/pba-d-01-kw2x/include/board.h
+++ b/boards/pba-d-01-kw2x/include/board.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- * Copyright (C) 2015 PHYTEC Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 PHYTEC Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/pba-d-01-kw2x/include/gpio_params.h
+++ b/boards/pba-d-01-kw2x/include/gpio_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017   HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- * Copyright (C) 2014 PHYTEC Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2014 PHYTEC Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/phynode-kw41z/Kconfig
+++ b/boards/phynode-kw41z/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "phynode-kw41z" if BOARD_PHYNODE_KW41Z

--- a/boards/phynode-kw41z/board.c
+++ b/boards/phynode-kw41z/board.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Eistec AB
- * Copyright (C) HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2018 Eistec AB
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/phynode-kw41z/include/adc_params.h
+++ b/boards/phynode-kw41z/include/adc_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Eistec AB
- * Copyright (C) 2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Eistec AB
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/phynode-kw41z/include/board.h
+++ b/boards/phynode-kw41z/include/board.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Eistec AB
- * Copyright (C) 2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2018 Eistec AB
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/phynode-kw41z/include/gpio_params.h
+++ b/boards/phynode-kw41z/include/gpio_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Eistec AB
- * Copyright (C) 2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Eistec AB
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/phynode-kw41z/include/periph_conf.h
+++ b/boards/phynode-kw41z/include/periph_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Eistec AB
- * Copyright (C) 2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2018 Eistec AB
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/pinetime/Kconfig
+++ b/boards/pinetime/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "pinetime" if BOARD_PINETIME

--- a/boards/pinetime/board.c
+++ b/boards/pinetime/board.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *               2020 Inria
- *               2020 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/boards/pinetime/include/board.h
+++ b/boards/pinetime/include/board.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2019 Inria
- *               2019 Freie Universität Berlin
- *               2019 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/pinetime/include/periph_conf.h
+++ b/boards/pinetime/include/periph_conf.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2019 Inria
- *               2019 Freie Universität Berlin
- *               2019 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/pyboard/Kconfig
+++ b/boards/pyboard/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config BOARD
     default "pyboard" if BOARD_PYBOARD

--- a/boards/pyboard/include/board.h
+++ b/boards/pyboard/include/board.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2019 Inria
- *               2019 Freie Universität Berlin
- *               2019 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/pyboard/include/gpio_params.h
+++ b/boards/pyboard/include/gpio_params.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2019 Inria
- *               2019 Freie Universität Berlin
- *               2019 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/boards/pyboard/include/periph_conf.h
+++ b/boards/pyboard/include/periph_conf.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2019 Inria
- *               2019 Freie Universität Berln
- *               2019 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once


### PR DESCRIPTION
### Contribution description

This PR moves license information from headers to SPDX format for boards which names starts with letter `d` to `p` (including).

Except detection of missing Copyright keyword https://github.com/RIOT-OS/RIOT/issues/21515#issuecomment-3058941739 and some strange https://github.com/RIOT-OS/RIOT/issues/21515#issuecomment-3083187003, which was fixed manually, other work is done automatically using scripts described in PR https://github.com/RIOT-OS/RIOT/issues/21515.

### Testing procedure

Review changed files.

### Issues/PRs references

Track #21515 
