### PR TITLE
sys/net/sntp: migrate from xtimer to ztimer

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -134,11 +134,8 @@ endif
 
 ifneq (,$(filter sntp,$(USEMODULE)))
   USEMODULE += sock_udp
-  USEMODULE += xtimer
-  ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
-    # requires 64bit ftimestamps
-    USEMODULE += ztimer64_xtimer_compat
-  endif
+  USEMODULE += ztimer64
+  USEMODULE += ztimer64_usec
 endif
 
 ifneq (,$(filter sock_%,$(USEMODULE)))

--- a/sys/include/net/ntp_packet.h
+++ b/sys/include/net/ntp_packet.h
@@ -14,6 +14,8 @@
  * @brief       The NTP packet module provides functionality to manipulate the NTP header
  * @{
  *
+ * @see         An implementation of Simple NTP can be found in @ref net_sntp.
+ *
  * @file
  * @brief       NTP packet definitions
  *
@@ -46,7 +48,7 @@ extern "C" {
 #define NTP_PORT             (123U)     /**< NTP port number */
 
 /**
- * @brief   Offset in seconds of NTP timestamp (seconds from 1990-01-01 00:00:00 UTC)
+ * @brief   Offset in seconds of NTP timestamp (seconds from 1900-01-01 00:00:00 UTC)
  *          to UNIX timestamp (seconds from 1970-01-01 00:00:00 UTC).
  */
 #define NTP_UNIX_OFFSET      (2208988800)

--- a/sys/include/net/sntp.h
+++ b/sys/include/net/sntp.h
@@ -15,6 +15,10 @@
  * @brief       Simple Network Time Protocol (SNTP) implementation
  * @{
  *
+ * @note        The current implementation of SNTP uses @ref sys_ztimer64 with
+ *              microsecond accuracy, which can have a strong impact on
+ *              the power consumption of your device.
+ *
  * @file
  * @brief       SNTP definitions
  *
@@ -27,7 +31,7 @@
 
 #include "net/ntp_packet.h"
 #include "net/sock/udp.h"
-#include "xtimer.h"
+#include "ztimer64.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,7 +49,7 @@ extern "C" {
 int sntp_sync(sock_udp_ep_t *server, uint32_t timeout);
 
 /**
- * @brief Get real time offset from system time as returned by @ref xtimer_now64()
+ * @brief Get real time offset from system time as returned by @ref ztimer64_now()
  *
  * @return Real time offset in microseconds relative to 1900-01-01 00:00 UTC
  */
@@ -58,7 +62,8 @@ int64_t sntp_get_offset(void);
  */
 static inline uint64_t sntp_get_unix_usec(void)
 {
-    return (uint64_t)(sntp_get_offset() - (NTP_UNIX_OFFSET * US_PER_SEC) + xtimer_now_usec64());
+    return (uint64_t)(sntp_get_offset() - (NTP_UNIX_OFFSET * US_PER_SEC) + \
+                      ztimer64_now(ZTIMER64_USEC));
 }
 
 #ifdef __cplusplus

--- a/sys/net/application_layer/sntp/sntp.c
+++ b/sys/net/application_layer/sntp/sntp.c
@@ -22,7 +22,7 @@
 #include "net/sntp.h"
 #include "net/ntp_packet.h"
 #include "net/sock/udp.h"
-#include "xtimer.h"
+#include "ztimer64.h"
 #include "mutex.h"
 #include "byteorder.h"
 
@@ -70,7 +70,7 @@ int sntp_sync(sock_udp_ep_t *server, uint32_t timeout)
     mutex_lock(&_sntp_mutex);
     _sntp_offset = (((int64_t)byteorder_ntohl(_sntp_packet.transmit.seconds)) * US_PER_SEC) +
                    ((((int64_t)byteorder_ntohl(_sntp_packet.transmit.fraction)) * 232)
-                   / 1000000) - xtimer_now_usec64();
+                   / 1000000) - ztimer64_now(ZTIMER64_USEC);
     mutex_unlock(&_sntp_mutex);
     return 0;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `sntp` module still uses the deprecated `xtimer`. This PR migrates it to `ztimer64`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Testing is a bit non-trivial because RIOT can't access internet-based NTP servers (I think?) and systemd has an integrated NTP client, which does not act as an NTP server itself.

Therefore you have to install the good old `ntpd` and run it as `sudo`. Also a tap-network has to be setup of course.

The output should look something like this. In the build log, you should see `ztimer64` instead of `xtimer` and the output of `ntpdate` should be pretty much the same.
```
cbuec@W11nMate:~/RIOTstuff/riot-crc8/RIOT$ PORT=tap0 make -C tests/net/sntp all term -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-crc8/RIOT/tests/net/sntp'
using BOARD="native64" as "native" on a 64-bit system
Building application "tests_sntp" for "native64" with CPU "native".

"make" -C /home/cbuec/RIOTstuff/riot-crc8/RIOT/boards
...
"make" -C /home/cbuec/RIOTstuff/riot-crc8/RIOT/sys/net/gnrc/transport_layer/udp
"make" -C /home/cbuec/RIOTstuff/riot-crc8/RIOT/sys/ztimer
"make" -C /home/cbuec/RIOTstuff/riot-crc8/RIOT/sys/ztimer64
"make" -C /home/cbuec/RIOTstuff/riot-crc8/RIOT/sys/net/gnrc/netif/ethernet
"make" -C /home/cbuec/RIOTstuff/riot-crc8/RIOT/sys/net/gnrc/netif/hdr
"make" -C /home/cbuec/RIOTstuff/riot-crc8/RIOT/sys/net/gnrc/netif/init_devs
   text    data     bss     dec     hex filename
 145294    2224  110768  258286   3f0ee /home/cbuec/RIOTstuff/riot-crc8/RIOT/tests/net/sntp/bin/native64/tests_sntp.elf
/home/cbuec/RIOTstuff/riot-crc8/RIOT/dist/tools/pyterm/pyterm -ps /home/cbuec/RIOTstuff/riot-crc8/RIOT/tests/net/sntp/bin/native64/tests_sntp.elf --process-args tap0
2025-07-30 23:54:40,148 # RIOT native interrupts/signals initialized.
Welcome to pyterm!
Type '/exit' to exit.
2025-07-30 23:54:40,149 # TZ not set, setting UTC
2025-07-30 23:54:40,151 # RIOT native64 board initialized.
2025-07-30 23:54:40,151 # RIOT native hardware initialization complete.
2025-07-30 23:54:40,151 #
2025-07-30 23:54:40,152 # main(): This is RIOT! (Version: 2025.07-devel-437-gded43-pr/sntp)
> ntpdate fe80::6cb9:43ff:fe48:a430
2025-07-30 23:54:42,616 # ntpdate fe80::6cb9:43ff:fe48:a430
2025-07-30 23:54:42,617 # 1753912482.1753912482 (-620366685 us)

```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
