### PR TITLE
drivers/sx126x: add support for Dio2 and Dio3

### DIFF
--- a/drivers/include/sx126x.h
+++ b/drivers/include/sx126x.h
@@ -79,6 +79,33 @@ typedef enum {
 } sx126x_type_t;
 
 /**
+ * @brief   Dio2 pin mode
+ */
+typedef enum {
+    SX126X_DIO2_UNUSED,     /**< Not used */
+    SX126X_DIO2_IRQ,        /**< IRQ pin (ToDo) */
+    SX126X_DIO2_RF_SWITCH,  /**< RF switch control pin */
+} sx126x_dio2_mode_t;
+
+/**
+ * @brief   Dio3 pin mode
+ */
+typedef enum {
+    SX126X_DIO3_UNUSED,     /**< Not used */
+    SX126X_DIO3_IRQ,        /**< IRQ pin (ToDo) */
+    SX126X_DIO3_TCXO,       /**< TCXO control pin */
+} sx126x_dio3_mode_t;
+
+/**
+ * @brief   Mask of all available interrupts
+ */
+#define SX126X_IRQ_MASK_ALL     (SX126X_IRQ_TX_DONE | SX126X_IRQ_RX_DONE | \
+                                 SX126X_IRQ_PREAMBLE_DETECTED | SX126X_IRQ_SYNC_WORD_VALID | \
+                                 SX126X_IRQ_HEADER_VALID | SX126X_IRQ_HEADER_ERROR | \
+                                 SX126X_IRQ_CRC_ERROR | SX126X_IRQ_CAD_DONE | \
+                                 SX126X_IRQ_CAD_DETECTED | SX126X_IRQ_TIMEOUT)
+
+/**
  * @brief   Device initialization parameters
  */
 typedef struct {
@@ -87,6 +114,17 @@ typedef struct {
     gpio_t reset_pin;                   /**< Reset pin */
     gpio_t busy_pin;                    /**< Busy pin */
     gpio_t dio1_pin;                    /**< Dio1 pin */
+#if IS_USED(MODULE_SX126X_DIO2)
+    sx126x_dio2_mode_t dio2_mode;       /**< Dio2 mode */
+#endif
+#if IS_USED(MODULE_SX126X_DIO3)
+    sx126x_dio3_mode_t dio3_mode;       /**< Dio3 mode */
+    struct {
+        unsigned tcxo_volt    :8;   /**< TCXO voltage (see sx126x_tcxo_ctrl_voltages_t)*/
+        unsigned tcxo_timeout :24;  /**< TCXO timeout to wait for 32MHz coming from TXC0,
+                                         Delay duration = Delay(23:0) * 15.625 μs */
+    } dio3_arg;
+#endif
     sx126x_reg_mod_t regulator;         /**< Power regulator mode */
     sx126x_type_t type;                 /**< Variant of sx126x */
 #if IS_USED(MODULE_SX126X_RF_SWITCH)

--- a/drivers/sx126x/Makefile.include
+++ b/drivers/sx126x/Makefile.include
@@ -7,6 +7,8 @@ PSEUDOMODULES += sx126x_stm32wl
 
 # include RF switch implemented in the board for use with sx126x
 PSEUDOMODULES += sx126x_rf_switch
+PSEUDOMODULES += sx126x_dio2
+PSEUDOMODULES += sx126x_dio3
 
 USEMODULE_INCLUDES_sx126x := $(LAST_MAKEFILEDIR)/include
 USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_sx126x)

--- a/drivers/sx126x/include/sx126x_params.h
+++ b/drivers/sx126x/include/sx126x_params.h
@@ -63,7 +63,11 @@ extern "C" {
 #  define SX126X_PARAM_DIO1                 GPIO_PIN(1, 4)  /* D5 */
 #endif
 
-#ifndef SX126X_PARAM_REGULATOR
+#if !defined(SX126X_PARAM_REGULATOR) || defined(DOXYGEN)
+/**
+ * @brief   Regulator type which can be
+ *          SX126X_REG_MODE_LDO or SX126X_REG_MODE_DCDC
+ */
 #  define SX126X_PARAM_REGULATOR            SX126X_REG_MODE_DCDC
 #endif
 
@@ -73,6 +77,48 @@ extern "C" {
 
 #ifndef SX126X_PARAM_TX_PA_MODE
 #  define SX126X_PARAM_TX_PA_MODE           SX126X_RF_MODE_TX_LPA
+#endif
+
+#if !defined(SX126X_PARAM_DIO2_MODE) || defined(DOXYGEN)
+/**
+ * @brief   DIO2 pin mode which can be
+ *          SX126X_DIO2_UNUSED, SX126X_DIO2_IRQ or SX126X_DIO2_RF_SWITCH
+ */
+#  define SX126X_PARAM_DIO2_MODE            SX126X_DIO2_UNUSED
+#endif
+
+#if !defined(SX126X_PARAM_DIO3_MODE) || defined(DOXYGEN)
+/**
+ * @brief   DIO3 pin mode which can be
+ *          SX126X_DIO3_UNUSED, SX126X_DIO3_IRQ or SX126X_DIO3_TCXO
+ */
+#  define SX126X_PARAM_DIO3_MODE            SX126X_DIO3_UNUSED
+#endif
+
+#if !defined(SX126X_PARAM_TCXO_VOLTAGE) || defined(DOXYGEN)
+/**
+ * @brief   TCXO voltage is configured to be 200 mV below the supply voltage.
+ *
+ * This means that even if tcxoVoltage is configured above the supply voltage,
+ * the supply voltage will be limited by: VDDop > VTCXO + 200 mV
+ */
+#  define SX126X_PARAM_TCXO_VOLTAGE         SX126X_TCXO_CTRL_3_0V
+#endif
+
+#if !defined(SX126X_PARAM_TCXO_TIMEOUT) || defined(DOXYGEN)
+/**
+ * @brief   Timeout for tcxo stabilization in 15.625 µs steps
+ *          The default value is 256 (4ms).
+ */
+#  define SX126X_PARAM_TCXO_TIMEOUT         256
+#endif
+
+#if !defined(SX126X_PARAM_DIO3_ARG) || defined(DOXYGEN)
+/**
+ * @brief   DIO3 argument if mode is SX126X_DIO3_TCXO
+ */
+#  define SX126X_PARAM_DIO3_ARG             { .tcxo_volt = SX126X_PARAM_TCXO_VOLTAGE, \
+                                              .tcxo_timeout = SX126X_PARAM_TCXO_TIMEOUT }
 #endif
 
 #ifndef SX126X_PARAM_TYPE
@@ -93,22 +139,49 @@ extern "C" {
 
 #if IS_USED(MODULE_SX126X_RF_SWITCH)
 #  define SX126X_SET_RF_MODE  .set_rf_mode = SX126X_PARAM_SET_RF_MODE_CB,
-#  define SX126X_TX_PA_MODE   .tx_pa_mode = SX126X_PARAM_TX_PA_MODE
+#  define SX126X_TX_PA_MODE   .tx_pa_mode = SX126X_PARAM_TX_PA_MODE,
 #else
 #  define SX126X_SET_RF_MODE
 #  define SX126X_TX_PA_MODE
 #endif
 
+#if IS_USED(MODULE_SX126X_DIO2) || defined(DOXYGEN)
+/**
+ * @brief   DIO2 pin mode
+ */
+#  define SX126X_DIO2_MODE      .dio2_mode = SX126X_PARAM_DIO2_MODE,
+#else
+#  define SX126X_DIO2_MODE
+#endif
+
+#if IS_USED(MODULE_SX126X_DIO3) || defined(DOXYGEN)
+/**
+ * @brief   DIO3 pin mode
+ */
+#  define SX126X_DIO3_MODE      .dio3_mode = SX126X_PARAM_DIO3_MODE,
+/**
+ * @brief   DIO3 pin argument
+ */
+#  define SX126X_DIO3_ARG       .dio3_arg = SX126X_PARAM_DIO3_ARG,
+#else
+#  define SX126X_DIO3_MODE
+#  define SX126X_DIO3_ARG
+#endif
+
 #ifndef SX126X_PARAMS
-#  define SX126X_PARAMS           { .spi = SX126X_PARAM_SPI,            \
-                                    .nss_pin = SX126X_PARAM_SPI_NSS,    \
-                                    .reset_pin = SX126X_PARAM_RESET,    \
-                                    .busy_pin = SX126X_PARAM_BUSY,      \
-                                    .dio1_pin = SX126X_PARAM_DIO1,      \
-                                    .type     = SX126X_PARAM_TYPE,      \
-                                    .regulator = SX126X_PARAM_REGULATOR, \
-                                    SX126X_SET_RF_MODE \
-                                    SX126X_TX_PA_MODE}
+#  define SX126X_PARAMS           { .spi = SX126X_PARAM_SPI,                      \
+                                    .nss_pin = SX126X_PARAM_SPI_NSS,              \
+                                    .reset_pin = SX126X_PARAM_RESET,              \
+                                    .busy_pin = SX126X_PARAM_BUSY,                \
+                                    .dio1_pin = SX126X_PARAM_DIO1,                \
+                                    .type     = SX126X_PARAM_TYPE,                \
+                                    .regulator = SX126X_PARAM_REGULATOR,          \
+                                    SX126X_SET_RF_MODE                            \
+                                    SX126X_TX_PA_MODE                             \
+                                    SX126X_DIO2_MODE                              \
+                                    SX126X_DIO3_MODE                              \
+                                    SX126X_DIO3_ARG                               \
+                                   }
 #endif
 
 /**@}*/


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

The dio2 and dio3 pins of `sx126x` are optional. They can be used as IRQ pins. dio2 can be used as RF switch pin and dio3 can be used to feed 32MHz to a Temperature-Compensated Crystal Oscillator (TCXO). Those are special hardware configurations.
Read:
[dio2](https://www.mouser.com/datasheet/2/761/DS_SX1261-2_V1.1-1307803.pdf#%5B%7B%22num%22%3A240%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C54%2C463%2Cnull%5D)
[dio3](https://www.mouser.com/datasheet/2/761/DS_SX1261-2_V1.1-1307803.pdf#%5B%7B%22num%22%3A240%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C95%2C217%2Cnull%5D)

By default if the modules `sx126x_dio2` and `sx126x_dio3` are used, the pins are assumed to be interrupt pins.

You can use the dio2 RF switch like this:

```C
#define SX126X_DIO2_MODE             SX126X_DIO2_RF_SWITCH
#define SX126X_PARAM_DIO2_ARG        { .rf_switch_pin = GPIO_UNDEF }
```

You can use a TCX0 on dio3 like this:


```C
#define SX126X_PARAM_DIO3_MODE             SX126X_DIO3_TCX0
#define SX126X_PARAM_DIO3_ARG              { .tcxo_volt = SX126X_COMMON_PARAM_TCXO_VOLTAGE, \
                                             .tcx0_timeout = SX126X_COMMON_PARAM_TCXO_TIMEOUT }
```

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

You need special hardware to test this, which is using a TCXO. We have that.

`USEMODULE += sx126x_dio2 sx126xdio3 make -C examples/networking/gnrc/gnrc_lorawan flash term`

If you have the hardware and the chip runs, then it worked.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Splitout of a splitout #21675 
