### PR TITLE
picotool/picosdk: Bump version

### DIFF
--- a/dist/tools/picotool/Makefile
+++ b/dist/tools/picotool/Makefile
@@ -1,6 +1,7 @@
 PKG_NAME=picotool
 PKG_URL=https://github.com/raspberrypi/picotool.git
-PKG_VERSION=de8ae5ac334e1126993f72a5c67949712fd1e1a4
+# Version 2.2.0-a4
+PKG_VERSION=25aa087b2c517b4901874a99536e869d4d27b678
 PKG_LICENSE=BSD-3-Clause
 
 # manually set some RIOT env vars, so this Makefile can be called stand-alone

--- a/pkg/picosdk/Makefile
+++ b/pkg/picosdk/Makefile
@@ -1,6 +1,7 @@
 PKG_NAME=picosdk
 PKG_URL=https://github.com/raspberrypi/pico-sdk.git
-PKG_VERSION=bddd20f928ce76142793bef434d4f75f4af6e433
+# Version 2.2.0
+PKG_VERSION=a1438dff1d38bd9c65dbd693f0e5db4b9ae91779
 PKG_LICENSE=BSD-3-Clause
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This mostly only adds support for the new revision of the pico2 (Technically it already worked but looked weird in picotool). All other changes, at most, affect advanced pico 2 related stuff when using picosdk, which we currently don't do.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Flash a project with `PROGRAMMER=picotool` to the pico 1 or pico 2. Note that I only tested it working on the pico 2 as I currently have no pico 1 here, though considering that the flashing process is nearly 1:1 between them it should work identically. 

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
