### PR TITLE
doc: Integrate Governance, Code of Conduct and C++ Tutorial into Starlight

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,1 @@
+guides/generated

--- a/doc/doxygen/src/using-cpp.md
+++ b/doc/doxygen/src/using-cpp.md
@@ -1,52 +1,5 @@
-Using C++ in RIOT                                                  {#using-cpp}
-=================
+Using C++ in RIOT    {#using-cpp}
+==================
 
-[TOC]
-
-Levels of Support                                          {#levels-of-support}
-=================
-
-A CPU in RIOT can have three levels of support for C++ code:
-
-1. No support for C++ at all
-2. C++ is supported, but no libstdc++ implementation is available
-3. C++ is supported and a libstdc++ implementation is available
-
-The reason for missing or only partial C++ support can be one (or more) of
-the following:
-
-- No libstdc++ implementation for the target platform is available to RIOT, or
-  the official RIOT docker image is missing it
-- Missing toolchain support for a given target platform
-- The C++ toolchain requires library code (such as constructor guards for the
-  thread safe initialization of statically allocated instances) or hooks in
-  the startup process to perform initialization
-
-Using C++
-=========
-
-In order for C++ code to compile with RIOT, the following needs to be done:
-
-- All C++ files must have the file extension `.cpp`, all C++ headers `.hpp`
-    - For external code, overwriting the make variable `SRCXXEXT` e.g. to
-      `cxx` can be used to compile C++ files with other extensions, e.g. `.cxx`
-- `FEATURES_REQUIRED += cpp` must be added to the applications `Makefile`
-    - If additionally the libstdc++ is used, `FEATURES_REQUIRED += libstdcpp`
-      must be used additionally
-
-RIOT Modules in C++                                              {#cpp-in-riot}
-===================
-
-RIOT modules should be written in C, so that boards/platforms without or partial
-C++ support can still use these modules. However, external modules, packages,
-and modules that require C++ support anyway (e.g. the Arduino compatibility
-features) can be written in C++. Also, some modules might be designed as
-compatibility layer for C++ or provide convenient access to RIOT-OS' features
-using C++ APIs.  These modules/packages have to depend on the
-`cpp` feature (`FEATURES_REQUIRED += cpp`) and possibly the `libstdcpp`
-feature using their `Makefile.dep`.
-
-See Also                                                            {#see-also}
-========
-
-Reference @ref cpp for a list of C++ modules.
+@deprecated Guides have moved to the [Guide Site](https://guide.riot-os.org/c_tutorials/using_cpp/).
+This page will be removed after release 2026.04.

--- a/doc/guides/c_tutorials/using_cpp.md
+++ b/doc/guides/c_tutorials/using_cpp.md
@@ -1,0 +1,51 @@
+---
+title: Using C++ in RIOT
+description: This document explains how to use C++ in RIOT, including levels of support and requirements for C++ code.
+---
+
+# Levels of Support
+
+A CPU in RIOT can have three levels of support for C++ code:
+
+1. No support for C++ at all
+2. C++ is supported, but no libstdc++ implementation is available
+3. C++ is supported and a libstdc++ implementation is available
+
+The reason for missing or only partial C++ support
+can be one (or more) of the following:
+
+- No libstdc++ implementation for the target platform is available to RIOT,
+    or the official RIOT docker image is missing it
+- Missing toolchain support for a given target platform
+- The C++ toolchain requires library code
+    (such as constructor guards for the thread safe initialization of statically
+    allocated instances) or hooks in the startup process to perform initialization
+
+# Using C++
+
+In order for C++ code to compile with RIOT, the following needs to be done:
+
+- All C++ files must have the file extension `.cpp`, all C++ headers `.hpp`
+    - For external code, overwriting the make variable `SRCXXEXT`
+        e.g. to `cxx` can be used to compile C++ files with other extensions,
+        e.g. `.cxx`
+- `FEATURES_REQUIRED += cpp` must be added to the applications `Makefile`
+    - If additionally the libstdc++ is used,
+        `FEATURES_REQUIRED += libstdcpp` must be set.
+
+## RIOT Modules in C++
+
+RIOT modules should be written in C, so that boards/platforms without
+or partial C++ support can still use these modules.
+However, external modules, packages and modules that require C++ support anyway
+(e.g. the Arduino compatibility features) can be written in C++.
+Also, some modules might be designed as compatibility layer for C++
+or provide convenient access to RIOT-OS' features using C++ APIs.
+These modules/packages have to depend on the `cpp` feature
+(`FEATURES_REQUIRED += cpp`) and possibly the `libstdcpp` feature
+using their `Makefile.dep`.
+
+## See Also
+
+Reference [C++ modules](https://doc.riot-os.org/group__cpp.html)
+for a list of C++ modules.

--- a/doc/starlight/Makefile
+++ b/doc/starlight/Makefile
@@ -3,7 +3,7 @@ RIOTMAKE  ?= $(RIOTBASE)/makefiles
 RIOTTOOLS ?= $(RIOTBASE)/dist/tools
 
 .PHONY: install
-install:
+install: integrate_outside_files
 	@echo "Installing starlight..."
 	@npm install --prefix $(CURDIR) --prefer-offline
 	@echo "Starlight installed successfully."
@@ -18,5 +18,20 @@ dev: install
 	@echo "Starting starlight live server..."
 	@npm run dev --prefix $(CURDIR)
 
+.PHONY: clean
 clean:
 	-@rm -rf node_modules .astro dist
+
+.PHONY: integrate_outside_files
+integrate_outside_files: code_of_conduct governance
+
+.PHONY: code_of_conduct
+code_of_conduct: ../../CODE_OF_CONDUCT.md
+	-@mkdir -p ../guides/generated
+	-@echo "Generating Code of Conduct documentation..."
+	-@sed '1,2d' $< | cat ./templates/CODE_OF_CONDUCT.template.md - > ../guides/generated/CODE_OF_CONDUCT.md
+
+.PHONY: governance
+governance: ../../GOVERNANCE.md
+	-@echo "Generating Governance documentation..."
+	-@sed '1,2d' $< | sed '/<!-- TOC start -->/,/<!-- TOC end -->/d' | cat ./templates/GOVERNANCE.template.md - > ../guides/generated/GOVERNANCE.md

--- a/doc/starlight/astro.config.mjs
+++ b/doc/starlight/astro.config.mjs
@@ -47,6 +47,8 @@ export default defineConfig({
             { label: "Introduction", slug: "index" },
             "general/structure",
             "general/vision",
+            "general/governance",
+            "general/code_of_conduct",
           ],
         },
         {
@@ -71,6 +73,7 @@ export default defineConfig({
                 "c_tutorials/threads",
                 "c_tutorials/gpio",
                 "c_tutorials/saul",
+                "c_tutorials/using_cpp",
               ],
             },
             {

--- a/doc/starlight/templates/CODE_OF_CONDUCT.template.md
+++ b/doc/starlight/templates/CODE_OF_CONDUCT.template.md
@@ -1,0 +1,5 @@
+---
+title: Code of Conduct
+description: This document outlines the code of conduct for contributors of RIOT.
+slug: general/code_of_conduct
+---

--- a/doc/starlight/templates/GOVERNANCE.template.md
+++ b/doc/starlight/templates/GOVERNANCE.template.md
@@ -1,0 +1,5 @@
+---
+title: Governance
+description: This document outlines the governance structure of RIOT.
+slug: general/governance
+---


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This integrates the Governance and Code of Conduct files into the starlight output. It should be noted that it does not touch the doxygen output and simply copies the way we do it within the doxygen output (Copy and modify the file when make gets called).

I also moved the C++ tutorial since that would mark the completion of moving all (first party) language related things into starlight. Though I wasn't sure which date to deprecate the old text so I left it TODO for now :) 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

A simple `make doc` for doxygen should showcase the deprecation of the c++ guide. (and no changes to coc/governance)
A simple `make doc-starlight` should showcase that Governance and COC are now part of the general section and C++ under the c_tutorials/ section


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

#21575 