### PR TITLE
tests/pkg/emlearn: fix wrong model header file name in README

### DIFF
--- a/tests/pkg/emlearn/README.md
+++ b/tests/pkg/emlearn/README.md
@@ -35,6 +35,6 @@ The application comes with 3 Python scripts:
   $ ./train_model.py
   ```
   will just train the model.
-- `generate_model.py` is used to generate the `sonar.h` header file from the
+- `generate_model.py` is used to generate the `model.h` header file from the
   `model` binary file. The script is called automatically by the build system
   when the `model` binary file is updated.

--- a/tests/pkg/emlearn/README.md
+++ b/tests/pkg/emlearn/README.md
@@ -36,5 +36,4 @@ The application comes with 3 Python scripts:
   ```
   will just train the model.
 - `generate_model.py` is used to generate the `model.h` header file from the
-  `model` binary file. The script is called automatically by the build system
-  when the `model` binary file is updated.
+  `model` binary file.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The model is actually generated in the model.h not sonar.h. I think that filename was used (hard coded?) in the very early versions of that example.
A second commit is added to drop the last sentence that states the header file is automatically generated which is not true anymore.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just read. The model header file is generated using the `generate_model.py` script. The `main.c` file doesn't include `sonar.h`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
