### PR TITLE
drivers/vl53l1x: add VL53L1X ToF ranging sensor driver

### DIFF
--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -52,6 +52,7 @@ rsource "sm_pwm_01c/Kconfig"
 rsource "sps30/Kconfig"
 rsource "tcs37727/Kconfig"
 rsource "tmp00x/Kconfig"
+rsource "vl53l1x/Kconfig"
 rsource "vl6180x/Kconfig"
 endmenu # Sensor Device Drivers
 

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -271,6 +271,10 @@ ifneq (,$(filter vcnl40%0,$(USEMODULE)))
   USEMODULE += vcnl40x0
 endif
 
+ifneq (,$(filter vl53l1x_%,$(USEMODULE)))
+  USEMODULE += vl53l1x
+endif
+
 ifneq (,$(filter vl6180x_%,$(USEMODULE)))
   USEMODULE += vl6180x
 endif

--- a/drivers/include/vl53l1x.h
+++ b/drivers/include/vl53l1x.h
@@ -1,0 +1,466 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @defgroup    drivers_vl53l1x VL53L1X Time-of-Flight (ToF) ranging sensor
+ * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
+ * @brief       Device driver for the ST VL53L1X Time-of-Flight (ToF) ranging sensor
+ *
+ * \section drivers_vl53l1x VL53L1X Time-of-Flight (ToF) ranging sensor
+ *
+ * ## Driver Variants
+ *
+ * Using the according module, the driver can be used in two different variants
+ * which differ in functionality and size:
+ *
+ * Module Name     | Driver             | Short Description
+ * :---------------|:-------------------|:----------------------------
+ * `vl53l1x_basic` | \ref vl53l1x_basic | Minimum functionality at small size
+ * `vl53l1x`       | \ref vl53l1x       | Complete functionality at acceptable size
+ *
+ * If the driver variant is not specified, \ref vl53l1x is used by default.
+ * Both driver variants provide \ref drivers_saul capabilities for distance.
+ *
+ * ## Basic Driver (vl53l1x_basic) {#vl53l1x_basic}
+ *
+ * This is the smallest driver variant that only provides some basic functions
+ * such as
+ *
+ * - distance measurements at acceptable accuracy,
+ * - data-ready interrupts, and
+ * - SAUL capability.
+ *
+ * This driver should be used when memory requirements are an issue.
+ *
+ * ## Default Driver (vl53l1x) {#vl53l1x}
+ *
+ * Using \ref vl53l1x variant provides the application with the functionality
+ * of the basic driver variant \ref vl53l1x_basic and additional functionality
+ * such as
+ *
+ * - configuration of sensor parameters (distance mode, timing budget
+ *   and inter-measurement period),
+ * - configuration and use of distance threshold interrupts, or
+ * - power handling.
+ *
+ * Additionally, it provides access to the complete functionality of the sensor
+ * by using VL53L1X ULD API functions directly. This is for example necessary to
+ * to calibrate the sensor. Even though the sensor is calibrated by ST during
+ * the final module test and these calibration data are loaded from NVM, the
+ * sensor should be calibrated on customers production line when soldered on
+ * customer board or adding a cover glass.
+ *
+ * Please refer the [VL53L1X ULD API user manual]
+ * (https://www.st.com/resource/en/user_manual/um2510-a-guide-to-using-the-vl53l1x-ultra-lite-driver-stmicroelectronics.pdf)
+ * for detailed information on how to use the API to calibrate the sensor.
+ *
+ * @note    Since the ST STSW-IMG009 VL53L1X ULD API provides functions that are
+ *          not required in most use cases, this driver variant should only be
+ *          used when memory requirements are not an issue.
+ *
+ * ## Driver Comparison Sheet
+ *
+ * Function / Property                     | vl53l1x_basic | vl53l1x
+ * :---------------------------------------|:-------------:|:--------------:
+ * Distance results in mm                  | X             | X
+ * Signal rate results in kcps             |               | X
+ * Measurement status information          |               | X
+ * SAUL capability                         | X             | X
+ * Distance mode configuration             |               | X
+ * Timing budget configuration             |               | X
+ * Inter-measurement period configuration  |               | X
+ * Region of Interest (ROI) configuration  |               | X
+ * Data-ready interrupts (ranging mode)    | X             | X
+ * Threshold interrupts (detection mode)   |               | X
+ * Power on/off functions                  |               | X
+ * SHUTDOWN pin support                    |               | X
+ * Calibration functions                   |               | X [1]
+ * Size on reference platform in kByte [2] | 1.0           | 2.9
+ *
+ * [1] These functions are available by using the ST VL53L1X ULD API directly.<br>
+ * [2] Reference platform: STM32F411RE
+ *
+ * @{
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "kernel_defines.h"
+#include "periph/gpio.h"
+#include "periph/i2c.h"
+
+#define VL53L1X_DEVICE_ID   (0xeacc)    /**< VL53L1X Model ID */
+#define VL53L1X_I2C_ADDRESS (0x29)      /**< VL53L1X I2C address */
+
+/**
+ * @brief   VL53L1X distance modes
+ *
+ * The values are reused from the ST VL53L1X ULD API for compatibility.
+ * Although the sensor supports 3 distance modes (short, medium, long),
+ * the ST VL53L1X ULD API supports only two which should be sufficient in
+ * most use cases.
+ *
+ * @note    Distance mode CANNOT be configured if module \ref vl53l1x_basic
+ *          is enabled.
+ */
+typedef enum {
+    VL53L1X_DIST_SHORT  = 1,        /**< up to 1.3 m */
+    VL53L1X_DIST_LONG   = 2,        /**< up to 4 m */
+} vl53l1x_dist_mode_t;
+
+/**
+ * @brief   Interrupt mode
+ *
+ * The interrupt mode defines when an interrupt is triggered. Interrupts can
+ * be triggered in each measurement cycle, either when new data is available
+ * (ranging mode) or when the distance threshold conditions defined by
+ * \ref vl53l1x_thresh_config_t are met (detection mode). Use the function
+ * \ref vl53l1x_int_config to configure these interrupts.
+ *
+ * @note    If the \ref vl53l1x_basic is used, only data-ready interrupts
+ *          are supported.
+ */
+typedef enum {
+    VL53L1X_INT_DATA_READY,  /**< interrupt on new data */
+    VL53L1X_INT_DIST_THRESH, /**< interrupt when distance threshold conditions are met */
+} vl53l1x_int_mode_t;
+
+/**
+ * @brief   Threshold modes used for detection mode
+ *
+ * The threshold mode defines how the upper and lower thresholds are used
+ * to trigger an interrupt in detection mode.
+ *
+ * @note Although the VL53L1X allows the definition of thresholds for distance
+ *       and signal rate, the ST VL53L1X ULD API only allows the definition
+ *       of thresholds for the distance.
+ */
+typedef enum {
+    VL53L1X_THRESH_HIGH = 0, /**< when the distance exceeds the upper threshold */
+    VL53L1X_THRESH_LOW  = 1, /**< when the distance falls below the lower threshold */
+    VL53L1X_THRESH_OUT  = 2, /**< when the distance exceeds the upper threshold or
+                                  falls below the lower threshold (the distance
+                                  leaves the threshold window) */
+    VL53L1X_THRESH_IN   = 3, /**< when the distance exceeds the lower threshold or
+                                  falls below the higher threshold (the distance
+                                  enters the threshold window) */
+} vl53l1x_thresh_mode_t;
+
+/**
+ * @brief   Distance threshold configuration
+ *
+ * The distance threshold configuration is used in function \ref vl53l1x_int_config
+ * to configure the conditions when interrupts are triggered in detection mode.
+ *
+ * @note    If the \ref vl53l1x_basic is used, only data-ready interrupts can be
+ *          used. The distance threshold configuration is not used in this case.
+ */
+typedef struct {
+    vl53l1x_thresh_mode_t mode; /**< threshold mode for distance */
+    uint16_t high;              /**< upper threshold for distance in mm */
+    uint16_t low;               /**< lower threshold for distance in mm */
+} vl53l1x_thresh_config_t;
+
+/**
+ * @brief   VL53L1X device initialization parameters
+ */
+typedef struct {
+    i2c_t i2c_dev;      /**< I2C device, default I2C_DEV(0) */
+    uint8_t i2c_addr;   /**< I2C slave address */
+    bool vddio_2v8;     /**< if true, I/O voltage is 2.8 V, otherwise 1.8 V */
+    gpio_t pin_int;     /**< Interrupt pin open drain, active low:
+                             \ref GPIO_UNDEF if not used */
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+    gpio_t pin_shutdown;/**< Shutdown pin low active:
+                             \ref GPIO_UNDEF if not used */
+    uint16_t budget;    /**< Timing budget given to the sensor to perform range
+                             measurements in ms [15, 20, 33, 50, 100, 200, 500],
+                             default: 50 ms */
+    uint32_t period;    /**< Inter-measurement period in ms which has to be
+                             at least vl53l1x_params_t::budget + 4ms,
+                             default: 100 ms */
+    vl53l1x_dist_mode_t mode; /**< Distance mode, default: VL53L1X_DIST_LONG */
+#endif /* !IS_USED(MODULE_VL53L1X_BASIC) */
+} vl53l1x_params_t;
+
+/**
+ * @brief   VL53L1X sensor device data structure type
+ */
+typedef struct {
+    uint16_t addr;      /**< Device address as used by the ST VL53L1X ULD API,
+                             format = I2C bus num << 8 | I2C slave address */
+    bool int_init;      /**< Interrupt pin is already initialized */
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+    uint16_t budget;    /**< Timing budget used */
+    uint32_t period;    /**< Inter-measurement period used */
+    vl53l1x_dist_mode_t mode;       /**< Distance mode used */
+#endif
+    const vl53l1x_params_t *params; /**< Device initialization parameters */
+} vl53l1x_t;
+
+/**
+ * @brief   VL53L1X ranging data
+ */
+typedef struct {
+    uint8_t  status;        /**< status for the current measurement */
+    uint16_t distance;      /**< distance in millimeter */
+    uint16_t signal_rate;   /**< signal rate in kcps (kilo count per seconds) */
+    uint16_t ambient_rate;  /**< ambient rate in kcps (kilo count per seconds) */
+} vl53l1x_data_t;
+
+/**
+ * @brief   VL53L1X region of interest (ROI)
+ *
+ * Defines the region of interest (ROI) within the 16 x 16 SPAD (single photon
+ * avalanche diode) array. The ROI is a square or rectangle defined by
+ * x and y dimension. The center is set automatically.
+ */
+typedef struct {
+    uint16_t x_size;     /**< ROI x size [4...16] (default 16)  */
+    uint16_t y_size;     /**< ROI y size [4...16] (default 16) */
+} vl53l1x_roi_t;
+
+/**
+ * @brief   Initialize the VL53L1X sensor device
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor to be initialized
+ * @param[in]   params  configuration parameters, see \ref vl53l1x_params_t
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ * @retval  -ENODEV no device found
+ */
+int vl53l1x_init(vl53l1x_t *dev, const vl53l1x_params_t *params);
+
+/**
+ * @brief   Data-ready status function
+ *
+ * The function can be used for polling to know when new ranging data are
+ * available.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ *
+ * @retval  0       new ranging data are ready
+ * @retval  -EAGAIN no new ranging data available
+ * @retval  -EIO    on I2C communication error
+ */
+int vl53l1x_data_ready(vl53l1x_t *dev);
+
+/**
+ * @brief   Read one ranging data sample in mm
+ *
+ * This function returns only the ranging data in millimeters.
+ *
+ * @note    Since reading any data resets the interrupt as well as the
+ *          data-ready flag, either function \ref vl53l1x_read_mm or function
+ *          \ref vl53l1x_read_data can be used in one measurement cycle.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ * @param[out]  mm      ranging data in mm
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ */
+int vl53l1x_read_mm(vl53l1x_t *dev, uint16_t *mm);
+
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+/**
+ * @brief   Read one ranging data sample with status and signal information
+ *
+ * This function returns the ranging data distance together with additional
+ * information about the measurement like the status and the signals.
+ *
+ * @note
+ * - Since reading any data resets the interrupt as well as the data-ready
+ *   flag, either function \ref vl53l1x_read_mm or function
+*    \ref vl53l1x_read_data can be used in one measurement cycle.
+ * - This function is NOT available if module \ref vl53l1x_basic is used.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ * @param[out]  data    ranging data
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ */
+int vl53l1x_read_data(vl53l1x_t *dev, vl53l1x_data_t *data);
+
+/**
+ * @brief   Power down the sensor
+ *
+ * This function requires that a GPIO connected to sensor's /XSHUT pin is
+ * defined by parameter vl53l1x_params_t::pin_shutdown.
+ *
+ * @note    This function is NOT available if module \ref vl53l1x_basic
+ *          is used.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ */
+int vl53l1x_power_down(const vl53l1x_t *dev);
+
+/**
+ * @brief   Power up the sensor
+ *
+ * This function requires that a GPIO connected to sensor's /XSHUT pin is
+ * defined by parameter vl53l1x_params_t::pin_shutdown.
+ *
+ * @note    This function is NOT available if module \ref vl53l1x_basic
+ *          is used.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ * @retval  -ENODEV no device found
+ */
+int vl53l1x_power_up(vl53l1x_t *dev);
+
+/**
+ * @brief   Change the timing budget in microseconds
+ *
+ * This function can be used to change the timing budget that was defined
+ * by configuration parameter vl53l1x_params_t::budget during sensor
+ * initialization.
+ *
+ * @note    This function is NOT available if module \ref vl53l1x_basic
+ *          is used.
+ *
+ * @param[in]   dev         device descriptor of VL53L1X sensor
+ * @param[in]   budget_ms   new timing budget in ms
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ * @retval  -EINVAL if the current distance mode or the given budget_ms parameter is invalid
+ */
+int vl53l1x_set_timing_budget(vl53l1x_t *dev, uint16_t budget_ms);
+
+/**
+ * @brief   Change the inter-measurement period im ms
+ *
+ * This function can be used to change the the inter-measurement period that was
+ * defined by configuration parameter vl53l1x_params_t::period during sensor
+ * initialization.
+ *
+ * @pre     The inter-measurement period MUST be longer than the timing budget
+ *          + 4 ms. Otherwise the function fails. Therefore, if the time
+ *          budget is also changed, it should be done first.
+ *
+ * @note    This function is NOT available if module \ref vl53l1x_basic
+ *          is used.
+ *
+ * @param[in]   dev         device descriptor of VL53L1X sensor
+ * @param[in]   period_ms   new measurement period in ms
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ */
+int vl53l1x_set_measurement_period(vl53l1x_t *dev, uint32_t period_ms);
+
+/**
+ * @brief   Change the distance mode
+ *
+ * This function can be used to change the the distance mode that was
+ * defined by configuration parameter vl53l1x_params_t::mode during sensor
+ * initialization.
+ *
+ * @note    This function is NOT available if module \ref vl53l1x_basic
+ *          is used.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ * @param[in]   mode    new distance mode, see \ref vl53l1x_dist_mode_t
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ * @retval  -EINVAL if the given mode parameter or the current budget is invalid
+ */
+int vl53l1x_set_distance_mode(vl53l1x_t *dev, vl53l1x_dist_mode_t mode);
+
+/**
+ * @brief   Set the region of interest (ROI)
+ *
+ * Using this function, the region of interest (ROI) within the 16 x 16 SPAD
+ * (single photon avalanche diode) array can be defined.
+ *
+ * @note    This function is NOT available if module \ref vl53l1x_basic
+ *          is used.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ * @param[in]   roi     new region of interest, see #vl53l1x_roi_t
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ */
+int vl53l1x_set_roi(vl53l1x_t *dev, vl53l1x_roi_t *roi);
+
+/**
+ * @brief   Get the region of interest (ROI)
+ *
+ * @note    This function is NOT available if module \ref vl53l1x_basic
+ *          is used.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ * @param[out]  roi     current region of interest, see \ref vl53l1x_roi_t
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ */
+int vl53l1x_get_roi(vl53l1x_t *dev, vl53l1x_roi_t *roi);
+
+#endif /* IS_USED(MODULE_VL53L1X_BASIC) */
+
+/**
+ * @brief   Configure interrupts
+ *
+ * The function
+ *
+ * - configures the interrupts of the sensor,
+ * - initializes the GPIO defined by vl53l1x_params_t::pin_int, and
+ * - attaches the ISR specified by the @p isr parameter to the interrupt.
+ *
+ * @warning Since the ISR is executed in the interrupt context, it must not be
+ *          blocking or time consuming. In addition, it must not access the
+ *          sensor directly via I2C. It should only indicate to a waiting
+ *          thread that an interrupt has occurred, which is then handled
+ *          in the thread context.
+ *          If it is tried to access the sensor in interrupt context, an
+ *          assertion blows up (if assertions are enabled).
+ *
+ * @note    The configuration of distance threshold interrupts is ONLY
+ *          used if the \ref vl53l1x driver variant is used. Otherwise, only
+ *          data-ready interrupts are used independent on the configuration given
+ *          by parameter \p cfg. In later case, parameter \p cfg can be NULL.
+ *
+ * @param[in]   dev     device descriptor of the VL53L1X sensor
+ * @param[in]   mode    interrupt mode, see \ref vl53l1x_int_mode_t
+ * @param[in]   cfg     threshold configuration, see \ref vl53l1x_thresh_config_t
+ * @param[in]   isr     ISR called for all types of interrupts
+ * @param[in]   isr_arg ISR argument, can be NULL
+ *
+ * @retval  0       on success
+ * @retval  -EIO    on I2C communication error
+ */
+int vl53l1x_int_config(vl53l1x_t *dev, vl53l1x_int_mode_t mode,
+                                       vl53l1x_thresh_config_t* cfg,
+                                       void (*isr)(void *),
+                                       void *isr_arg);
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/drivers/saul/init_devs/auto_init_vl53l1x.c
+++ b/drivers/saul/init_devs/auto_init_vl53l1x.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2021 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/*
+ * @ingroup     drivers_vl53l1x
+ * @ingroup     sys_auto_init_saul
+ * @brief       Auto initialization of ST VL53L1X Time-of-Flight (ToF) ranging sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ */
+
+#ifdef MODULE_VL53L1X
+
+#include "assert.h"
+#include "log.h"
+#include "saul_reg.h"
+#include "vl53l1x.h"
+#include "vl53l1x_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define VL53L1X_NUM    (sizeof(vl53l1x_params) / sizeof(vl53l1x_params[0]))
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static vl53l1x_t vl53l1x_devs[VL53L1X_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[VL53L1X_NUM];
+
+/**
+ * @brief   Define the number of saul info
+ */
+#define VL53L1X_INFO_NUM (sizeof(vl53l1x_saul_info) / sizeof(vl53l1x_saul_info[0]))
+
+/**
+ * @brief   Reference the driver structs
+ */
+extern saul_driver_t vl53l1x_saul_driver;
+
+void auto_init_vl53l1x(void)
+{
+    assert(VL53L1X_INFO_NUM == VL53L1X_NUM);
+
+    for (unsigned i = 0; i < VL53L1X_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing vl53l1x #%u\n", i);
+
+        if (vl53l1x_init(&vl53l1x_devs[i], &vl53l1x_params[i]) != VL53L1X_OK) {
+            LOG_ERROR("[auto_init_saul] error initializing vl53l1x #%u\n", i);
+            continue;
+        }
+
+        saul_entries[i].dev = &(vl53l1x_devs[i]);
+        saul_entries[i].name = vl53l1x_saul_info[i].name;
+        saul_entries[i].driver = &vl53l1x_saul_driver;
+        saul_reg_add(&(saul_entries[i]));
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_VL53L1X */

--- a/drivers/saul/init_devs/init.c
+++ b/drivers/saul/init_devs/init.c
@@ -359,6 +359,10 @@ void saul_init_devs(void)
         extern void auto_init_veml6070(void);
         auto_init_veml6070();
     }
+    if (IS_USED(MODULE_VL53L1X)) {
+        extern void auto_init_vl53l1x(void);
+        auto_init_vl53l1x();
+    }
     if (IS_USED(MODULE_VL6180X)) {
         extern void auto_init_vl6180x(void);
         auto_init_vl6180x();

--- a/drivers/vl53l1x/Kconfig
+++ b/drivers/vl53l1x/Kconfig
@@ -1,0 +1,47 @@
+# Copyright (c) 2025 Gunar Schorcht
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+if !USEMODULE_VL53L1X_BASIC
+
+menu "VL53L1X Time-of-Flight (ToF) ranging sensor"
+
+choice
+    bool "Distance mode"
+    default VL53L1X_DIST_LONG
+    config VL53L1X_DIST_SHORT
+        bool "Short - up to 1.3 m"
+    config VL53L1X_DIST_LONG
+        bool "Long - up to 4 m"
+endchoice
+
+choice
+    bool "Timing budget"
+    default VL53L1X_PARAM_TIMING_BUDGET_50
+    config VL53L1X_PARAM_TIMING_BUDGET_15
+        bool "15 ms"
+    config VL53L1X_PARAM_TIMING_BUDGET_20
+        bool "20 ms"
+    config VL53L1X_PARAM_TIMING_BUDGET_33
+        bool "33 ms"
+    config VL53L1X_PARAM_TIMING_BUDGET_50
+        bool "50 ms"
+    config VL53L1X_PARAM_TIMING_BUDGET_100
+        bool "100 ms"
+    config VL53L1X_PARAM_TIMING_BUDGET_200
+        bool "200 ms"
+    config VL53L1X_PARAM_TIMING_BUDGET_500
+        bool "500 ms"
+endchoice
+
+config VL53L1X_PARAM_PERIOD
+    int "Inter-measurement period [ms]"
+    default 100
+    range 20 1000
+
+endmenu
+
+endif # !USEMODULE_VL53L1X_BASIC

--- a/drivers/vl53l1x/Makefile
+++ b/drivers/vl53l1x/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/vl53l1x/Makefile.dep
+++ b/drivers/vl53l1x/Makefile.dep
@@ -1,0 +1,15 @@
+USEPKG += driver_vl53l1x_st_api
+
+ifneq (,$(filter vl53l1x_%,$(USEMODULE)))
+  USEMODULE += vl53l1x
+endif
+
+USEMODULE += vl53l1x_st_api_core
+USEMODULE += vl53l1x_st_api_platform
+
+ifneq (,$(filter vl53l1x,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio_irq
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_i2c
+  USEMODULE += ztimer_msec
+endif

--- a/drivers/vl53l1x/Makefile.include
+++ b/drivers/vl53l1x/Makefile.include
@@ -1,0 +1,5 @@
+# include variants of VL53L1X drivers as pseudo modules
+PSEUDOMODULES += vl53l1x_basic
+
+USEMODULE_INCLUDES_vl53l1x := $(LAST_MAKEFILEDIR)/include
+USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_vl53l1x)

--- a/drivers/vl53l1x/include/vl53l1x_params.h
+++ b/drivers/vl53l1x/include/vl53l1x_params.h
@@ -1,0 +1,145 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     drivers_vl53l1x
+ * @brief       Default configuration for ST VL53L1X Time-of-Flight (ToF) ranging sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#include "board.h"
+#include "saul_reg.h"
+
+#include "vl53l1x.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Default hardware configuration parameters
+ * @{
+ */
+
+/**
+ * @brief    Default device is I2C_DEV(0)
+ */
+#ifndef VL53L1X_PARAM_DEV
+#  define VL53L1X_PARAM_DEV             I2C_DEV(0)
+#endif
+
+/**
+ * @brief    Default I2C slave address
+ */
+#ifndef VL53L1X_PARAM_ADDR
+#  define VL53L1X_PARAM_ADDR            (VL53L1X_I2C_ADDRESS)
+#endif
+
+/**
+ * @brief   Default I2C VDDIO voltage: 2.8 V
+ */
+#ifndef VL53L1X_PARAM_VDDIO_2V8
+#  define VL53L1X_PARAM_VDDIO_2V8       (true)
+#endif
+
+/**
+ * @brief   Default interrupt pin: not used
+ */
+#ifndef VL53L1X_PARAM_PIN_INT
+#  define VL53L1X_PARAM_PIN_INT         (GPIO_UNDEF)
+#endif
+
+/**
+ * @brief   Default shutdown pin: not used
+ */
+#ifndef VL53L1X_PARAM_PIN_SHUTDOWN
+#  define VL53L1X_PARAM_PIN_SHUTDOWN    (GPIO_UNDEF)
+#endif
+/** @} */
+
+/**
+ * @name    Default sensor configuration parameters
+ * @{
+ */
+
+/**
+ * @brief   Default inter-measurement period [ms]: 100 ms
+ */
+#ifndef CONFIG_VL53L1X_PARAM_PERIOD
+#  define CONFIG_VL53L1X_PARAM_PERIOD           (100)
+#endif
+
+/**
+ * @brief   Default Timing budget [ms]: 50 ms
+ */
+#ifndef CONFIG_VL53L1X_PARAM_TIMING_BUDGET
+#  define CONFIG_VL53L1X_PARAM_TIMING_BUDGET    (50)
+#endif
+
+/**
+ * @brief   Default distance mode: long
+ */
+#ifndef CONFIG_VL53L1X_PARAM_DISTANCE_MODE
+#  define CONFIG_VL53L1X_PARAM_DISTANCE_MODE    (VL53L1X_DIST_LONG)
+#endif
+/**@}*/
+
+/**
+ * @brief   Default VL53L1X configuration parameter set
+ */
+#ifndef VL53L1X_PARAMS
+#  if !IS_USED(MODULE_VL53L1X_BASIC)
+#    define VL53L1X_PARAMS { \
+                                .i2c_dev = VL53L1X_PARAM_DEV, \
+                                .i2c_addr = VL53L1X_PARAM_ADDR, \
+                                .vddio_2v8 = VL53L1X_PARAM_VDDIO_2V8, \
+                                .pin_int = VL53L1X_PARAM_PIN_INT, \
+                                .pin_shutdown = VL53L1X_PARAM_PIN_SHUTDOWN, \
+                                .budget = CONFIG_VL53L1X_PARAM_TIMING_BUDGET, \
+                                .period = CONFIG_VL53L1X_PARAM_PERIOD, \
+                                .mode = CONFIG_VL53L1X_PARAM_DISTANCE_MODE, \
+                        }
+#  else /* !IS_USED(MODULE_VL53L1X_BASIC) */
+#    define VL53L1X_PARAMS  { \
+                                .i2c_dev = VL53L1X_PARAM_DEV, \
+                                .i2c_addr = VL53L1X_PARAM_ADDR, \
+                                .vddio_2v8 = VL53L1X_PARAM_VDDIO_2V8, \
+                                .pin_int = VL53L1X_PARAM_PIN_INT, \
+                            }
+#  endif /* !IS_USED(MODULE_VL53L1X_BASIC) */
+#endif /* VL53L1X_PARAMS */
+
+/**
+ * @brief   Default SAUL device information
+ */
+#ifndef VL53L1X_SAUL_INFO
+#  define VL53L1X_SAUL_INFO { .name = "vl53l1x" }
+#endif
+
+/**
+ * @brief   Allocate some memory to store the default configuration
+ */
+static const vl53l1x_params_t vl53l1x_params[] =
+{
+    VL53L1X_PARAMS
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t vl53l1x_saul_info[] =
+{
+    VL53L1X_SAUL_INFO
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/drivers/vl53l1x/include/vl53l1x_params.h
+++ b/drivers/vl53l1x/include/vl53l1x_params.h
@@ -68,6 +68,33 @@ extern "C" {
  * @{
  */
 
+#if !DOXYGEN
+
+/* Mapping of Kconfig defines to the respective driver enumeration values */
+#  ifdef CONFIG_VL53L1X_DIST_SHORT
+#    define CONFIG_VL53L1X_PARAM_DISTANCE_MODE      (VL53L1X_DIST_SHORT)
+#  elif CONFIG_VL53L1X_DIST_LONG
+#    define CONFIG_VL53L1X_PARAM_DISTANCE_MODE      (VL53L1X_DIST_LONG)
+#  endif
+
+#  ifdef CONFIG_VL53L1X_PARAM_TIMING_BUDGET_15
+#     define CONFIG_VL53L1X_PARAM_TIMING_BUDGET     (15)
+#  elif CONFIG_VL53L1X_PARAM_TIMING_BUDGET_20
+#     define CONFIG_VL53L1X_PARAM_TIMING_BUDGET     (20)
+#  elif    CONFIG_VL53L1X_PARAM_TIMING_BUDGET_33
+#     define CONFIG_VL53L1X_PARAM_TIMING_BUDGET     (33)
+#  elif    CONFIG_VL53L1X_PARAM_TIMING_BUDGET_50
+#     define CONFIG_VL53L1X_PARAM_TIMING_BUDGET     (50)
+#  elif    CONFIG_VL53L1X_PARAM_TIMING_BUDGET_100
+#     define CONFIG_VL53L1X_PARAM_TIMING_BUDGET     (100)
+#  elif    CONFIG_VL53L1X_PARAM_TIMING_BUDGET_200
+#     define CONFIG_VL53L1X_PARAM_TIMING_BUDGET     (200)
+#  elif    CONFIG_VL53L1X_PARAM_TIMING_BUDGET_500
+#     define CONFIG_VL53L1X_PARAM_TIMING_BUDGET     (500)
+#  endif
+
+#endif /* !DOXYGEN */
+
 /**
  * @brief   Default inter-measurement period [ms]: 100 ms
  */

--- a/drivers/vl53l1x/include/vl53l1x_regs.h
+++ b/drivers/vl53l1x/include/vl53l1x_regs.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     drivers_vl53l1x
+ * @brief       Register definitions for ST VL53L1X Time-of-Flight (ToF) ranging sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#if !DOXYGEN
+/**
+ * @name    Register addresses
+ *
+ * @{
+ */
+#  define VL53L1X_IDENTIFICATION__REVISION_ID   (0x0111)
+#  define VL53L1X_IDENTIFICATION__MODULE_TYPE   (0x0110)
+#  define VL53L1X_IDENTIFICATION__MODULE_ID     (0x0112)
+#  define VL53L1X_PAD_I2C_HV__EXTSUP_CONFIG     (0x002e)
+#  define VL53L1X_SOFT_RESET                    (0x0b00)
+/** @} */
+#endif /* !DOXYGEN */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/drivers/vl53l1x/vl53l1x.c
+++ b/drivers/vl53l1x/vl53l1x.c
@@ -1,0 +1,434 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     drivers_vl53l1x
+ * @brief       Device driver for the ST VL53L1X Time-of-Flight (ToF) ranging sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "vl53l1x_regs.h"
+#include "vl53l1x.h"
+
+#include "VL53L1X_api.h"
+
+#include "irq.h"
+#include "log.h"
+#include "time_units.h"
+#include "ztimer.h"
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+
+#if IS_ACTIVE(ENABLE_DEBUG)
+
+#  define ASSERT_PARAM(cond) \
+    if (!(cond)) { \
+        DEBUG("[vl53l1x] %s: %s\n", \
+              __func__, "parameter condition (" # cond ") not fulfilled"); \
+        assert(cond); \
+    }
+
+#  define DEBUG_DEV(f, d, ...) \
+        DEBUG("[vl53l1x] %s i2c dev=%d addr=%02x: " f "\n", \
+              __func__, d->params->i2c_dev, d->params->i2c_addr, ## __VA_ARGS__);
+
+#else /* IS_ACTIVE(ENABLE_DEBUG) */
+
+#  define ASSERT_PARAM(cond) assert(cond);
+#  define DEBUG_DEV(f, d, ...)
+
+#endif /* IS_ACTIVE(ENABLE_DEBUG) */
+
+#define ERROR_DEV(f, d, ...) \
+        LOG_ERROR("[vl53l1x] %s i2c dev=%d addr=%02x: " f "\n", \
+                  __func__, d->params->i2c_dev, d->params->i2c_addr, ## __VA_ARGS__);
+
+#define EXEC_RET(f) { \
+    int _r; \
+    if ((_r = f) != 0) { \
+        DEBUG("[vl53l1x] %s: error code %d\n", __func__, _r); \
+        return _r; \
+    } \
+}
+
+#define EXEC_RET_CODE(f, c) { \
+    int _r; \
+    if ((_r = f) != 0) { \
+        DEBUG("[vl53l1x] %s: error code %d\n", __func__, _r); \
+        return c; \
+    } \
+}
+
+#define EXEC(f) { \
+    int _r; \
+    if ((_r = f) != 0) { \
+        DEBUG("[vl53l1x] %s: error code %d\n", __func__, _r); \
+        return; \
+    } \
+}
+
+#define VL53L1X_BOOT_TIMEOUT_MS   10      /* 10 ms */
+
+/** Forward declaration of functions for internal use */
+static int _is_available(const vl53l1x_t *dev);
+static int _reset(vl53l1x_t *dev);
+static int _init(vl53l1x_t *dev);
+//static int _update(const vl53l1x_t *dev, uint16_t index, uint8_t mask, uint8_t data);
+
+#define _read_byte(d, i, b)   VL53L1_RdByte(d->addr, i, b)
+#define _read_word(d, i, w)   VL53L1_RdWord(d->addr, i, w)
+#define _read(d, i, p, l)     VL53L1_ReadMulti(d->addr, i, p, l)
+
+#define _write_byte(d, i, b)  VL53L1_WrByte(d->addr, i, b)
+#define _write_word(d, i, w)  VL53L1_WrWord(d->addr, i, w)
+#define _write(d, i, p, l)    VL53L1_WriteMulti(d->addr, i, p, l)
+
+#define _start_meas(d)        VL53L1X_StartRanging(d->addr)
+
+int vl53l1x_init(vl53l1x_t *dev, const vl53l1x_params_t *params)
+{
+    /* some parameter sanity checks */
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(params != NULL);
+
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+    ASSERT_PARAM(params->budget <= 500);
+    ASSERT_PARAM(params->period >= (uint32_t)params->budget + 4);
+
+    dev->budget = params->budget;
+    dev->period = params->period;
+#endif /* !IS_USED(MODULE_VL53L1X_BASIC) */
+
+    DEBUG_DEV("params=%p", dev, params);
+
+    /* init sensor data structure */
+    dev->params = params;
+    dev->int_init = false;
+
+    dev->addr = dev->params->i2c_dev << 8 | dev->params->i2c_addr;
+
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+    /* if shutdown pin is defined, it is initialized first and set */
+    if (params->pin_shutdown != GPIO_UNDEF) {
+        gpio_init(params->pin_shutdown, GPIO_OUT);
+        gpio_write(params->pin_shutdown, 1);
+    }
+#endif
+
+    /* init the sensor and start measurement */
+    EXEC_RET(_init(dev));
+
+    return 0;
+}
+
+int vl53l1x_data_ready(vl53l1x_t *dev)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("", dev);
+
+    uint8_t ready;
+    EXEC_RET(VL53L1X_CheckForDataReady(dev->addr, &ready));
+    return (ready) ? 0 : -EAGAIN;
+}
+
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+int vl53l1x_read_data(vl53l1x_t *dev, vl53l1x_data_t *data)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(data != NULL);
+    DEBUG_DEV("data=%p", dev, data);
+
+    EXEC_RET(VL53L1X_GetRangeStatus(dev->addr, &data->status));
+    EXEC_RET(VL53L1X_GetDistance(dev->addr, &data->distance));
+    EXEC_RET(VL53L1X_GetSignalRate(dev->addr, &data->signal_rate));
+    EXEC_RET(VL53L1X_GetAmbientRate(dev->addr, &data->ambient_rate));
+    EXEC_RET(VL53L1X_ClearInterrupt(dev->addr));
+
+    return 0;
+}
+#endif
+
+int vl53l1x_read_mm(vl53l1x_t *dev, uint16_t *mm)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(mm != NULL);
+    DEBUG_DEV("mm=%p", dev, mm);
+
+    uint8_t status;
+    EXEC_RET(VL53L1X_GetRangeStatus(dev->addr, &status));
+    EXEC_RET(VL53L1X_GetDistance(dev->addr, mm));
+    EXEC_RET(VL53L1X_ClearInterrupt(dev->addr));
+
+    return 0;
+}
+
+int vl53l1x_int_config(vl53l1x_t *dev, vl53l1x_int_mode_t mode,
+                                       vl53l1x_thresh_config_t* cfg,
+                                       void (*isr)(void *),
+                                       void *isr_arg)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(dev->params->pin_int != GPIO_UNDEF);
+
+    DEBUG_DEV("cfg=%p isr=%p isr_arg=%p", dev, cfg, isr, isr_arg);
+
+    if (!dev->int_init) {
+        /* set polarity to LOW active */
+        EXEC_RET(VL53L1X_SetInterruptPolarity(dev->addr, 0));
+
+        dev->int_init = true;
+        gpio_init_int(dev->params->pin_int, GPIO_IN_PU, GPIO_FALLING,
+                      isr, isr_arg);
+    }
+
+    if (IS_USED(MODULE_VL53L1X_BASIC) || (mode == VL53L1X_INT_DATA_READY)) {
+        /* User manual UM2510, section: write 0x20 to the 0x46 register (8 bits) */
+        EXEC_RET(_write_byte(dev, SYSTEM__INTERRUPT_CONFIG_GPIO, 0x20));
+    }
+    else {
+        ASSERT_PARAM(cfg);
+        EXEC_RET(VL53L1X_StopRanging(dev->addr));
+        EXEC_RET(VL53L1X_SetDistanceThreshold(dev->addr,
+                                              cfg->low, cfg->high,
+                                              cfg->mode, 0));
+        EXEC_RET(VL53L1X_StartRanging(dev->addr));
+    }
+
+    EXEC_RET(VL53L1X_ClearInterrupt(dev->addr));
+
+    return 0;
+}
+
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+
+int vl53l1x_power_down(const vl53l1x_t *dev)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("", dev);
+
+    if (dev->params->pin_shutdown == GPIO_UNDEF) {
+        DEBUG_DEV("Pin connected to sensor's XSHUT pin not defined", dev);
+        return -ENODEV;
+    }
+
+    gpio_clear(dev->params->pin_shutdown);
+    return 0;
+}
+
+int vl53l1x_power_up(vl53l1x_t *dev)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("", dev);
+
+    if (dev->params->pin_shutdown == GPIO_UNDEF) {
+        DEBUG_DEV("Pin connected to sensor's XSHUT pin not defined", dev);
+        return -ENODEV;
+    }
+
+    gpio_set(dev->params->pin_shutdown);
+
+    /* init the sensor and start measurement */
+    EXEC_RET(_init(dev));
+
+    return 0;
+}
+
+int vl53l1x_set_timing_budget(vl53l1x_t *dev, uint16_t budget_ms)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("budget_ms=%" PRIu16, dev, budget_ms);
+
+    /* VL53L1X_SetTimingBudgetInMs sets a hard error code of 1 */
+    int8_t ret = VL53L1X_SetTimingBudgetInMs(dev->addr, budget_ms);
+    if (ret == 1) {
+        /* current distance mode or the given parameter budget_ms is invalid */
+        return -EINVAL;
+    }
+    else if (ret) {
+        return ret;
+    }
+
+    /* save the timing budget */
+    dev->budget = budget_ms;
+
+    return 0;
+}
+
+int vl53l1x_set_measurement_period(vl53l1x_t *dev, uint32_t period_ms)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM((period_ms + 4) > dev->budget);
+    DEBUG_DEV("period_ms=%" PRIu32, dev, period_ms);
+
+    EXEC_RET(VL53L1X_SetInterMeasurementInMs(dev->addr, period_ms));
+
+    /* save the measurement period */
+    dev->period = period_ms;
+
+    return 0;
+}
+
+int vl53l1x_set_distance_mode(vl53l1x_t *dev, vl53l1x_dist_mode_t mode)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("mode=%u", dev, mode);
+
+    /* VL53L1X_SetDistanceMode sets a hard error code of 1 */
+    int8_t ret = VL53L1X_SetDistanceMode(dev->addr, mode);
+    if (ret == 1) {
+        /* the given mode parameter or the current timing budget is invalid */
+        return -EINVAL;
+    }
+    else if (ret) {
+        return ret;
+    }
+
+    /* save the distance mode */
+    dev->mode = mode;
+
+    return 0;
+}
+
+int vl53l1x_set_roi(vl53l1x_t *dev, vl53l1x_roi_t *roi)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(roi != NULL);
+
+    ASSERT_PARAM(roi->x_size >= 4);
+    ASSERT_PARAM(roi->x_size <= 15);
+    ASSERT_PARAM(roi->y_size >= 4);
+    ASSERT_PARAM(roi->y_size <= 15);
+
+    DEBUG_DEV("roi=%p", dev, roi);
+
+    EXEC_RET(VL53L1X_SetROI(dev->addr, roi->x_size, roi->y_size));
+
+    return 0;
+}
+
+int vl53l1x_get_roi(vl53l1x_t *dev, vl53l1x_roi_t *roi)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(roi != NULL);
+
+    DEBUG_DEV("roi=%p", dev, roi);
+
+    EXEC_RET(VL53L1X_GetROI_XY(dev->addr, &roi->x_size, &roi->y_size));
+
+    return 0;
+}
+
+#endif /* !IS_USED(MODULE_VL53L1X_BASIC) */
+
+/** Functions for internal use only */
+
+/**
+ * @brief   Check the chip ID to test whether sensor is available
+ */
+static int _is_available(const vl53l1x_t *dev)
+{
+    DEBUG_DEV("", dev);
+
+    uint16_t id;
+    /* read the chip id */
+    EXEC_RET(VL53L1X_GetSensorId(dev->addr, &id));
+
+    if (id != VL53L1X_DEVICE_ID) {
+        DEBUG_DEV("sensor is not available, wrong device id %02x, "
+                  "should be %02x", dev, id, VL53L1X_DEVICE_ID);
+        return -ENODEV;
+    }
+
+#if IS_ACTIVE(ENABLE_DEBUG)
+    uint8_t rev;
+    uint8_t mod_type;
+    uint16_t mod_id = 0;
+
+    EXEC_RET(_read_byte(dev, VL53L1X_IDENTIFICATION__REVISION_ID, &rev));
+    EXEC_RET(_read_byte(dev, VL53L1X_IDENTIFICATION__MODULE_TYPE, &mod_type));
+    EXEC_RET(_read_word(dev, VL53L1X_IDENTIFICATION__MODULE_ID, &mod_id));
+
+    DEBUG_DEV("rev=%02x, module type=%02x id=%04x", dev, rev, mod_type, mod_id);
+#endif
+
+    return 0;
+}
+
+static int _init(vl53l1x_t *dev)
+{
+    /* wait for 6 ms after power on reset */
+    ztimer_sleep(ZTIMER_MSEC, 6);
+
+    /* check availability of the sensor */
+    EXEC_RET(_is_available(dev));
+
+    /* reset, wait for 4 ms, and wait that devices has been booted */
+    EXEC_RET(_reset(dev));
+
+    EXEC_RET(VL53L1X_SensorInit(dev->addr));
+
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+    /* set measurement parameters */
+    EXEC_RET(vl53l1x_set_distance_mode(dev, dev->params->mode));
+    EXEC_RET(vl53l1x_set_timing_budget(dev, dev->params->budget));
+    EXEC_RET(vl53l1x_set_measurement_period(dev, dev->params->period));
+#endif /* IS_USED(MODULE_VL53L1X_BASIC) */
+
+    /* start measurement */
+    EXEC_RET(_start_meas(dev));
+
+    return 0;
+}
+
+static int _reset(vl53l1x_t *dev)
+{
+    /* write reset impuls of at least 100 us, we use 1 ms */
+    _write_byte(dev, VL53L1X_SOFT_RESET, 0);
+    ztimer_sleep(ZTIMER_MSEC, 1);
+    _write_byte(dev, VL53L1X_SOFT_RESET, 1);
+
+    /* wait until the sensor has been booted in 1 ms steps*/
+    unsigned timeout = VL53L1X_BOOT_TIMEOUT_MS;
+    uint8_t state;
+    while (timeout) {
+        timeout--;
+        EXEC_RET(VL53L1X_BootState(dev->addr, &state));
+        if (state) {
+            break;
+        }
+        ztimer_sleep(ZTIMER_MSEC, 1);
+    }
+    if (timeout == 0) {
+        DEBUG_DEV("could not boot the sensor", dev);
+        return EBUSY;
+    }
+#if 0
+    /* set VDDIO */
+    EXEC_RET(_update(dev, VL53L1X_PAD_I2C_HV__EXTSUP_CONFIG,
+                          0xfe, dev->params->vddio_2v8 ? 1 : 0));
+#endif
+
+    return 0;
+}
+#if 0
+static int _update(const vl53l1x_t *dev, uint16_t index, uint8_t mask,
+                                                         uint8_t data)
+{
+    uint8_t byte;
+    EXEC_RET(_read_byte(dev, index, &byte));
+    byte &= mask;
+    byte |= data;
+    EXEC_RET(_write_byte(dev, index, byte));
+
+    return 0;
+}
+#endif

--- a/drivers/vl53l1x/vl53l1x_saul.c
+++ b/drivers/vl53l1x/vl53l1x_saul.c
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 20215 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     drivers_vl53l1x
+ * @brief       VL53L1X adaption to the RIOT actuator/sensor interface
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "vl53l1x.h"
+
+static int read(const void *dev, phydat_t *res)
+{
+    uint16_t mm;
+    if (vl53l1x_data_ready((vl53l1x_t*)dev) == 0 &&
+        vl53l1x_read_mm((vl53l1x_t*)dev, &mm) == 0) {
+        res->val[0] = mm;
+        res->unit = UNIT_M;
+        res->scale = -3;
+        return 1;
+    }
+    return -ECANCELED;
+}
+
+const saul_driver_t vl53l1x_saul_driver = {
+    .read = read,
+    .write = saul_write_notsup,
+    .type = SAUL_SENSE_DISTANCE,
+};

--- a/pkg/driver_vl53l1x_st_api/Makefile
+++ b/pkg/driver_vl53l1x_st_api/Makefile
@@ -1,0 +1,12 @@
+PKG_NAME=driver_vl53l1x_st_api
+PKG_URL=https://github.com/gschorcht/riot_st_vl53l1x_uld_api.git
+PKG_VERSION=ec885135dd145b4fad1c91ac3fe67b8e359a22b1
+PKG_LICENSE=BSD
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+.PHONY: all
+
+all:
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/core -f $(RIOTBASE)/Makefile.base MODULE=vl53l1x_st_api_core
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/platform -f $(RIOTBASE)/Makefile.base MODULE=vl53l1x_st_api_platform

--- a/pkg/driver_vl53l1x_st_api/Makefile.include
+++ b/pkg/driver_vl53l1x_st_api/Makefile.include
@@ -1,0 +1,4 @@
+PSEUDOMODULES += driver_vl53l1x_st_api
+
+INCLUDES += -I$(PKGDIRBASE)/driver_vl53l1x_st_api/core
+INCLUDES += -I$(PKGDIRBASE)/driver_vl53l1x_st_api/platform

--- a/pkg/driver_vl53l1x_st_api/doc.md
+++ b/pkg/driver_vl53l1x_st_api/doc.md
@@ -1,0 +1,8 @@
+@defgroup pkg_driver_vl53l1x_st_api ST VL53L1X ULD API package
+@ingroup  pkg
+@brief    Ultra light driver API package for the ST VL53L1X Time-of-Flight (ToF) ranging sensor
+@see      drivers_vl53l1x
+@see      [VL53L1X ULD API user manual](https://www.st.com/resource/en/user_manual/um2510-a-guide-to-using-the-vl53l1x-ultra-lite-driver-stmicroelectronics.pdf)
+
+This package provides the ST VL53L1X ULD API package (STSW-IMG009),
+adapted for use with RIOT-OS.

--- a/tests/drivers/vl53l1x/Makefile
+++ b/tests/drivers/vl53l1x/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.drivers_common
+
+DRIVER ?= vl53l1x
+
+USEMODULE += $(DRIVER)
+USEMODULE += ztimer_msec
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/drivers/vl53l1x/Makefile.ci
+++ b/tests/drivers/vl53l1x/Makefile.ci
@@ -1,0 +1,5 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    atmega8 \
+    nucleo-l011k4 \
+    samd10-xmini \
+    #

--- a/tests/drivers/vl53l1x/README.md
+++ b/tests/drivers/vl53l1x/README.md
@@ -1,0 +1,31 @@
+# VL53L1x Driver Test
+
+## About
+
+The test application demonstrates the usage of different functions
+dependent on used driver variant:
+
+- `vl53l1x_basic`  Basic driver with only very basic functionality
+- `vl53l1x`        Default driver with complete functionality
+
+## Usage
+
+The driver variant used is defined by my variable DRIVER, which is set to
+`vl53l1x` by default. In this case, it is not necessary to specify
+the DRIVER variable in the make command:
+```
+    make flash -C tests/drivers/vl53l1x BOARD=...
+```
+To use the `vl53l1x_basic` driver variant, define it in it the make command:
+```
+    DRIVER=vl53l1x_basic make flash -C tests/drivers/vl53l1x BOARD=...
+```
+If the configuration parameter VL53L1X_PARAM_PIN_INT is defined, interrupts
+are used to get data instead of polling for new data. In the case of driver
+variant `vl53l1x`, threshold interrupts are configured. Otherwise
+only data interrupts are used.
+
+In all cases, the sensor is configured with following default parameters:
+
+- timing budget of 50 ms
+- intermeasurement period of 100 ms

--- a/tests/drivers/vl53l1x/main.c
+++ b/tests/drivers/vl53l1x/main.c
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     tests
+ * @brief       Test application for ST VL53L1X Time-of-Flight distance sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ *
+ * The test application demonstrates the usage of different functions
+ * dependent on used driver variant:
+ *
+ * - `vl53l1x_basic`  Basic driver with only very basic functionality
+ * - `vl53l1x`        Default driver with complete functionality
+ *
+ * The driver variant used is defined by my variable DRIVER, which is set to
+ * `vl53l1x` by default. In this case, it is not necessary to specify
+ * the DRIVER variable in the make command:
+ * ```
+ *     make flash -C tests/drivers/vl53l1x BOARD=...
+ * ```
+ * To use the `vl53l1x_basic` driver variant, define it in it the make command:
+ * ```
+ *     DRIVER=vl53l1x_basic make flash -C tests/drivers/vl53l1x BOARD=...
+ * ```
+ * If the configuration parameter VL53L1X_PARAM_PIN_INT is defined, interrupts
+ * are used to get data instead of polling for new data. In the case of driver
+ * variant `vl53l1x`, threshold interrupts are configured. Otherwise
+ * only data interrupts are used.
+ *
+ * In all cases, the sensor is configured with following default parameters:
+ *
+ * - timing budget of 50 ms
+ * - intermeasurement period of 100 ms *
+ */
+
+#include <stdio.h>
+
+#include "mutex.h"
+#include "thread.h"
+#include "ztimer.h"
+
+#include "vl53l1x.h"
+#include "vl53l1x_params.h"
+
+static void isr (void *arg)
+{
+    /*
+     * The ISR function is executed in the interrupt context. It must not be
+     * blocking or time-consuming and must not access the sensor directly
+     * via I2C.
+     *
+     * Therefore, the ISR function only indicates to the waiting thread that
+     * an interrupt has occurred which needs to be handled in the thread
+     * context.
+     */
+    mutex_unlock(arg);
+}
+
+int main(void)
+{
+    /* Initialize the sensor */
+    vl53l1x_t dev;
+
+    /* initialize the sensor  */
+    puts("VL53L1X Time-of-Flight distance sensor\n");
+    puts("Initializing VL53L1X sensor");
+
+    if (vl53l1x_init(&dev, &vl53l1x_params[0]) == 0) {
+        printf("[OK]\n");
+    }
+    else {
+        printf("[Failed]\n");
+        return 1;
+    }
+
+#if !IS_USED(MODULE_VL53L1X_BASIC)
+    /* optional read and print the ROI */
+    vl53l1x_roi_t roi;
+    if (vl53l1x_get_roi(&dev, &roi) == 0) {
+        printf("old ROI [x_size=%d, y_size=%d]\n", roi.x_size, roi.y_size);
+    }
+    roi.x_size = 8;
+    roi.y_size = 8;
+    if (vl53l1x_set_roi(&dev, &roi) == 0 &&
+        vl53l1x_get_roi(&dev, &roi) == 0) {
+        printf("new ROI [x_size=%d, y_size=%d]\n", roi.x_size, roi.y_size);
+    }
+#endif /* !IS_USED(MODULE_VL53L1X_BASIC) */
+
+    mutex_t mtx = MUTEX_INIT_LOCKED;
+
+    /* if interrupt pin is defined, enable the interrupt */
+    if (vl53l1x_params[0].pin_int != GPIO_UNDEF) {
+#if IS_USED(MODULE_VL53L1X_BASIC)
+        /* only data ready interrupts are supported and cfg has to be NULL */
+        vl53l1x_int_config(&dev, VL53L1X_INT_DATA_READY, 0, isr, &mtx);
+#else
+        /* generate interrupts when distance is between 200 mm and 400 mm */
+        vl53l1x_thresh_config_t cfg = {
+            .mode = VL53L1X_THRESH_IN,
+            .high = 400,
+            .low  = 200,
+        };
+        vl53l1x_int_config(&dev, VL53L1X_INT_DIST_THRESH, &cfg, isr, &mtx);
+#endif /* IS_USED(MODULE_VL53L1X_BASIC) */
+    }
+
+    while (1) {
+        /* if interrupt pin is defined, wait for the interrupt */
+        if (vl53l1x_params[0].pin_int != GPIO_UNDEF) {
+            mutex_lock(&mtx);
+        }
+        else {
+            /* otherwise wait 100 ms. */
+            ztimer_sleep(ZTIMER_MSEC, 100);
+        }
+
+#if IS_USED(MODULE_VL53L1X_BASIC)
+        uint16_t mm;
+
+        if (vl53l1x_data_ready(&dev) == 0 &&
+            vl53l1x_read_mm(&dev, &mm) == 0) {
+
+            printf("distance=%" PRIi16 " [mm]\n", mm);
+        }
+#else /* IS_USED(MODULE_VL53L1X_BASIC) */
+
+        vl53l1x_data_t data;
+
+        if (vl53l1x_data_ready(&dev) == 0 &&
+            vl53l1x_read_data(&dev, &data) == 0) {
+            printf("distance=%" PRIi16 " [mm] status=%u "
+                   "signal=%" PRIu16 " [kcps] ambient=%" PRIu16 " [kcps]\n",
+                   data.distance, data.status,
+                   data.signal_rate, data.ambient_rate);
+        }
+#endif /* IS_USED(MODULE_VL53L1X_BASIC) */
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

This PR adds a device driver for ST VL53L1X Time-of-Flight laser-ranging sensor which allows accurate and fast ranging up to 4 m at a frequency of up to 50 Hz. It is a complete rework of PR #10363 and uses the ST VL53L1X ULD API (STSW-IMG009) instead of the ST VL53L1X API (STSW-IMG007) that were used in PR #10363.

There are two variants of the driver which differ in functionality and size:

| Module Name     | Driver             | Short Description
|:----------------|:-------------------|:----------------------------
| `vl53l1x_basic` | Basic Driver       | Minimum functionality at small size
| `vl53l1x`       | Default Driver     | Complete functionality at acceptable size

The `vl53l1x_basic` driver variant is the smallest driver variant which provides only some basic functions such as the distance measurement and the data-ready interrupt.

The `vl53l1x` driver variant (default) is a compromise of size and functionality. It provides the application with most functionality of the sensor. The driver can be used when memory requirements are important and most of the functionality should be used.

Both driver variants use the ST VL53L1X ULD API (STSW-IMG009) as vendor code, provide SAUL capabilities and data-ready interrupt functionality. The `vl53l1x` driver variant allows to use threshold interrupts.

Function / Property                     | vl53l1x_basic | vl53l1x
:---------------------------------------|:-------------:|:--------------:
Distance results in mm                  | X             | X
Signal rate results in kcps             |               | X
Measurement status information          |               | X
SAUL capability                         | X             | X
Distance mode configuration             |               | X
Timing budget configuration             |               | X
Inter-measurement period configuration  |               | X
Region of Interest (ROI) configuration  |               | X
Data-ready interrupts (ranging mode)    | X             | X
Threshold interrupts (detection mode)   |               | X
Power on/off functions                  |               | X
SHUTDOWN pin support                    |               | X
Calibration functions                   |               | X [1]
Size on reference platform in kByte [2] | 1.0           | 2.9

[1] These functions are available by using the ST VL53L1X ULD API directly.
[2] Reference platform: STM32F411RE

### Testing procedure

The driver variants can be tested by using the test application with different modules where the standard variant `vl53l1x` is used by default:
```python
make flash -C tests/driver_vl53l1x BOARD=...
```
To use the `vl53l1x_basic` driver variant, define it in it the make command:
```python
DRIVER=vl53l1x_basic make flash -C tests/driver_vl53l1x BOARD=...
```

If the configuration parameter `VL53L1X_PARAM_PIN_INT ` is defined, e.g.,
```python
CFLAGS='-DVL53L1X_PARAM_PIN_INT=\(GPIO\(0,\1\)' make flash -C tests/driver_vl53l1x BOARD=...
``` 
interrupts are used to get data instead of polling for new data. In the case of the  `vl53l1x` driver variant, threshold interrupts are configured.

In all cases, the sensor is configured with following default parameters:
- timing budget of 50 ms
- intermeasurement period of 100 ms

### Issues/PRs references

This PR is a complete rework of PR #10363.