### PR TITLE
[HACK] cpu/sam0_common: eth: delay init by 10ms for more stable Ethernet

### DIFF
--- a/cpu/sam0_common/sam0_eth/eth-netdev.c
+++ b/cpu/sam0_common/sam0_eth/eth-netdev.c
@@ -153,6 +153,10 @@ static inline void _setup_phy_irq(gpio_cb_t cb, void *arg)
 
 static int _sam0_eth_init(netdev_t *netdev)
 {
+    /* HACK: without the delay we see random hard faults or no sent/received
+       frames after boot. */
+    ztimer_sleep(ZTIMER_MSEC, 10);
+
     sam0_eth_init();
     eui48_t hwaddr;
     netdev_eui48_get(netdev, &hwaddr);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We often see hard faults right after boot, sometimes the Ethernet does not send / receive frames at all.

Adding a small delay before initializing the GMAC seems to fix it…

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
