### PR TITLE
boards: add Arduino Nano ESP32 board

### DIFF
--- a/boards/arduino-nano-esp32/Kconfig
+++ b/boards/arduino-nano-esp32/Kconfig
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
+
+config BOARD
+    default "arduino-nano-esp32" if BOARD_ARDUINO_NANO_ESP32
+
+config BOARD_ARDUINO_NANO_ESP32
+    bool
+    default y
+    select BOARD_COMMON_ESP32S3
+    select CPU_MODEL_ESP32S3_R8
+
+source "$(RIOTBOARD)/common/esp32s3/Kconfig"

--- a/boards/arduino-nano-esp32/Makefile
+++ b/boards/arduino-nano-esp32/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/esp32s3
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/arduino-nano-esp32/Makefile.dep
+++ b/boards/arduino-nano-esp32/Makefile.dep
@@ -1,0 +1,6 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+include $(RIOTBOARD)/common/esp32s3/stdio_esp32s3_default.dep.mk
+include $(RIOTBOARD)/common/esp32s3/Makefile.dep

--- a/boards/arduino-nano-esp32/Makefile.features
+++ b/boards/arduino-nano-esp32/Makefile.features
@@ -1,0 +1,24 @@
+# the board uses a ESP32-S3 with embedded 8MB QSPI PSRAM and a 16MB QSPI Flash
+CPU_MODEL = esp32s3r8
+
+# common board and CPU features
+include $(RIOTBOARD)/common/esp32s3/Makefile.features
+
+# peripherals provided by the board
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_usbdev
+
+# other features provided by the board
+FEATURES_PROVIDED += arduino_analog
+FEATURES_PROVIDED += arduino_i2c
+FEATURES_PROVIDED += arduino_pins
+FEATURES_PROVIDED += arduino_pwm
+FEATURES_PROVIDED += arduino_spi
+FEATURES_PROVIDED += arduino_uart
+
+FEATURES_PROVIDED += esp_jtag
+FEATURES_PROVIDED += highlevel_stdio
+FEATURES_PROVIDED += tinyusb_device

--- a/boards/arduino-nano-esp32/Makefile.include
+++ b/boards/arduino-nano-esp32/Makefile.include
@@ -1,0 +1,8 @@
+# the board uses a ESP32-S3 with embedded 8MB QSPI PSRAM and a 16MB QSPI Flash
+FLASH_SIZE ?= 16
+
+PORT_LINUX ?= /dev/ttyACM0
+
+OPENOCD_CONFIG ?= board/esp32s3-builtin.cfg
+
+include $(RIOTBOARD)/common/esp32s3/Makefile.include

--- a/boards/arduino-nano-esp32/doc.md
+++ b/boards/arduino-nano-esp32/doc.md
@@ -1,0 +1,178 @@
+<!--
+SPDX-FileCopyrightText: 2025 Gunar Schorcht
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+
+@defgroup   boards_arduino_nano_esp32 Arduino Nano ESP32
+@ingroup    boards
+@ingroup    boards_esp32s3
+@brief      Support for the Arduino Nano ESP32 board
+@author     Gunar Schorcht <gunar@schorcht.net>
+
+\section arduino_nano_esp32 Arduino Nano ESP32
+
+## Table of Contents {#arduino_nano_esp32_toc}
+
+-# [Overview](#arduino_nano_esp32_overview)
+-# [Hardware](#arduino_nano_esp32_hardware)
+    -# [MCU](#arduino_nano_esp32_mcu)
+    -# [Board Configuration](#arduino_nano_esp32_board_configuration)
+    -# [Board Pinout](#arduino_nano_esp32_pinout)
+-# [Flashing the Device](#arduino_nano_esp32_flashing)
+-# [Using STDIO](#arduino_nano_esp32_stdio)
+
+## Overview {#arduino_nano_esp32_overview}
+
+The [Arduino Nano ESP32](https://docs.arduino.cc/hardware/nano-esp32/) is an
+ESP32-S3 board in Arduino Nano format that uses the u-Blox NORA-W106 module.
+@image html https://store.arduino.cc/cdn/shop/files/ABX00092_00.default_643x483.jpg "Arduino Nano ESP32" width=400px
+
+The main features of the board are:
+
+- ESP32-S3 SoC with 2.4 GHz WiFi 802.11b/g/n and Bluetooth5, BLE
+- 8 MByte embedded QSPI RAM
+- 16 MByte Flash
+- RGB LED with separate colour LEDs
+- Native USB and USB Serial JTAG
+
+[Back to table of contents](#arduino_nano_esp32_toc)
+
+## Hardware {#arduino_nano_esp32_hardware}
+
+This section describes
+
+- the [MCU](#arduino_nano_esp32_mcu),
+- the default [board configuration](#arduino_nano_esp32_board_configuration),
+- the [board pinout](#arduino_nano_esp32_pinout).
+
+[Back to table of contents](#arduino_nano_esp32_toc)
+
+### MCU {#arduino_nano_esp32_mcu}
+
+Most features of the board are provided by the ESP32-S3 SoC. For detailed
+information about the ESP32-S3 SoC variant (family) and ESP32x SoCs,
+see section \ref esp32_mcu_esp32 "ESP32 SoC Series".
+
+[Back to table of contents](#arduino_nano_esp32_toc)
+
+### Board Configuration {#arduino_nano_esp32_board_configuration}
+
+Arduino Nano ESP32 boards have no special hardware on board with the exception
+of an RGB-LED with separate LEDs for each color.
+
+The board configuration provides:
+
+- 8 x ADC channels (4 x ADC channels if module `periph_i2c` is used)
+- 1 x SPI
+- 1 x I2C
+- 1 x UART
+- 2 x PWM (4 channels on PWM_DEV(0), 3 RGB LED channels on PWM_DEV(1))
+
+The following table shows the default board configuration, which is sorted
+according to the defined functionality of GPIOs. This configuration can be
+overridden by \ref esp32_application_specific_configurations
+"application-specific configurations".
+
+<center>
+Function        | GPIOs  | Remarks | Configuration
+:---------------|:-------|:--------|:----------------------------------
+ADC_LINE(0)     | GPIO1  | | \ref esp32_adc_channels "ADC Channels"
+ADC_LINE(1)     | GPIO2  | | \ref esp32_adc_channels "ADC Channels"
+ADC_LINE(2)     | GPIO3  | | \ref esp32_adc_channels "ADC Channels"
+ADC_LINE(3)     | GPIO4  | | \ref esp32_adc_channels "ADC Channels"
+ADC_LINE(4)     | GPIO11 | N/A if `periph_i2c` is used | \ref esp32_adc_channels "ADC Channels"
+ADC_LINE(5)     | GPIO12 | N/A if `periph_i2c` is used | \ref esp32_adc_channels "ADC Channels"
+ADC_LINE(6)     | GPIO13 | N/A if `periph_i2c` is used | \ref esp32_adc_channels "ADC Channels"
+ADC_LINE(7)     | GPIO14 | N/A if `periph_i2c` is used | \ref esp32_adc_channels "ADC Channels"
+PWM_DEV(0):0    | GPIO6  |           | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(0):1    | GPIO8  |           | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(0):2    | GPIO9  |           | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(0):3    | GPIO18 |           | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(1):0    | GPIO46 | LED red   | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(1):1    | GPIO0  | LED green | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(1):2    | GPIO45 | LED blue  | \ref esp32_pwm_channels "PWM Channels"
+I2C_DEV(0):SCL  | GPIO12 | | \ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(0):SDA  | GPIO11 | | \ref esp32_i2c_interfaces "I2C Interfaces"
+SPI_DEV(0):CLK  | GPIO48 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MISO | GPIO47 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MOSI | GPIO38 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):CS0  | GPIO21 | SPI2_HOST (FSPI) is used | \ref esp32_spi_interfaces "SPI Interfaces"
+UART_DEV(0):TxD | GPIO43 | Console (fixed) | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(0):RxD | GPIO44 | Console (fixed) | \ref esp32_uart_interfaces "UART interfaces"
+</center>
+\n
+
+For detailed information about the peripheral configurations of ESP32-S3
+boards, see section \ref esp32_peripherals "Common Peripherals".
+
+[Back to table of contents](#arduino_nano_esp32_toc)
+
+### Board Pinout {#arduino_nano_esp32_pinout}
+
+The following figure shows the pinout as configured by board definition.
+
+@image html https://edistechlab.com/wp-content/uploads/2023/11/Pinout_arduino_nano_esp32.png "Arduino Nano ESP32 Pinout" width=600px
+
+An advanced pinout version with front view, back view and some additional
+information can be found
+[here](https://docs.arduino.cc/resources/pinouts/ABX00083-full-pinout.pdf).
+The corresponding board schematic can be found
+[here](https://docs.arduino.cc/resources/schematics/ABX00083-schematics.pdf).
+
+[Back to table of contents](#arduino_nano_esp32_toc)
+
+## Flashing the Device {#arduino_nano_esp32_flashing}
+
+Since the board does not have a USB-to-Serial chip, the easiest way to flash
+the board is using the USB Serial/JTAG interface. Just connect the board to
+your host computer and use the following command:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BOARD=arduino-nano-esp32 make flash ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+@note Usually the make system resets the board before flashing to enable the
+USB Serial/JTAG interface. In some special cases this reset does not work so
+that the programmer cannot connect to the board and the flashing is aborted
+with a timeout:
+```
+Serial port /dev/ttyACM0
+Connecting...
+...
+serial.serialutil.SerialTimeoutException: Write timeout
+```
+This can happen for example if the board is not yet flashed with RIOT or the
+USB interface is used for another purpose. In this case, restart the board
+manually in download mode by pressing and releasing the RESET button while
+pulling down the GPIO0 (B1) pin. In download mode, the USB Serial/JTAG
+interface is always available.
+
+Alternatively, an external USB-to-Serial adapter can be used. In this case,
+the USB-to-Serial adapter has to be connected to TxD (GPIO43) and RxD (GPIO44)
+of the UART0 interface. Before RIOT can be flashed, the board has also to be
+switched to download mode. To do this, press and release the RESET button
+while pulling down the GPIO0 (B1) pin. Once the board is in download mode, use
+the following command to flash RIOT:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BOARD=arduino-nano-esp32 make flash ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For detailed information about ESP32-S3 as well as configuring and compiling
+RIOT for ESP32-S3 boards, see \ref esp32_riot.
+
+[Back to table of contents](#arduino_nano_esp32_toc)
+
+## Using STDIO {#arduino_nano_esp32_stdio}
+
+Since the board does not have a USB-to-Serial chip, the USB Serial/JTAG
+interface is used by default for the STDIO (module `stdio_usb_serial_jtag`)
+which provides an USB CDC ACM interface.
+
+If the USB port is used by the USBUS stack or the tinyUSB stack, implicitly
+the module `stdio_cdc_acm` or `stdio_tinyusb_cdc_acm` is used for the STDIO
+via the USB CDC ACM interface.
+
+Alternatively, the UART interface could be used with an external USB-to-Serial
+adapter. Simply add `stdio_uart` to the list of used modules for this purpose:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BOARD=arduino-nano-esp32 USEMODULE=stdio_uart make flash ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/boards/arduino-nano-esp32/include/arduino_iomap.h
+++ b/boards/arduino-nano-esp32/include/arduino_iomap.h
@@ -1,0 +1,132 @@
+/*
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_esp32_esp-wrover-kit
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0       GPIO44  /**< Arduino pin 0 (RxD) */
+#define ARDUINO_PIN_1       GPIO43  /**< Arduino pin 1 (TxD) */
+
+#define ARDUINO_PIN_2       GPIO5   /**< Arduino pin 2 (PWM) */
+#define ARDUINO_PIN_3       GPIO6   /**< Arduino pin 3 (PWM) */
+#define ARDUINO_PIN_4       GPIO7   /**< Arduino pin 4 (PWM) */
+#define ARDUINO_PIN_5       GPIO8   /**< Arduino pin 5 (PWM) */
+#define ARDUINO_PIN_6       GPIO9   /**< Arduino pin 6 (PWM) */
+#define ARDUINO_PIN_7       GPIO10  /**< Arduino pin 7 (PWM) */
+#define ARDUINO_PIN_8       GPIO17  /**< Arduino pin 8 (PWM) */
+#define ARDUINO_PIN_9       GPIO18  /**< Arduino pin 9 (PWM) */
+
+#define ARDUINO_PIN_10      GPIO21  /**< Arduino pin 10 (CS0)  */
+#define ARDUINO_PIN_11      GPIO38  /**< Arduino pin 11 (MOSI) */
+#define ARDUINO_PIN_12      GPIO47  /**< Arduino pin 12 (MISO) */
+#define ARDUINO_PIN_13      GPIO48  /**< Arduino pin 13 (SCK)  */
+
+#define ARDUINO_PIN_14      GPIO46  /**< Arduino pin 14 (LED red) */
+#define ARDUINO_PIN_15      GPIO0   /**< Arduino pin 15 (LED green) */
+#define ARDUINO_PIN_16      GPIO45  /**< Arduino pin 16 (LED blue) */
+
+#define ARDUINO_PIN_17      GPIO1   /**< Arduino pin 17 (A0) */
+#define ARDUINO_PIN_18      GPIO2   /**< Arduino pin 18 (A1) */
+#define ARDUINO_PIN_19      GPIO3   /**< Arduino pin 19 (A2) */
+#define ARDUINO_PIN_20      GPIO4   /**< Arduino pin 20 (A3) */
+#define ARDUINO_PIN_21      GPIO11  /**< Arduino pin 21 (A4 / SDA) */
+#define ARDUINO_PIN_22      GPIO12  /**< Arduino pin 22 (A5 / SCL) */
+#define ARDUINO_PIN_23      GPIO13  /**< Arduino pin 23 (A6) */
+#define ARDUINO_PIN_24      GPIO14  /**< Arduino pin 24 (A7) */
+
+#define ARDUINO_PIN_LAST    24      /**< Last Arduino pin index */
+/** @} */
+
+/**
+ * @name    Aliases for analog pins
+ * @{
+ */
+#define ARDUINO_PIN_A0    ARDUINO_PIN_17  /**< Arduino pin A0 */
+#define ARDUINO_PIN_A1    ARDUINO_PIN_18  /**< Arduino pin A1 */
+#define ARDUINO_PIN_A2    ARDUINO_PIN_19  /**< Arduino pin A2 */
+#define ARDUINO_PIN_A3    ARDUINO_PIN_20  /**< Arduino pin A3 */
+#if !MODULE_PERIPH_I2C
+#  define ARDUINO_PIN_A4  ARDUINO_PIN_21  /**< Arduino pin A4 */
+#  define ARDUINO_PIN_A5  ARDUINO_PIN_22  /**< Arduino pin A5 */
+#  define ARDUINO_PIN_A6  ARDUINO_PIN_23  /**< Arduino pin A6 */
+#  define ARDUINO_PIN_A7  ARDUINO_PIN_24  /**< Arduino pin A7 */
+#endif
+/** @} */
+
+/**
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
+ * @{
+ */
+#define ARDUINO_A0        ADC_LINE(0)     /**< ADC line for Arduino pin A0 */
+#define ARDUINO_A1        ADC_LINE(1)     /**< ADC line for Arduino pin A1 */
+#define ARDUINO_A2        ADC_LINE(2)     /**< ADC line for Arduino pin A2 */
+#define ARDUINO_A3        ADC_LINE(3)     /**< ADC line for Arduino pin A3 */
+#if !MODULE_PERIPH_I2C
+#  define ARDUINO_A4      ADC_LINE(4)     /**< ADC line for Arduino pin A4 */
+#  define ARDUINO_A5      ADC_LINE(5)     /**< ADC line for Arduino pin A5 */
+#  define ARDUINO_A6      ADC_LINE(6)     /**< ADC line for Arduino pin A6 */
+#  define ARDUINO_A7      ADC_LINE(7)     /**< ADC line for Arduino pin A7 */
+#endif
+
+#if !MODULE_PERIPH_I2C
+#  define ARDUINO_ANALOG_PIN_LAST 7      /**< Last Arduino analog pin index */
+#else
+#  define ARDUINO_ANALOG_PIN_LAST 3      /**< Last Arduino analog pin index */
+#endif
+/** @} */
+
+/**
+ * @name    Mapping of Arduino pins to RIOT PWM dev and channel pairs
+ * @{
+ */
+#define ARDUINO_PIN_2_PWM_DEV   PWM_DEV(0)  /**< PWM device for Arduino pin 2 */
+#define ARDUINO_PIN_2_PWM_CHAN  0           /**< PWM channel for Arduino pin 2 */
+#define ARDUINO_PIN_3_PWM_DEV   PWM_DEV(0)  /**< PWM device for Arduino pin 3 */
+#define ARDUINO_PIN_3_PWM_CHAN  1           /**< PWM channel for Arduino pin 3 */
+#define ARDUINO_PIN_4_PWM_DEV   PWM_DEV(0)  /**< PWM device for Arduino pin 4 */
+#define ARDUINO_PIN_4_PWM_CHAN  2           /**< PWM channel for Arduino pin 4 */
+#define ARDUINO_PIN_5_PWM_DEV   PWM_DEV(0)  /**< PWM device for Arduino pin 5 */
+#define ARDUINO_PIN_5_PWM_CHAN  3           /**< PWM channel for Arduino pin 5 */
+#define ARDUINO_PIN_6_PWM_DEV   PWM_DEV(0)  /**< PWM device for Arduino pin 6 */
+#define ARDUINO_PIN_6_PWM_CHAN  4           /**< PWM channel for Arduino pin 6 */
+#define ARDUINO_PIN_7_PWM_DEV   PWM_DEV(0)  /**< PWM device for Arduino pin 7 */
+#define ARDUINO_PIN_7_PWM_CHAN  5           /**< PWM channel for Arduino pin 7 */
+#define ARDUINO_PIN_8_PWM_DEV   PWM_DEV(0)  /**< PWM device for Arduino pin 8 */
+#define ARDUINO_PIN_8_PWM_CHAN  6           /**< PWM channel for Arduino pin 8 */
+#define ARDUINO_PIN_9_PWM_DEV   PWM_DEV(0)  /**< PWM device for Arduino pin 9 */
+#define ARDUINO_PIN_9_PWM_CHAN  7           /**< PWM channel for Arduino pin 9 */
+#define ARDUINO_PIN_14_PWM_DEV  PWM_DEV(1)  /**< PWM device for Arduino pin 14 */
+#define ARDUINO_PIN_14_PWM_CHAN 0           /**< PWM channel for Arduino pin 14 */
+#define ARDUINO_PIN_15_PWM_DEV  PWM_DEV(1)  /**< PWM device for Arduino pin 15 */
+#define ARDUINO_PIN_15_PWM_CHAN 1           /**< PWM channel for Arduino pin 15 */
+#define ARDUINO_PIN_16_PWM_DEV  PWM_DEV(1)  /**< PWM device for Arduino pin 16 */
+#define ARDUINO_PIN_16_PWM_CHAN 2           /**< PWM channel for Arduino pin 16 */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/arduino-nano-esp32/include/board.h
+++ b/boards/arduino-nano-esp32/include/board.h
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_arduino_nano_esp32
+ * @brief       Board definitions for Arduino Nano ESP32 boards
+ * @{
+ *
+ * The board definitions in this file are valid for the Arduino Nano ESP32 board.
+ *
+ * Any modifications required for specific applications
+ * can be overridden by \ref esp32_application_specific_configurations
+ * "application-specific board configuration".
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include <stdint.h>
+
+/**
+ * @name    LED (on-board) configuration
+ *
+ * The board has a RGB-LED connected with separate color LEDs.
+ * @{
+ */
+#define LED0_PIN        GPIO46  /**< LED0 pin (red) */
+#define LED0_ACTIVE     (0)     /**< LED0 is low active */
+
+#define LED1_PIN        GPIO0    /**< LED1 pin (green) */
+#define LED1_ACTIVE     (0)      /**< LED1 is low active */
+
+#define LED2_PIN        GPIO45   /**< LED2 pin (blue) */
+#define LED2_ACTIVE     (0)      /**< LED2 is low active */
+
+#ifdef  LED0_PIN
+#  define LED_RED_PIN   LED0_PIN /**< LED0 is a red LED */
+#endif
+
+#ifdef  LED1_PIN
+#  define LED_GREEN_PIN LED1_PIN /**< LED1 is a green LED */
+#endif
+
+#ifdef  LED2_PIN
+#  define LED_BLUE_PIN  LED2_PIN /**< LED2 is a blue LED */
+#endif
+/** @} */
+
+/* include common board definitions as last step */
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/** @} */

--- a/boards/arduino-nano-esp32/include/gpio_params.h
+++ b/boards/arduino-nano-esp32/include/gpio_params.h
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_arduino_nano_esp32
+ * @brief       Board specific configuration of direct mapped GPIOs
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @{
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   LED and button configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+#ifdef LED0_PIN
+    {
+        .name = "LED red",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+#endif
+#ifdef LED1_PIN
+    {
+        .name = "LED blue",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+#endif
+#ifdef LED2_PIN
+    {
+        .name = "LED green",
+        .pin = LED2_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED,
+    }
+#endif
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/arduino-nano-esp32/include/periph_conf.h
+++ b/boards/arduino-nano-esp32/include/periph_conf.h
@@ -1,0 +1,185 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_arduino_nano_esp32
+ * @brief       Peripheral configurations for Arduino Nano ESP32 boards
+ * @{
+ *
+ * The peripheral configurations in this file can be used for the
+ * Arduino Nano ESP32 board.
+ *
+ * Any modifications required for specific applications
+ * can be overridden by \ref esp32_application_specific_configurations
+ * "application-specific board configuration".
+ *
+ * For detailed information about the peripheral configuration for ESP32-S3
+ * boards, see section \ref esp32_peripherals "Common Peripherals".
+ *
+ * @note
+ * Most definitions can be overridden by an \ref esp32_application_specific_configurations
+ * "application-specific board configuration" if necessary.
+ *
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    ADC and DAC channel configuration
+ * @{
+ */
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ *
+ * If the `periph_i2c` module is used, two GPIOs connected to ADC2 (GPIO11 and
+ * GPIO12) are used as I2C signals. To avoid conflicts, only the GPIOs
+ * connected to ADC1 are defined as ADC lines in this case. Otherwise,
+ * GPIOs connected to ADC1 and ADC2 are defined as ADC lines.
+ *
+ * Please keep in mind that GPIO3 is a strapping pin if `EFUSE_STRAP_JTAG_SEL`
+ * is set, see \ref esp32_gpio_pins_esp32s3_strapping.
+ *
+ * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
+ * channels with the `adc_init` function, they can be used for other
+ * purposes.
+ */
+#ifndef ADC_GPIOS
+#  if !MODULE_PERIPH_I2C
+#    define ADC_GPIOS   { GPIO1, GPIO2, GPIO3, GPIO4, GPIO11, GPIO12, GPIO13, GPIO14 }
+#  else /* !MODULE_PERIPH_I2C */
+#    define ADC_GPIOS   { GPIO1, GPIO2, GPIO3, GPIO4 }
+#  endif /* !MODULE_PERIPH_I2C */
+#endif
+/** @} */
+
+/**
+ * @name   I2C configuration
+ *
+ * For generic boards, only one I2C interface I2C_DEV(0) is defined.
+ *
+ * @note The GPIOs listed in the configuration are only initialized as I2C
+ * signals when module `periph_i2c` is used. Otherwise they are not allocated
+ * and can be used for other purposes.
+ *
+ * @{
+ */
+#ifndef I2C0_SPEED
+#  define I2C0_SPEED    I2C_SPEED_FAST  /**< I2C bus speed of I2C_DEV(0) */
+#endif
+
+#ifndef I2C0_SCL
+#  define I2C0_SCL      GPIO12           /**< SCL signal of I2C_DEV(0) */
+#endif
+
+#ifndef I2C0_SDA
+#  define I2C0_SDA      GPIO11           /**< SDA signal of I2C_DEV(0) */
+#endif
+/** @} */
+
+/**
+ * @name   PWM channel configuration
+ *
+ * Two PWM devices are configured. These devices can use all GPIOs that are not
+ * defined as I2C, SPI or UART for this board. Generally, all outputs pins
+ * could be used as PWM channels.
+ *
+ * @note As long as the according PWM device is not initialized with
+ * the `pwm_init`, the GPIOs declared for this device can be used
+ * for other purposes.
+ *
+ * @{
+ */
+
+/**
+ * @brief Declaration of the channels for device PWM_DEV(0),
+ *        at maximum eight channels (PWM_CH_NUMOF_MAX).
+ *
+ * Classic Arduino pins with PWM capability that are not configured as SPI
+ * pins are defined as PWM channels of PWM_DEV(0). These are the Arduino pins
+ * D3, D5, D6, and D9.
+ */
+#ifndef PWM0_GPIOS
+#  define PWM0_GPIOS  { GPIO6, GPIO8, GPIO9, GPIO18 }
+#endif
+
+/**
+ * @brief Declaration of the channels for device PWM_DEV(1),
+ *        at maximum eight channels (PWM_CH_NUMOF_MAX).
+ *
+ * GPIOs connected to the RGB LED are defined as PWM channels of PWM_DEV(1)
+ * as follows:
+ * - PWM1:0 - Red LED (GPIO46)
+ * - PWM1:1 - Green LED (GPIO0)
+ * - PWM1:2 - Blue LED (GPIO45)
+ */
+#ifndef PWM1_GPIOS
+#  define PWM1_GPIOS  { GPIO46, GPIO0, GPIO45 }
+#endif
+
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * @note The GPIOs listed in the configuration are first initialized as SPI
+ * signals when the corresponding SPI interface is used for the first time
+ * by either calling the `spi_init_cs` function or the `spi_acquire`
+ * function. That is, they are not allocated as SPI signals before and can
+ * be used for other purposes as long as the SPI interface is not used.
+ * @{
+ */
+#ifndef SPI0_CTRL
+#  define SPI0_CTRL FSPI    /**< FSPI is used as SPI_DEV(0) */
+#endif
+
+#ifndef SPI0_SCK
+#  define SPI0_SCK  GPIO48  /**< Routed vio the GPIO matrix to FSPI CLK signal */
+#endif
+
+#ifndef SPI0_MISO
+#  define SPI0_MISO GPIO47  /**< Routed vio the GPIO matrix to FSPI MISO signal */
+#endif
+
+#ifndef SPI0_MOSI
+#  define SPI0_MOSI GPIO38  /**< Routed vio the GPIO matrix to FSPI MOSI signal */
+#endif
+
+#ifndef SPI0_CS0
+#  define SPI0_CS0  GPIO21  /**< Routed vio the GPIO matrix to FSPI CS0 signal */
+#endif
+/** @} */
+
+/**
+ * @name   UART configuration
+ *
+ * ESP32-S3 provides 3 UART interfaces at maximum:
+ *
+ * UART_DEV(0) uses fixed standard configuration.<br>
+ * UART_DEV(1) is not used.<br>
+ * UART_DEV(2) is not used.<br>
+ *
+ * @{
+ */
+#define UART0_TXD   GPIO43  /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO44  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/* include common peripheral definitions as last step */
+#include "periph_conf_common.h"
+
+/** @} */


### PR DESCRIPTION
### Contribution description

This PR adds the board definition for the [Arduino Nano ESP32](https://docs.arduino.cc/hardware/nano-esp32) board, an ESP32-S3 board in Arduino Nano format.

### Testing procedure

Basic tests for the board should work. The following tests have already been executed:

<details><summary>Shell</summary>

```
main(): This is RIOT! (Version: 2025.10-devel-111-g12a65-boards/arduino-nano-esp32)
test_shell.
> help
Command              Description
---------------------------------------
bufsize              Get the shell's buffer size
start_test           starts a test
end_test             ends a test
echo                 prints the input command
empty                print nothing on command
periodic             periodically print command
xfa_test1            xfa test command 1
xfa_test2            xfa test command 2
app_metadata         Returns application metadata
pm                   interact with layered PM subsystem
ps                   Prints information about running threads.
version              Prints current RIOT_VERSION
reboot               Reboot the node
> 
> version
2025.10-devel-111-g12a65-boards/arduino-nano-esp32
> 
```

</details>
<details><summary>ADC when <code>periph_i2c</code> is used, <code>ADC_LINE(3)</code> pulled to Vcc</summary>

```
ADC_LINE(0): 11  46  179  693    -1    -1
ADC_LINE(1): 11  44  171  663    -1    -1
ADC_LINE(2): 10  38  150  575    -1    -1
ADC_LINE(3): 63 255 1023 4095    -1    -1

ADC_LINE(0): 11  46  178  684    -1    -1
ADC_LINE(1): 11  43  168  649    -1    -1
ADC_LINE(2):  9  37  145  553    -1    -1
ADC_LINE(3): 63 255 1023 4095    -1    -1
```

</details>
<details><summary>ADC when <code>periph_i2c</code> is not used, <code>ADC_LINE(3)</code> pulled to Vcc</summary>

```
ADC_LINE(0): 12  46  181  694    -1    -1
ADC_LINE(1): 11  45  174  677    -1    -1
ADC_LINE(2): 10  38  150  582    -1    -1
ADC_LINE(3): 63 255 1023 4095    -1    -1
ADC_LINE(4):  8  33  123  455    -1    -1
ADC_LINE(5):  9  35  134  493    -1    -1
ADC_LINE(6): 10  38  145  526    -1    -1
ADC_LINE(7):  3  14   52  126    -1    -1

ADC_LINE(0): 12  46  180  698    -1    -1
ADC_LINE(1): 11  45  175  681    -1    -1
ADC_LINE(2): 10  38  149  575    -1    -1
ADC_LINE(3): 63 255 1023 4095    -1    -1
ADC_LINE(4):  9  33  125  468    -1    -1
ADC_LINE(5):  9  35  134  490    -1    -1
ADC_LINE(6): 10  38  145  527    -1    -1
ADC_LINE(7):  3  13   49  118    -1    -1
```

</details>
<details><summary>I2C with VCNL4010</summary>

```
main(): This is RIOT! (Version: 2025.10-devel-111-g12a65-boards/arduino-nano-esp32)
VCNL40X0 test application

+------------Initializing------------+
Initialization successful


+--------Starting Measurements--------+
Proximity [cts]: 1985
Ambient light [cts]: 1024
Illuminance [lx]: 254

+-------------------------------------+
Proximity [cts]: 1992
Ambient light [cts]: 818
Illuminance [lx]: 199

+-------------------------------------+
Proximity [cts]: 2193
Ambient light [cts]: 381
Illuminance [lx]: 80

+-------------------------------------+
Proximity [cts]: 14041
Ambient light [cts]: 3
Illuminance [lx]: 0

+-------------------------------------+
Proximity [cts]: 2056
Ambient light [cts]: 751
Illuminance [lx]: 199

+-------------------------------------+
Proximity [cts]: 1984
Ambient light [cts]: 957
Illuminance [lx]: 241

+-------------------------------------+
Proximity [cts]: 1983
Ambient light [cts]: 1043
Illuminance [lx]: 260

+-------------------------------------+
```

</details>
<details><summary>PWM with oscillating RGB LEDs</summary>

```
main(): This is RIOT! (Version: 2025.10-devel-111-g12a65-boards/arduino-nano-esp32)
PWM peripheral driver test

> osci

RIOT PWM test
Connect an LED or scope to PWM pins to see something.

Available PWM device between 0 and 1
Initialized PWM_0 @ 1000Hz.
Initialized PWM_1 @ 1000Hz.

Letting the PWM pins oscillate now...
```

</details>
<details><summary>SPI with BME680</summary>

```
main(): This is RIOT! (Version: 2025.10-devel-110-gee140-boards/arduino-nano-esp32)
Initialize BME680 sensor 0 ... OK
[bme680]: dev=0, T = 25.22 degC, P = 98631 Pa, H = 56.949 %, G = 449383 ohms
+-----------------------------------------+
[bme680]: dev=0, T = 25.20 degC, P = 98633 Pa, H = 54.960 %, G = 350722 ohms
+-----------------------------------------+
[bme680]: dev=0, T = 25.16 degC, P = 98633 Pa, H = 53.695 %, G = 289837 ohms
+-----------------------------------------+
[bme680]: dev=0, T = 25.11 degC, P = 98631 Pa, H = 52.903 %, G = 248262 ohms
+-----------------------------------------+
[bme680]: dev=0, T = 25.04 degC, P = 98631 Pa, H = 52.419 %, G = 217118 ohms
+-----------------------------------------+
```

</details>

### Issues/PRs references

Fixes issue #21232 
