### PR TITLE
dist/tools: Move `picosdk` to `pkg` folder, improve `picotool.sh` script

### DIFF
--- a/dist/tools/picosdk/.gitignore
+++ b/dist/tools/picosdk/.gitignore
@@ -1,1 +1,0 @@
-picosdk/

--- a/dist/tools/picotool/Makefile
+++ b/dist/tools/picotool/Makefile
@@ -8,10 +8,7 @@ RIOTBASE ?= $(CURDIR)/../../..
 RIOTTOOLS ?= $(CURDIR)/..
 
 # Location of the picosdk package
-PICOSDK_DIR = ../../../picosdk
-PICO_SDK_PATH ?= $(PICOSDK_DIR)/picosdk
-
-USEPKG += picosdk
+PICOSDK_DIR = $(RIOTBASE)/build/pkg/picosdk
 
 PKG_SOURCE_DIR = $(CURDIR)/source
 PKG_BUILD_DIR = $(PKG_SOURCE_DIR)/build
@@ -21,18 +18,15 @@ PKG_BUILD_DIR = $(PKG_SOURCE_DIR)/build
 include $(RIOTBASE)/pkg/pkg.mk
 
 # Create a dependency on the picosdk build
-$(CURDIR)/picotool: $(PKG_PREPARED) $(PICOSDK_DIR)/.prepared
+$(CURDIR)/picotool: $(PKG_PREPARED) picosdk
 	@echo "[INFO] compiling picotool from source now"
-	@cd $(PKG_SOURCE_DIR) && cmake -B build -S . -DPICO_SDK_PATH=$(PICO_SDK_PATH) -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+	@cd $(PKG_SOURCE_DIR) && cmake -B build -S . -DPICO_SDK_PATH=$(PICOSDK_DIR) -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
 	@cd $(PKG_BUILD_DIR) && env --unset=CC --unset=CXX $(MAKE)
 	@cp $(PKG_BUILD_DIR)/picotool $(CURDIR)/picotool
 
-# Create a phony target to ensure picosdk is built
 .PHONY: picosdk
-picosdk: $(PICOSDK_DIR)/.prepared
-
-$(PICOSDK_DIR)/.prepared:
-	$(MAKE) -C $(RIOTBASE)/dist/tools/picosdk
+picosdk:
+	$(MAKE) -C $(RIOTBASE)/pkg/picosdk
 
 all: $(CURDIR)/picotool
 

--- a/dist/tools/picotool/picotool.sh
+++ b/dist/tools/picotool/picotool.sh
@@ -7,10 +7,10 @@ UF2FILE="${UF2FILE:-${ELFFILE%%.elf}.uf2}"
 
 udev_warning='[WARNING] Picotool udev rules are not set yet. You won`t be able to '\
 'run picotool without sudo. See: '\
-'https://github.com/raspberrypi/picotool/tree/master?tab=readme-ov-file#linux--macos\n'\
+'https://github.com/raspberrypi/picotool/blob/master/BUILDING.md#linux--macos\n'\
 'The udev rule file can be found in '$(dirname "$0")'/source/udev'
 
-if ! [ -e /etc/udev/rules.d/99-picotool.rules ]
+if ! ls /etc/udev/rules.d/[0-9][0-9]-picotool.rules >/dev/null 2>&1
 then
   printf '\033[1;31m%b\033[0m\n' "$udev_warning"
 fi

--- a/pkg/picosdk/Makefile
+++ b/pkg/picosdk/Makefile
@@ -2,12 +2,8 @@ PKG_NAME=picosdk
 PKG_URL=https://github.com/raspberrypi/pico-sdk.git
 PKG_VERSION=bddd20f928ce76142793bef434d4f75f4af6e433
 PKG_LICENSE=BSD-3-Clause
-PKG_SOURCE_DIR = $(CURDIR)/picosdk
-PKG_BUILD_DIR = $(PKG_SOURCE_DIR)
-
-RIOTBASE ?= $(CURDIR)/../../..
-RIOTTOOLS ?= $(CURDIR)/..
 
 include $(RIOTBASE)/pkg/pkg.mk
 
-all: $(CURDIR)/picosdk
+# nothing to build
+all:

--- a/pkg/picosdk/Makefile.include
+++ b/pkg/picosdk/Makefile.include
@@ -1,0 +1,1 @@
+PSEUDOMODULES += picosdk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `picosdk` is required for the RP2350 support #21545 and it would be convenient to use it through the `USEPKG` mechanism.

~~TODO: I think I removed too much from the `picotool` Makefile. The `picotool` has to be built for the RP2040 as well, but that does not use the `picosdk`.~~
Fixed.

Ping @AnnsAnns :)
I decided it would be easier if I create a separate PR (I'll send you a modified patch later for your PR), see the TODO...

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Make sure `BOARD=rpi-pico make -C tests/minimal flash` still works.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Requirement for #21545.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
