### PR TITLE
makefiles/boot/riotboot: pass BUILD_DIR to recursive Make call

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -86,6 +86,7 @@ riotboot/flash-bootloader: riotboot/bootloader/flash
 riotboot/bootloader/%: $$(if $$(filter riotboot/bootloader/clean,$$@),,$$(BUILDDEPS) pkg-prepare)
 	$(Q)/usr/bin/env -i \
 		QUIET=$(QUIET) PATH="$(PATH)" USER="$(USER)"\
+		BUILD_DIR="$(BUILD_DIR)"\
 		INCLUDES="$(INCLUDES)"\
 		EXTERNAL_BOARD_DIRS="$(EXTERNAL_BOARD_DIRS)" BOARD=$(BOARD) \
 		OPENOCD_DEBUG_ADAPTER=$(OPENOCD_DEBUG_ADAPTER) \


### PR DESCRIPTION
### Contribution description

riotboot for some reason resets the environment before a recursive make call. The new environment lacks `BUILD_DIR`.

### Testing procedure

`BUILD_DIR=test make -C tests/riotboot all` fails on `master` with:

```
fatal: not a git repository: '.git'
fatal: not a git repository: '.git'
make[1]: *** [/home/mikolai/TUD/Code/RIOT/pkg/pkg.mk:132: /home/mikolai/TUD/Code/RIOT/build/pkg/cmsis/.pkg-state.git-downloaded] Error 128
```

With this change, it passes.

### Issues/PRs references

Found while investigating https://github.com/RIOT-OS/RIOT/pull/21438#issuecomment-3213512440
