### PR TITLE
sys/suit: print firmware URL if download fails

### DIFF
--- a/sys/suit/handlers_command_seq.c
+++ b/sys/suit/handlers_command_seq.c
@@ -475,7 +475,7 @@ static int _dtv_fetch(suit_manifest_t *manifest, int key,
         suit_component_set_flag(comp, SUIT_COMPONENT_STATE_FETCH_FAILED);
         /* TODO: The leftover data from a failed fetch should be purged. It
          * could contain potential malicious data from an attacker */
-        LOG_INFO("image download failed with code %i\n", res);
+        LOG_INFO("image download (%s) failed with code %i\n", manifest->urlbuf, res);
         return res;
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The firmware URL is actually interesting if something goes wrong, increase the log level from DEBUG to INFO.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
