### PR TITLE
dist/tools/vera++: allow comments to be overlong

### DIFF
--- a/dist/tools/vera++/scripts/rules/L004.tcl
+++ b/dist/tools/vera++/scripts/rules/L004.tcl
@@ -7,7 +7,10 @@ foreach f [getSourceFileNames] {
     set lineNumber 1
     foreach line [getAllLines $f] {
         if {[string length $line] > $maxLength} {
-            report $f $lineNumber "line is longer than ${maxLength} characters"
+            # ignore overlong line if it appears to be within a comment
+            if {!([string match " \* *" $line] || [string match "// *" $line])} {
+                report $f $lineNumber "line is longer than ${maxLength} characters"
+            }
         }
         incr lineNumber
     }


### PR DESCRIPTION
### Contribution description

The line length check is very noisy, especially in the Github web view with annotations added to every overlong line. Reducing the number of false positives there for is very valuable.

In comments, we often have overlong lines e.g. because an URL is longer than 100 chars, because we add a larger markdown table, we add ASCII art to visualize data structures, or because we add dot syntax that may just need overlong lines.

Since vera++ does not support annotations with magic comments to disable the length check just for a table / URL / graphic, this just disables the length checks for all comments outright.

### Testing procedure

- There should still be complaints about overlong lines if they are in the code
- There should be no complaints about overlong lines if they are in comments

### Issues/PRs references

None