### PR TITLE
Allow for building the `suit-tool` as a self-contained binary

### DIFF
--- a/dist/tools/suit/suit-manifest-generator/suit_tool/clidriver.py
+++ b/dist/tools/suit/suit-manifest-generator/suit_tool/clidriver.py
@@ -65,3 +65,6 @@ class CLIDriver(object):
         }[self.options.action](self.options) or 0
 
         sys.exit(rc)
+
+if __name__ == "__main__":
+    main()

--- a/dist/tools/suit/suit-manifest-generator/suit_tool/clidriver.py
+++ b/dist/tools/suit/suit-manifest-generator/suit_tool/clidriver.py
@@ -17,18 +17,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ----------------------------------------------------------------------------
-import logging, sys
+import logging
+import sys
 
 from suit_tool.argparser import MainArgumentParser
-from suit_tool import create, sign, parse, get_pubkey, keygen, sever #, verify, cert, init
+from suit_tool import create, sign, parse, get_pubkey, keygen, sever  # , verify, cert, init
 
 
 LOG = logging.getLogger(__name__)
-LOG_FORMAT='[%(levelname)s] %(asctime)s - %(name)s - %(message)s'
+LOG_FORMAT = '[%(levelname)s] %(asctime)s - %(name)s - %(message)s'
+
 
 def main():
     driver = CLIDriver()
     return driver.main()
+
 
 class CLIDriver(object):
 
@@ -44,9 +47,9 @@ class CLIDriver(object):
         logging.basicConfig(level=log_level,
                             format=LOG_FORMAT,
                             datefmt='%Y-%m-%d %H:%M:%S')
-        logging.addLevelName( logging.INFO, "\033[1;32m%s\033[1;0m" % logging.getLevelName(logging.INFO))
-        logging.addLevelName( logging.WARNING, "\033[1;93m%s\033[1;0m" % logging.getLevelName(logging.WARNING))
-        logging.addLevelName( logging.CRITICAL, "\033[1;31m%s\033[1;0m" % logging.getLevelName(logging.CRITICAL))
+        logging.addLevelName(logging.INFO, "\033[1;32m%s\033[1;0m" % logging.getLevelName(logging.INFO))
+        logging.addLevelName(logging.WARNING, "\033[1;93m%s\033[1;0m" % logging.getLevelName(logging.WARNING))
+        logging.addLevelName(logging.CRITICAL, "\033[1;31m%s\033[1;0m" % logging.getLevelName(logging.CRITICAL))
 
         LOG.debug('CLIDriver created. Arguments parsed and logging setup.')
 
@@ -61,10 +64,11 @@ class CLIDriver(object):
           "pubkey": get_pubkey.main,
           "sign": sign.main,
           "keygen": keygen.main,
-          "sever" : sever.main,
+          "sever": sever.main,
         }[self.options.action](self.options) or 0
 
         sys.exit(rc)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Contribution description

I would like to build the `suit-tool` as a self-contained binary. E.g. like this:

```console
$ cd dist/tools/suit/suit-manifest-generator
$ pyinstaller --onefile --name suit-tool suit_tool/clidriver.py
```

However, the `main()` function was not called.
This code change fixes this by:

* Execute the `main()` function when the script is run directly
* Please the Flake8 linter according to your coding convention

Now the binary can be created as stated above.


### Testing procedure

The binary can print its version:

```console
$ file ./dist/suit-tool 
./dist/suit-tool: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, BuildID[sha1]=eb586756c39e4efd29c393a8b324b3af04fd9a90, stripped
$  ./dist/suit-tool --version
0.0.2
```

Also the existing example that uses the `suit-tool` still compiles well, like this: (but only after applying [this fix #21510](https://github.com/RIOT-OS/RIOT/pull/21510)!)

```console
$ cd examples/advanced/suit_update
$ rm -rf bin/
$ make suit/manifest
...
$ echo $?
0
```


### Issues/PRs references

No references.