### PR TITLE
sys/suit: print warning if offset does not match

### DIFF
--- a/sys/include/suit/storage.h
+++ b/sys/include/suit/storage.h
@@ -543,8 +543,8 @@ static inline bool suit_storage_has_location(suit_storage_t *storage,
  * @returns     True if the location matches the offset,
  * @returns     False otherwise
  */
-static inline int suit_storage_match_offset(const suit_storage_t *storage,
-                                            size_t offset)
+static inline bool suit_storage_match_offset(const suit_storage_t *storage,
+                                             size_t offset)
 {
     return storage->driver->match_offset(storage, offset);
 }

--- a/sys/suit/handlers_command_seq.c
+++ b/sys/suit/handlers_command_seq.c
@@ -160,8 +160,12 @@ static int _cond_comp_offset(suit_manifest_t *manifest,
     LOG_INFO("Comparing manifest offset %"PRIx32" with other slot offset\n",
              offset);
 
-    return suit_storage_match_offset(comp->storage_backend, offset) ?
-        SUIT_OK : SUIT_ERR_COND;
+    bool match = suit_storage_match_offset(comp->storage_backend, offset);
+    if (match) {
+        return SUIT_OK;
+    }
+    LOG_WARNING("offset does not match\n");
+    return SUIT_ERR_COND;
 }
 
 static int _dtv_set_comp_idx(suit_manifest_t *manifest,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently, `_cond_comp_offset()` only prints the offset that was read from then manifest, it does not indicate whether the offset is correct or not.

This leads to the SUIT proccess failing with just a 

```
[INF] suit_worker: suit_parse() failed. res=-4
```

with no indication what went wrong.

### Testing procedure

A manifest with wrong offsets will now produce a much more clear error

```
2025-07-30 09:32:39,884 # [INF] suit_worker: started.
2025-07-30 09:32:39,895 # [INF] suit_worker: downloading "coap://[fdea:dbee:f::1]/fw/1/m/DCs?hwr=0&fwt=22&fwr=3000001"
2025-07-30 09:32:39,901 # [INF] suit_worker: got manifest with size 489
2025-07-30 09:32:39,907 # [INF] suit: verifying manifest signature
2025-07-30 09:32:41,037 # [INF] Unable to validate signature: -2
2025-07-30 09:32:41,049 # [INF] suit: verifying manifest signature
2025-07-30 09:32:42,189 # [INF] suit: validated manifest version
2025-07-30 09:32:42,196 # [INF] Manifest seq_no: 3000002, highest available: 3000001
2025-07-30 09:32:42,202 # [INF] suit: validated sequence number
2025-07-30 09:32:42,207 # [INF] Formatted component name:
2025-07-30 09:32:42,214 # [INF] Comparing manifest offset 4400 with other slot offset
2025-07-30 09:32:42,222 # [ERR] offset does not match
2025-07-30 09:32:42,230 # [INF] Comparing manifest offset 82400 with other slot offset
2025-07-30 09:32:42,238 # [ERR] offset does not match
2025-07-30 09:32:42,244 # [INF] suit_worker: suit_parse() failed. res=-4
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
