### PR TITLE
drivers/vl53l1x: add VL53L1X ToF ranging sensor driver

### DIFF
--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -52,6 +52,7 @@ rsource "sm_pwm_01c/Kconfig"
 rsource "sps30/Kconfig"
 rsource "tcs37727/Kconfig"
 rsource "tmp00x/Kconfig"
+rsource "vl53l1x/Kconfig"
 rsource "vl6180x/Kconfig"
 endmenu # Sensor Device Drivers
 

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -271,6 +271,10 @@ ifneq (,$(filter vcnl40%0,$(USEMODULE)))
   USEMODULE += vcnl40x0
 endif
 
+ifneq (,$(filter vl53l1x_%,$(USEMODULE)))
+  USEMODULE += vl53l1x
+endif
+
 ifneq (,$(filter vl6180x_%,$(USEMODULE)))
   USEMODULE += vl6180x
 endif

--- a/drivers/include/vl53l1x.h
+++ b/drivers/include/vl53l1x.h
@@ -1,0 +1,466 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @defgroup    drivers_vl53l1x VL53L1X Time-of-Flight (ToF) ranging sensor
+ * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
+ * @brief       Device driver for the ST VL53L1X Time-of-Flight (ToF) ranging sensor
+ *
+ * \section drivers_vl53l1x VL53L1X Time-of-Flight (ToF) ranging sensor
+ *
+ * ## Driver Variants
+ *
+ * Using the according module, the driver can be used in two different variants
+ * which differ in functionality and size:
+ *
+ * Module Name     | Driver             | Short Description
+ * :---------------|:-------------------|:----------------------------
+ * `vl53l1x_basic` | \ref vl53l1x_basic | Minimum functionality at small size
+ * `vl53l1x`       | \ref vl53l1x       | Complete functionality at acceptable size
+ *
+ * If the driver variant is not specified, \ref vl53l1x is used by default.
+ * Both driver variants provide \ref drivers_saul capabilities for distance.
+ *
+ * ## Basic Driver (vl53l1x_basic) {#vl53l1x_basic}
+ *
+ * This is the smallest driver variant that only provides some basic functions
+ * such as
+ *
+ * - distance measurements at acceptable accuracy,
+ * - data-ready interrupts, and
+ * - SAUL capability.
+ *
+ * This driver should be used when memory requirements are an issue.
+ *
+ * ## Default Driver (vl53l1x) {#vl53l1x}
+ *
+ * Using \ref vl53l1x variant provides the application with the functionality
+ * of the basic driver variant \ref vl53l1x_basic and additional functionality
+ * such as
+ *
+ * - configuration of sensor parameters (distance mode, timing budget
+ *   and inter-measurement period),
+ * - configuration and use of distance threshold interrupts, or
+ * - power handling.
+ *
+ * Additionally, it provides access to the complete functionality of the sensor
+ * by using VL53L1X ULD API functions directly. This is for example necessary to
+ * to calibrate the sensor. Even though the sensor is calibrated by ST during
+ * the final module test and these calibration data are loaded from NVM, the
+ * sensor should be calibrated on customers production line when soldered on
+ * customer board or adding a cover glass.
+ *
+ * Please refer the [VL53L1X ULD API user manual]
+ * (https://www.st.com/resource/en/user_manual/um2510-a-guide-to-using-the-vl53l1x-ultra-lite-driver-stmicroelectronics.pdf)
+ * for detailed information on how to use the API to calibrate the sensor.
+ *
+ * @note    Since the ST STSW-IMG009 VL53L1X ULD API provides functions that are
+ *          not required in most use cases, this driver variant should only be
+ *          used when memory requirements are not an issue.
+ *
+ * ## Driver Comparison Sheet
+ *
+ * Function / Property                     | vl53l1x_basic | vl53l1x
+ * :---------------------------------------|:-------------:|:--------------:
+ * Distance results in mm                  | X             | X
+ * Signal rate results in kcps             |               | X
+ * Measurement status information          |               | X
+ * SAUL capability                         | X             | X
+ * Distance mode configuration             |               | X
+ * Timing budget configuration             |               | X
+ * Inter-measurement period configuration  |               | X
+ * Region of Interest (ROI) configuration  |               | X
+ * Data-ready interrupts (ranging mode)    | X             | X
+ * Threshold interrupts (detection mode)   |               | X
+ * Power on/off functions                  |               | X
+ * SHUTDOWN pin support                    |               | X
+ * Calibration functions                   |               | X [1]
+ * Size on reference platform in kByte [2] | 1.0           | 2.9
+ *
+ * [1] These functions are available by using the ST VL53L1X ULD API directly.<br>
+ * [2] Reference platform: STM32F411RE
+ *
+ * @{
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "kernel_defines.h"
+#include "periph/gpio.h"
+#include "periph/i2c.h"
+
+#define VL53L1X_DEVICE_ID   (0xeacc)    /**< VL53L1X Model ID */
+#define VL53L1X_I2C_ADDRESS (0x29)      /**< VL53L1X I2C address */
+
+/**
+ * @brief   VL53L1X distance modes
+ *
+ * The values are reused from the ST VL53L1X ULD API for compatibility.
+ * Although the sensor supports 3 distance modes (short, medium, long),
+ * the ST VL53L1X ULD API supports only two which should be sufficient in
+ * most use cases.
+ *
+ * @note    Distance mode CANNOT be configured if module \ref vl53l1x_basic
+ *          is enabled.
+ */
+typedef enum {
+    VL53L1X_DIST_SHORT  = 1,        /**< up to 1.3 m */
+    VL53L1X_DIST_LONG   = 2,        /**< up to 4 m */
+} vl53l1x_dist_mode_t;
+
+/**
+ * @brief   Interrupt mode
+ *
+ * The interrupt mode defines when an interrupt is triggered. Interrupts can
+ * be triggered in each measurement cycle, either when new data is available
+ * (ranging mode) or when the distance threshold conditions defined by
+ * \ref vl53l1x_thresh_config_t are met (detection mode). Use the function
+ * \ref vl53l1x_int_config to configure these interrupts.
+ *
+ * @note    If the \ref vl53l1x_basic is used, only data-ready interrupts
+ *          are supported.
+ */
+typedef enum {
+    VL53L1X_INT_DATA_READY,  /**< interrupt on new data */
+    VL53L1X_INT_DIST_THRESH, /**< interrupt when distance threshold conditions are met */
+} vl53l1x_int_mode_t;
+
+/**
+ * @brief   Threshold modes used for detection mode
+ *
+ * The threshold mode defines how the upper and lower thresholds are used
+ * to trigger an interrupt in detection mode.
+ *
+ * @note Although the VL53L1X allows the definition of thresholds for distance
+ *       and signal rate, the ST VL53L1X ULD API only allows the definition
+ *       of thresholds for the distance.
+ */
+typedef enum {
+    VL53L1X_THRESH_HIGH = 0, /**< when the distance exceeds the upper threshold */
+    VL53L1X_THRESH_LOW  = 1, /**< when the distance falls below the lower threshold */
+    VL53L1X_THRESH_OUT  = 2, /**< when the distance exceeds the upper threshold or
+                                  falls below the lower threshold (the distance
+                                  leaves the threshold window) */
+    VL53L1X_THRESH_IN   = 3, /**< when the distance exceeds the lower threshold or
+                                  falls below the higher threshold (the distance
+                                  enters the threshold window) */
+} vl53l1x_thresh_mode_t;
+
+/**
+ * @brief   Distance threshold configuration
+ *
+ * The distance threshold configuration is used in function \ref vl53l1x_int_config
+ * to configure the conditions when interrupts are triggered in detection mode.
+ *
+ * @note    If the \ref vl53l1x_basic is used, only data-ready interrupts can be
+ *          used. The distance threshold configuration is not used in this case.
+ */
+typedef struct {
+    vl53l1x_thresh_mode_t mode; /**< threshold mode for distance */
+    uint16_t high;              /**< upper threshold for distance in mm */
+    uint16_t low;               /**< lower threshold for distance in mm */
+} vl53l1x_thresh_config_t;
+
+/**
+ * @brief   VL53L1X device initialization parameters
+ */
+typedef struct {
+    i2c_t i2c_dev;      /**< I2C device, default I2C_DEV(0) */
+    uint8_t i2c_addr;   /**< I2C slave address */
+    bool vddio_2v8;     /**< if true, I/O voltage is 2.8 V, otherwise 1.8 V */
+    gpio_t pin_int;     /**< Interrupt pin open drain, active low:
+                             \ref GPIO_UNDEF if not used */
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+    gpio_t pin_shutdown;/**< Shutdown pin low active:
+                             \ref GPIO_UNDEF if not used */
+    uint16_t budget;    /**< Timing budget given to the sensor to perform range
+                             measurements in ms [15, 20, 33, 50, 100, 200, 500],
+                             default: 50 ms */
+    uint32_t period;    /**< Inter-measurement period in ms which has to be
+                             at least vl53l1x_params_t::budget + 4ms,
+                             default: 100 ms */
+    vl53l1x_dist_mode_t mode; /**< Distance mode, default: VL53L1X_DIST_LONG */
+#endif /* !IS_USED(MODULE_VL53L1X_BASIC) */
+} vl53l1x_params_t;
+
+/**
+ * @brief   VL53L1X sensor device data structure type
+ */
+typedef struct {
+    uint16_t addr;      /**< Device address as used by the ST VL53L1X ULD API,
+                             format = I2C bus num << 8 | I2C slave address */
+    bool int_init;      /**< Interrupt pin is already initialized */
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+    uint16_t budget;    /**< Timing budget used */
+    uint32_t period;    /**< Inter-measurement period used */
+    vl53l1x_dist_mode_t mode;       /**< Distance mode used */
+#endif
+    const vl53l1x_params_t *params; /**< Device initialization parameters */
+} vl53l1x_t;
+
+/**
+ * @brief   VL53L1X ranging data
+ */
+typedef struct {
+    uint8_t  status;        /**< status for the current measurement */
+    uint16_t distance;      /**< distance in millimeter */
+    uint16_t signal_rate;   /**< signal rate in kcps (kilo count per seconds) */
+    uint16_t ambient_rate;  /**< ambient rate in kcps (kilo count per seconds) */
+} vl53l1x_data_t;
+
+/**
+ * @brief   VL53L1X region of interest (ROI)
+ *
+ * Defines the region of interest (ROI) within the 16 x 16 SPAD (single photon
+ * avalanche diode) array. The ROI is a square or rectangle defined by
+ * x and y dimension. The center is set automatically.
+ */
+typedef struct {
+    uint16_t x_size;     /**< ROI x size [4...16] (default 16)  */
+    uint16_t y_size;     /**< ROI y size [4...16] (default 16) */
+} vl53l1x_roi_t;
+
+/**
+ * @brief   Initialize the VL53L1X sensor device
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor to be initialized
+ * @param[in]   params  configuration parameters, see \ref vl53l1x_params_t
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ * @retval  -ENODEV no device found
+ */
+int vl53l1x_init(vl53l1x_t *dev, const vl53l1x_params_t *params);
+
+/**
+ * @brief   Data-ready status function
+ *
+ * The function can be used for polling to know when new ranging data are
+ * available.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ *
+ * @retval  0       new ranging data are ready
+ * @retval  -EAGAIN no new ranging data available
+ * @retval  -EIO    on I2C communication error
+ */
+int vl53l1x_data_ready(vl53l1x_t *dev);
+
+/**
+ * @brief   Read one ranging data sample in mm
+ *
+ * This function returns only the ranging data in millimeters.
+ *
+ * @note    Since reading any data resets the interrupt as well as the
+ *          data-ready flag, either function \ref vl53l1x_read_mm or function
+ *          \ref vl53l1x_read_data can be used in one measurement cycle.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ * @param[out]  mm      ranging data in mm
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ */
+int vl53l1x_read_mm(vl53l1x_t *dev, uint16_t *mm);
+
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+/**
+ * @brief   Read one ranging data sample with status and signal information
+ *
+ * This function returns the ranging data distance together with additional
+ * information about the measurement like the status and the signals.
+ *
+ * @note
+ * - Since reading any data resets the interrupt as well as the data-ready
+ *   flag, either function \ref vl53l1x_read_mm or function
+*    \ref vl53l1x_read_data can be used in one measurement cycle.
+ * - This function is NOT available if module \ref vl53l1x_basic is used.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ * @param[out]  data    ranging data
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ */
+int vl53l1x_read_data(vl53l1x_t *dev, vl53l1x_data_t *data);
+
+/**
+ * @brief   Power down the sensor
+ *
+ * This function requires that a GPIO connected to sensor's /XSHUT pin is
+ * defined by parameter vl53l1x_params_t::pin_shutdown.
+ *
+ * @note    This function is NOT available if module \ref vl53l1x_basic
+ *          is used.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ */
+int vl53l1x_power_down(const vl53l1x_t *dev);
+
+/**
+ * @brief   Power up the sensor
+ *
+ * This function requires that a GPIO connected to sensor's /XSHUT pin is
+ * defined by parameter vl53l1x_params_t::pin_shutdown.
+ *
+ * @note    This function is NOT available if module \ref vl53l1x_basic
+ *          is used.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ * @retval  -ENODEV no device found
+ */
+int vl53l1x_power_up(vl53l1x_t *dev);
+
+/**
+ * @brief   Change the timing budget in microseconds
+ *
+ * This function can be used to change the timing budget that was defined
+ * by configuration parameter vl53l1x_params_t::budget during sensor
+ * initialization.
+ *
+ * @note    This function is NOT available if module \ref vl53l1x_basic
+ *          is used.
+ *
+ * @param[in]   dev         device descriptor of VL53L1X sensor
+ * @param[in]   budget_ms   new timing budget in ms
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ * @retval  -EINVAL if the current distance mode or the given budget_ms parameter is invalid
+ */
+int vl53l1x_set_timing_budget(vl53l1x_t *dev, uint16_t budget_ms);
+
+/**
+ * @brief   Change the inter-measurement period im ms
+ *
+ * This function can be used to change the the inter-measurement period that was
+ * defined by configuration parameter vl53l1x_params_t::period during sensor
+ * initialization.
+ *
+ * @pre     The inter-measurement period MUST be longer than the timing budget
+ *          + 4 ms. Otherwise the function fails. Therefore, if the time
+ *          budget is also changed, it should be done first.
+ *
+ * @note    This function is NOT available if module \ref vl53l1x_basic
+ *          is used.
+ *
+ * @param[in]   dev         device descriptor of VL53L1X sensor
+ * @param[in]   period_ms   new measurement period in ms
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ */
+int vl53l1x_set_measurement_period(vl53l1x_t *dev, uint32_t period_ms);
+
+/**
+ * @brief   Change the distance mode
+ *
+ * This function can be used to change the the distance mode that was
+ * defined by configuration parameter vl53l1x_params_t::mode during sensor
+ * initialization.
+ *
+ * @note    This function is NOT available if module \ref vl53l1x_basic
+ *          is used.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ * @param[in]   mode    new distance mode, see \ref vl53l1x_dist_mode_t
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ * @retval  -EINVAL if the given mode parameter or the current budget is invalid
+ */
+int vl53l1x_set_distance_mode(vl53l1x_t *dev, vl53l1x_dist_mode_t mode);
+
+/**
+ * @brief   Set the region of interest (ROI)
+ *
+ * Using this function, the region of interest (ROI) within the 16 x 16 SPAD
+ * (single photon avalanche diode) array can be defined.
+ *
+ * @note    This function is NOT available if module \ref vl53l1x_basic
+ *          is used.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ * @param[in]   roi     new region of interest, see #vl53l1x_roi_t
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ */
+int vl53l1x_set_roi(vl53l1x_t *dev, vl53l1x_roi_t *roi);
+
+/**
+ * @brief   Get the region of interest (ROI)
+ *
+ * @note    This function is NOT available if module \ref vl53l1x_basic
+ *          is used.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ * @param[out]  roi     current region of interest, see \ref vl53l1x_roi_t
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ */
+int vl53l1x_get_roi(vl53l1x_t *dev, vl53l1x_roi_t *roi);
+
+#endif /* IS_USED(MODULE_VL53L1X_BASIC) */
+
+/**
+ * @brief   Configure interrupts
+ *
+ * The function
+ *
+ * - configures the interrupts of the sensor,
+ * - initializes the GPIO defined by vl53l1x_params_t::pin_int, and
+ * - attaches the ISR specified by the @p isr parameter to the interrupt.
+ *
+ * @warning Since the ISR is executed in the interrupt context, it must not be
+ *          blocking or time consuming. In addition, it must not access the
+ *          sensor directly via I2C. It should only indicate to a waiting
+ *          thread that an interrupt has occurred, which is then handled
+ *          in the thread context.
+ *          If it is tried to access the sensor in interrupt context, an
+ *          assertion blows up (if assertions are enabled).
+ *
+ * @note    The configuration of distance threshold interrupts is ONLY
+ *          used if the \ref vl53l1x driver variant is used. Otherwise, only
+ *          data-ready interrupts are used independent on the configuration given
+ *          by parameter \p cfg. In later case, parameter \p cfg can be NULL.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ * @param[in]   mode    interrupt mode, see \ref vl53l1x_int_mode_t
+ * @param[in]   cfg     threshold configuration, see \ref vl53l1x_thresh_config_t
+ * @param[in]   isr     ISR called for all types of interrupts
+ * @param[in]   isr_arg ISR argument, can be NULL
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ */
+int vl53l1x_int_config(vl53l1x_t *dev, vl53l1x_int_mode_t mode,
+                                       vl53l1x_thresh_config_t* cfg,
+                                       void (*isr)(void *),
+                                       void *isr_arg);
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/drivers/saul/init_devs/auto_init_vl53l1x.c
+++ b/drivers/saul/init_devs/auto_init_vl53l1x.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2021 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/*
+ * @ingroup     drivers_vl53l1x
+ * @ingroup     sys_auto_init_saul
+ * @brief       Auto initialization of ST VL53L1X Time-of-Flight (ToF) ranging sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ */
+
+#ifdef MODULE_VL53L1X
+
+#include "assert.h"
+#include "log.h"
+#include "saul_reg.h"
+#include "vl53l1x.h"
+#include "vl53l1x_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define VL53L1X_NUM    (sizeof(vl53l1x_params) / sizeof(vl53l1x_params[0]))
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static vl53l1x_t vl53l1x_devs[VL53L1X_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[VL53L1X_NUM];
+
+/**
+ * @brief   Define the number of saul info
+ */
+#define VL53L1X_INFO_NUM (sizeof(vl53l1x_saul_info) / sizeof(vl53l1x_saul_info[0]))
+
+/**
+ * @brief   Reference the driver structs
+ */
+extern saul_driver_t vl53l1x_saul_driver;
+
+void auto_init_vl53l1x(void)
+{
+    assert(VL53L1X_INFO_NUM == VL53L1X_NUM);
+
+    for (unsigned i = 0; i < VL53L1X_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing vl53l1x #%u\n", i);
+
+        if (vl53l1x_init(&vl53l1x_devs[i], &vl53l1x_params[i]) != VL53L1X_OK) {
+            LOG_ERROR("[auto_init_saul] error initializing vl53l1x #%u\n", i);
+            continue;
+        }
+
+        saul_entries[i].dev = &(vl53l1x_devs[i]);
+        saul_entries[i].name = vl53l1x_saul_info[i].name;
+        saul_entries[i].driver = &vl53l1x_saul_driver;
+        saul_reg_add(&(saul_entries[i]));
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_VL53L1X */

--- a/drivers/saul/init_devs/init.c
+++ b/drivers/saul/init_devs/init.c
@@ -359,6 +359,10 @@ void saul_init_devs(void)
         extern void auto_init_veml6070(void);
         auto_init_veml6070();
     }
+    if (IS_USED(MODULE_VL53L1X)) {
+        extern void auto_init_vl53l1x(void);
+        auto_init_vl53l1x();
+    }
     if (IS_USED(MODULE_VL6180X)) {
         extern void auto_init_vl6180x(void);
         auto_init_vl6180x();

--- a/drivers/vl53l1x/Kconfig
+++ b/drivers/vl53l1x/Kconfig
@@ -1,0 +1,47 @@
+# Copyright (c) 2025 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+if !USEMODULE_VL53L1X_BASIC
+
+menu "VL53L1X Time-of-Flight (ToF) ranging sensor"
+
+choice
+    bool "Distance mode"
+    default VL53L1X_DIST_LONG
+    config VL53L1X_DIST_SHORT
+        bool "Short - up to 1.3 m"
+    config VL53L1X_DIST_LONG
+        bool "Long - up to 4 m"
+endchoice
+
+choice
+    bool "Timing budget"
+    default VL53L1X_PARAM_TIMING_BUDGET_50
+    config VL53L1X_PARAM_TIMING_BUDGET_15
+        bool "15 ms"
+    config VL53L1X_PARAM_TIMING_BUDGET_20
+        bool "20 ms"
+    config VL53L1X_PARAM_TIMING_BUDGET_33
+        bool "33 ms"
+    config VL53L1X_PARAM_TIMING_BUDGET_50
+        bool "50 ms"
+    config VL53L1X_PARAM_TIMING_BUDGET_100
+        bool "100 ms"
+    config VL53L1X_PARAM_TIMING_BUDGET_200
+        bool "200 ms"
+    config VL53L1X_PARAM_TIMING_BUDGET_500
+        bool "500 ms"
+endchoice
+
+config VL53L1X_PARAM_PERIOD
+    int "Inter-measurement period [ms]"
+    default 100
+    range 20 1000
+
+endmenu
+
+endif # !USEMODULE_VL53L1X_BASIC

--- a/drivers/vl53l1x/Makefile
+++ b/drivers/vl53l1x/Makefile
@@ -1,0 +1,4 @@
+DIRS += vendor/core
+DIRS += vendor/platform
+
+include $(RIOTBASE)/Makefile.base

--- a/drivers/vl53l1x/Makefile.dep
+++ b/drivers/vl53l1x/Makefile.dep
@@ -1,0 +1,13 @@
+ifneq (,$(filter vl53l1x_%,$(USEMODULE)))
+  USEMODULE += vl53l1x
+endif
+
+USEMODULE += vl53l1x_st_api_core
+USEMODULE += vl53l1x_st_api_platform
+
+ifneq (,$(filter vl53l1x,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio_irq
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_i2c
+  USEMODULE += ztimer_msec
+endif

--- a/drivers/vl53l1x/Makefile.include
+++ b/drivers/vl53l1x/Makefile.include
@@ -1,0 +1,10 @@
+# include variants of VL53L1X drivers as pseudo modules
+PSEUDOMODULES += vl53l1x_basic
+
+USEMODULE_INCLUDES_vl53l1x := $(LAST_MAKEFILEDIR)/include
+USEMODULE_INCLUDES_vl53l1x_vendor_core := $(LAST_MAKEFILEDIR)/vendor/core
+USEMODULE_INCLUDES_vl53l1x_vendor_platform := $(LAST_MAKEFILEDIR)/vendor/platform
+
+USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_vl53l1x)
+USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_vl53l1x_vendor_core)
+USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_vl53l1x_vendor_platform)

--- a/drivers/vl53l1x/include/vl53l1x_params.h
+++ b/drivers/vl53l1x/include/vl53l1x_params.h
@@ -1,0 +1,145 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     drivers_vl53l1x
+ * @brief       Default configuration for ST VL53L1X Time-of-Flight (ToF) ranging sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#include "board.h"
+#include "saul_reg.h"
+
+#include "vl53l1x.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Default hardware configuration parameters
+ * @{
+ */
+
+/**
+ * @brief    Default device is I2C_DEV(0)
+ */
+#ifndef VL53L1X_PARAM_DEV
+#  define VL53L1X_PARAM_DEV             I2C_DEV(0)
+#endif
+
+/**
+ * @brief    Default I2C slave address
+ */
+#ifndef VL53L1X_PARAM_ADDR
+#  define VL53L1X_PARAM_ADDR            (VL53L1X_I2C_ADDRESS)
+#endif
+
+/**
+ * @brief   Default I2C VDDIO voltage: 2.8 V
+ */
+#ifndef VL53L1X_PARAM_VDDIO_2V8
+#  define VL53L1X_PARAM_VDDIO_2V8       (true)
+#endif
+
+/**
+ * @brief   Default interrupt pin: not used
+ */
+#ifndef VL53L1X_PARAM_PIN_INT
+#  define VL53L1X_PARAM_PIN_INT         (GPIO_UNDEF)
+#endif
+
+/**
+ * @brief   Default shutdown pin: not used
+ */
+#ifndef VL53L1X_PARAM_PIN_SHUTDOWN
+#  define VL53L1X_PARAM_PIN_SHUTDOWN    (GPIO_UNDEF)
+#endif
+/** @} */
+
+/**
+ * @name    Default sensor configuration parameters
+ * @{
+ */
+
+/**
+ * @brief   Default inter-measurement period [ms]: 100 ms
+ */
+#ifndef CONFIG_VL53L1X_PARAM_PERIOD
+#  define CONFIG_VL53L1X_PARAM_PERIOD           (100)
+#endif
+
+/**
+ * @brief   Default Timing budget [ms]: 50 ms
+ */
+#ifndef CONFIG_VL53L1X_PARAM_TIMING_BUDGET
+#  define CONFIG_VL53L1X_PARAM_TIMING_BUDGET    (50)
+#endif
+
+/**
+ * @brief   Default distance mode: long
+ */
+#ifndef CONFIG_VL53L1X_PARAM_DISTANCE_MODE
+#  define CONFIG_VL53L1X_PARAM_DISTANCE_MODE    (VL53L1X_DIST_LONG)
+#endif
+/**@}*/
+
+/**
+ * @brief   Default VL53L1X configuration parameter set
+ */
+#ifndef VL53L1X_PARAMS
+#  if !IS_USED(MODULE_VL53L1X_BASIC)
+#    define VL53L1X_PARAMS { \
+                                .i2c_dev = VL53L1X_PARAM_DEV, \
+                                .i2c_addr = VL53L1X_PARAM_ADDR, \
+                                .vddio_2v8 = VL53L1X_PARAM_VDDIO_2V8, \
+                                .pin_int = VL53L1X_PARAM_PIN_INT, \
+                                .pin_shutdown = VL53L1X_PARAM_PIN_SHUTDOWN, \
+                                .budget = CONFIG_VL53L1X_PARAM_TIMING_BUDGET, \
+                                .period = CONFIG_VL53L1X_PARAM_PERIOD, \
+                                .mode = CONFIG_VL53L1X_PARAM_DISTANCE_MODE, \
+                        }
+#  else /* !IS_USED(MODULE_VL53L1X_BASIC) */
+#    define VL53L1X_PARAMS  { \
+                                .i2c_dev = VL53L1X_PARAM_DEV, \
+                                .i2c_addr = VL53L1X_PARAM_ADDR, \
+                                .vddio_2v8 = VL53L1X_PARAM_VDDIO_2V8, \
+                                .pin_int = VL53L1X_PARAM_PIN_INT, \
+                            }
+#  endif /* !IS_USED(MODULE_VL53L1X_BASIC) */
+#endif /* VL53L1X_PARAMS */
+
+/**
+ * @brief   Default SAUL device information
+ */
+#ifndef VL53L1X_SAUL_INFO
+#  define VL53L1X_SAUL_INFO { .name = "vl53l1x" }
+#endif
+
+/**
+ * @brief   Allocate some memory to store the default configuration
+ */
+static const vl53l1x_params_t vl53l1x_params[] =
+{
+    VL53L1X_PARAMS
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t vl53l1x_saul_info[] =
+{
+    VL53L1X_SAUL_INFO
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/drivers/vl53l1x/include/vl53l1x_params.h
+++ b/drivers/vl53l1x/include/vl53l1x_params.h
@@ -68,6 +68,33 @@ extern "C" {
  * @{
  */
 
+#if !DOXYGEN
+
+/* Mapping of Kconfig defines to the respective driver enumeration values */
+#  ifdef CONFIG_VL53L1X_DIST_SHORT
+#    define CONFIG_VL53L1X_PARAM_DISTANCE_MODE      (VL53L1X_DIST_SHORT)
+#  elif CONFIG_VL53L1X_DIST_LONG
+#    define CONFIG_VL53L1X_PARAM_DISTANCE_MODE      (VL53L1X_DIST_LONG)
+#  endif
+
+#  ifdef CONFIG_VL53L1X_PARAM_TIMING_BUDGET_15
+#     define CONFIG_VL53L1X_PARAM_TIMING_BUDGET     (15)
+#  elif CONFIG_VL53L1X_PARAM_TIMING_BUDGET_20
+#     define CONFIG_VL53L1X_PARAM_TIMING_BUDGET     (20)
+#  elif    CONFIG_VL53L1X_PARAM_TIMING_BUDGET_33
+#     define CONFIG_VL53L1X_PARAM_TIMING_BUDGET     (33)
+#  elif    CONFIG_VL53L1X_PARAM_TIMING_BUDGET_50
+#     define CONFIG_VL53L1X_PARAM_TIMING_BUDGET     (50)
+#  elif    CONFIG_VL53L1X_PARAM_TIMING_BUDGET_100
+#     define CONFIG_VL53L1X_PARAM_TIMING_BUDGET     (100)
+#  elif    CONFIG_VL53L1X_PARAM_TIMING_BUDGET_200
+#     define CONFIG_VL53L1X_PARAM_TIMING_BUDGET     (200)
+#  elif    CONFIG_VL53L1X_PARAM_TIMING_BUDGET_500
+#     define CONFIG_VL53L1X_PARAM_TIMING_BUDGET     (500)
+#  endif
+
+#endif /* !DOXYGEN */
+
 /**
  * @brief   Default inter-measurement period [ms]: 100 ms
  */

--- a/drivers/vl53l1x/include/vl53l1x_regs.h
+++ b/drivers/vl53l1x/include/vl53l1x_regs.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     drivers_vl53l1x
+ * @brief       Register definitions for ST VL53L1X Time-of-Flight (ToF) ranging sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#if !DOXYGEN
+/**
+ * @name    Register addresses
+ *
+ * @{
+ */
+#  define VL53L1X_IDENTIFICATION__REVISION_ID   (0x0111)
+#  define VL53L1X_IDENTIFICATION__MODULE_TYPE   (0x0110)
+#  define VL53L1X_IDENTIFICATION__MODULE_ID     (0x0112)
+#  define VL53L1X_PAD_I2C_HV__EXTSUP_CONFIG     (0x002e)
+#  define VL53L1X_SOFT_RESET                    (0x0b00)
+/** @} */
+#endif /* !DOXYGEN */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/drivers/vl53l1x/vendor/LICENSE.txt
+++ b/drivers/vl53l1x/vendor/LICENSE.txt
@@ -1,0 +1,7 @@
+This software component is provided to you as part of a software package and
+applicable license terms are in the  Package_license file. If you received this
+software component outside of a package or without applicable license terms,
+the terms of the BSD OPEN SOURCE SLA0103 license shall apply. 
+You may obtain a copy of the BSD OPEN SOURCE SLA0103 at:
+https://www.st.com/SLA0103
+

--- a/drivers/vl53l1x/vendor/core/Makefile
+++ b/drivers/vl53l1x/vendor/core/Makefile
@@ -1,0 +1,3 @@
+MODULE=vl53l1x_st_api_core
+
+include $(RIOTBASE)/Makefile.base

--- a/drivers/vl53l1x/vendor/core/VL53L1X_api.c
+++ b/drivers/vl53l1x/vendor/core/VL53L1X_api.c
@@ -1,0 +1,807 @@
+/**
+  *
+  * Copyright (c) 2023 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/**
+ * @file  vl53l1x_api.c
+ * @brief Functions implementation
+ */
+
+#include "VL53L1X_api.h"
+#include <string.h>
+
+#if 0
+uint8_t VL51L1X_NVM_CONFIGURATION[] = {
+0x00, /* 0x00 : not user-modifiable */
+0x29, /* 0x01 : 7 bits I2C address (default=0x29), use SetI2CAddress(). Warning: after changing the register value to a new I2C address, the device will only answer to the new address */
+0x00, /* 0x02 : not user-modifiable */
+0x00, /* 0x03 : not user-modifiable */
+0x00, /* 0x04 : not user-modifiable */
+0x00, /* 0x05 : not user-modifiable */
+0x00, /* 0x06 : not user-modifiable */
+0x00, /* 0x07 : not user-modifiable */
+0x00, /* 0x08 : not user-modifiable */
+0x50, /* 0x09 : not user-modifiable */
+0x00, /* 0x0A : not user-modifiable */
+0x00, /* 0x0B : not user-modifiable */
+0x00, /* 0x0C : not user-modifiable */
+0x00, /* 0x0D : not user-modifiable */
+0x0a, /* 0x0E : not user-modifiable */
+0x00, /* 0x0F : not user-modifiable */
+0x00, /* 0x10 : not user-modifiable */
+0x00, /* 0x11 : not user-modifiable */
+0x00, /* 0x12 : not user-modifiable */
+0x00, /* 0x13 : not user-modifiable */
+0x00, /* 0x14 : not user-modifiable */
+0x00, /* 0x15 : not user-modifiable */
+0x00, /* 0x16 : Xtalk calibration value MSB (7.9 format in kcps), use SetXtalk() */
+0x00, /* 0x17 : Xtalk calibration value LSB */
+0x00, /* 0x18 : not user-modifiable */
+0x00, /* 0x19 : not user-modifiable */
+0x00, /* 0x1a : not user-modifiable */
+0x00, /* 0x1b : not user-modifiable */
+0x00, /* 0x1e : Part to Part offset x4 MSB (in mm), use SetOffset() */
+0x50, /* 0x1f : Part to Part offset x4 LSB */
+0x00, /* 0x20 : not user-modifiable */
+0x00, /* 0x21 : not user-modifiable */
+0x00, /* 0x22 : not user-modifiable */
+0x00, /* 0x23 : not user-modifiable */
+}
+#endif
+
+static const uint8_t VL51L1X_DEFAULT_CONFIGURATION[] = {
+0x00, /* 0x2d : set bit 2 and 5 to 1 for fast plus mode (1MHz I2C), else don't touch */
+0x00, /* 0x2e : bit 0 if I2C pulled up at 1.8V, else set bit 0 to 1 (pull up at AVDD) */
+0x00, /* 0x2f : bit 0 if GPIO pulled up at 1.8V, else set bit 0 to 1 (pull up at AVDD) */
+0x01, /* 0x30 : set bit 4 to 0 for active high interrupt and 1 for active low (bits 3:0 must be 0x1), use SetInterruptPolarity() */
+0x02, /* 0x31 : bit 1 = interrupt depending on the polarity, use CheckForDataReady() */
+0x00, /* 0x32 : not user-modifiable */
+0x02, /* 0x33 : not user-modifiable */
+0x08, /* 0x34 : not user-modifiable */
+0x00, /* 0x35 : not user-modifiable */
+0x08, /* 0x36 : not user-modifiable */
+0x10, /* 0x37 : not user-modifiable */
+0x01, /* 0x38 : not user-modifiable */
+0x01, /* 0x39 : not user-modifiable */
+0x00, /* 0x3a : not user-modifiable */
+0x00, /* 0x3b : not user-modifiable */
+0x00, /* 0x3c : not user-modifiable */
+0x00, /* 0x3d : not user-modifiable */
+0xff, /* 0x3e : not user-modifiable */
+0x00, /* 0x3f : not user-modifiable */
+0x0F, /* 0x40 : not user-modifiable */
+0x00, /* 0x41 : not user-modifiable */
+0x00, /* 0x42 : not user-modifiable */
+0x00, /* 0x43 : not user-modifiable */
+0x00, /* 0x44 : not user-modifiable */
+0x00, /* 0x45 : not user-modifiable */
+0x20, /* 0x46 : interrupt configuration 0->level low detection, 1-> level high, 2-> Out of window, 3->In window, 0x20-> New sample ready , TBC */
+0x0b, /* 0x47 : not user-modifiable */
+0x00, /* 0x48 : not user-modifiable */
+0x00, /* 0x49 : not user-modifiable */
+0x02, /* 0x4a : not user-modifiable */
+0x0a, /* 0x4b : not user-modifiable */
+0x21, /* 0x4c : not user-modifiable */
+0x00, /* 0x4d : not user-modifiable */
+0x00, /* 0x4e : not user-modifiable */
+0x05, /* 0x4f : not user-modifiable */
+0x00, /* 0x50 : not user-modifiable */
+0x00, /* 0x51 : not user-modifiable */
+0x00, /* 0x52 : not user-modifiable */
+0x00, /* 0x53 : not user-modifiable */
+0xc8, /* 0x54 : not user-modifiable */
+0x00, /* 0x55 : not user-modifiable */
+0x00, /* 0x56 : not user-modifiable */
+0x38, /* 0x57 : not user-modifiable */
+0xff, /* 0x58 : not user-modifiable */
+0x01, /* 0x59 : not user-modifiable */
+0x00, /* 0x5a : not user-modifiable */
+0x08, /* 0x5b : not user-modifiable */
+0x00, /* 0x5c : not user-modifiable */
+0x00, /* 0x5d : not user-modifiable */
+0x01, /* 0x5e : not user-modifiable */
+0xcc, /* 0x5f : not user-modifiable */
+0x0f, /* 0x60 : not user-modifiable */
+0x01, /* 0x61 : not user-modifiable */
+0xf1, /* 0x62 : not user-modifiable */
+0x0d, /* 0x63 : not user-modifiable */
+0x01, /* 0x64 : Sigma threshold MSB (mm in 14.2 format for MSB+LSB), use SetSigmaThreshold(), default value 90 mm  */
+0x68, /* 0x65 : Sigma threshold LSB */
+0x00, /* 0x66 : Min count Rate MSB (MCPS in 9.7 format for MSB+LSB), use SetSignalThreshold() */
+0x80, /* 0x67 : Min count Rate LSB */
+0x08, /* 0x68 : not user-modifiable */
+0xb8, /* 0x69 : not user-modifiable */
+0x00, /* 0x6a : not user-modifiable */
+0x00, /* 0x6b : not user-modifiable */
+0x00, /* 0x6c : Intermeasurement period MSB, 32 bits register, use SetIntermeasurementInMs() */
+0x00, /* 0x6d : Intermeasurement period */
+0x0f, /* 0x6e : Intermeasurement period */
+0x89, /* 0x6f : Intermeasurement period LSB */
+0x00, /* 0x70 : not user-modifiable */
+0x00, /* 0x71 : not user-modifiable */
+0x00, /* 0x72 : distance threshold high MSB (in mm, MSB+LSB), use SetD:tanceThreshold() */
+0x00, /* 0x73 : distance threshold high LSB */
+0x00, /* 0x74 : distance threshold low MSB ( in mm, MSB+LSB), use SetD:tanceThreshold() */
+0x00, /* 0x75 : distance threshold low LSB */
+0x00, /* 0x76 : not user-modifiable */
+0x01, /* 0x77 : not user-modifiable */
+0x0f, /* 0x78 : not user-modifiable */
+0x0d, /* 0x79 : not user-modifiable */
+0x0e, /* 0x7a : not user-modifiable */
+0x0e, /* 0x7b : not user-modifiable */
+0x00, /* 0x7c : not user-modifiable */
+0x00, /* 0x7d : not user-modifiable */
+0x02, /* 0x7e : not user-modifiable */
+0xc7, /* 0x7f : ROI center, use SetROI() */
+0xff, /* 0x80 : XY ROI (X=Width, Y=Height), use SetROI() */
+0x9B, /* 0x81 : not user-modifiable */
+0x00, /* 0x82 : not user-modifiable */
+0x00, /* 0x83 : not user-modifiable */
+0x00, /* 0x84 : not user-modifiable */
+0x01, /* 0x85 : not user-modifiable */
+0x00, /* 0x86 : clear interrupt, use ClearInterrupt() */
+0x00  /* 0x87 : start ranging, use StartRanging() or StopRanging(), If you want an automatic start after VL53L1X_init() call, put 0x40 in location 0x87 */
+};
+
+static const uint8_t status_rtn[24] = { 255, 255, 255, 5, 2, 4, 1, 7, 3, 0,
+	255, 255, 9, 13, 255, 255, 255, 255, 10, 6,
+	255, 255, 11, 12
+};
+
+VL53L1X_ERROR VL53L1X_GetSWVersion(VL53L1X_Version_t *pVersion)
+{
+	VL53L1X_ERROR Status = 0;
+
+	pVersion->major = VL53L1X_IMPLEMENTATION_VER_MAJOR;
+	pVersion->minor = VL53L1X_IMPLEMENTATION_VER_MINOR;
+	pVersion->build = VL53L1X_IMPLEMENTATION_VER_SUB;
+	pVersion->revision = VL53L1X_IMPLEMENTATION_VER_REVISION;
+	return Status;
+}
+
+VL53L1X_ERROR VL53L1X_SetI2CAddress(uint16_t dev, uint8_t new_address)
+{
+	VL53L1X_ERROR status = 0;
+
+	status |= VL53L1_WrByte(dev, VL53L1_I2C_SLAVE__DEVICE_ADDRESS, new_address >> 1);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SensorInit(uint16_t dev)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t Addr = 0x00, tmp;
+
+	for (Addr = 0x2D; Addr <= 0x87; Addr++){
+		status |= VL53L1_WrByte(dev, Addr, VL51L1X_DEFAULT_CONFIGURATION[Addr - 0x2D]);
+	}
+	status |= VL53L1X_StartRanging(dev);
+	tmp  = 0;
+	while(tmp==0){
+			status |= VL53L1X_CheckForDataReady(dev, &tmp);
+	}
+	status |= VL53L1X_ClearInterrupt(dev);
+	status |= VL53L1X_StopRanging(dev);
+	status |= VL53L1_WrByte(dev, VL53L1_VHV_CONFIG__TIMEOUT_MACROP_LOOP_BOUND, 0x09); /* two bounds VHV */
+	status |= VL53L1_WrByte(dev, 0x0B, 0); /* start VHV from the previous temperature */
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_ClearInterrupt(uint16_t dev)
+{
+	VL53L1X_ERROR status = 0;
+
+	status |= VL53L1_WrByte(dev, SYSTEM__INTERRUPT_CLEAR, 0x01);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetInterruptPolarity(uint16_t dev, uint8_t NewPolarity)
+{
+	uint8_t Temp;
+	VL53L1X_ERROR status = 0;
+
+	status |= VL53L1_RdByte(dev, GPIO_HV_MUX__CTRL, &Temp);
+	Temp = Temp & 0xEF;
+	status |= VL53L1_WrByte(dev, GPIO_HV_MUX__CTRL, Temp | (!(NewPolarity & 1)) << 4);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetInterruptPolarity(uint16_t dev, uint8_t *pInterruptPolarity)
+{
+	uint8_t Temp;
+	VL53L1X_ERROR status = 0;
+
+	status |= VL53L1_RdByte(dev, GPIO_HV_MUX__CTRL, &Temp);
+	Temp = Temp & 0x10;
+	*pInterruptPolarity = !(Temp>>4);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_StartRanging(uint16_t dev)
+{
+	VL53L1X_ERROR status = 0;
+
+	status |= VL53L1_WrByte(dev, SYSTEM__MODE_START, 0x40);	/* Enable VL53L1X */
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_StopRanging(uint16_t dev)
+{
+	VL53L1X_ERROR status = 0;
+
+	status |= VL53L1_WrByte(dev, SYSTEM__MODE_START, 0x00);	/* Disable VL53L1X */
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_CheckForDataReady(uint16_t dev, uint8_t *isDataReady)
+{
+	uint8_t Temp;
+	uint8_t IntPol;
+	VL53L1X_ERROR status = 0;
+
+	status |= VL53L1X_GetInterruptPolarity(dev, &IntPol);
+	status |= VL53L1_RdByte(dev, GPIO__TIO_HV_STATUS, &Temp);
+	/* Read in the register to check if a new value is available */
+	if (status == 0){
+		if ((Temp & 1) == IntPol)
+			*isDataReady = 1;
+		else
+			*isDataReady = 0;
+	}
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetTimingBudgetInMs(uint16_t dev, uint16_t TimingBudgetInMs)
+{
+	uint16_t DM;
+	VL53L1X_ERROR  status=0;
+
+	status |= VL53L1X_GetDistanceMode(dev, &DM);
+	if (DM == 0)
+		return 1;
+	else if (DM == 1) {	/* Short DistanceMode */
+		switch (TimingBudgetInMs) {
+		case 15: /* only available in short distance mode */
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x01D);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x0027);
+			break;
+		case 20:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x0051);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x006E);
+			break;
+		case 33:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x00D6);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x006E);
+			break;
+		case 50:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x1AE);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x01E8);
+			break;
+		case 100:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x02E1);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x0388);
+			break;
+		case 200:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x03E1);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x0496);
+			break;
+		case 500:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x0591);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x05C1);
+			break;
+		default:
+			status = 1;
+			break;
+		}
+	} else {
+		switch (TimingBudgetInMs) {
+		case 20:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x001E);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x0022);
+			break;
+		case 33:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x0060);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x006E);
+			break;
+		case 50:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x00AD);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x00C6);
+			break;
+		case 100:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x01CC);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x01EA);
+			break;
+		case 200:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x02D9);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x02F8);
+			break;
+		case 500:
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI,
+					0x048F);
+			VL53L1_WrWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_B_HI,
+					0x04A4);
+			break;
+		default:
+			status = 1;
+			break;
+		}
+	}
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetTimingBudgetInMs(uint16_t dev, uint16_t *pTimingBudget)
+{
+	uint16_t Temp;
+	VL53L1X_ERROR status = 0;
+
+	status |= VL53L1_RdWord(dev, RANGE_CONFIG__TIMEOUT_MACROP_A_HI, &Temp);
+	switch (Temp) {
+		case 0x001D :
+			*pTimingBudget = 15;
+			break;
+		case 0x0051 :
+		case 0x001E :
+			*pTimingBudget = 20;
+			break;
+		case 0x00D6 :
+		case 0x0060 :
+			*pTimingBudget = 33;
+			break;
+		case 0x1AE :
+		case 0x00AD :
+			*pTimingBudget = 50;
+			break;
+		case 0x02E1 :
+		case 0x01CC :
+			*pTimingBudget = 100;
+			break;
+		case 0x03E1 :
+		case 0x02D9 :
+			*pTimingBudget = 200;
+			break;
+		case 0x0591 :
+		case 0x048F :
+			*pTimingBudget = 500;
+			break;
+		default:
+			status = 1;
+			*pTimingBudget = 0;
+	}
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetDistanceMode(uint16_t dev, uint16_t DM)
+{
+	uint16_t TB;
+	VL53L1X_ERROR status = 0;
+
+	status |= VL53L1X_GetTimingBudgetInMs(dev, &TB);
+	if (status != 0)
+		return 1;
+	switch (DM) {
+	case 1:
+		status = VL53L1_WrByte(dev, PHASECAL_CONFIG__TIMEOUT_MACROP, 0x14);
+		status = VL53L1_WrByte(dev, RANGE_CONFIG__VCSEL_PERIOD_A, 0x07);
+		status = VL53L1_WrByte(dev, RANGE_CONFIG__VCSEL_PERIOD_B, 0x05);
+		status = VL53L1_WrByte(dev, RANGE_CONFIG__VALID_PHASE_HIGH, 0x38);
+		status = VL53L1_WrWord(dev, SD_CONFIG__WOI_SD0, 0x0705);
+		status = VL53L1_WrWord(dev, SD_CONFIG__INITIAL_PHASE_SD0, 0x0606);
+		break;
+	case 2:
+		status = VL53L1_WrByte(dev, PHASECAL_CONFIG__TIMEOUT_MACROP, 0x0A);
+		status = VL53L1_WrByte(dev, RANGE_CONFIG__VCSEL_PERIOD_A, 0x0F);
+		status = VL53L1_WrByte(dev, RANGE_CONFIG__VCSEL_PERIOD_B, 0x0D);
+		status = VL53L1_WrByte(dev, RANGE_CONFIG__VALID_PHASE_HIGH, 0xB8);
+		status = VL53L1_WrWord(dev, SD_CONFIG__WOI_SD0, 0x0F0D);
+		status = VL53L1_WrWord(dev, SD_CONFIG__INITIAL_PHASE_SD0, 0x0E0E);
+		break;
+	default:
+		status = 1;
+		break;
+	}
+
+	if (status == 0)
+		status |= VL53L1X_SetTimingBudgetInMs(dev, TB);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetDistanceMode(uint16_t dev, uint16_t *DM)
+{
+	uint8_t TempDM, status=0;
+
+	status |= VL53L1_RdByte(dev,PHASECAL_CONFIG__TIMEOUT_MACROP, &TempDM);
+	if (TempDM == 0x14)
+		*DM=1;
+	if(TempDM == 0x0A)
+		*DM=2;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetInterMeasurementInMs(uint16_t dev, uint32_t InterMeasMs)
+{
+	uint16_t ClockPLL;
+	VL53L1X_ERROR status = 0;
+
+	status |= VL53L1_RdWord(dev, VL53L1_RESULT__OSC_CALIBRATE_VAL, &ClockPLL);
+	ClockPLL = ClockPLL&0x3FF;
+	VL53L1_WrDWord(dev, VL53L1_SYSTEM__INTERMEASUREMENT_PERIOD,
+			(uint32_t)(ClockPLL * InterMeasMs * 1.075));
+	return status;
+
+}
+
+VL53L1X_ERROR VL53L1X_GetInterMeasurementInMs(uint16_t dev, uint16_t *pIM)
+{
+	uint16_t ClockPLL;
+	VL53L1X_ERROR status = 0;
+	uint32_t tmp;
+
+	status |= VL53L1_RdDWord(dev,VL53L1_SYSTEM__INTERMEASUREMENT_PERIOD, &tmp);
+	*pIM = (uint16_t)tmp;
+	status |= VL53L1_RdWord(dev, VL53L1_RESULT__OSC_CALIBRATE_VAL, &ClockPLL);
+	ClockPLL = ClockPLL&0x3FF;
+	*pIM= (uint16_t)(*pIM/(ClockPLL*1.065));
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_BootState(uint16_t dev, uint8_t *state)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t tmp = 0;
+
+	status |= VL53L1_RdByte(dev,VL53L1_FIRMWARE__SYSTEM_STATUS, &tmp);
+	*state = tmp;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetSensorId(uint16_t dev, uint16_t *sensorId)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp = 0;
+
+	status |= VL53L1_RdWord(dev, VL53L1_IDENTIFICATION__MODEL_ID, &tmp);
+	*sensorId = tmp;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetDistance(uint16_t dev, uint16_t *distance)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp;
+
+	status |= (VL53L1_RdWord(dev,
+			VL53L1_RESULT__FINAL_CROSSTALK_CORRECTED_RANGE_MM_SD0, &tmp));
+	*distance = tmp;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetSignalPerSpad(uint16_t dev, uint16_t *signalRate)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t SpNb=1, signal;
+
+	status |= VL53L1_RdWord(dev,
+		VL53L1_RESULT__PEAK_SIGNAL_COUNT_RATE_CROSSTALK_CORRECTED_MCPS_SD0, &signal);
+	status |= VL53L1_RdWord(dev,
+		VL53L1_RESULT__DSS_ACTUAL_EFFECTIVE_SPADS_SD0, &SpNb);
+	*signalRate = (uint16_t) (200.0*signal/SpNb);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetAmbientPerSpad(uint16_t dev, uint16_t *ambPerSp)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t AmbientRate, SpNb = 1;
+
+	status |= VL53L1_RdWord(dev, RESULT__AMBIENT_COUNT_RATE_MCPS_SD, &AmbientRate);
+	status |= VL53L1_RdWord(dev, VL53L1_RESULT__DSS_ACTUAL_EFFECTIVE_SPADS_SD0, &SpNb);
+	*ambPerSp=(uint16_t) (200.0 * AmbientRate / SpNb);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetSignalRate(uint16_t dev, uint16_t *signal)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp;
+
+	status |= VL53L1_RdWord(dev,
+		VL53L1_RESULT__PEAK_SIGNAL_COUNT_RATE_CROSSTALK_CORRECTED_MCPS_SD0, &tmp);
+	*signal = tmp*8;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetSpadNb(uint16_t dev, uint16_t *spNb)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp;
+
+	status |= VL53L1_RdWord(dev,
+			      VL53L1_RESULT__DSS_ACTUAL_EFFECTIVE_SPADS_SD0, &tmp);
+	*spNb = tmp >> 8;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetAmbientRate(uint16_t dev, uint16_t *ambRate)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp;
+
+	status |= VL53L1_RdWord(dev, RESULT__AMBIENT_COUNT_RATE_MCPS_SD, &tmp);
+	*ambRate = tmp*8;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetRangeStatus(uint16_t dev, uint8_t *rangeStatus)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t RgSt;
+
+	*rangeStatus = 255;
+	status |= VL53L1_RdByte(dev, VL53L1_RESULT__RANGE_STATUS, &RgSt);
+	RgSt = RgSt & 0x1F;
+	if (RgSt < 24)
+		*rangeStatus = status_rtn[RgSt];
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetResult(uint16_t dev, VL53L1X_Result_t *pResult)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t Temp[17];
+	uint8_t RgSt = 255;
+
+	status |= VL53L1_ReadMulti(dev, VL53L1_RESULT__RANGE_STATUS, Temp, 17);
+	RgSt = Temp[0] & 0x1F;
+	if (RgSt < 24)
+		RgSt = status_rtn[RgSt];
+	pResult->Status = RgSt;
+	pResult->Ambient = (Temp[7] << 8 | Temp[8]) * 8;
+	pResult->NumSPADs = Temp[3];
+	pResult->SigPerSPAD = (Temp[15] << 8 | Temp[16]) * 8;
+	pResult->Distance = Temp[13] << 8 | Temp[14];
+
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetOffset(uint16_t dev, int16_t OffsetValue)
+{
+	VL53L1X_ERROR status = 0;
+	int16_t Temp;
+
+	Temp = (OffsetValue*4);
+	status |= VL53L1_WrWord(dev, ALGO__PART_TO_PART_RANGE_OFFSET_MM,
+			(uint16_t)Temp);
+	status |= VL53L1_WrWord(dev, MM_CONFIG__INNER_OFFSET_MM, 0x0);
+	status |= VL53L1_WrWord(dev, MM_CONFIG__OUTER_OFFSET_MM, 0x0);
+	return status;
+}
+
+VL53L1X_ERROR  VL53L1X_GetOffset(uint16_t dev, int16_t *offset)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t Temp;
+
+	status |= VL53L1_RdWord(dev,ALGO__PART_TO_PART_RANGE_OFFSET_MM, &Temp);
+	Temp = Temp<<3;
+	Temp = Temp>>5;
+   *offset = (int16_t)(Temp);
+
+   if(*offset > 1024) 
+   {
+		*offset = *offset - 2048;
+   }
+
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetXtalk(uint16_t dev, uint16_t XtalkValue)
+{
+/* XTalkValue in count per second to avoid float type */
+	VL53L1X_ERROR status = 0;
+
+	status |= VL53L1_WrWord(dev,
+			ALGO__CROSSTALK_COMPENSATION_X_PLANE_GRADIENT_KCPS,
+			0x0000);
+	status |= VL53L1_WrWord(dev, ALGO__CROSSTALK_COMPENSATION_Y_PLANE_GRADIENT_KCPS,
+			0x0000);
+	status |= VL53L1_WrWord(dev, ALGO__CROSSTALK_COMPENSATION_PLANE_OFFSET_KCPS,
+			(XtalkValue<<9)/1000); /* * << 9 (7.9 format) and /1000 to convert cps to kpcs */
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetXtalk(uint16_t dev, uint16_t *xtalk )
+{
+	VL53L1X_ERROR status = 0;
+
+	status |= VL53L1_RdWord(dev,ALGO__CROSSTALK_COMPENSATION_PLANE_OFFSET_KCPS, xtalk);
+	*xtalk = (uint16_t)((*xtalk*1000)>>9); /* * 1000 to convert kcps to cps and >> 9 (7.9 format) */
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetDistanceThreshold(uint16_t dev, uint16_t ThreshLow,
+			      uint16_t ThreshHigh, uint8_t Window,
+			      uint8_t IntOnNoTarget)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t Temp = 0;
+
+	status |= VL53L1_RdByte(dev, SYSTEM__INTERRUPT_CONFIG_GPIO, &Temp);
+	Temp = Temp & (~0x6F);
+	Temp = Temp|Window;
+	if (IntOnNoTarget == 0) {
+		status = VL53L1_WrByte(dev, SYSTEM__INTERRUPT_CONFIG_GPIO,Temp);
+	} else {
+		status = VL53L1_WrByte(dev, SYSTEM__INTERRUPT_CONFIG_GPIO,(Temp | 0x40));
+	}
+	status |= VL53L1_WrWord(dev, SYSTEM__THRESH_HIGH, ThreshHigh);
+	status |= VL53L1_WrWord(dev, SYSTEM__THRESH_LOW, ThreshLow);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetDistanceThresholdWindow(uint16_t dev, uint16_t *window)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t tmp;
+	status |= VL53L1_RdByte(dev,SYSTEM__INTERRUPT_CONFIG_GPIO, &tmp);
+	*window = (uint16_t)(tmp & 0x3);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetDistanceThresholdLow(uint16_t dev, uint16_t *low)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp;
+
+	status |= VL53L1_RdWord(dev,SYSTEM__THRESH_LOW, &tmp);
+	*low = tmp;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetDistanceThresholdHigh(uint16_t dev, uint16_t *high)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp;
+
+	status |= VL53L1_RdWord(dev,SYSTEM__THRESH_HIGH, &tmp);
+	*high = tmp;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetROICenter(uint16_t dev, uint8_t ROICenter)
+{
+	VL53L1X_ERROR status = 0;
+	status |= VL53L1_WrByte(dev, ROI_CONFIG__USER_ROI_CENTRE_SPAD, ROICenter);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetROICenter(uint16_t dev, uint8_t *ROICenter)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t tmp;
+	status |= VL53L1_RdByte(dev, ROI_CONFIG__USER_ROI_CENTRE_SPAD, &tmp);
+	*ROICenter = tmp;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetROI(uint16_t dev, uint16_t X, uint16_t Y)
+{
+	uint8_t OpticalCenter;
+	VL53L1X_ERROR status = 0;
+
+	status |=VL53L1_RdByte(dev, VL53L1_ROI_CONFIG__MODE_ROI_CENTRE_SPAD, &OpticalCenter);
+	if (X > 16)
+		X = 16;
+	if (Y > 16)
+		Y = 16;
+	if (X > 10 || Y > 10){
+		OpticalCenter = 199;
+	}
+	status |= VL53L1_WrByte(dev, ROI_CONFIG__USER_ROI_CENTRE_SPAD, OpticalCenter);
+	status |= VL53L1_WrByte(dev, ROI_CONFIG__USER_ROI_REQUESTED_GLOBAL_XY_SIZE,
+		       (Y - 1) << 4 | (X - 1));
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetROI_XY(uint16_t dev, uint16_t *ROI_X, uint16_t *ROI_Y)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t tmp;
+
+	status = VL53L1_RdByte(dev,ROI_CONFIG__USER_ROI_REQUESTED_GLOBAL_XY_SIZE, &tmp);
+	*ROI_X = ((uint16_t)tmp & 0x0F) + 1;
+	*ROI_Y = (((uint16_t)tmp & 0xF0) >> 4) + 1;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetSignalThreshold(uint16_t dev, uint16_t Signal)
+{
+	VL53L1X_ERROR status = 0;
+
+	status |= VL53L1_WrWord(dev,RANGE_CONFIG__MIN_COUNT_RATE_RTN_LIMIT_MCPS,Signal>>3);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetSignalThreshold(uint16_t dev, uint16_t *signal)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp;
+
+	status |= VL53L1_RdWord(dev,
+				RANGE_CONFIG__MIN_COUNT_RATE_RTN_LIMIT_MCPS, &tmp);
+	*signal = tmp <<3;
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_SetSigmaThreshold(uint16_t dev, uint16_t Sigma)
+{
+	VL53L1X_ERROR status = 0;
+
+	if(Sigma>(0xFFFF>>2)){
+		return 1;
+	}
+	/* 16 bits register 14.2 format */
+	status |= VL53L1_WrWord(dev,RANGE_CONFIG__SIGMA_THRESH,Sigma<<2);
+	return status;
+}
+
+VL53L1X_ERROR VL53L1X_GetSigmaThreshold(uint16_t dev, uint16_t *sigma)
+{
+	VL53L1X_ERROR status = 0;
+	uint16_t tmp;
+
+	status |= VL53L1_RdWord(dev,RANGE_CONFIG__SIGMA_THRESH, &tmp);
+	*sigma = tmp >> 2;
+	return status;
+
+}
+
+VL53L1X_ERROR VL53L1X_StartTemperatureUpdate(uint16_t dev)
+{
+	VL53L1X_ERROR status = 0;
+	uint8_t tmp=0;
+
+	status |= VL53L1_WrByte(dev,VL53L1_VHV_CONFIG__TIMEOUT_MACROP_LOOP_BOUND,0x81); /* full VHV */
+	status |= VL53L1_WrByte(dev,0x0B,0x92);
+	status |= VL53L1X_StartRanging(dev);
+	while(tmp==0){
+		status |= VL53L1X_CheckForDataReady(dev, &tmp);
+	}
+	tmp  = 0;
+	status |= VL53L1X_ClearInterrupt(dev);
+	status |= VL53L1X_StopRanging(dev);
+	status |= VL53L1_WrByte(dev, VL53L1_VHV_CONFIG__TIMEOUT_MACROP_LOOP_BOUND, 0x09); /* two bounds VHV */
+	status |= VL53L1_WrByte(dev, 0x0B, 0); /* start VHV from the previous temperature */
+	return status;
+}

--- a/drivers/vl53l1x/vendor/core/VL53L1X_api.h
+++ b/drivers/vl53l1x/vendor/core/VL53L1X_api.h
@@ -1,0 +1,343 @@
+/**
+  *
+  * Copyright (c) 2023 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/**
+ * @file  vl53l1x_api.h
+ * @brief Functions definition
+ */
+
+#ifndef _API_H_
+#define _API_H_
+
+#include "vl53l1_platform.h"
+
+#define VL53L1X_IMPLEMENTATION_VER_MAJOR       3
+#define VL53L1X_IMPLEMENTATION_VER_MINOR       5
+#define VL53L1X_IMPLEMENTATION_VER_SUB         4
+#define VL53L1X_IMPLEMENTATION_VER_REVISION  0000
+
+typedef int8_t VL53L1X_ERROR;
+
+#define SOFT_RESET											0x0000
+#define VL53L1_I2C_SLAVE__DEVICE_ADDRESS					0x0001
+#define VL53L1_VHV_CONFIG__TIMEOUT_MACROP_LOOP_BOUND        0x0008
+#define ALGO__CROSSTALK_COMPENSATION_PLANE_OFFSET_KCPS 		0x0016
+#define ALGO__CROSSTALK_COMPENSATION_X_PLANE_GRADIENT_KCPS 	0x0018
+#define ALGO__CROSSTALK_COMPENSATION_Y_PLANE_GRADIENT_KCPS 	0x001A
+#define ALGO__PART_TO_PART_RANGE_OFFSET_MM					0x001E
+#define MM_CONFIG__INNER_OFFSET_MM							0x0020
+#define MM_CONFIG__OUTER_OFFSET_MM 							0x0022
+#define GPIO_HV_MUX__CTRL									0x0030
+#define GPIO__TIO_HV_STATUS       							0x0031
+#define SYSTEM__INTERRUPT_CONFIG_GPIO 						0x0046
+#define PHASECAL_CONFIG__TIMEOUT_MACROP     				0x004B
+#define RANGE_CONFIG__TIMEOUT_MACROP_A_HI   				0x005E
+#define RANGE_CONFIG__VCSEL_PERIOD_A        				0x0060
+#define RANGE_CONFIG__VCSEL_PERIOD_B						0x0063
+#define RANGE_CONFIG__TIMEOUT_MACROP_B_HI  					0x0061
+#define RANGE_CONFIG__TIMEOUT_MACROP_B_LO  					0x0062
+#define RANGE_CONFIG__SIGMA_THRESH 							0x0064
+#define RANGE_CONFIG__MIN_COUNT_RATE_RTN_LIMIT_MCPS			0x0066
+#define RANGE_CONFIG__VALID_PHASE_HIGH      				0x0069
+#define VL53L1_SYSTEM__INTERMEASUREMENT_PERIOD				0x006C
+#define SYSTEM__THRESH_HIGH 								0x0072
+#define SYSTEM__THRESH_LOW 									0x0074
+#define SD_CONFIG__WOI_SD0                  				0x0078
+#define SD_CONFIG__INITIAL_PHASE_SD0        				0x007A
+#define ROI_CONFIG__USER_ROI_CENTRE_SPAD					0x007F
+#define ROI_CONFIG__USER_ROI_REQUESTED_GLOBAL_XY_SIZE		0x0080
+#define SYSTEM__SEQUENCE_CONFIG								0x0081
+#define VL53L1_SYSTEM__GROUPED_PARAMETER_HOLD 				0x0082
+#define SYSTEM__INTERRUPT_CLEAR       						0x0086
+#define SYSTEM__MODE_START                 					0x0087
+#define VL53L1_RESULT__RANGE_STATUS							0x0089
+#define VL53L1_RESULT__DSS_ACTUAL_EFFECTIVE_SPADS_SD0		0x008C
+#define RESULT__AMBIENT_COUNT_RATE_MCPS_SD					0x0090
+#define VL53L1_RESULT__FINAL_CROSSTALK_CORRECTED_RANGE_MM_SD0				0x0096
+#define VL53L1_RESULT__PEAK_SIGNAL_COUNT_RATE_CROSSTALK_CORRECTED_MCPS_SD0 	0x0098
+#define VL53L1_RESULT__OSC_CALIBRATE_VAL					0x00DE
+#define VL53L1_FIRMWARE__SYSTEM_STATUS                      0x00E5
+#define VL53L1_IDENTIFICATION__MODEL_ID                     0x010F
+#define VL53L1_ROI_CONFIG__MODE_ROI_CENTRE_SPAD				0x013E
+
+/****************************************
+ * PRIVATE define do not edit
+ ****************************************/
+
+/**
+ *  @brief defines SW Version
+ */
+typedef struct {
+	uint8_t      major;    /*!< major number */
+	uint8_t      minor;    /*!< minor number */
+	uint8_t      build;    /*!< build number */
+	uint32_t     revision; /*!< revision number */
+} VL53L1X_Version_t;
+
+/**
+ *  @brief defines packed reading results type
+ */
+typedef struct {
+	uint8_t Status;		/*!< ResultStatus */
+	uint16_t Distance;	/*!< ResultDistance */
+	uint16_t Ambient;	/*!< ResultAmbient */
+	uint16_t SigPerSPAD;/*!< ResultSignalPerSPAD */
+	uint16_t NumSPADs;	/*!< ResultNumSPADs */
+} VL53L1X_Result_t;
+
+/**
+ * @brief This function returns the SW driver version
+ */
+VL53L1X_ERROR VL53L1X_GetSWVersion(VL53L1X_Version_t *pVersion);
+
+/**
+ * @brief This function sets the sensor I2C address used in case multiple devices application, default address 0x52
+ */
+VL53L1X_ERROR VL53L1X_SetI2CAddress(uint16_t, uint8_t new_address);
+
+/**
+ * @brief This function loads the 135 bytes default values to initialize the sensor.
+ * @param dev Device address
+ * @return 0:success, != 0:failed
+ */
+VL53L1X_ERROR VL53L1X_SensorInit(uint16_t dev);
+
+/**
+ * @brief This function clears the interrupt, to be called after a ranging data reading
+ * to arm the interrupt for the next data ready event.
+ */
+VL53L1X_ERROR VL53L1X_ClearInterrupt(uint16_t dev);
+
+/**
+ * @brief This function programs the interrupt polarity\n
+ * 1=active high (default), 0=active low
+ */
+VL53L1X_ERROR VL53L1X_SetInterruptPolarity(uint16_t dev, uint8_t IntPol);
+
+/**
+ * @brief This function returns the current interrupt polarity\n
+ * 1=active high (default), 0=active low
+ */
+VL53L1X_ERROR VL53L1X_GetInterruptPolarity(uint16_t dev, uint8_t *pIntPol);
+
+/**
+ * @brief This function starts the ranging distance operation\n
+ * The ranging operation is continuous. The clear interrupt has to be done after each get data to allow the interrupt to raise when the next data is ready\n
+ * 1=active high (default), 0=active low, use SetInterruptPolarity() to change the interrupt polarity if required.
+ */
+VL53L1X_ERROR VL53L1X_StartRanging(uint16_t dev);
+
+/**
+ * @brief This function stops the ranging.
+ */
+VL53L1X_ERROR VL53L1X_StopRanging(uint16_t dev);
+
+/**
+ * @brief This function checks if the new ranging data is available by polling the dedicated register.
+ * @param : isDataReady==0 -> not ready; isDataReady==1 -> ready
+ */
+VL53L1X_ERROR VL53L1X_CheckForDataReady(uint16_t dev, uint8_t *isDataReady);
+
+/**
+ * @brief This function programs the timing budget in ms.
+ * Predefined values = 15, 20, 33, 50, 100(default), 200, 500.
+ */
+VL53L1X_ERROR VL53L1X_SetTimingBudgetInMs(uint16_t dev, uint16_t TimingBudgetInMs);
+
+/**
+ * @brief This function returns the current timing budget in ms.
+ */
+VL53L1X_ERROR VL53L1X_GetTimingBudgetInMs(uint16_t dev, uint16_t *pTimingBudgetInMs);
+
+/**
+ * @brief This function programs the distance mode (1=short, 2=long(default)).
+ * Short mode max distance is limited to 1.3 m but better ambient immunity.\n
+ * Long mode can range up to 4 m in the dark with 200 ms timing budget.
+ */
+VL53L1X_ERROR VL53L1X_SetDistanceMode(uint16_t dev, uint16_t DistanceMode);
+
+/**
+ * @brief This function returns the current distance mode (1=short, 2=long).
+ */
+VL53L1X_ERROR VL53L1X_GetDistanceMode(uint16_t dev, uint16_t *pDistanceMode);
+
+/**
+ * @brief This function programs the Intermeasurement period in ms\n
+ * Intermeasurement period must be >/= timing budget. This condition is not checked by the API,
+ * the customer has the duty to check the condition. Default = 100 ms
+ */
+VL53L1X_ERROR VL53L1X_SetInterMeasurementInMs(uint16_t dev,
+					 uint32_t InterMeasurementInMs);
+
+/**
+ * @brief This function returns the Intermeasurement period in ms.
+ */
+VL53L1X_ERROR VL53L1X_GetInterMeasurementInMs(uint16_t dev, uint16_t * pIM);
+
+/**
+ * @brief This function returns the boot state of the device (1:booted, 0:not booted)
+ */
+VL53L1X_ERROR VL53L1X_BootState(uint16_t dev, uint8_t *state);
+
+/**
+ * @brief This function returns the sensor id, sensor Id must be 0xEEAC
+ */
+VL53L1X_ERROR VL53L1X_GetSensorId(uint16_t dev, uint16_t *id);
+
+/**
+ * @brief This function returns the distance measured by the sensor in mm
+ */
+VL53L1X_ERROR VL53L1X_GetDistance(uint16_t dev, uint16_t *distance);
+
+/**
+ * @brief This function returns the returned signal per SPAD in kcps/SPAD.
+ * With kcps stands for Kilo Count Per Second
+ */
+VL53L1X_ERROR VL53L1X_GetSignalPerSpad(uint16_t dev, uint16_t *signalPerSp);
+
+/**
+ * @brief This function returns the ambient per SPAD in kcps/SPAD
+ */
+VL53L1X_ERROR VL53L1X_GetAmbientPerSpad(uint16_t dev, uint16_t *amb);
+
+/**
+ * @brief This function returns the returned signal in kcps.
+ */
+VL53L1X_ERROR VL53L1X_GetSignalRate(uint16_t dev, uint16_t *signalRate);
+
+/**
+ * @brief This function returns the current number of enabled SPADs
+ */
+VL53L1X_ERROR VL53L1X_GetSpadNb(uint16_t dev, uint16_t *spNb);
+
+/**
+ * @brief This function returns the ambient rate in kcps
+ */
+VL53L1X_ERROR VL53L1X_GetAmbientRate(uint16_t dev, uint16_t *ambRate);
+
+/**
+ * @brief This function returns the ranging status error \n
+ * (0:no error, 1:sigma failed, 2:signal failed, ..., 7:wrap-around)
+ */
+VL53L1X_ERROR VL53L1X_GetRangeStatus(uint16_t dev, uint8_t *rangeStatus);
+
+/**
+ * @brief This function returns measurements and the range status in a single read access
+ */
+VL53L1X_ERROR VL53L1X_GetResult(uint16_t dev, VL53L1X_Result_t *pResult);
+
+/**
+ * @brief This function programs the offset correction in mm
+ * @param OffsetValue:the offset correction value to program in mm
+ */
+VL53L1X_ERROR VL53L1X_SetOffset(uint16_t dev, int16_t OffsetValue);
+
+/**
+ * @brief This function returns the programmed offset correction value in mm
+ */
+VL53L1X_ERROR VL53L1X_GetOffset(uint16_t dev, int16_t *Offset);
+
+/**
+ * @brief This function programs the xtalk correction value in cps (Count Per Second).\n
+ * This is the number of photons reflected back from the cover glass in cps.
+ */
+VL53L1X_ERROR VL53L1X_SetXtalk(uint16_t dev, uint16_t XtalkValue);
+
+/**
+ * @brief This function returns the current programmed xtalk correction value in cps
+ */
+VL53L1X_ERROR VL53L1X_GetXtalk(uint16_t dev, uint16_t *Xtalk);
+
+/**
+ * @brief This function programs the threshold detection mode\n
+ * Example:\n
+ * VL53L1X_SetDistanceThreshold(dev,100,300,0,1): Below 100 \n
+ * VL53L1X_SetDistanceThreshold(dev,100,300,1,1): Above 300 \n
+ * VL53L1X_SetDistanceThreshold(dev,100,300,2,1): Out of window \n
+ * VL53L1X_SetDistanceThreshold(dev,100,300,3,1): In window \n
+ * @param   dev : device address
+ * @param  	ThreshLow(in mm) : the threshold under which one the device raises an interrupt if Window = 0
+ * @param 	ThreshHigh(in mm) :  the threshold above which one the device raises an interrupt if Window = 1
+ * @param   Window detection mode : 0=below, 1=above, 2=out, 3=in
+ * @param   IntOnNoTarget = 0 (No longer used - just use 0)
+ */
+VL53L1X_ERROR VL53L1X_SetDistanceThreshold(uint16_t dev, uint16_t ThreshLow,
+			      uint16_t ThreshHigh, uint8_t Window,
+			      uint8_t IntOnNoTarget);
+
+/**
+ * @brief This function returns the window detection mode (0=below; 1=above; 2=out; 3=in)
+ */
+VL53L1X_ERROR VL53L1X_GetDistanceThresholdWindow(uint16_t dev, uint16_t *window);
+
+/**
+ * @brief This function returns the low threshold in mm
+ */
+VL53L1X_ERROR VL53L1X_GetDistanceThresholdLow(uint16_t dev, uint16_t *low);
+
+/**
+ * @brief This function returns the high threshold in mm
+ */
+VL53L1X_ERROR VL53L1X_GetDistanceThresholdHigh(uint16_t dev, uint16_t *high);
+
+/**
+ * @brief This function programs the ROI (Region of Interest)\n
+ * The ROI position is centered, only the ROI size can be reprogrammed.\n
+ * The smallest acceptable ROI size = 4\n
+ * @param X:ROI Width; Y=ROI Height
+ */
+VL53L1X_ERROR VL53L1X_SetROI(uint16_t dev, uint16_t X, uint16_t Y);
+
+/**
+ *@brief This function returns width X and height Y
+ */
+VL53L1X_ERROR VL53L1X_GetROI_XY(uint16_t dev, uint16_t *ROI_X, uint16_t *ROI_Y);
+
+/**
+ *@brief This function programs the new user ROI center, please to be aware that there is no check in this function.
+ *if the ROI center vs ROI size is out of border the ranging function return error #13
+ */
+VL53L1X_ERROR VL53L1X_SetROICenter(uint16_t dev, uint8_t ROICenter);
+
+/**
+ *@brief This function returns the current user ROI center
+ */
+VL53L1X_ERROR VL53L1X_GetROICenter(uint16_t dev, uint8_t *ROICenter);
+
+/**
+ * @brief This function programs a new signal threshold in kcps (default=1024 kcps\n
+ */
+VL53L1X_ERROR VL53L1X_SetSignalThreshold(uint16_t dev, uint16_t signal);
+
+/**
+ * @brief This function returns the current signal threshold in kcps
+ */
+VL53L1X_ERROR VL53L1X_GetSignalThreshold(uint16_t dev, uint16_t *signal);
+
+/**
+ * @brief This function programs a new sigma threshold in mm (default=15 mm)
+ */
+VL53L1X_ERROR VL53L1X_SetSigmaThreshold(uint16_t dev, uint16_t sigma);
+
+/**
+ * @brief This function returns the current sigma threshold in mm
+ */
+VL53L1X_ERROR VL53L1X_GetSigmaThreshold(uint16_t dev, uint16_t *signal);
+
+/**
+ * @brief This function performs the temperature calibration.
+ * It is recommended to call this function any time the temperature might have changed by more than 8 deg C
+ * without sensor ranging activity for an extended period.
+ */
+VL53L1X_ERROR VL53L1X_StartTemperatureUpdate(uint16_t dev);
+
+#endif

--- a/drivers/vl53l1x/vendor/core/VL53L1X_calibration.c
+++ b/drivers/vl53l1x/vendor/core/VL53L1X_calibration.c
@@ -1,0 +1,89 @@
+/**
+  *
+  * Copyright (c) 2023 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/**
+ * @file  vl53l1x_calibration.c
+ * @brief Calibration functions implementation
+ */
+#include "VL53L1X_api.h"
+#include "VL53L1X_calibration.h"
+
+#define ALGO__PART_TO_PART_RANGE_OFFSET_MM	0x001E
+#define MM_CONFIG__INNER_OFFSET_MM			0x0020
+#define MM_CONFIG__OUTER_OFFSET_MM 			0x0022
+
+int8_t VL53L1X_CalibrateOffset(uint16_t dev, uint16_t TargetDistInMm, int16_t *offset)
+{
+	uint8_t i, tmp;
+	int16_t AverageDistance = 0;
+	uint16_t distance;
+	VL53L1X_ERROR status = 0;
+
+	status |= VL53L1_WrWord(dev, ALGO__PART_TO_PART_RANGE_OFFSET_MM, 0x0);
+	status |= VL53L1_WrWord(dev, MM_CONFIG__INNER_OFFSET_MM, 0x0);
+	status |= VL53L1_WrWord(dev, MM_CONFIG__OUTER_OFFSET_MM, 0x0);
+	status |= VL53L1X_StartRanging(dev);	/* Enable VL53L1X sensor */
+	for (i = 0; i < 50; i++) {
+		tmp = 0;
+		while (tmp == 0){
+			status |= VL53L1X_CheckForDataReady(dev, &tmp);
+		}
+		status |= VL53L1X_GetDistance(dev, &distance);
+		status |= VL53L1X_ClearInterrupt(dev);
+		AverageDistance = AverageDistance + distance;
+	}
+	status |= VL53L1X_StopRanging(dev);
+	AverageDistance = AverageDistance / 50;
+	*offset = TargetDistInMm - AverageDistance;
+	status |= VL53L1_WrWord(dev, ALGO__PART_TO_PART_RANGE_OFFSET_MM, *offset*4);
+	return status;
+}
+
+int8_t VL53L1X_CalibrateXtalk(uint16_t dev, uint16_t TargetDistInMm, uint16_t *xtalk)
+{
+	uint8_t i, tmp;
+	float AverageSignalRate = 0;
+	float AverageDistance = 0;
+	float AverageSpadNb = 0;
+	uint16_t distance = 0, spadNum;
+	uint16_t sr;
+	VL53L1X_ERROR status = 0;
+	uint32_t calXtalk;
+
+	status |= VL53L1_WrWord(dev, 0x0016,0);
+	status |= VL53L1X_StartRanging(dev);
+	for (i = 0; i < 50; i++) {
+		tmp = 0;
+		while (tmp == 0){
+			status |= VL53L1X_CheckForDataReady(dev, &tmp);
+		}
+		status |= VL53L1X_GetSignalRate(dev, &sr);
+		status |= VL53L1X_GetDistance(dev, &distance);
+		status |= VL53L1X_ClearInterrupt(dev);
+		AverageDistance = AverageDistance + distance;
+		status = VL53L1X_GetSpadNb(dev, &spadNum);
+		AverageSpadNb = AverageSpadNb + spadNum;
+		AverageSignalRate =
+		    AverageSignalRate + sr;
+	}
+	status |= VL53L1X_StopRanging(dev);
+	AverageDistance = AverageDistance / 50;
+	AverageSpadNb = AverageSpadNb / 50;
+	AverageSignalRate = AverageSignalRate / 50;
+	/* Calculate Xtalk value */
+	calXtalk = (uint16_t)(512*(AverageSignalRate*(1-(AverageDistance/TargetDistInMm)))/AverageSpadNb);
+	if(calXtalk  > 0xffff)
+		calXtalk = 0xffff;
+	*xtalk = (uint16_t)((calXtalk*1000)>>9);
+	status |= VL53L1_WrWord(dev, 0x0016, (uint16_t)calXtalk);
+	return status;
+}

--- a/drivers/vl53l1x/vendor/core/VL53L1X_calibration.h
+++ b/drivers/vl53l1x/vendor/core/VL53L1X_calibration.h
@@ -1,0 +1,44 @@
+/**
+  *
+  * Copyright (c) 2023 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/**
+ * @file  vl53l1x_calibration.h
+ * @brief Calibration Functions definition
+ */
+
+#ifndef _CALIBRATION_H_
+#define _CALIBRATION_H_
+
+/**
+ * @brief This function performs the offset calibration.\n
+ * The function returns the offset value found and programs the offset compensation into the device.
+ * @param TargetDistInMm target distance in mm, ST recommended 100 mm
+ * Target reflectance = grey17%
+ * @return 0:success, !=0: failed
+ * @return offset pointer contains the offset found in mm
+ */
+int8_t VL53L1X_CalibrateOffset(uint16_t dev, uint16_t TargetDistInMm, int16_t *offset);
+
+/**
+ * @brief This function performs the xtalk calibration.\n
+ * The function returns the xtalk value found and programs the xtalk compensation to the device
+ * @param TargetDistInMm target distance in mm\n
+ * The target distance : the distance where the sensor start to "under range"\n
+ * due to the influence of the photons reflected back from the cover glass becoming strong\n
+ * It's also called inflection point\n
+ * Target reflectance = grey 17%
+ * @return 0: success, !=0: failed
+ * @return xtalk pointer contains the xtalk value found in cps (number of photons in count per second)
+ */
+int8_t VL53L1X_CalibrateXtalk(uint16_t dev, uint16_t TargetDistInMm, uint16_t *xtalk);
+
+#endif

--- a/drivers/vl53l1x/vendor/docs/Readme.txt
+++ b/drivers/vl53l1x/vendor/docs/Readme.txt
@@ -1,0 +1,2 @@
+VL53L1X ULD user manual UM2510 is avaliable on below link:
+https://www.st.com/resource/en/user_manual/um2510-a-guide-to-using-the-vl53l1x-ultra-lite-driver-stmicroelectronics.pdf

--- a/drivers/vl53l1x/vendor/platform/Makefile
+++ b/drivers/vl53l1x/vendor/platform/Makefile
@@ -1,0 +1,3 @@
+MODULE=vl53l1x_st_api_platform
+
+include $(RIOTBASE)/Makefile.base

--- a/drivers/vl53l1x/vendor/platform/vl53l1_platform.c
+++ b/drivers/vl53l1x/vendor/platform/vl53l1_platform.c
@@ -1,0 +1,52 @@
+/**
+  *
+  * Copyright (c) 2023 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+#include "vl53l1_platform.h"
+#include <string.h>
+#include <time.h>
+#include <math.h>
+
+int8_t VL53L1_WriteMulti( uint16_t dev, uint16_t index, uint8_t *pdata, uint32_t count) {
+	return 0; // to be implemented
+}
+
+int8_t VL53L1_ReadMulti(uint16_t dev, uint16_t index, uint8_t *pdata, uint32_t count){
+	return 0; // to be implemented
+}
+
+int8_t VL53L1_WrByte(uint16_t dev, uint16_t index, uint8_t data) {
+	return 0; // to be implemented
+}
+
+int8_t VL53L1_WrWord(uint16_t dev, uint16_t index, uint16_t data) {
+	return 0; // to be implemented
+}
+
+int8_t VL53L1_WrDWord(uint16_t dev, uint16_t index, uint32_t data) {
+	return 0; // to be implemented
+}
+
+int8_t VL53L1_RdByte(uint16_t dev, uint16_t index, uint8_t *data) {
+	return 0; // to be implemented
+}
+
+int8_t VL53L1_RdWord(uint16_t dev, uint16_t index, uint16_t *data) {
+	return 0; // to be implemented
+}
+
+int8_t VL53L1_RdDWord(uint16_t dev, uint16_t index, uint32_t *data) {
+	return 0; // to be implemented
+}
+
+int8_t VL53L1_WaitMs(uint16_t dev, int32_t wait_ms){
+	return 0; // to be implemented
+}

--- a/drivers/vl53l1x/vendor/platform/vl53l1_platform.c
+++ b/drivers/vl53l1x/vendor/platform/vl53l1_platform.c
@@ -11,42 +11,258 @@
   */
 
 #include "vl53l1_platform.h"
+
+#include <errno.h>
 #include <string.h>
-#include <time.h>
-#include <math.h>
 
-int8_t VL53L1_WriteMulti( uint16_t dev, uint16_t index, uint8_t *pdata, uint32_t count) {
-	return 0; // to be implemented
+#include "macros/units.h"
+#include "periph/i2c.h"
+#include "ztimer.h"
+
+#include "vl53l1x.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#define VL53L1_I2C_DEV      (dev >> 8)
+#define VL53L1_I2C_ADDR     (dev & 0xff)
+
+#if ENABLE_DEBUG
+
+#define ASSERT_PARAM(cond) \
+    if (!(cond)) { \
+        DEBUG("[vl53l1x] %s: %s\n", \
+              __func__, "parameter condition (" # cond ") not fulfilled"); \
+        assert(cond); \
+    }
+
+#define DEBUG_DEV(format, dev, ...) \
+        DEBUG("[vl53l1x] %s i2c dev=%u addr=%02x: " format "\n", \
+              __func__, VL53L1_I2C_DEV, VL53L1_I2C_ADDR, ## __VA_ARGS__);
+
+#define DEBUG_NODEV(format, ...) \
+        DEBUG("[vl53l1x] %s: " format "\n", \
+              __func__, ## __VA_ARGS__);
+
+#else /* ENABLE_DEBUG */
+
+#define ASSERT_PARAM(cond) assert(cond);
+#define DEBUG_DEV(format, dev, ...)
+#define DEBUG_NODEV(format, ...)
+
+#endif /* ENABLE_DEBUG */
+
+#define VL53L1_BUFSIZ 32
+
+static uint8_t _buffer[VL53L1_BUFSIZ];
+
+int8_t VL53L1_WriteMulti( uint16_t dev, uint16_t index, uint8_t *pdata, uint32_t count)
+{
+    ASSERT_PARAM(pdata != NULL);
+    DEBUG_DEV("index=%04x pdata=%p count=%"PRIu32, dev, index, pdata, count);
+
+    i2c_acquire(VL53L1_I2C_DEV);
+
+    /* write blockwise with a maximum size of VL53L1_BUFSIZ-2 */
+    while (count) {
+
+        uint8_t cnt = (count < (VL53L1_BUFSIZ - 2)) ? count : VL53L1_BUFSIZ - 2;
+
+        /* fill the first 2 bytes of the buffer with the index */
+        _buffer[0] = (index >> 8) & 0xff;
+        _buffer[1] = index & 0xff;
+
+        /* fill the buffer with data bytes */
+        memcpy(_buffer + 2, pdata, cnt);
+
+        if (i2c_write_bytes(VL53L1_I2C_DEV, VL53L1_I2C_ADDR, _buffer, cnt + 2, 0) != 0) {
+            i2c_release(VL53L1_I2C_DEV);
+            return -EIO;
+        }
+        count -= cnt;
+        pdata += cnt;
+        index += cnt;
+    }
+
+    /* release the I2C device */
+    i2c_release(VL53L1_I2C_DEV);
+
+    return 0;
 }
 
-int8_t VL53L1_ReadMulti(uint16_t dev, uint16_t index, uint8_t *pdata, uint32_t count){
-	return 0; // to be implemented
+int8_t VL53L1_ReadMulti(uint16_t dev, uint16_t index, uint8_t *pdata, uint32_t count)
+{
+    ASSERT_PARAM(pdata != NULL);
+    DEBUG_DEV("index=%04x pdata=%p count=%"PRIu32, dev, index, pdata, count);
+
+    /* acquire the I2C device */
+    i2c_acquire(VL53L1_I2C_DEV);
+
+    /* read blockwise with a maximum size of VL53L1_BUFSIZ */
+    while (count) {
+
+        uint8_t bytes[2] = { (index >> 8) & 0xff, index & 0xff };
+
+        /* write the register index for the block */
+        if (i2c_write_bytes(VL53L1_I2C_DEV, VL53L1_I2C_ADDR, bytes, 2, 0) != 0) {
+            i2c_release(VL53L1_I2C_DEV);
+            return -EIO;
+        }
+
+        uint8_t cnt = (count < VL53L1_BUFSIZ) ? count : VL53L1_BUFSIZ;
+
+        if (i2c_read_bytes(VL53L1_I2C_DEV, VL53L1_I2C_ADDR, _buffer, cnt, 0) != 0) {
+            i2c_release(VL53L1_I2C_DEV);
+            return -EIO;
+        }
+
+        memcpy(pdata, _buffer, cnt);
+        count -= cnt;
+        pdata += cnt;
+        index += cnt;
+    }
+
+    /* release the I2C device */
+    i2c_release(VL53L1_I2C_DEV);
+
+    return 0;
 }
 
-int8_t VL53L1_WrByte(uint16_t dev, uint16_t index, uint8_t data) {
-	return 0; // to be implemented
+int8_t VL53L1_WrByte(uint16_t dev, uint16_t index, uint8_t data)
+{
+    int8_t Status = 0;
+
+    DEBUG_DEV("index=%04x data=%02x", dev, index, data);
+
+    i2c_acquire(VL53L1_I2C_DEV);
+
+    uint8_t bytes[3] = { (index >> 8) & 0xff, index & 0xff, data };
+
+    if (i2c_write_bytes(VL53L1_I2C_DEV, VL53L1_I2C_ADDR, bytes, 3, 0) != 0) {
+        Status = -EIO;
+    }
+
+    i2c_release(VL53L1_I2C_DEV);
+
+    return Status;
 }
 
-int8_t VL53L1_WrWord(uint16_t dev, uint16_t index, uint16_t data) {
-	return 0; // to be implemented
+int8_t VL53L1_WrWord(uint16_t dev, uint16_t index, uint16_t data)
+{
+    int8_t Status = 0;
+
+    DEBUG_DEV("index=%04x data=%04x", dev, index, data);
+
+    i2c_acquire(VL53L1_I2C_DEV);
+
+    uint8_t bytes[4] = { (index >> 8) & 0xff, index & 0xff,
+                         (data >> 8) & 0xff, data & 0xff };
+
+    if (i2c_write_bytes(VL53L1_I2C_DEV, VL53L1_I2C_ADDR, bytes, 4, 0) != 0) {
+        Status = -EIO;
+    }
+
+    i2c_release(VL53L1_I2C_DEV);
+
+    return Status;
 }
 
-int8_t VL53L1_WrDWord(uint16_t dev, uint16_t index, uint32_t data) {
-	return 0; // to be implemented
+int8_t VL53L1_WrDWord(uint16_t dev, uint16_t index, uint32_t data)
+{
+    int8_t Status = 0;
+
+    DEBUG_DEV("index=%04x data=%08"PRIx32, dev, index, data);
+
+    i2c_acquire(VL53L1_I2C_DEV);
+
+    uint8_t bytes[6] = { (index >> 8) & 0xff, index & 0xff,
+                         (data >> 24) & 0xff, (data >> 16) & 0xff,
+                         (data >> 8) & 0xff, data & 0xff };
+
+    if (i2c_write_bytes(VL53L1_I2C_DEV, VL53L1_I2C_ADDR, bytes, 6, 0) != 0) {
+        Status = -EIO;
+    }
+
+    i2c_release(VL53L1_I2C_DEV);
+
+    return Status;
 }
 
-int8_t VL53L1_RdByte(uint16_t dev, uint16_t index, uint8_t *data) {
-	return 0; // to be implemented
+int8_t VL53L1_RdByte(uint16_t dev, uint16_t index, uint8_t *data)
+{
+    int8_t Status = 0;
+
+    ASSERT_PARAM(data != NULL);
+    DEBUG_DEV("index=%04x data=%p", dev, index, data);
+
+    i2c_acquire(VL53L1_I2C_DEV);
+
+    uint8_t bytes[2] = { (index >> 8) & 0xff, index & 0xff };
+
+    if (i2c_write_bytes(VL53L1_I2C_DEV, VL53L1_I2C_ADDR, bytes, 2, 0) != 0 ||
+        i2c_read_byte(VL53L1_I2C_DEV, VL53L1_I2C_ADDR, data, 0) != 0) {
+        Status = -EIO;
+    }
+
+    i2c_release(VL53L1_I2C_DEV);
+
+    return Status;
 }
 
-int8_t VL53L1_RdWord(uint16_t dev, uint16_t index, uint16_t *data) {
-	return 0; // to be implemented
+int8_t VL53L1_RdWord(uint16_t dev, uint16_t index, uint16_t *data)
+{
+    int8_t Status = 0;
+
+    ASSERT_PARAM(data != NULL);
+    DEBUG_DEV("index=%04x data=%p", dev, index, data);
+
+    i2c_acquire(VL53L1_I2C_DEV);
+
+    uint8_t bytes[2] = { (index >> 8) & 0xff, index & 0xff };
+
+    if (i2c_write_bytes(VL53L1_I2C_DEV, VL53L1_I2C_ADDR, bytes, 2, 0) != 0 ||
+        i2c_read_bytes(VL53L1_I2C_DEV, VL53L1_I2C_ADDR, bytes, 2, 0) != 0) {
+        Status = -EIO;
+    }
+    *data = (bytes[0] << 8) + (bytes[1]);
+
+    i2c_release(VL53L1_I2C_DEV);
+
+    return Status;
 }
 
-int8_t VL53L1_RdDWord(uint16_t dev, uint16_t index, uint32_t *data) {
-	return 0; // to be implemented
+int8_t VL53L1_RdDWord(uint16_t dev, uint16_t index, uint32_t *data)
+{
+    int8_t Status = 0;
+
+    ASSERT_PARAM(data != NULL);
+    DEBUG_DEV("index=%04x data=%p", dev, index, data);
+
+    i2c_acquire(VL53L1_I2C_DEV);
+
+    uint8_t bytes[4] = { (index >> 8) & 0xff, index & 0xff };
+
+    if (i2c_write_bytes(VL53L1_I2C_DEV, VL53L1_I2C_ADDR, bytes, 2, 0) != 0 ||
+        i2c_read_bytes(VL53L1_I2C_DEV, VL53L1_I2C_ADDR, bytes, 4, 0) != 0) {
+        Status = -EIO;
+    }
+    *data = ((uint32_t)bytes[0] << 24) +
+            ((uint32_t)bytes[1] << 16) +
+            ((uint32_t)bytes[2] <<  8) + bytes[3];
+
+    i2c_release(VL53L1_I2C_DEV);
+
+    return Status;
 }
 
-int8_t VL53L1_WaitMs(uint16_t dev, int32_t wait_ms){
-	return 0; // to be implemented
+int8_t VL53L1_WaitMs(uint16_t dev, int32_t wait_ms)
+{
+    int8_t Status = 0;
+
+    (void)dev;
+    DEBUG_NODEV("wait_ms=%"PRIi32, wait_ms);
+
+    ztimer_sleep(ZTIMER_MSEC, wait_ms);
+
+    return Status;
 }

--- a/drivers/vl53l1x/vendor/platform/vl53l1_platform.h
+++ b/drivers/vl53l1x/vendor/platform/vl53l1_platform.h
@@ -1,0 +1,103 @@
+/**
+  *
+  * Copyright (c) 2023 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+  
+/**
+ * @file  vl53l1_platform.h
+ * @brief Those platform functions are platform dependent and have to be implemented by the user
+ */
+ 
+#ifndef _VL53L1_PLATFORM_H_
+#define _VL53L1_PLATFORM_H_
+
+#include "vl53l1_types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef struct {
+	uint32_t dummy;
+} VL53L1_Dev_t;
+
+typedef VL53L1_Dev_t *VL53L1_DEV;
+
+/** @brief VL53L1_WriteMulti() definition.\n
+ * To be implemented by the developer
+ */
+int8_t VL53L1_WriteMulti(
+		uint16_t 			dev,
+		uint16_t      index,
+		uint8_t      *pdata,
+		uint32_t      count);
+/** @brief VL53L1_ReadMulti() definition.\n
+ * To be implemented by the developer
+ */
+int8_t VL53L1_ReadMulti(
+		uint16_t 			dev,
+		uint16_t      index,
+		uint8_t      *pdata,
+		uint32_t      count);
+/** @brief VL53L1_WrByte() definition.\n
+ * To be implemented by the developer
+ */
+int8_t VL53L1_WrByte(
+		uint16_t dev,
+		uint16_t      index,
+		uint8_t       data);
+/** @brief VL53L1_WrWord() definition.\n
+ * To be implemented by the developer
+ */
+int8_t VL53L1_WrWord(
+		uint16_t dev,
+		uint16_t      index,
+		uint16_t      data);
+/** @brief VL53L1_WrDWord() definition.\n
+ * To be implemented by the developer
+ */
+int8_t VL53L1_WrDWord(
+		uint16_t dev,
+		uint16_t      index,
+		uint32_t      data);
+/** @brief VL53L1_RdByte() definition.\n
+ * To be implemented by the developer
+ */
+int8_t VL53L1_RdByte(
+		uint16_t dev,
+		uint16_t      index,
+		uint8_t      *pdata);
+/** @brief VL53L1_RdWord() definition.\n
+ * To be implemented by the developer
+ */
+int8_t VL53L1_RdWord(
+		uint16_t dev,
+		uint16_t      index,
+		uint16_t     *pdata);
+/** @brief VL53L1_RdDWord() definition.\n
+ * To be implemented by the developer
+ */
+int8_t VL53L1_RdDWord(
+		uint16_t dev,
+		uint16_t      index,
+		uint32_t     *pdata);
+/** @brief VL53L1_WaitMs() definition.\n
+ * To be implemented by the developer
+ */
+int8_t VL53L1_WaitMs(
+		uint16_t dev,
+		int32_t       wait_ms);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/drivers/vl53l1x/vendor/platform/vl53l1_types.h
+++ b/drivers/vl53l1x/vendor/platform/vl53l1_types.h
@@ -1,0 +1,99 @@
+/**
+  *
+  * Copyright (c) 2023 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/**
+ * @file  vl53l1_types.h
+ * @brief VL53L1 types definition
+ */
+
+#ifndef _VL53L1_TYPES_H_
+#define _VL53L1_TYPES_H_
+
+/** @defgroup porting_type  Basic type definition
+ *  @ingroup  api_platform
+ *
+ *  @brief  file vl53l1_types.h files hold basic type definition that may requires porting
+ *
+ *  contains type that must be defined for the platform\n
+ *  when target platform and compiler provide stdint.h and stddef.h it is enough to include it.\n
+ *  If stdint.h is not available review and adapt all signed and unsigned 8/16/32 bits basic types. \n
+ *  If stddef.h is not available review and adapt NULL definition .
+ */
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef NULL
+#error "Error NULL definition should be done. Please add required include "
+#endif
+
+
+#if !defined(STDINT_H) && !defined(_STDINT_H) && !defined(_GCC_STDINT_H) && !defined(__STDINT_DECLS) && !defined(_GCC_WRAP_STDINT_H)  && !defined(_STDINT)
+
+ #pragma message("Please review  type definition of STDINT define for your platform and add to list above ")
+
+ /*
+  *  target platform do not provide stdint or use a different #define than above
+  *  to avoid seeing the message below addapt the #define list above or implement
+  *  all type and delete these pragma
+  */
+
+/** \ingroup VL53L1_portingType_group
+ * @{
+ */
+
+
+typedef unsigned long long uint64_t;
+
+
+/** @brief Typedef defining 32 bit unsigned int type.\n
+ * The developer should modify this to suit the platform being deployed.
+ */
+typedef unsigned int uint32_t;
+
+/** @brief Typedef defining 32 bit int type.\n
+ * The developer should modify this to suit the platform being deployed.
+ */
+typedef int int32_t;
+
+/** @brief Typedef defining 16 bit unsigned short type.\n
+ * The developer should modify this to suit the platform being deployed.
+ */
+typedef unsigned short uint16_t;
+
+/** @brief Typedef defining 16 bit short type.\n
+ * The developer should modify this to suit the platform being deployed.
+ */
+typedef short int16_t;
+
+/** @brief Typedef defining 8 bit unsigned char type.\n
+ * The developer should modify this to suit the platform being deployed.
+ */
+typedef unsigned char uint8_t;
+
+/** @brief Typedef defining 8 bit char type.\n
+ * The developer should modify this to suit the platform being deployed.
+ */
+typedef signed char int8_t;
+
+/** @}  */
+#endif /* _STDINT_H */
+
+
+/** use where fractional values are expected
+ *
+ * Given a floating point value f it's .16 bit point is (int)(f*(1<<16))*/
+typedef uint32_t FixPoint1616_t;
+
+#endif /* VL53L1_TYPES_H_ */

--- a/drivers/vl53l1x/vl53l1x.c
+++ b/drivers/vl53l1x/vl53l1x.c
@@ -1,0 +1,434 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     drivers_vl53l1x
+ * @brief       Device driver for the ST VL53L1X Time-of-Flight (ToF) ranging sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "vl53l1x_regs.h"
+#include "vl53l1x.h"
+
+#include "VL53L1X_api.h"
+
+#include "irq.h"
+#include "log.h"
+#include "time_units.h"
+#include "ztimer.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+#if IS_ACTIVE(ENABLE_DEBUG)
+
+#  define ASSERT_PARAM(cond) \
+    if (!(cond)) { \
+        DEBUG("[vl53l1x] %s: %s\n", \
+              __func__, "parameter condition (" # cond ") not fulfilled"); \
+        assert(cond); \
+    }
+
+#  define DEBUG_DEV(f, d, ...) \
+        DEBUG("[vl53l1x] %s i2c dev=%d addr=%02x: " f "\n", \
+              __func__, d->params->i2c_dev, d->params->i2c_addr, ## __VA_ARGS__);
+
+#else /* IS_ACTIVE(ENABLE_DEBUG) */
+
+#  define ASSERT_PARAM(cond) assert(cond);
+#  define DEBUG_DEV(f, d, ...)
+
+#endif /* IS_ACTIVE(ENABLE_DEBUG) */
+
+#define ERROR_DEV(f, d, ...) \
+        LOG_ERROR("[vl53l1x] %s i2c dev=%d addr=%02x: " f "\n", \
+                  __func__, d->params->i2c_dev, d->params->i2c_addr, ## __VA_ARGS__);
+
+#define EXEC_RET(f) { \
+    int _r; \
+    if ((_r = f) != 0) { \
+        DEBUG("[vl53l1x] %s: error code %d\n", __func__, _r); \
+        return _r; \
+    } \
+}
+
+#define EXEC_RET_CODE(f, c) { \
+    int _r; \
+    if ((_r = f) != 0) { \
+        DEBUG("[vl53l1x] %s: error code %d\n", __func__, _r); \
+        return c; \
+    } \
+}
+
+#define EXEC(f) { \
+    int _r; \
+    if ((_r = f) != 0) { \
+        DEBUG("[vl53l1x] %s: error code %d\n", __func__, _r); \
+        return; \
+    } \
+}
+
+#define VL53L1X_BOOT_TIMEOUT_MS   10      /* 10 ms */
+
+/** Forward declaration of functions for internal use */
+static int _is_available(const vl53l1x_t *dev);
+static int _reset(vl53l1x_t *dev);
+static int _init(vl53l1x_t *dev);
+//static int _update(const vl53l1x_t *dev, uint16_t index, uint8_t mask, uint8_t data);
+
+#define _read_byte(d, i, b)   VL53L1_RdByte(d->addr, i, b)
+#define _read_word(d, i, w)   VL53L1_RdWord(d->addr, i, w)
+#define _read(d, i, p, l)     VL53L1_ReadMulti(d->addr, i, p, l)
+
+#define _write_byte(d, i, b)  VL53L1_WrByte(d->addr, i, b)
+#define _write_word(d, i, w)  VL53L1_WrWord(d->addr, i, w)
+#define _write(d, i, p, l)    VL53L1_WriteMulti(d->addr, i, p, l)
+
+#define _start_meas(d)        VL53L1X_StartRanging(d->addr)
+
+int vl53l1x_init(vl53l1x_t *dev, const vl53l1x_params_t *params)
+{
+    /* some parameter sanity checks */
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(params != NULL);
+
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+    ASSERT_PARAM(params->budget <= 500);
+    ASSERT_PARAM(params->period >= (uint32_t)params->budget + 4);
+
+    dev->budget = params->budget;
+    dev->period = params->period;
+#endif /* !IS_USED(MODULE_VL53L1X_BASIC) */
+
+    DEBUG_DEV("params=%p", dev, params);
+
+    /* init sensor data structure */
+    dev->params = params;
+    dev->int_init = false;
+
+    dev->addr = dev->params->i2c_dev << 8 | dev->params->i2c_addr;
+
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+    /* if shutdown pin is defined, it is initialized first and set */
+    if (params->pin_shutdown != GPIO_UNDEF) {
+        gpio_init(params->pin_shutdown, GPIO_OUT);
+        gpio_write(params->pin_shutdown, 1);
+    }
+#endif
+
+    /* init the sensor and start measurement */
+    EXEC_RET(_init(dev));
+
+    return 0;
+}
+
+int vl53l1x_data_ready(vl53l1x_t *dev)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("", dev);
+
+    uint8_t ready;
+    EXEC_RET(VL53L1X_CheckForDataReady(dev->addr, &ready));
+    return (ready) ? 0 : -EAGAIN;
+}
+
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+int vl53l1x_read_data(vl53l1x_t *dev, vl53l1x_data_t *data)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(data != NULL);
+    DEBUG_DEV("data=%p", dev, data);
+
+    EXEC_RET(VL53L1X_GetRangeStatus(dev->addr, &data->status));
+    EXEC_RET(VL53L1X_GetDistance(dev->addr, &data->distance));
+    EXEC_RET(VL53L1X_GetSignalRate(dev->addr, &data->signal_rate));
+    EXEC_RET(VL53L1X_GetAmbientRate(dev->addr, &data->ambient_rate));
+    EXEC_RET(VL53L1X_ClearInterrupt(dev->addr));
+
+    return 0;
+}
+#endif
+
+int vl53l1x_read_mm(vl53l1x_t *dev, uint16_t *mm)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(mm != NULL);
+    DEBUG_DEV("mm=%p", dev, mm);
+
+    uint8_t status;
+    EXEC_RET(VL53L1X_GetRangeStatus(dev->addr, &status));
+    EXEC_RET(VL53L1X_GetDistance(dev->addr, mm));
+    EXEC_RET(VL53L1X_ClearInterrupt(dev->addr));
+
+    return 0;
+}
+
+int vl53l1x_int_config(vl53l1x_t *dev, vl53l1x_int_mode_t mode,
+                                       vl53l1x_thresh_config_t* cfg,
+                                       void (*isr)(void *),
+                                       void *isr_arg)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(dev->params->pin_int != GPIO_UNDEF);
+
+    DEBUG_DEV("cfg=%p isr=%p isr_arg=%p", dev, cfg, isr, isr_arg);
+
+    if (!dev->int_init) {
+        /* set polarity to LOW active */
+        EXEC_RET(VL53L1X_SetInterruptPolarity(dev->addr, 0));
+
+        dev->int_init = true;
+        gpio_init_int(dev->params->pin_int, GPIO_IN_PU, GPIO_FALLING,
+                      isr, isr_arg);
+    }
+
+    if (IS_USED(MODULE_VL53L1X_BASIC) || (mode == VL53L1X_INT_DATA_READY)) {
+        /* User manual UM2510, section: write 0x20 to the 0x46 register (8 bits) */
+        EXEC_RET(_write_byte(dev, SYSTEM__INTERRUPT_CONFIG_GPIO, 0x20));
+    }
+    else {
+        ASSERT_PARAM(cfg);
+        EXEC_RET(VL53L1X_StopRanging(dev->addr));
+        EXEC_RET(VL53L1X_SetDistanceThreshold(dev->addr,
+                                              cfg->low, cfg->high,
+                                              cfg->mode, 0));
+        EXEC_RET(VL53L1X_StartRanging(dev->addr));
+    }
+
+    EXEC_RET(VL53L1X_ClearInterrupt(dev->addr));
+
+    return 0;
+}
+
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+
+int vl53l1x_power_down(const vl53l1x_t *dev)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("", dev);
+
+    if (dev->params->pin_shutdown == GPIO_UNDEF) {
+        DEBUG_DEV("Pin connected to sensor's XSHUT pin not defined", dev);
+        return -ENODEV;
+    }
+
+    gpio_clear(dev->params->pin_shutdown);
+    return 0;
+}
+
+int vl53l1x_power_up(vl53l1x_t *dev)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("", dev);
+
+    if (dev->params->pin_shutdown == GPIO_UNDEF) {
+        DEBUG_DEV("Pin connected to sensor's XSHUT pin not defined", dev);
+        return -ENODEV;
+    }
+
+    gpio_set(dev->params->pin_shutdown);
+
+    /* init the sensor and start measurement */
+    EXEC_RET(_init(dev));
+
+    return 0;
+}
+
+int vl53l1x_set_timing_budget(vl53l1x_t *dev, uint16_t budget_ms)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("budget_ms=%" PRIu16, dev, budget_ms);
+
+    /* VL53L1X_SetTimingBudgetInMs sets a hard error code of 1 */
+    int8_t ret = VL53L1X_SetTimingBudgetInMs(dev->addr, budget_ms);
+    if (ret == 1) {
+        /* current distance mode or the given parameter budget_ms is invalid */
+        return -EINVAL;
+    }
+    else if (ret) {
+        return ret;
+    }
+
+    /* save the timing budget */
+    dev->budget = budget_ms;
+
+    return 0;
+}
+
+int vl53l1x_set_measurement_period(vl53l1x_t *dev, uint32_t period_ms)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM((period_ms + 4) > dev->budget);
+    DEBUG_DEV("period_ms=%" PRIu32, dev, period_ms);
+
+    EXEC_RET(VL53L1X_SetInterMeasurementInMs(dev->addr, period_ms));
+
+    /* save the measurement period */
+    dev->period = period_ms;
+
+    return 0;
+}
+
+int vl53l1x_set_distance_mode(vl53l1x_t *dev, vl53l1x_dist_mode_t mode)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("mode=%u", dev, mode);
+
+    /* VL53L1X_SetDistanceMode sets a hard error code of 1 */
+    int8_t ret = VL53L1X_SetDistanceMode(dev->addr, mode);
+    if (ret == 1) {
+        /* the given mode parameter or the current timing budget is invalid */
+        return -EINVAL;
+    }
+    else if (ret) {
+        return ret;
+    }
+
+    /* save the distance mode */
+    dev->mode = mode;
+
+    return 0;
+}
+
+int vl53l1x_set_roi(vl53l1x_t *dev, vl53l1x_roi_t *roi)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(roi != NULL);
+
+    ASSERT_PARAM(roi->x_size >= 4);
+    ASSERT_PARAM(roi->x_size <= 15);
+    ASSERT_PARAM(roi->y_size >= 4);
+    ASSERT_PARAM(roi->y_size <= 15);
+
+    DEBUG_DEV("roi=%p", dev, roi);
+
+    EXEC_RET(VL53L1X_SetROI(dev->addr, roi->x_size, roi->y_size));
+
+    return 0;
+}
+
+int vl53l1x_get_roi(vl53l1x_t *dev, vl53l1x_roi_t *roi)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(roi != NULL);
+
+    DEBUG_DEV("roi=%p", dev, roi);
+
+    EXEC_RET(VL53L1X_GetROI_XY(dev->addr, &roi->x_size, &roi->y_size));
+
+    return 0;
+}
+
+#endif /* !IS_USED(MODULE_VL53L1X_BASIC) */
+
+/** Functions for internal use only */
+
+/**
+ * @brief   Check the chip ID to test whether sensor is available
+ */
+static int _is_available(const vl53l1x_t *dev)
+{
+    DEBUG_DEV("", dev);
+
+    uint16_t id;
+    /* read the chip id */
+    EXEC_RET(VL53L1X_GetSensorId(dev->addr, &id));
+
+    if (id != VL53L1X_DEVICE_ID) {
+        DEBUG_DEV("sensor is not available, wrong device id %02x, "
+                  "should be %02x", dev, id, VL53L1X_DEVICE_ID);
+        return -ENODEV;
+    }
+
+#if IS_ACTIVE(ENABLE_DEBUG)
+    uint8_t rev;
+    uint8_t mod_type;
+    uint16_t mod_id = 0;
+
+    EXEC_RET(_read_byte(dev, VL53L1X_IDENTIFICATION__REVISION_ID, &rev));
+    EXEC_RET(_read_byte(dev, VL53L1X_IDENTIFICATION__MODULE_TYPE, &mod_type));
+    EXEC_RET(_read_word(dev, VL53L1X_IDENTIFICATION__MODULE_ID, &mod_id));
+
+    DEBUG_DEV("rev=%02x, module type=%02x id=%04x", dev, rev, mod_type, mod_id);
+#endif
+
+    return 0;
+}
+
+static int _init(vl53l1x_t *dev)
+{
+    /* wait for 6 ms after power on reset */
+    ztimer_sleep(ZTIMER_MSEC, 6);
+
+    /* check availability of the sensor */
+    EXEC_RET(_is_available(dev));
+
+    /* reset, wait for 4 ms, and wait that devices has been booted */
+    EXEC_RET(_reset(dev));
+
+    EXEC_RET(VL53L1X_SensorInit(dev->addr));
+
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+    /* set measurement parameters */
+    EXEC_RET(vl53l1x_set_distance_mode(dev, dev->params->mode));
+    EXEC_RET(vl53l1x_set_timing_budget(dev, dev->params->budget));
+    EXEC_RET(vl53l1x_set_measurement_period(dev, dev->params->period));
+#endif /* IS_USED(MODULE_VL53L1X_BASIC) */
+
+    /* start measurement */
+    EXEC_RET(_start_meas(dev));
+
+    return 0;
+}
+
+static int _reset(vl53l1x_t *dev)
+{
+    /* write reset impuls of at least 100 us, we use 1 ms */
+    _write_byte(dev, VL53L1X_SOFT_RESET, 0);
+    ztimer_sleep(ZTIMER_MSEC, 1);
+    _write_byte(dev, VL53L1X_SOFT_RESET, 1);
+
+    /* wait until the sensor has been booted in 1 ms steps*/
+    unsigned timeout = VL53L1X_BOOT_TIMEOUT_MS;
+    uint8_t state;
+    while (timeout) {
+        timeout--;
+        EXEC_RET(VL53L1X_BootState(dev->addr, &state));
+        if (state) {
+            break;
+        }
+        ztimer_sleep(ZTIMER_MSEC, 1);
+    }
+    if (timeout == 0) {
+        DEBUG_DEV("could not boot the sensor", dev);
+        return EBUSY;
+    }
+#if 0
+    /* set VDDIO */
+    EXEC_RET(_update(dev, VL53L1X_PAD_I2C_HV__EXTSUP_CONFIG,
+                          0xfe, dev->params->vddio_2v8 ? 1 : 0));
+#endif
+
+    return 0;
+}
+#if 0
+static int _update(const vl53l1x_t *dev, uint16_t index, uint8_t mask,
+                                                         uint8_t data)
+{
+    uint8_t byte;
+    EXEC_RET(_read_byte(dev, index, &byte));
+    byte &= mask;
+    byte |= data;
+    EXEC_RET(_write_byte(dev, index, byte));
+
+    return 0;
+}
+#endif

--- a/drivers/vl53l1x/vl53l1x_saul.c
+++ b/drivers/vl53l1x/vl53l1x_saul.c
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 20215 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     drivers_vl53l1x
+ * @brief       VL53L1X adaption to the RIOT actuator/sensor interface
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "vl53l1x.h"
+
+static int read(const void *dev, phydat_t *res)
+{
+    uint16_t mm;
+    if (vl53l1x_data_ready((vl53l1x_t*)dev) == 0 &&
+        vl53l1x_read_mm((vl53l1x_t*)dev, &mm) == 0) {
+        res->val[0] = mm;
+        res->unit = UNIT_M;
+        res->scale = -3;
+        return 1;
+    }
+    return -ECANCELED;
+}
+
+const saul_driver_t vl53l1x_saul_driver = {
+    .read = read,
+    .write = saul_write_notsup,
+    .type = SAUL_SENSE_DISTANCE,
+};

--- a/tests/drivers/vl53l1x/Makefile
+++ b/tests/drivers/vl53l1x/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.drivers_common
+
+DRIVER ?= vl53l1x
+
+USEMODULE += $(DRIVER)
+USEMODULE += ztimer_msec
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/drivers/vl53l1x/Makefile.ci
+++ b/tests/drivers/vl53l1x/Makefile.ci
@@ -1,0 +1,5 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    atmega8 \
+    nucleo-l011k4 \
+    samd10-xmini \
+    #

--- a/tests/drivers/vl53l1x/README.md
+++ b/tests/drivers/vl53l1x/README.md
@@ -14,11 +14,11 @@ The driver variant used is defined by my variable DRIVER, which is set to
 `vl53l1x` by default. In this case, it is not necessary to specify
 the DRIVER variable in the make command:
 ```
-    make flash -C tests/driver_vl53l1x BOARD=...
+    make flash -C tests/drivers/vl53l1x BOARD=...
 ```
 To use the `vl53l1x_basic` driver variant, define it in it the make command:
 ```
-    DRIVER=vl53l1x_basic make flash -C tests/driver_vl53l1x BOARD=...
+    DRIVER=vl53l1x_basic make flash -C tests/drivers/vl53l1x BOARD=...
 ```
 If the configuration parameter VL53L1X_PARAM_PIN_INT is defined, interrupts
 are used to get data instead of polling for new data. In the case of driver

--- a/tests/drivers/vl53l1x/README.md
+++ b/tests/drivers/vl53l1x/README.md
@@ -1,0 +1,31 @@
+# VL53L1x Driver Test
+
+## About
+
+The test application demonstrates the usage of different functions
+dependent on used driver variant:
+
+- `vl53l1x_basic`  Basic driver with only very basic functionality
+- `vl53l1x`        Default driver with complete functionality
+
+## Usage
+
+The driver variant used is defined by my variable DRIVER, which is set to
+`vl53l1x` by default. In this case, it is not necessary to specify
+the DRIVER variable in the make command:
+```
+    make flash -C tests/driver_vl53l1x BOARD=...
+```
+To use the `vl53l1x_basic` driver variant, define it in it the make command:
+```
+    DRIVER=vl53l1x_basic make flash -C tests/driver_vl53l1x BOARD=...
+```
+If the configuration parameter VL53L1X_PARAM_PIN_INT is defined, interrupts
+are used to get data instead of polling for new data. In the case of driver
+variant `vl53l1x`, threshold interrupts are configured. Otherwise
+only data interrupts are used.
+
+In all cases, the sensor is configured with following default parameters:
+
+- timing budget of 50 ms
+- intermeasurement period of 100 ms

--- a/tests/drivers/vl53l1x/main.c
+++ b/tests/drivers/vl53l1x/main.c
@@ -19,11 +19,11 @@
  * `vl53l1x` by default. In this case, it is not necessary to specify
  * the DRIVER variable in the make command:
  * ```
- *     make flash -C tests/driver_vl53l1x BOARD=...
+ *     make flash -C tests/drivers/vl53l1x BOARD=...
  * ```
  * To use the `vl53l1x_basic` driver variant, define it in it the make command:
  * ```
- *     DRIVER=vl53l1x_basic make flash -C tests/driver_vl53l1x BOARD=...
+ *     DRIVER=vl53l1x_basic make flash -C tests/drivers/vl53l1x BOARD=...
  * ```
  * If the configuration parameter VL53L1X_PARAM_PIN_INT is defined, interrupts
  * are used to get data instead of polling for new data. In the case of driver

--- a/tests/drivers/vl53l1x/main.c
+++ b/tests/drivers/vl53l1x/main.c
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     tests
+ * @brief       Test application for ST VL53L1X Time-of-Flight distance sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ *
+ * The test application demonstrates the usage of different functions
+ * dependent on used driver variant:
+ *
+ * - `vl53l1x_basic`  Basic driver with only very basic functionality
+ * - `vl53l1x`        Default driver with complete functionality
+ *
+ * The driver variant used is defined by my variable DRIVER, which is set to
+ * `vl53l1x` by default. In this case, it is not necessary to specify
+ * the DRIVER variable in the make command:
+ * ```
+ *     make flash -C tests/driver_vl53l1x BOARD=...
+ * ```
+ * To use the `vl53l1x_basic` driver variant, define it in it the make command:
+ * ```
+ *     DRIVER=vl53l1x_basic make flash -C tests/driver_vl53l1x BOARD=...
+ * ```
+ * If the configuration parameter VL53L1X_PARAM_PIN_INT is defined, interrupts
+ * are used to get data instead of polling for new data. In the case of driver
+ * variant `vl53l1x`, threshold interrupts are configured. Otherwise
+ * only data interrupts are used.
+ *
+ * In all cases, the sensor is configured with following default parameters:
+ *
+ * - timing budget of 50 ms
+ * - intermeasurement period of 100 ms *
+ */
+
+#include <stdio.h>
+
+#include "mutex.h"
+#include "thread.h"
+#include "ztimer.h"
+
+#include "vl53l1x.h"
+#include "vl53l1x_params.h"
+
+static void isr (void *arg)
+{
+    /*
+     * The ISR function is executed in the interrupt context. It must not be
+     * blocking or time-consuming and must not access the sensor directly
+     * via I2C.
+     *
+     * Therefore, the ISR function only indicates to the waiting thread that
+     * an interrupt has occurred which needs to be handled in the thread
+     * context.
+     */
+    mutex_unlock(arg);
+}
+
+int main(void)
+{
+    /* Initialize the sensor */
+    vl53l1x_t dev;
+
+    /* initialize the sensor  */
+    puts("VL53L1X Time-of-Flight distance sensor\n");
+    puts("Initializing VL53L1X sensor");
+
+    if (vl53l1x_init(&dev, &vl53l1x_params[0]) == 0) {
+        printf("[OK]\n");
+    }
+    else {
+        printf("[Failed]\n");
+        return 1;
+    }
+
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+    /* optional read and print the ROI */
+    vl53l1x_roi_t roi;
+    if (vl53l1x_get_roi(&dev, &roi) == 0) {
+        printf("old ROI [x_size=%d, y_size=%d]\n", roi.x_size, roi.y_size);
+    }
+    roi.x_size = 8;
+    roi.y_size = 8;
+    if (vl53l1x_set_roi(&dev, &roi) == 0 &&
+        vl53l1x_get_roi(&dev, &roi) == 0) {
+        printf("new ROI [x_size=%d, y_size=%d]\n", roi.x_size, roi.y_size);
+    }
+#endif /* !IS_USED(MODULE_VL53L1X_BASIC) */
+
+    mutex_t mtx = MUTEX_INIT_LOCKED;
+
+    /* if interrupt pin is defined, enable the interrupt */
+    if (vl53l1x_params[0].pin_int != GPIO_UNDEF) {
+#if IS_USED(MODULE_VL53L1X_BASIC)
+        /* only data ready interrupts are supported and cfg has to be NULL */
+        vl53l1x_int_config(&dev, VL53L1X_INT_DATA_READY, 0, isr, &mtx);
+#else
+        /* generate interrupts when distance is between 200 mm and 400 mm */
+        vl53l1x_thresh_config_t cfg = {
+            .mode = VL53L1X_THRESH_IN,
+            .high = 400,
+            .low  = 200,
+        };
+        vl53l1x_int_config(&dev, VL53L1X_INT_DIST_THRESH, &cfg, isr, &mtx);
+#endif /* IS_USED(MODULE_VL53L1X_BASIC) */
+    }
+
+    while (1) {
+        /* if interrupt pin is defined, wait for the interrupt */
+        if (vl53l1x_params[0].pin_int != GPIO_UNDEF) {
+            mutex_lock(&mtx);
+        }
+        else {
+            /* otherwise wait 100 ms. */
+            ztimer_sleep(ZTIMER_MSEC, 100);
+        }
+
+#if IS_USED(MODULE_VL53L1X_BASIC)
+        uint16_t mm;
+
+        if (vl53l1x_data_ready(&dev) == 0 &&
+            vl53l1x_read_mm(&dev, &mm) == 0) {
+
+            printf("distance=%" PRIi16 " [mm]\n", mm);
+        }
+#else /* IS_USED(MODULE_VL53L1X_BASIC) */
+
+        vl53l1x_data_t data;
+
+        if (vl53l1x_data_ready(&dev) == 0 &&
+            vl53l1x_read_data(&dev, &data) == 0) {
+            printf("distance=%" PRIi16 " [mm] status=%u "
+                   "signal=%" PRIu16 " [kcps] ambient=%" PRIu16 " [kcps]\n",
+                   data.distance, data.status,
+                   data.signal_rate, data.ambient_rate);
+        }
+#endif /* IS_USED(MODULE_VL53L1X_BASIC) */
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

This PR adds a device driver for ST VL53L1X Time-of-Flight laser-ranging sensor which allows accurate and fast ranging up to 4 m at a frequency of up to 50 Hz. It is a complete rework of PR #10363 and uses the ST VL53L1X ULD API (STSW-IMG009) instead of the ST VL53L1X API (STSW-IMG007) that were used in PR #10363.

There are two variants of the driver which differ in functionality and size:

| Module Name     | Driver             | Short Description
|:----------------|:-------------------|:----------------------------
| `vl53l1x_basic` | Basic Driver       | Minimum functionality at small size
| `vl53l1x`       | Default Driver     | Complete functionality at acceptable size

The `vl53l1x_basic` driver variant is the smallest driver variant which provides only some basic functions such as the distance measurement and the data-ready interrupt.

The `vl53l1x` driver variant (default) is a compromise of size and functionality. It provides the application with most functionality of the sensor. The driver can be used when memory requirements are important and most of the functionality should be used.

Both driver variants use the ST VL53L1X ULD API (STSW-IMG009) as vendor code, provide SAUL capabilities and data-ready interrupt functionality. The `vl53l1x` driver variant allows to use threshold interrupts.

Function / Property                     | vl53l1x_basic | vl53l1x
:---------------------------------------|:-------------:|:--------------:
Distance results in mm                  | X             | X
Signal rate results in kcps             |               | X
Measurement status information          |               | X
SAUL capability                         | X             | X
Distance mode configuration             |               | X
Timing budget configuration             |               | X
Inter-measurement period configuration  |               | X
Region of Interest (ROI) configuration  |               | X
Data-ready interrupts (ranging mode)    | X             | X
Threshold interrupts (detection mode)   |               | X
Power on/off functions                  |               | X
SHUTDOWN pin support                    |               | X
Calibration functions                   |               | X [1]
Size on reference platform in kByte [2] | 1.0           | 2.9

[1] These functions are available by using the ST VL53L1X ULD API directly.
[2] Reference platform: STM32F411RE

### Testing procedure

The driver variants can be tested by using the test application with different modules where the standard variant `vl53l1x` is used by default:
```python
make flash -C tests/driver_vl53l1x BOARD=...
```
To use the `vl53l1x_basic` driver variant, define it in it the make command:
```python
DRIVER=vl53l1x_basic make flash -C tests/driver_vl53l1x BOARD=...
```

If the configuration parameter `VL53L1X_PARAM_PIN_INT ` is defined, e.g.,
```python
CFLAGS='-DVL53L1X_PARAM_PIN_INT=\(GPIO\(0,\1\)' make flash -C tests/driver_vl53l1x BOARD=...
``` 
interrupts are used to get data instead of polling for new data. In the case of the  `vl53l1x` driver variant, threshold interrupts are configured.

In all cases, the sensor is configured with following default parameters:
- timing budget of 50 ms
- intermeasurement period of 100 ms

### Issues/PRs references

This PR is a complete rework of PR #10363.