### PR TITLE
boards: move licenses to SPDX format in doc.md files

### DIFF
--- a/boards/common/cc2538/doc.md
+++ b/boards/common/cc2538/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2020 Inria
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2020 Inria
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup    boards_common_cc2538 cc2538 Configuration Snippets

--- a/boards/common/esp32/doc.md
+++ b/boards/common/esp32/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2018 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2018 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup    boards_common_esp32  ESP32 Common

--- a/boards/common/esp32c3/doc.md
+++ b/boards/common/esp32c3/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2018 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2018 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup    boards_common_esp32c3  ESP32-C3 Common

--- a/boards/common/esp32c6/doc.md
+++ b/boards/common/esp32c6/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2025 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2025 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup    boards_common_esp32c6  ESP32-C6 Common

--- a/boards/common/esp32h2/doc.md
+++ b/boards/common/esp32h2/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2025 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2025 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup    boards_common_esp32h2  ESP32-H2 Common

--- a/boards/common/esp32s2/doc.md
+++ b/boards/common/esp32s2/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2018 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2018 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup    boards_common_esp32s2  ESP32-S2 Common

--- a/boards/common/esp32s3/doc.md
+++ b/boards/common/esp32s3/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2018 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2018 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup    boards_common_esp32s3  ESP32-S3 Common

--- a/boards/common/esp32x/doc.md
+++ b/boards/common/esp32x/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2018 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2018 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup    boards_common_esp32x  ESP32x Common

--- a/boards/common/frdm/doc.md
+++ b/boards/common/frdm/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2017 HAW Hamburg
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2017 HAW Hamburg
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup    boards_common_frdm NXP FRDM Common

--- a/boards/common/gd32v/doc.md
+++ b/boards/common/gd32v/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2023 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2023 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup    boards_common_gd32v GD32V Common Configuration

--- a/boards/common/msp430/doc.md
+++ b/boards/common/msp430/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2023 Otto-von-Guericke-Universität Magdeburg
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2023 Otto-von-Guericke-Universität Magdeburg
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup    boards_common_msp430    Common Configuration Snippets for MSP430 boards

--- a/boards/common/silabs/doc.md
+++ b/boards/common/silabs/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2018 Bas Stottelaar <basstottelaar@gmail.com>
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2018 Bas Stottelaar <basstottelaar@gmail.com>
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup    boards_common_silabs Silicon Labs Common

--- a/boards/common/silabs/drivers/doc.md
+++ b/boards/common/silabs/drivers/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2018 Bas Stottelaar <basstottelaar@gmail.com>
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2018 Bas Stottelaar <basstottelaar@gmail.com>
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup    boards_common_silabs_drivers Silicon Labs Common Drivers

--- a/boards/common/stm32/doc.md
+++ b/boards/common/stm32/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2018 Freie Universität Berlin
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup    boards_common_stm32 STM32 Configuration Snippets

--- a/boards/esp32-ethernet-kit-v1_0/doc.md
+++ b/boards/esp32-ethernet-kit-v1_0/doc.md
@@ -1,10 +1,7 @@
 <!--
-Copyright (C) 2018 Gunar Schorcht
-Copyright (C) 2020 Google LLC
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2018 Gunar Schorcht
+SPDX-FileCopyrightText: 2020 Google LLC
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32_esp-ethernet-kit-v1_0 ESP32-Ethernet-Kit V1.0 Board

--- a/boards/esp32-ethernet-kit-v1_1/doc.md
+++ b/boards/esp32-ethernet-kit-v1_1/doc.md
@@ -1,10 +1,7 @@
 <!--
-Copyright (C) 2018 Gunar Schorcht
-Copyright (C) 2020 Google LLC
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2018 Gunar Schorcht
+SPDX-FileCopyrightText: 2020 Google LLC
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32_esp-ethernet-kit-v1_1 ESP32-Ethernet-Kit V1.1 Board

--- a/boards/esp32-ethernet-kit-v1_2/doc.md
+++ b/boards/esp32-ethernet-kit-v1_2/doc.md
@@ -1,10 +1,7 @@
 <!--
-Copyright (C) 2018 Gunar Schorcht
-Copyright (C) 2020 Google LLC
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2018 Gunar Schorcht
+SPDX-FileCopyrightText: 2020 Google LLC
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32_esp-ethernet-kit-v1_2 ESP32-Ethernet-Kit V1.2 Board

--- a/boards/esp32-heltec-lora32-v2/doc.md
+++ b/boards/esp32-heltec-lora32-v2/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2018 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2018 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32_heltec-lora32-v2 Heltec WiFi LoRa 32 V2 boards

--- a/boards/esp32-mh-et-live-minikit/doc.md
+++ b/boards/esp32-mh-et-live-minikit/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2018 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2018 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32_mh-et-live-minikit MH-ET LIVE MiniKit

--- a/boards/esp32-olimex-evb/doc.md
+++ b/boards/esp32-olimex-evb/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2018 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2018 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32_olimex-esp32-evb Olimex ESP32-EVB

--- a/boards/esp32-ttgo-t-beam/doc.md
+++ b/boards/esp32-ttgo-t-beam/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2019 Yegor Yefremov
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2019 Yegor Yefremov
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32_ttgo-t-beam TTGO T-Beam

--- a/boards/esp32-wemos-lolin-d32-pro/doc.md
+++ b/boards/esp32-wemos-lolin-d32-pro/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2018 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2018 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32_wemos-lolin-d32-pro Wemos LOLIN D32 Pro

--- a/boards/esp32-wroom-32/doc.md
+++ b/boards/esp32-wroom-32/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2018 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2018 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32_wroom-32 Generic ESP32-WROOM-32 boards

--- a/boards/esp32-wrover-kit/doc.md
+++ b/boards/esp32-wrover-kit/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2018 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2018 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32_esp-wrover-kit ESP-WROVER-KIT V3

--- a/boards/esp32c3-devkit/doc.md
+++ b/boards/esp32c3-devkit/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2022 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2022 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32c3_devkit ESP32-C3-DevKit Board

--- a/boards/esp32c3-wemos-mini/doc.md
+++ b/boards/esp32c3-wemos-mini/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2023 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2023 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32c3_wemos_mini Wemos ESP32-C3 mini

--- a/boards/esp32c6-devkit/doc.md
+++ b/boards/esp32c6-devkit/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2025 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2025 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup    boards_esp32c6_devkit ESP32-C6-DevKit Board

--- a/boards/esp32h2-devkit/doc.md
+++ b/boards/esp32h2-devkit/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2025 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2025 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup    boards_esp32h2_devkit ESP32-H2-DevKitM-1 Board

--- a/boards/esp32s2-devkit/doc.md
+++ b/boards/esp32s2-devkit/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2022 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2022 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32s2_devkit ESP32-S2-DevKit Board

--- a/boards/esp32s2-lilygo-ttgo-t8/doc.md
+++ b/boards/esp32s2-lilygo-ttgo-t8/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2022 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2022 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32s2_lilygo_ttgo_t8 LILYGO TTGO T8 ESP32-S2 Board

--- a/boards/esp32s2-wemos-mini/doc.md
+++ b/boards/esp32s2-wemos-mini/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2022 Benjamin Valentin
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2022 Benjamin Valentin
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32s2-wemos-mini Wemos S2 mini Board

--- a/boards/esp32s3-box/doc.md
+++ b/boards/esp32s3-box/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2023 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2023 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32s3_box ESP32-S3-Box

--- a/boards/esp32s3-devkit/doc.md
+++ b/boards/esp32s3-devkit/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2022 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2022 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32s3_devkit ESP32-S3-DevKit Board

--- a/boards/esp32s3-pros3/doc.md
+++ b/boards/esp32s3-pros3/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2023 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2023 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32s3_pros3 ESP32 ProS3 Board

--- a/boards/esp32s3-usb-otg/doc.md
+++ b/boards/esp32s3-usb-otg/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2023 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2023 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32s3_usb_otg ESP32-S3-USB-OTG Board

--- a/boards/esp32s3-wt32-sc01-plus/doc.md
+++ b/boards/esp32s3-wt32-sc01-plus/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2023 Gunar Schorcht
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2023 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   boards_esp32s3_wt32_sc01_plus ESP32-S3 WT32-SC01 Plus

--- a/boards/seeedstudio-xiao-esp32c3/doc.md
+++ b/boards/seeedstudio-xiao-esp32c3/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2025 David Picard
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2025 David Picard
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup    boards_seeedstudio-xiao-esp32c3 Seeed Studio Xiao ESP32C3


### PR DESCRIPTION
### Contribution description

This PR moves license information from headers to SPDX format in `doc.md` files from `boards` directory. 

Conversion is conducted automatically (but later checked ;) ) using scirpt described in the https://github.com/RIOT-OS/RIOT/issues/21515#issuecomment-3164249070 .

### Testing procedure

Review changed files.

### Issues/PRs references

Track https://github.com/RIOT-OS/RIOT/issues/21515