### PR TITLE
boards: decleare netif feature when netdev_default is supported

### DIFF
--- a/boards/arduino-mkr1000/Makefile.features
+++ b/boards/arduino-mkr1000/Makefile.features
@@ -1,1 +1,4 @@
 include $(RIOTBOARD)/common/arduino-mkr/Makefile.features
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += netif

--- a/boards/avsextrem/Makefile.features
+++ b/boards/avsextrem/Makefile.features
@@ -7,4 +7,5 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += netif

--- a/boards/bastwan/Makefile.features
+++ b/boards/bastwan/Makefile.features
@@ -13,5 +13,6 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
-FEATURES_PROVIDED += riotboot
 FEATURES_PROVIDED += highlevel_stdio
+FEATURES_PROVIDED += netif
+FEATURES_PROVIDED += riotboot

--- a/boards/feather-m0-lora/Makefile.features
+++ b/boards/feather-m0-lora/Makefile.features
@@ -1,1 +1,4 @@
 include $(RIOTBOARD)/feather-m0/Makefile.features
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += netif

--- a/boards/feather-m0-wifi/Makefile.features
+++ b/boards/feather-m0-wifi/Makefile.features
@@ -1,1 +1,4 @@
 include $(RIOTBOARD)/feather-m0/Makefile.features
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += netif

--- a/boards/i-nucleo-lrwan1/Makefile.features
+++ b/boards/i-nucleo-lrwan1/Makefile.features
@@ -9,3 +9,6 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi periph_spi_gpio_mode
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += netif

--- a/boards/im880b/Makefile.features
+++ b/boards/im880b/Makefile.features
@@ -9,3 +9,6 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += netif

--- a/boards/msba2/Makefile.features
+++ b/boards/msba2/Makefile.features
@@ -10,4 +10,5 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-# Various other features (if any)
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += netif

--- a/boards/msbiot/Makefile.features
+++ b/boards/msbiot/Makefile.features
@@ -10,3 +10,6 @@ FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += netif

--- a/boards/samr34-xpro/Makefile.features
+++ b/boards/samr34-xpro/Makefile.features
@@ -13,5 +13,6 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += netif
 FEATURES_PROVIDED += riotboot
 FEATURES_PROVIDED += tinyusb_device

--- a/tests/net/netstats_l2/Makefile.ci
+++ b/tests/net/netstats_l2/Makefile.ci
@@ -1,3 +1,3 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    stm32f030f4-demo \
+    i-nucleo-lrwan1 \
     #


### PR DESCRIPTION
This adds the `netif` feature to boards that do provide some network interface when `netdev_default` is used. As a result, they should now provide the `ifconfig` shell in the default app and have their netif up and running.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

1. Create a list of boards that do handle `netdev_default`, e.g. using:

``` sh
grep -rl 'netdev_default' boards | grep 'Makefile\.dep' | awk -F'/' '{print $2}'| uniq
```

2. Create a list of bards that do provide the `netif` feature, e.g. using:

```sh
cd examples/basic/default
for board in $(make info-boards-supported 2> /dev/null); do
    make BOARD=$board info-features-used 2> /dev/null | grep --silent netif && echo $board
done
```

3. Check that the list of boards handling `netdev_default` is included in the list of bards declaring `netif`

(Note: There can be boards that declare `netif` via something in `boards/common/`. But they will also handle `netdev_default` in `boards/common/foobar/Makefile.dep`.)

### Issues/PRs references

None