### PR TITLE
Optmodempr

### DIFF
--- a/drivers/include/optmodem.h
+++ b/drivers/include/optmodem.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <errno.h>
+
+#include "periph/uart.h"
+#include "iolist.h"
+#include "net/netdev.h"
+#include "net/netopt.h"
+#include "net/ethernet.h"   /* for ETHERNET_* constants & 6-byte MAC */
+
+/*
+ * A lightweight optical-modem netdev. It treats the optical hardware as a
+ * byte stream (UART). Each L2 frame is sent/received with a 2-byte length
+ * prefix (host order). The modem/PHY is responsible for actual modulation
+ * (OOK, QAM, …), timing, and optional integrity/FEC.
+ *
+ * By default we present as an Ethernet-like link to reuse GNRC/lwIP adapters.
+ * If you prefer raw L2, set OPTMODEM_PRESENTS_AS_ETHERNET to 0 and attach
+ * with gnrc_netif_raw_create().
+ *
+ * See:
+ *   - netdev API: send/confirm_send/recv/isr/get/set
+ *   - netopt options (ADDRESS, MAX_PDU_SIZE, DEVICE_TYPE, IS_WIRED, STATE)
+ */
+
+#ifndef OPTMODEM_PRESENTS_AS_ETHERNET
+#define OPTMODEM_PRESENTS_AS_ETHERNET   (1)
+#endif
+
+#ifndef OPTMODEM_UART_DEV
+#define OPTMODEM_UART_DEV               UART_DEV(1)
+#endif
+
+#ifndef OPTMODEM_UART_BAUD
+#define OPTMODEM_UART_BAUD              (115200U)
+#endif
+
+/* Maximum frame length we allow up the stack (including L2 header).
+ * Choose Ethernet maxima for widest compatibility with GNRC/lwIP adapters. */
+#if OPTMODEM_PRESENTS_AS_ETHERNET
+#define OPTMODEM_MAX_FRAME              (ETHERNET_MAX_LEN)   /* 1518 incl. FCS */
+#define OPTMODEM_ADDR_LEN               (ETHERNET_ADDR_LEN)  /* 6 */
+#else
+/* Raw mode: pick something sane; adjust to your optical modem constraints */
+#define OPTMODEM_MAX_FRAME              (1536)
+#define OPTMODEM_ADDR_LEN               (0)                  /* if address-less */
+#endif
+
+/* Optional: driver-local “mode” to reflect modem modulation the *hardware*
+ * performs. These are not exposed via netopt (to avoid inventing public ABI)
+ * but can be set from board code or apps that know this driver. */
+typedef enum {
+    OPTMODEM_MODE_UNKNOWN = 0,
+    OPTMODEM_MODE_OOK,
+    OPTMODEM_MODE_QAM16,
+    OPTMODEM_MODE_QAM64,
+    OPTMODEM_MODE_QPSK,
+} optmodem_mode_t;
+
+/* Minimal parameterization (expand to SPI, GPIOs, flow control as needed) */
+typedef struct {
+    uart_t      uart;
+    uint32_t    baud;
+    uint8_t     mac[ETHERNET_ADDR_LEN];   /* used when presenting as Ethernet */
+} optmodem_params_t;
+
+typedef struct {
+    /* netdev “base” must be first */
+    netdev_t                netdev;
+
+    /* static parameters */
+    optmodem_params_t       params;
+
+    /* RX staging buffer (single in-flight frame) */
+    uint8_t                 rx_buf[OPTMODEM_MAX_FRAME];
+    size_t                  rx_expected;      /* frame length we’re collecting */
+    size_t                  rx_have;          /* bytes currently in rx_buf */
+    bool                    rx_ready;         /* true when a full frame is buffered */
+
+    /* TX (we send directly from iolist; this can remain empty) */
+
+    /* driver-local */
+    optmodem_mode_t         mode;
+    netopt_state_t          state;
+} optmodem_t;
+
+/* Public driver vtable */
+extern const netdev_driver_t optmodem_driver;
+
+/* Convenience init: fill dev->params first, then call this. */
+int optmodem_init(optmodem_t *dev);
+
+/* Optional driver-local helpers to steer the hardware modulation mode. */
+static inline void optmodem_set_mode(optmodem_t *dev, optmodem_mode_t m) { dev->mode = m; }
+static inline optmodem_mode_t optmodem_get_mode(const optmodem_t *dev)   { return dev->mode; }
+

--- a/drivers/optmodem/Kconfig
+++ b/drivers/optmodem/Kconfig
@@ -1,0 +1,5 @@
+menu "Optical modem driver"
+config MODULE_OPTMODEM
+    bool "optmodem (optical modem) driver"
+    select MODULE_PERIPH_UART
+endmenu

--- a/drivers/optmodem/Makefile
+++ b/drivers/optmodem/Makefile
@@ -1,0 +1,3 @@
+MODULE = optmodem
+FEATURES_REQUIRED += periph_uart
+include $(RIOTBASE)/Makefile.base

--- a/drivers/optmodem/optmodem.c
+++ b/drivers/optmodem/optmodem.c
@@ -1,0 +1,302 @@
+#include <string.h>
+#include "optmodem.h"
+
+#include "net/netdev.h"
+#include "net/netopt.h"
+#include "iolist.h"
+
+#if OPTMODEM_PRESENTS_AS_ETHERNET
+#include "net/ethernet.h"
+#endif
+
+/* --- Forward decls --- */
+static int  _send(netdev_t *netdev, const iolist_t *iolist);
+static int  _confirm_send(netdev_t *netdev, void *info);
+static int  _recv(netdev_t *netdev, void *buf, size_t len, void *info);
+static int  _init(netdev_t *netdev);
+static void _isr(netdev_t *netdev);
+static int  _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len);
+static int  _set(netdev_t *netdev, netopt_t opt, const void *value, size_t value_len);
+
+/* Driver vtable */
+const netdev_driver_t optmodem_driver = {
+    .send         = _send,
+    .confirm_send = _confirm_send,
+    .recv         = _recv,
+    .init         = _init,
+    .isr          = _isr,
+    .get          = _get,
+    .set          = _set,
+};
+
+/* UART RX interrupt: called per byte in IRQ context */
+static void _uart_rx_cb(void *arg, uint8_t data)
+{
+    optmodem_t *dev = (optmodem_t *)arg;
+
+    /* Simple length-prefixed framing: first two bytes = length (host order) */
+    if (dev->rx_expected == 0) {
+        /* gather 2-byte length header */
+        if (dev->rx_have == 0) {
+            dev->rx_buf[0] = data;
+            dev->rx_have = 1;
+            return;
+        }
+        else {
+            uint16_t len = ((uint16_t)dev->rx_buf[0]) | (((uint16_t)data) << 8);
+            dev->rx_expected = len;
+            dev->rx_have = 0;
+            /* sanity clamp */
+            if (dev->rx_expected > OPTMODEM_MAX_FRAME) {
+                dev->rx_expected = 0;
+                dev->rx_have = 0;
+                return;
+            }
+            return;
+        }
+    }
+
+    if (dev->rx_have < dev->rx_expected) {
+        dev->rx_buf[dev->rx_have++] = data;
+        if (dev->rx_have == dev->rx_expected) {
+            dev->rx_ready = true;
+            /* Notify upper layer in IRQ-safe way */
+            netdev_trigger_event_isr(&dev->netdev);
+        }
+    }
+}
+
+/* --- netdev ops --- */
+
+static int _init(netdev_t *netdev)
+{
+    optmodem_t *dev = (optmodem_t *)netdev;
+
+    dev->mode       = OPTMODEM_MODE_UNKNOWN;
+    dev->state      = NETOPT_STATE_IDLE;
+    dev->rx_expected = 0;
+    dev->rx_have     = 0;
+    dev->rx_ready    = false;
+
+    int res = uart_init(dev->params.uart, dev->params.baud, _uart_rx_cb, dev);
+    if (res < 0) {
+        return res;
+    }
+
+    /* If you need RTS/CTS, parity, or collision detect: call uart_mode() /
+     * uart_* helpers here. */
+
+    return 0;
+}
+
+static int _send(netdev_t *netdev, const iolist_t *iolist)
+{
+    optmodem_t *dev = (optmodem_t *)netdev;
+
+    /* Flatten outgoing iolist (L2 header + payload) into a bounded stack buffer */
+    size_t total = iolist_size(iolist);
+    if (total > OPTMODEM_MAX_FRAME) {
+        return -EMSGSIZE;
+    }
+
+    /* Write 2-byte length, then the bytes */
+    uint8_t len_hdr[2];
+    len_hdr[0] = (uint8_t)(total & 0xff);
+    len_hdr[1] = (uint8_t)((total >> 8) & 0xff);
+
+    uart_write(dev->params.uart, len_hdr, sizeof(len_hdr));
+
+    /* Stream out each iolist chunk without copying if possible */
+    for (const iolist_t *p = iolist; p; p = p->iol_next) {
+        if (p->iol_len) {
+            uart_write(dev->params.uart, (const uint8_t *)p->iol_base, p->iol_len);
+        }
+    }
+
+    /* We implement a blocking send (UART is synchronous here).
+     * Per netdev “new API”, returning the number of bytes means no TX_COMPLETE
+     * event will be emitted and confirm_send() won’t be called. */
+    return (int)total;
+}
+
+static int _confirm_send(netdev_t *netdev, void *info)
+{
+    (void)netdev; (void)info;
+    /* Not used for blocking UART; see send() note. */
+    return -EAGAIN;
+}
+
+static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
+{
+    (void)info;
+    optmodem_t *dev = (optmodem_t *)netdev;
+
+    if (!dev->rx_ready) {
+        /* Nothing buffered; upper layer should only call after RX_COMPLETE */
+        return -EAGAIN;
+    }
+
+    /* Query length without consuming */
+    if (buf == NULL && len == 0) {
+        return (int)dev->rx_expected;
+    }
+
+    /* Drop frame request */
+    if (buf == NULL && len > 0) {
+        dev->rx_ready    = false;
+        dev->rx_expected = 0;
+        dev->rx_have     = 0;
+        return 0;
+    }
+
+    /* Copy out the frame */
+    if (len < dev->rx_expected) {
+        /* drop and report ENOBUFS per netdev semantics */
+        dev->rx_ready    = false;
+        dev->rx_expected = 0;
+        dev->rx_have     = 0;
+        return -ENOBUFS;
+    }
+
+    memcpy(buf, dev->rx_buf, dev->rx_expected);
+    int out = (int)dev->rx_expected;
+
+    dev->rx_ready    = false;
+    dev->rx_expected = 0;
+    dev->rx_have     = 0;
+
+    return out;
+}
+
+static void _isr(netdev_t *netdev)
+{
+    /* Called from the GNRC/lwIP hosting thread after netdev_trigger_event_isr().
+     * We simply escalate to RX_COMPLETE so the stack can fetch the frame. */
+    if (netdev->event_callback) {
+        netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
+    }
+}
+
+static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
+{
+    optmodem_t *dev = (optmodem_t *)netdev;
+
+    switch (opt) {
+    case NETOPT_DEVICE_TYPE:
+        if (max_len < sizeof(uint16_t)) return -EINVAL;
+#if OPTMODEM_PRESENTS_AS_ETHERNET
+        *(uint16_t *)value = NETDEV_TYPE_ETHERNET;
+#else
+        *(uint16_t *)value = NETDEV_TYPE_RAW;
+#endif
+        return sizeof(uint16_t);
+
+    case NETOPT_IS_WIRED: {
+        if (max_len < sizeof(netopt_enable_t)) return -EINVAL;
+        *(netopt_enable_t *)value = NETOPT_ENABLE; /* optical ≈ wired for stacks */
+        return sizeof(netopt_enable_t);
+    }
+
+    case NETOPT_ADDR_LEN:
+        if (max_len < sizeof(uint16_t)) return -EINVAL;
+        *(uint16_t *)value = OPTMODEM_ADDR_LEN;
+        return sizeof(uint16_t);
+
+#if OPTMODEM_PRESENTS_AS_ETHERNET
+    case NETOPT_ADDRESS:
+        if (max_len < ETHERNET_ADDR_LEN) return -EINVAL;
+        memcpy(value, dev->params.mac, ETHERNET_ADDR_LEN);
+        return ETHERNET_ADDR_LEN;
+#endif
+
+    case NETOPT_MAX_PDU_SIZE: {
+        if (max_len < sizeof(uint16_t)) return -EINVAL;
+        uint16_t sz = (uint16_t)OPTMODEM_MAX_FRAME;
+        *(uint16_t *)value = sz;
+        return sizeof(uint16_t);
+    }
+
+    case NETOPT_STATE:
+        if (max_len < sizeof(netopt_state_t)) return -EINVAL;
+        *(netopt_state_t *)value = dev->state;
+        return sizeof(netopt_state_t);
+
+    /* We don’t add software CRC/FEC; modem/PHY should handle integrity.
+       Expose as disabled if queried. */
+    case NETOPT_INTEGRITY_CHECK: {
+        if (max_len < sizeof(netopt_enable_t)) return -EINVAL;
+        *(netopt_enable_t *)value = NETOPT_DISABLE;
+        return sizeof(netopt_enable_t);
+    }
+
+    default:
+        return -ENOTSUP;
+    }
+}
+
+static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t value_len)
+{
+    optmodem_t *dev = (optmodem_t *)netdev;
+
+    switch (opt) {
+#if OPTMODEM_PRESENTS_AS_ETHERNET
+    case NETOPT_ADDRESS:
+        if (value_len != ETHERNET_ADDR_LEN) return -EINVAL;
+        memcpy(dev->params.mac, value, ETHERNET_ADDR_LEN);
+        return (int)value_len;
+#endif
+
+    case NETOPT_STATE: {
+        if (value_len != sizeof(netopt_state_t)) return -EINVAL;
+        netopt_state_t st = *(const netopt_state_t *)value;
+        if (st == NETOPT_STATE_RESET) {
+            dev->rx_expected = dev->rx_have = 0;
+            dev->rx_ready    = false;
+            dev->state       = NETOPT_STATE_IDLE;
+            return sizeof(netopt_state_t);
+        }
+        /* We ignore other state transitions in this minimal driver */
+        dev->state = st;
+        return sizeof(netopt_state_t);
+    }
+
+    /* If you later map modem bandwidth, channel (wavelength), or TX power,
+       you can implement NETOPT_BANDWIDTH, NETOPT_CHANNEL_FREQUENCY, NETOPT_TX_POWER here. */
+
+    default:
+        return -ENOTSUP;
+    }
+}
+
+/* Public convenience init */
+int optmodem_init(optmodem_t *dev)
+{
+    memset(dev, 0, sizeof(*dev));
+    dev->netdev.driver = &optmodem_driver;
+    dev->state = NETOPT_STATE_IDLE;
+
+    /* Ensure UART index/baud are set by caller prior to init() */
+    if (dev->params.uart == UART_UNDEF || dev->params.baud == 0) {
+        dev->params.uart = OPTMODEM_UART_DEV;
+        dev->params.baud = OPTMODEM_UART_BAUD;
+    }
+#if OPTMODEM_PRESENTS_AS_ETHERNET
+    /* Default to a locally administered MAC if none was provided */
+    if (dev->params.mac[0] == 0 &&
+        dev->params.mac[1] == 0 &&
+        dev->params.mac[2] == 0 &&
+        dev->params.mac[3] == 0 &&
+        dev->params.mac[4] == 0 &&
+        dev->params.mac[5] == 0) {
+        /* 02:00:00:xx:yy:zz */
+        dev->params.mac[0] = 0x02;
+        dev->params.mac[1] = 0x00;
+        dev->params.mac[2] = 0x00;
+        dev->params.mac[3] = 0x00;
+        dev->params.mac[4] = 0x00;
+        dev->params.mac[5] = 0x01;
+    }
+#endif
+
+    return _init(&dev->netdev);
+}


### PR DESCRIPTION
This Pull Request is just an outline somebody can work with; there is still much that needs to be done here. The basic idea is that so far RIOT, for free-space communication, only uses radio frequency. I thought it would be a good idea to also make it able to use optical frequency (communication via lasers, for instance). Especially for satellites in space, using optical frequency has a lot of nice advantages.

In this PR I have added the basic outline for an optmodem driver under drivers/ to make optical frequency communication possible in RIOT. My initial approach uses Ethernet-over-optical so that we do not need to redefine data link layer framing. However, because this is optical communication, in some cases it could be useful to define custom framing, so in my implementation there is also a raw mode available.

The driver implements the following netdev ops:
send, recv, init, isr, get, set (basic), plus a stub confirm_send.

It also supports the following netopt options:
DEVICE_TYPE, IS_WIRED, ADDR_LEN (+ ADDRESS when in Ethernet mode), MAX_PDU_SIZE, STATE, and INTEGRITY_CHECK (disabled).

This is not a complete implementation — it is just a starting point. Real PHY functionality such as modulation, timing, and FEC/CRC is assumed to be handled by the optical hardware itself. The main work remaining will be for someone who actually has such laser devices to test, refine, and integrate this with the rest of RIOT. My hope is that this code provides a foundation that developers with the right hardware can use to bring optical frequency communication into RIOT.