### PR TITLE
guides/installing: add psutil requirement for pyterm

### DIFF
--- a/doc/guides/getting-started/installing.mdx
+++ b/doc/guides/getting-started/installing.mdx
@@ -50,13 +50,13 @@ Depending on the operation distribution you are using, the installation of the r
 #### Ubuntu
 
 ```bash title="Ubuntu command to install required packages"
-    sudo apt install make gcc-multilib python3-serial wget unzip git openocd gdb-multiarch esptool podman-docker clangd clang
+    sudo apt install make gcc-multilib python3-serial python3-psutil wget unzip git openocd gdb-multiarch esptool podman-docker clangd clang
 ```
 
 #### Arch Linux
 
 ```bash title="Arch Linux command to install required packages"
-    sudo pacman -S make gcc-multilib python-pyserial wget unzip git openocd gdb esptool podman-docker clang
+    sudo pacman -S make gcc-multilib python-pyserial python-psutil wget unzip git openocd gdb esptool podman-docker clang
 ```
 
 This will show something like this depending on your distribution:


### PR DESCRIPTION
### Contribution description

Application of https://github.com/RIOT-OS/RIOT/pull/21399 to the new guides site which apparently got overlooked while migrating. @AnnsAnns 


### Testing procedure

Check diff, double-check package names.


### Issues/PRs references

Previously fixed with https://github.com/RIOT-OS/RIOT/pull/21399, but apparently not carried over with https://github.com/RIOT-OS/RIOT/pull/21573
