### PR TITLE
boards/common/nucleo144: fix and complete Arduino configuration

### DIFF
--- a/boards/common/nucleo144/Makefile.features
+++ b/boards/common/nucleo144/Makefile.features
@@ -1,5 +1,8 @@
 # Various common features of Nucleo-144 boards
 FEATURES_PROVIDED += arduino_analog
+FEATURES_PROVIDED += arduino_i2c
 FEATURES_PROVIDED += arduino_pins
 FEATURES_PROVIDED += arduino_shield_mega
 FEATURES_PROVIDED += arduino_shield_uno
+FEATURES_PROVIDED += arduino_spi
+FEATURES_PROVIDED += arduino_uart

--- a/boards/common/nucleo144/include/arduino_iomap.h
+++ b/boards/common/nucleo144/include/arduino_iomap.h
@@ -56,8 +56,8 @@ extern "C" {
 #define ARDUINO_PIN_12          GPIO_PIN(PORT_A, 6)
 #define ARDUINO_PIN_13          GPIO_PIN(PORT_A, 5)
 
-#define ARDUINO_PIN_14          GPIO_PIN(PORT_B, 8)
-#define ARDUINO_PIN_15          GPIO_PIN(PORT_B, 9)
+#define ARDUINO_PIN_14          GPIO_PIN(PORT_B, 9)
+#define ARDUINO_PIN_15          GPIO_PIN(PORT_B, 8)
 
 #define ARDUINO_PIN_16          GPIO_PIN(PORT_A, 3)
 #define ARDUINO_PIN_17          GPIO_PIN(PORT_C, 0)

--- a/boards/common/nucleo144/include/arduino_iomap.h
+++ b/boards/common/nucleo144/include/arduino_iomap.h
@@ -59,22 +59,31 @@ extern "C" {
 #define ARDUINO_PIN_14          GPIO_PIN(PORT_B, 9)
 #define ARDUINO_PIN_15          GPIO_PIN(PORT_B, 8)
 
-#define ARDUINO_PIN_16          GPIO_PIN(PORT_A, 3)
-#define ARDUINO_PIN_17          GPIO_PIN(PORT_C, 0)
-#define ARDUINO_PIN_18          GPIO_PIN(PORT_C, 3)
-#if defined(CPU_MODEL_STM32F413ZH) || defined(CPU_MODEL_STM32F412ZG) || \
-    defined(CPU_MODEL_STM32L496ZG)
-#  define ARDUINO_PIN_19        GPIO_PIN(PORT_C, 1)
-#  define ARDUINO_PIN_20        GPIO_PIN(PORT_C, 4)
-#  define ARDUINO_PIN_21        GPIO_PIN(PORT_C, 5)
-#elif defined(CPU_MODEL_STM32F303ZE)
-#  define ARDUINO_PIN_19        GPIO_PIN(PORT_D, 11)
-#  define ARDUINO_PIN_20        GPIO_PIN(PORT_D, 12)
-#  define ARDUINO_PIN_21        GPIO_PIN(PORT_D, 13)
+#if defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5)
+#  define ARDUINO_PIN_16        GPIO_PIN(PORT_A, 3)
+#  define ARDUINO_PIN_17        GPIO_PIN(PORT_A, 2)
+#  define ARDUINO_PIN_18        GPIO_PIN(PORT_C, 3)
+#  define ARDUINO_PIN_19        GPIO_PIN(PORT_B, 0)
+#  define ARDUINO_PIN_20        GPIO_PIN(PORT_C, 1)
+#  define ARDUINO_PIN_21        GPIO_PIN(PORT_C, 0)
 #else
-#  define ARDUINO_PIN_19        GPIO_PIN(PORT_F, 3)
-#  define ARDUINO_PIN_20        GPIO_PIN(PORT_F, 5)
-#  define ARDUINO_PIN_21        GPIO_PIN(PORT_F, 10)
+#  define ARDUINO_PIN_16        GPIO_PIN(PORT_A, 3)
+#  define ARDUINO_PIN_17        GPIO_PIN(PORT_C, 0)
+#  define ARDUINO_PIN_18        GPIO_PIN(PORT_C, 3)
+#  if defined(CPU_MODEL_STM32F413ZH) || defined(CPU_MODEL_STM32F412ZG) || \
+      defined(CPU_FAM_STM32L4)
+#    define ARDUINO_PIN_19      GPIO_PIN(PORT_C, 1)
+#    define ARDUINO_PIN_20      GPIO_PIN(PORT_C, 4)
+#    define ARDUINO_PIN_21      GPIO_PIN(PORT_C, 5)
+#  elif defined(CPU_MODEL_STM32F303ZE)
+#    define ARDUINO_PIN_19      GPIO_PIN(PORT_D, 11)
+#    define ARDUINO_PIN_20      GPIO_PIN(PORT_D, 12)
+#    define ARDUINO_PIN_21      GPIO_PIN(PORT_D, 13)
+#  else
+#    define ARDUINO_PIN_19      GPIO_PIN(PORT_F, 3)
+#    define ARDUINO_PIN_20      GPIO_PIN(PORT_F, 5)
+#    define ARDUINO_PIN_21      GPIO_PIN(PORT_F, 10)
+#  endif
 #endif
 
 #define ARDUINO_PIN_LAST        21

--- a/boards/common/nucleo144/include/arduino_iomap.h
+++ b/boards/common/nucleo144/include/arduino_iomap.h
@@ -26,6 +26,38 @@ extern "C" {
 #endif
 
 /**
+ * @name    Arduino's UART devices
+ * @{
+ */
+#define ARDUINO_UART_D0D1       UART_DEV(1)
+/** @} */
+
+/**
+ * @name    Arduino's SPI buses
+ * @{
+ */
+#if !defined(ARDUINO_SPI_D11D12D13) && defined(SPI_NUMOF)
+/**
+ * @brief   SPI_DEV(0) is connected to D11/D12/D13 for most Nucleo-144 boards
+ *
+ * This can be overwritten in `boards/nucleo-<foobar>/include/periph_conf.h` by
+ * providing a custom `ARDUINO_SPI_D11D12D13`.
+ */
+#  define ARDUINO_SPI_D11D12D13 SPI_DEV(0)
+#endif
+/** @} */
+
+/**
+ * @name    Arduino's I2C buses
+ * @{
+ */
+/**
+ * @brief   The first I2C bus is where shields for the Arduino UNO expect it
+ */
+#define ARDUINO_I2C_UNO         I2C_DEV(0)
+/** @} */
+
+/**
  * @name    Mapping of MCU pins to Arduino pins
  * @{
  */

--- a/boards/common/nucleo144/include/arduino_iomap.h
+++ b/boards/common/nucleo144/include/arduino_iomap.h
@@ -30,11 +30,17 @@ extern "C" {
  * @{
  */
 #if defined(CPU_MODEL_STM32F303ZE)
-#define ARDUINO_PIN_0           GPIO_PIN(PORT_C, 5)
-#define ARDUINO_PIN_1           GPIO_PIN(PORT_C, 4)
+#  define ARDUINO_PIN_0         GPIO_PIN(PORT_C, 5)
+#  define ARDUINO_PIN_1         GPIO_PIN(PORT_C, 4)
+#elif defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32L5)
+#  define ARDUINO_PIN_0         GPIO_PIN(PORT_D, 9)
+#  define ARDUINO_PIN_1         GPIO_PIN(PORT_D, 8)
+#elif defined(CPU_FAM_STM32U5)
+#  define ARDUINO_PIN_0         GPIO_PIN(PORT_G, 8)
+#  define ARDUINO_PIN_1         GPIO_PIN(PORT_G, 7)
 #else
-#define ARDUINO_PIN_0           GPIO_PIN(PORT_G, 9)
-#define ARDUINO_PIN_1           GPIO_PIN(PORT_G, 14)
+#  define ARDUINO_PIN_0         GPIO_PIN(PORT_G, 9)
+#  define ARDUINO_PIN_1         GPIO_PIN(PORT_G, 14)
 #endif
 #define ARDUINO_PIN_2           GPIO_PIN(PORT_F, 15)
 #define ARDUINO_PIN_3           GPIO_PIN(PORT_E, 13)


### PR DESCRIPTION
### Contribution description

This PR includes some fixes of Arduino pin configurations for Nucleo144 boards with L4, L5 and U5 and completes the Arduino configuration for I2C, SPI, and UART devices of Nucleo144 boards.

In detail:
1. On Nucleo144 boards for L4, L5 and U5, Arduino connector pins D0/D1 have a different configuration. According to the user manuals for
   - [L4 boards]( https://www.st.com/resource/en/user_manual/um2179-stm32-nucleo144-boards-mb1312-stmicroelectronics.pdf), D0/D1 are GPIOs PD9/PD8
   - [L5 boards](https://www.st.com/resource/en/user_manual/um2581-stm32l5-nucleo144-board-mb1361-stmicroelectronics.pdf), D0/D1 are GPIOs PD9/PD8
   - [U5 boards](https://www.st.com/resource/en/user_manual/um2861-stm32u5-nucleo144-board-mb1549-stmicroelectronics.pdf), D0/D1 are GPIOs PG8/PG7
2. According to the user manuals Arduino pins D14/D15 are GPIOs PB9/PB8. The configuration was mixed up. `I2C_DEV(1)` uses PB9 as SDA and PB8 as SCL signals that have to be mapped to Arduino pins D14=SDA and D15=SCL, respectively, to be compatibly with Arduino shields.
3. Nucleo144 boards for L5 and U5 have a completely different analog pin configuration.
4. Defines for `ARDUINO_UART_D0D1`, `ARDUINO_SPI_D11D12D13` and ARDUINO_I2C_UNO` as well as the corresponding features were added.

### Testing procedure

t.b.d

### Issues/PRs references
