### PR TITLE
drivers/sx126x: fail on init if no device is connected

### DIFF
--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -184,6 +184,14 @@ int sx126x_init(sx126x_t *dev)
     /* Reset the device */
     sx126x_reset(dev);
 
+    /* read status to verify device presence */
+    sx126x_chip_status_t radio_status;
+    sx126x_get_status(dev, &radio_status);
+    if (!radio_status.chip_mode) {
+        DEBUG("[sx126x] error: no device found\n");
+        return -ENODEV;
+    }
+
     /* Configure the power regulator mode */
     sx126x_set_reg_mode(dev, dev->params->regulator);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Fail `init()` when no `sx126x` driver is connected.
Else this https://github.com/RIOT-OS/RIOT/blob/3eee3687d80fc5a365d8dece7be6df26d30b7fb3/sys/net/gnrc/netif/gnrc_netif.c#L1636 assert() triggers for the driver.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Run `DEVELHELP=1 VERBOSE_ASSERT=1 BOARD=adafruit-metro-m4-express USEMODULE+="shell_cmd_ps shield_sx1262" make -C examples/networking/gnrc/gnrc_lorawan flash term PORT=/dev/ttyACM0` with and without a connected device.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
