### PR TITLE
pkg/nanopb: use hash instead of tag for version

### DIFF
--- a/pkg/nanopb/Makefile
+++ b/pkg/nanopb/Makefile
@@ -1,6 +1,7 @@
 PKG_NAME=nanopb
 PKG_URL=https://github.com/nanopb/nanopb
-PKG_VERSION=nanopb-0.4.9.1
+# 0.4.9.1
+PKG_VERSION=cad3c18ef15a663e30e3e43e3a752b66378adec1
 PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The tag isn't always properly fetched, leading to build issues. Let's just always use the commit hash, like in other pkgs.


### Testing procedure

No change - tag points to this commit.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
