### PR TITLE
nanocoap_server: use zero-copy network buffer for parsing request

### DIFF
--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -476,18 +476,17 @@ static inline uint16_t nanocoap_sock_next_msg_id(nanocoap_sock_t *sock)
 }
 
 /**
- * @brief   Start a nanocoap server instance
+ * @brief   Start a nanoCoAP server instance
  *
- * This function only returns if there's an error binding to @p local, or if
- * receiving of UDP packets fails.
+ * This function only returns if there's an error binding to @p local.
  *
  * @param[in]   local   local UDP endpoint to bind to
- * @param[in]   buf     input buffer to use
+ * @param[in]   buf     response buffer to use
  * @param[in]   bufsize size of @p buf
  *
- * @returns     -1 on error
+ * @returns     return code of @see sock_udp_create on error
  */
-int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize);
+int nanocoap_server(sock_udp_ep_t *local, void *buf, size_t bufsize);
 
 /**
  * @brief   Create and start the nanoCoAP server thread

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -778,6 +778,9 @@ ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
                    ntohs(pkt->hdr->id));
     len += payload_len;
 
+    /* HACK: many CoAP handlers assume that the pkt buffer is also used for the response */
+    pkt->hdr = (void *)rbuf;
+
     return len;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Requests larger than `CONFIG_NANOCOAP_SERVER_BUF_SIZE` were previously silently ignored.
But we can do better: With `sock_udp_recv_buf_aux()` we don't need to copy the request into a separate buffer but can just use the buffer allocated by the network stack.

We still need `CONFIG_NANOCOAP_SERVER_BUF_SIZE` for the response as otherwise the size of the request packet would be the limit for the response packet. But this is now both in control of the server, a good server implementation can only use this for the header and keep the payload in a separate buffer.

The only problem is that several CoAP handler functions (e.g. [`_sha256_handler()`](https://github.com/RIOT-OS/RIOT/blob/master/examples/networking/coap/nanocoap_server/coap_handler.c#L116)) expect `pkt->hdr` to point to the response buffer and use `pkt->hdr` and `buf` interchangeably.

As a workaround, this also sets `pkt->hdr = rbuf` in `coap_build_reply()` to accommodate those handler functions.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
