### PR TITLE
cpu/cc2538: timer: fix 'irqn' may be used uninitialized

### DIFF
--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -121,6 +121,9 @@ static inline void _irq_enable(tim_t tim)
             case 3:
                 irqn = GPTIMER_3A_IRQn;
                 break;
+            default:
+                assume(0);
+                return;
         }
         NVIC_SetPriority(irqn, TIMER_IRQ_PRIO);
         NVIC_EnableIRQ(irqn);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Fix the uninitialized variable warning:

```
In file included from /home/benjamin.valentin@ml-pa.com/dev/rdpd-dft-rtos/ext/RIOT/cpu/cc2538/include/cc2538.h:117,
                 from /home/benjamin.valentin@ml-pa.com/dev/rdpd-dft-rtos/ext/RIOT/cpu/cc2538/include/cpu_conf.h:23,
                 from /home/benjamin.valentin@ml-pa.com/dev/rdpd-dft-rtos/ext/RIOT/core/lib/include/irq.h:26,
                 from /home/benjamin.valentin@ml-pa.com/dev/rdpd-dft-rtos/ext/RIOT/cpu/cortexm_common/include/cpu.h:32,
                 from /home/benjamin.valentin@ml-pa.com/dev/rdpd-dft-rtos/ext/RIOT/boards/openmote-b/include/board.h:23,
                 from /home/benjamin.valentin@ml-pa.com/dev/rdpd-dft-rtos/ext/RIOT/cpu/cc2538/periph/timer.c:28:
In function '__NVIC_SetPriority',
    inlined from '_irq_enable' at /home/benjamin.valentin@ml-pa.com/dev/rdpd-dft-rtos/ext/RIOT/cpu/cc2538/periph/timer.c:125:9:
/home/benjamin.valentin@ml-pa.com/dev/rdpd-dft-rtos/ext/RIOT/build/pkg/cmsis/CMSIS/Core/Include/core_cm3.h:1640:6: error: 'irqn' may be used uninitialized [-Werror=maybe-uninitialized]
 1640 |   if ((int32_t)(IRQn) >= 0)
      |      ^
/home/benjamin.valentin@ml-pa.com/dev/rdpd-dft-rtos/ext/RIOT/cpu/cc2538/periph/timer.c: In function '_irq_enable':
/home/benjamin.valentin@ml-pa.com/dev/rdpd-dft-rtos/ext/RIOT/cpu/cc2538/periph/timer.c:110:19: note: 'irqn' was declared here
  110 |         IRQn_Type irqn;
      |                   ^~~~
cc1: all warnings being treated as errors

```


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
