### PR TITLE
makefiles/suit: add `SUIT_GEN_PUBKEY` variable to inhibit public key generation

### DIFF
--- a/makefiles/suit.base.inc.mk
+++ b/makefiles/suit.base.inc.mk
@@ -60,7 +60,13 @@ $(SUIT_SEC): | $(CLEAN)
 	)
 	$(Q)if [ ! -s $@ ]; then rm $@; fi
 
-%.pem.pub: %.pem
+# Allow to disable auto-generating public key from private key, e.g. if only the
+# public key is available at build time and manifest is created elsewhere.
+SUIT_GEN_PUBKEY ?= 1
+ifeq (1, $(SUIT_GEN_PUBKEY))
+  _PUB_FROM_SEC := %.pem
+endif
+%.pem.pub: $(_PUB_FROM_SEC)
 	$(Q)openssl ec -inform pem -in $< -outform pem -pubout -out $@
 
 # Convert public keys to C headers - only last 32 bytes are key material


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

If we only have access the the public key, we don't want it to be accidentally overwritten by the build system.

Intrudce a new `SUIT_GEN_PUBKEY` that defaults to 1, but can be set to 0 to disable auto-generating the public key from the private key (and generating a new private/public key pair if the private key does not exist).


### Testing procedure

 - delete `~/.local/share/RIOT/keys/default.pem` (assuming `default.pem.pub` already exists)
 - try to build `examples/advanced/suit_update`
   - it asks you to generate a new key pair. Abort that.
 - try to build `examples/advanced/suit_update` with `SUIT_GEN_PUBKEY=0`
   - the build succeeds without a private key


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
