### PR TITLE
 pkg: replace header guards with #pragma once

### DIFF
--- a/pkg/cryptoauthlib/include/atca.h
+++ b/pkg/cryptoauthlib/include/atca.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_cryptoauthlib
  * @{
@@ -16,9 +18,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef ATCA_H
-#define ATCA_H
 
 #include "periph/i2c.h"
 #include "cryptoauthlib.h"
@@ -74,5 +73,4 @@ typedef struct {
 }
 #endif
 
-#endif /* ATCA_H */
 /** @} */

--- a/pkg/cryptoauthlib/include/atca_config.h
+++ b/pkg/cryptoauthlib/include/atca_config.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_cryptoauthlib
  * @{
@@ -17,9 +19,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef ATCA_CONFIG_H
-#define ATCA_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,5 +47,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* ATCA_CONFIG_H */
 /** @} */

--- a/pkg/cryptoauthlib/include/atca_params.h
+++ b/pkg/cryptoauthlib/include/atca_params.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_cryptoauthlib
  * @{
@@ -16,9 +18,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef ATCA_PARAMS_H
-#define ATCA_PARAMS_H
 
 #include "board.h"
 #include "periph/i2c.h"
@@ -124,5 +123,4 @@ extern ATCADevice atca_devs_ptr[ATCA_NUMOF];
 }
 #endif
 
-#endif /* ATCA_PARAMS_H */
 /** @} */

--- a/pkg/cryptoauthlib/include/atecc608a_config.h
+++ b/pkg/cryptoauthlib/include/atecc608a_config.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @file
  * @brief       Example configuration for Microchip CryptoAuth devices
@@ -25,9 +27,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef ATECC608A_CONFIG_H
-#define ATECC608A_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -112,5 +111,3 @@ const uint8_t atecc608a_config[] = {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* ATECC608A_CONFIG_H */

--- a/pkg/cryptoauthlib/include/cryptoauthlib_test.h
+++ b/pkg/cryptoauthlib/include/cryptoauthlib_test.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_cryptoauthlib
  * @{
@@ -15,9 +17,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef CRYPTOAUTHLIB_TEST_H
-#define CRYPTOAUTHLIB_TEST_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,5 +37,4 @@ int atca_run_cmd(char *command, size_t len);
 }
 #endif
 
-#endif /* CRYPTOAUTHLIB_TEST_H */
 /** @} */

--- a/pkg/driver_bme680/include/bme680_hal.h
+++ b/pkg/driver_bme680/include/bme680_hal.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_driver_bme680
  * @{
@@ -15,9 +17,6 @@
  *
  * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
  */
-
-#ifndef BME680_HAL_H
-#define BME680_HAL_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,5 +44,4 @@ int8_t bme680_spi_write_hal(uint8_t dev_id, uint8_t reg_addr,
 }
 #endif
 
-#endif /* BME680_HAL_H */
 /** @} */

--- a/pkg/driver_cryptocell_310/include/cryptocell_310_util.h
+++ b/pkg/driver_cryptocell_310/include/cryptocell_310_util.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_driver_cryptocell_310
  * @{
@@ -16,8 +18,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-#ifndef CRYPTOCELL_310_UTIL_H
-#define CRYPTOCELL_310_UTIL_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,5 +68,4 @@ void driver_cryptocell_310_terminate(void);
 }
 #endif
 
-#endif /* CRYPTOCELL_310_UTIL_H */
 /** @} */

--- a/pkg/driver_cryptocell_310/include/psa_cryptocell_310_aes_common.h
+++ b/pkg/driver_cryptocell_310/include/psa_cryptocell_310_aes_common.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_driver_cryptocell_310
  * @{
@@ -17,9 +19,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTOCELL_310_AES_COMMON_H
-#define PSA_CRYPTOCELL_310_AES_COMMON_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -69,5 +68,4 @@ psa_status_t cryptocell_310_common_aes_encrypt_decrypt(SaSiAesUserContext_t *ctx
 }
 #endif
 
-#endif /* PSA_CRYPTOCELL_310_AES_COMMON_H */
 /** @} */

--- a/pkg/driver_cryptocell_310/include/psa_cryptocell_310_ecc_common.h
+++ b/pkg/driver_cryptocell_310/include/psa_cryptocell_310_ecc_common.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_driver_cryptocell_310
  * @{
@@ -17,9 +19,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_CRYPTOCELL_310_ECC_COMMON_H
-#define PSA_CRYPTOCELL_310_ECC_COMMON_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -140,5 +139,4 @@ psa_status_t cryptocell_310_common_ecc_verify(const uint8_t *pub_key,
 }
 #endif
 
-#endif /* PSA_CRYPTOCELL_310_ECC_COMMON_H */
 /** @} */

--- a/pkg/driver_cryptocell_310/include/psa_cryptocell_310_hashes_common.h
+++ b/pkg/driver_cryptocell_310/include/psa_cryptocell_310_hashes_common.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_driver_cryptocell_310
  * @{
@@ -17,8 +19,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-#ifndef PSA_CRYPTOCELL_310_HASHES_COMMON_H
-#define PSA_CRYPTOCELL_310_HASHES_COMMON_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -67,5 +67,4 @@ psa_status_t cryptocell_310_common_hash_finish(CRYS_HASHUserContext_t *ctx,
 }
 #endif
 
-#endif /* PSA_CRYPTOCELL_310_HASHES_COMMON_H */
 /** @} */

--- a/pkg/driver_cryptocell_310/include/psa_error.h
+++ b/pkg/driver_cryptocell_310/include/psa_error.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_driver_cryptocell_310
  * @{
@@ -16,8 +18,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-#ifndef PSA_ERROR_H
-#define PSA_ERROR_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -58,5 +58,4 @@ const char *cryptocell310_status_to_humanly_readable(uint32_t status);
 }
 #endif
 
-#endif /* PSA_ERROR_H */
 /** @} */

--- a/pkg/driver_cryptocell_310/include/psa_periph_aes_ctx.h
+++ b/pkg/driver_cryptocell_310/include/psa_periph_aes_ctx.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_driver_cryptocell_310
  * @{
@@ -16,8 +18,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-#ifndef PSA_PERIPH_AES_CTX_H
-#define PSA_PERIPH_AES_CTX_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,5 +37,4 @@ typedef SaSiAesUserContext_t psa_cipher_aes_128_ctx_t;
 }
 #endif
 
-#endif /* PSA_PERIPH_AES_CTX_H */
 /** @} */

--- a/pkg/driver_cryptocell_310/include/psa_periph_hashes_ctx.h
+++ b/pkg/driver_cryptocell_310/include/psa_periph_hashes_ctx.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_driver_cryptocell_310
  * @{
@@ -16,9 +18,6 @@
  * @author      Lena Boeckmann <lena.boeckmann@haw-hamburg.de>
  *
  */
-
-#ifndef PSA_PERIPH_HASHES_CTX_H
-#define PSA_PERIPH_HASHES_CTX_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,5 +59,4 @@ typedef CRYS_HASHUserContext_t psa_hashes_sha512_ctx_t;
 }
 #endif
 
-#endif /* PSA_PERIPH_HASHES_CTX_H */
 /** @} */

--- a/pkg/edhoc-c/include/edhoc_config.h
+++ b/pkg/edhoc-c/include/edhoc_config.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_edhoc_c
  * @{
@@ -17,9 +19,6 @@
  *
  * @}
  */
-
-#ifndef EDHOC_CONFIG_H
-#define EDHOC_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -117,5 +116,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* EDHOC_CONFIG_H */

--- a/pkg/esp8266_sdk/bootloader/sdkconfig.h
+++ b/pkg/esp8266_sdk/bootloader/sdkconfig.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_esp8266_sdk
  * @{
@@ -23,9 +25,6 @@
  *
  * @author      iosabi <iosabi@protonmail.com>
  */
-
-#ifndef SDKCONFIG_H
-#define SDKCONFIG_H
 
 #if !DOXYGEN
 
@@ -81,5 +80,4 @@ extern "C" {
 #endif
 
 #endif /* !DOXYGEN */
-#endif /* SDKCONFIG_H */
 /** @} */

--- a/pkg/etl/config/etl_profile.h
+++ b/pkg/etl/config/etl_profile.h
@@ -6,6 +6,8 @@
 * directory for more details.
 */
 
+#pragma once
+
 /**
 * @ingroup     pkg_etl
 * @brief
@@ -18,8 +20,6 @@
 *              This is configured by compiler defines the in Makefile.include
 * @author      Jens Wetterich <jens@wetterich-net.de>
 */
-#ifndef ETL_PROFILE_H
-#define ETL_PROFILE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,5 +50,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* ETL_PROFILE_H */
 /** @} */

--- a/pkg/fatfs/fatfs_diskio/mtd/include/fatfs_diskio_mtd.h
+++ b/pkg/fatfs/fatfs_diskio/mtd/include/fatfs_diskio_mtd.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_fatfs
  * @brief
@@ -14,9 +16,6 @@
  * @brief       Common defines for fatfs low-level diskio defines
  * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
  */
-
-#ifndef FATFS_DISKIO_MTD_H
-#define FATFS_DISKIO_MTD_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,5 +41,4 @@ extern "C" {
 }
 #endif
 
-#endif /* FATFS_DISKIO_MTD_H */
 /** @} */

--- a/pkg/flashdb/include/fal_cfg.h
+++ b/pkg/flashdb/include/fal_cfg.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_flashdb
  * @{
@@ -21,9 +23,6 @@
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  */
-
-#ifndef FAL_CFG_H
-#define FAL_CFG_H
 
 #include "board.h"
 #include "macros/units.h"
@@ -195,5 +194,4 @@ extern struct fal_flash_dev mtd_flash0;
 #ifdef __cplusplus
 }
 #endif
-#endif /* FAL_CFG_H */
 /** @} */

--- a/pkg/flashdb/include/fdb_cfg.h
+++ b/pkg/flashdb/include/fdb_cfg.h
@@ -4,13 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#pragma once
+
 /**
  * @file
  * @brief configuration file
  */
-
-#ifndef FDB_CFG_H
-#define FDB_CFG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,4 +25,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* FDB_CFG_H */

--- a/pkg/libb2/include/libb2_config.h
+++ b/pkg/libb2/include/libb2_config.h
@@ -1,5 +1,4 @@
-#ifndef LIBB2_CONFIG_H
-#define LIBB2_CONFIG_H
+#pragma once
 
 #include "cpu.h"
 
@@ -18,4 +17,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* LIBB2_CONFIG_H */

--- a/pkg/libcose/include/cose/crypto/riot.h
+++ b/pkg/libcose/include/cose/crypto/riot.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_libcose
  *
@@ -16,9 +18,6 @@
  *
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  */
-
-#ifndef COSE_CRYPTO_RIOT_H
-#define COSE_CRYPTO_RIOT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,7 +49,5 @@ void libcose_crypt_init(void);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* COSE_CRYPTO_RIOT_H */
 
 /** @} */

--- a/pkg/libschc/include/libschc/config.h
+++ b/pkg/libschc/include/libschc/config.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_libschc_config libSCHC compile-time configuration
  * @ingroup     pkg_libschc
@@ -18,8 +20,6 @@
  *
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef LIBSCHC_CONFIG_H
-#define LIBSCHC_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,5 +68,4 @@ extern "C" {
 }
 #endif
 
-#endif /* LIBSCHC_CONFIG_H */
 /** @} */

--- a/pkg/libschc/include/rules/rule_config.h
+++ b/pkg/libschc/include/rules/rule_config.h
@@ -16,13 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 /**
  * @internal
  * @author  boortmans <bart.moons@gmail.com>
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef RULES_RULE_CONFIG_H
-#define RULES_RULE_CONFIG_H
 
 #include "rules.h"
 
@@ -33,5 +33,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* RULES_RULE_CONFIG_H */

--- a/pkg/libschc/include/rules/rules.h
+++ b/pkg/libschc/include/rules/rules.h
@@ -16,13 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 /**
  * @internal
  * @author  boortmans <bart.moons@gmail.com>
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef RULES_RULES_H
-#define RULES_RULES_H
 
 #include "kernel_defines.h"
 
@@ -340,5 +340,3 @@ static const struct schc_device* devices[] = { &node1, &node2 };
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* RULES_RULES_H */

--- a/pkg/libschc/include/schc_config.h
+++ b/pkg/libschc/include/schc_config.h
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 /**
  * @addtogroup  pkg_libschc_config
  *
@@ -31,8 +33,6 @@
  * @author  boortmans <bart.moons@gmail.com>
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  */
-#ifndef SCHC_CONFIG_H
-#define SCHC_CONFIG_H
 
 #include <stdio.h>
 #include <unistd.h>
@@ -121,7 +121,6 @@ extern "C" {
 }
 #endif
 
-#endif /* SCHC_CONFIG_H */
 /**
  * @internal
  * @}

--- a/pkg/littlefs/lfs_log.h
+++ b/pkg/littlefs/lfs_log.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     sys_littlefs
  * @{
@@ -20,9 +22,6 @@
  * @author      Joshua DeWeese <josh.deweese@gmail.com>
  *
  */
-
-#ifndef LFS_LOG_H
-#define LFS_LOG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -70,5 +69,4 @@ extern "C" {
 
 /** @} */
 
-#endif /* LFS_LOG_H */
 /** @} */

--- a/pkg/littlefs2/lfs_log.h
+++ b/pkg/littlefs2/lfs_log.h
@@ -6,6 +6,8 @@
  * details.
  */
 
+#pragma once
+
 /**
  * @ingroup     sys_littlefs2
  * @{
@@ -20,9 +22,6 @@
  * @author      Joshua DeWeese <josh.deweese@gmail.com>
  *
  */
-
-#ifndef LFS_LOG_H
-#define LFS_LOG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -91,5 +90,4 @@ extern "C" {
 
 /** @} */
 
-#endif /* LFS_LOG_H */
 /** @} */

--- a/pkg/lua/contrib/binsearch.h
+++ b/pkg/lua/contrib/binsearch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @internal
  * @file
@@ -40,9 +42,6 @@
  * Where stride=12 bytes and offset = 4 bytes.
  * @{
  */
-
-#ifndef BINSEARCH_H
-#define BINSEARCH_H
 
 #include <stdint.h>
 #include <errno.h>
@@ -133,6 +132,5 @@ const void *binsearch_str_p(const void *start, size_t offset, size_t stride,
 }
 #endif
 
-#endif /* BINSEARCH_H */
 /** @internal
  * @} */

--- a/pkg/lua/include/lua_builtin.h
+++ b/pkg/lua/include/lua_builtin.h
@@ -5,6 +5,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+
+#pragma once
+
 /**
  * @ingroup  pkg_lua
  * @{
@@ -21,9 +24,6 @@
  * These symbols are defined as weak, so there if they are not defined elsewhere
  * they will default to zero (or NULL), that is, empty tables.
  */
-
-#ifndef LUA_BUILTIN_H
-#define LUA_BUILTIN_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -78,7 +78,5 @@ extern WEAK const size_t lua_riot_builtin_c_table_len;
 #ifdef __cplusplus
 extern "C" }
 #endif
-
-#endif /* LUA_BUILTIN_H */
 
 /** @} */

--- a/pkg/lua/include/lua_loadlib.h
+++ b/pkg/lua/include/lua_loadlib.h
@@ -5,6 +5,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+
+#pragma once
+
 /**
  * @ingroup  pkg_lua
  * @{
@@ -14,9 +17,6 @@
  * @author  Juan Carrano <j.carrano@fu-berlin.de>
  *
  */
-
-#ifndef LUA_LOADLIB_H
-#define LUA_LOADLIB_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -52,7 +52,5 @@ int lua_riot_getloader(lua_State *L, const char *name);
 extern "C"
 }
 #endif
-
-#endif /* LUA_LOADLIB_H */
 
 /** @} */

--- a/pkg/lua/include/lua_run.h
+++ b/pkg/lua/include/lua_run.h
@@ -5,6 +5,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+
+#pragma once
+
 /**
  * @ingroup  pkg_lua
  * @file
@@ -26,9 +29,6 @@
  * cases, and thus avoids code repetition in applications.
  *
  */
-
-#ifndef LUA_RUN_H
-#define LUA_RUN_H
 
 #include <stdint.h>
 
@@ -219,5 +219,3 @@ extern "C" }
 #endif
 
 /** @} */
-
-#endif /* LUA_RUN_H */

--- a/pkg/lv_drivers/include/lv_drv_conf.h
+++ b/pkg/lv_drivers/include/lv_drv_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_lv_drivers
  * @brief       LVGL Drivers SDL2 configuration headers
@@ -15,9 +17,6 @@
  *
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  */
-
-#ifndef LV_DRV_CONF_H
-#define LV_DRV_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -80,5 +79,4 @@ extern "C" {
 }
 #endif
 
-#endif /* LV_DRV_CONF_H */
 /** @} */

--- a/pkg/lvgl/include/lv_conf.h
+++ b/pkg/lvgl/include/lv_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_lvgl
  * @brief       LVGL configuration macros
@@ -13,9 +15,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef LV_CONF_H
-#define LV_CONF_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -552,5 +551,4 @@ e.g. "stm32f769xx.h" or "stm32f429xx.h"*/
 }
 #endif
 
-#endif /* LV_CONF_H */
 /** @} */

--- a/pkg/lvgl/include/lvgl_riot.h
+++ b/pkg/lvgl/include/lvgl_riot.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_lvgl
  * @{
@@ -15,9 +17,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef LVGL_RIOT_H
-#define LVGL_RIOT_H
 
 #include "screen_dev.h"
 
@@ -56,5 +55,4 @@ void lvgl_wakeup(void);
 }
 #endif
 
-#endif /* LVGL_RIOT_H */
 /** @} */

--- a/pkg/lvgl/include/lvgl_riot_conf.h
+++ b/pkg/lvgl/include/lvgl_riot_conf.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_lvgl
  * @{
@@ -15,9 +17,6 @@
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef LVGL_RIOT_CONF_H
-#define LVGL_RIOT_CONF_H
 
 #include "kernel_defines.h"
 #include "board.h"
@@ -62,5 +61,4 @@ typedef int16_t lv_coord_t;
 }
 #endif
 
-#endif /* LVGL_RIOT_CONF_H */
 /** @} */

--- a/pkg/lwip/include/arch/cc.h
+++ b/pkg/lwip/include/arch/cc.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup  pkg_lwip_sys
  * @brief       Describes compiler and processor to lwIP
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef ARCH_CC_H
-#define ARCH_CC_H
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -107,5 +107,4 @@ extern "C" {
 }
 #endif
 
-#endif /* ARCH_CC_H */
 /** @} */

--- a/pkg/lwip/include/arch/sys_arch.h
+++ b/pkg/lwip/include/arch/sys_arch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_lwip_sys    Porting layer
  * @ingroup     pkg_lwip
@@ -18,8 +20,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef ARCH_SYS_ARCH_H
-#define ARCH_SYS_ARCH_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -140,5 +140,4 @@ void sys_unlock_tcpip_core(void);
 }
 #endif
 
-#endif /* ARCH_SYS_ARCH_H */
 /** @} */

--- a/pkg/lwip/include/lwip.h
+++ b/pkg/lwip/include/lwip.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_lwip
  *
@@ -16,8 +18,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef LWIP_H
-#define LWIP_H
 
 #include "event.h"
 
@@ -42,5 +42,4 @@ void lwip_bootstrap(void);
 }
 #endif
 
-#endif /* LWIP_H */
 /** @} */

--- a/pkg/lwip/include/lwip/netif/compat.h
+++ b/pkg/lwip/include/lwip/netif/compat.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_lwip
  *
@@ -17,8 +19,6 @@
  *
  * @author  Erik Ekman <eekman@google.com>
  */
-#ifndef LWIP_NETIF_COMPAT_H
-#define LWIP_NETIF_COMPAT_H
 
 #include "bhp/event.h"
 #include "event.h"
@@ -82,5 +82,4 @@ static inline void lwip_netif_dev_release(struct netif *netif)
 }
 #endif
 
-#endif /* LWIP_NETIF_COMPAT_H */
 /** @} */

--- a/pkg/lwip/include/lwip/netif/netdev.h
+++ b/pkg/lwip/include/lwip/netif/netdev.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_lwip_netdev    lwIP netdev adapter
  * @ingroup     pkg_lwip
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef LWIP_NETIF_NETDEV_H
-#define LWIP_NETIF_NETDEV_H
 
 #include "net/ethernet.h"
 #include "net/netdev.h"
@@ -59,5 +59,4 @@ err_t lwip_netdev_init(struct netif *netif);
 }
 #endif
 
-#endif /* LWIP_NETIF_NETDEV_H */
 /** @} */

--- a/pkg/lwip/include/lwip/sock_internal.h
+++ b/pkg/lwip/include/lwip/sock_internal.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_lwip_sock   lwIP-specific implementation of sock API
  * @ingroup     pkg_lwip
@@ -19,8 +21,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef LWIP_SOCK_INTERNAL_H
-#define LWIP_SOCK_INTERNAL_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -77,6 +77,5 @@ static inline ssize_t lwip_sock_send(struct netconn *conn,
 }
 #endif
 
-#endif /* LWIP_SOCK_INTERNAL_H */
 /** @internal
  * @} */

--- a/pkg/lwip/include/lwip_init_devs.h
+++ b/pkg/lwip/include/lwip_init_devs.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup sys_auto_init_lwip_netif
  *
@@ -16,9 +18,6 @@
  *
  * @author  Erik Ekman <eekman@google.com>
  */
-
-#ifndef LWIP_INIT_DEVS_H
-#define LWIP_INIT_DEVS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -73,5 +72,4 @@ typedef void (*lwip_netif_setup_func_t)(void);
 }
 #endif
 
-#endif /* LWIP_INIT_DEVS_H */
 /** @} */

--- a/pkg/lwip/include/lwipopts.h
+++ b/pkg/lwip/include/lwipopts.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_lwip_opts   lwIP options
  * @ingroup     pkg_lwip
@@ -17,8 +19,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef LWIPOPTS_H
-#define LWIPOPTS_H
 
 #include "thread.h"
 #include "net/gnrc/netif/hdr.h"
@@ -186,5 +186,4 @@ bool sys_check_core_locked(void);
 }
 #endif
 
-#endif /* LWIPOPTS_H */
 /** @} */

--- a/pkg/lwip/include/sock_types.h
+++ b/pkg/lwip/include/sock_types.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @addtogroup pkg_lwip_sock
  * @{
@@ -15,8 +17,6 @@
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
-#ifndef SOCK_TYPES_H
-#define SOCK_TYPES_H
 
 #include "net/af.h"
 #include "lwip/api.h"
@@ -133,5 +133,4 @@ struct sock_udp {
 }
 #endif
 
-#endif /* SOCK_TYPES_H */
 /** @} */

--- a/pkg/mbedtls/include/entropy_mbedtls_riot.h
+++ b/pkg/mbedtls/include/entropy_mbedtls_riot.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_mbedtls_entropy Access API to Mbed TLS entropy module
  * @ingroup     pkg_mbedtls
@@ -18,9 +20,6 @@
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  *
  */
-
-#ifndef ENTROPY_MBEDTLS_RIOT_H
-#define ENTROPY_MBEDTLS_RIOT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -77,5 +76,3 @@ int entropy_mbedtls_riot_get(unsigned char *output, size_t len);
 }
 #endif
 /** @} */
-
-#endif /* ENTROPY_MBEDTLS_RIOT_H */

--- a/pkg/mbedtls/include/entropy_sources_mbedtls_riot.h
+++ b/pkg/mbedtls/include/entropy_sources_mbedtls_riot.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_mbedtls_entropy_sources Entropy source API to Mbed TLS
  * @ingroup     pkg_mbedtls
@@ -17,9 +19,6 @@
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  *
  */
-
-#ifndef ENTROPY_SOURCES_MBEDTLS_RIOT_H
-#define ENTROPY_SOURCES_MBEDTLS_RIOT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -89,5 +88,3 @@ int riot_adc_poll(void *data, unsigned char *output, size_t len,
 }
 #endif
 /** @} */
-
-#endif /* ENTROPY_SOURCES_MBEDTLS_RIOT_H */

--- a/pkg/mbedtls/include/riot_mbedtls_config.h
+++ b/pkg/mbedtls/include/riot_mbedtls_config.h
@@ -28,8 +28,7 @@
  *  limitations under the License.
  */
 
-#ifndef RIOT_MBEDTLS_CONFIG_H
-#define RIOT_MBEDTLS_CONFIG_H
+#pragma once
 
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_DEPRECATE)
 #define _CRT_SECURE_NO_DEPRECATE 1
@@ -235,5 +234,4 @@ extern "C" {
 }
 #endif
 
-#endif /* RIOT_MBEDTLS_CONFIG_H */
 /** @} */

--- a/pkg/mbedtls/include/sha256_alt.h
+++ b/pkg/mbedtls/include/sha256_alt.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_mbedtls
  *
@@ -15,9 +17,6 @@
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  *
  */
-
-#ifndef SHA256_ALT_H
-#define SHA256_ALT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -44,4 +43,3 @@ typedef struct {
 }
 #endif
 /** @} */
-#endif /* SHA256_ALT_H */

--- a/pkg/mbedtls/include/threading_alt.h
+++ b/pkg/mbedtls/include/threading_alt.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_mbedtls
  *
@@ -15,9 +17,6 @@
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  *
  */
-
-#ifndef THREADING_ALT_H
-#define THREADING_ALT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,4 +40,3 @@ typedef struct {
 }
 #endif
 /** @} */
-#endif /* THREADING_ALT_H */

--- a/pkg/micropython/include/micropython.h
+++ b/pkg/micropython/include/micropython.h
@@ -8,6 +8,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_micropython
  *
@@ -18,9 +20,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef MICROPYTHON_H
-#define MICROPYTHON_H
 
 #include <stdint.h>
 
@@ -55,5 +54,4 @@ void mp_riot_init(char* heap, size_t heap_size);
  */
 void mp_do_str(const char *src, int len);
 
-#endif /* MICROPYTHON_H */
 /** @} */

--- a/pkg/mynewt-core/include/hal/hal_gpio.h
+++ b/pkg/mynewt-core/include/hal/hal_gpio.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_dw1000
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef HAL_HAL_GPIO_H
-#define HAL_HAL_GPIO_H
 
 #include "periph/gpio.h"
 
@@ -193,5 +192,3 @@ static inline void hal_gpio_irq_disable(gpio_t pin)
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* HAL_HAL_GPIO_H */

--- a/pkg/mynewt-core/include/hal/hal_spi.h
+++ b/pkg/mynewt-core/include/hal/hal_spi.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_dw1000
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef HAL_HAL_SPI_H
-#define HAL_HAL_SPI_H
 
 #include "periph/spi.h"
 
@@ -165,5 +164,3 @@ int hal_spi_txrx_noblock(int spi_num, void *txbuf, void *rxbuf, int cnt);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* HAL_HAL_SPI_H */

--- a/pkg/mynewt-core/include/log/log.h
+++ b/pkg/mynewt-core/include/log/log.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_mynewt_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef LOG_LOG_H
-#define LOG_LOG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -44,5 +43,3 @@ struct log {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* LOG_LOG_H */

--- a/pkg/mynewt-core/include/mcu/mcu.h
+++ b/pkg/mynewt-core/include/mcu/mcu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_mynewt_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef MCU_MCU_H
-#define MCU_MCU_H
 
 #include "cpu.h"
 
@@ -57,5 +56,3 @@ void nrf5x_hw_set_isr(int irqn, void (*addr)(void));
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* MCU_MCU_H */

--- a/pkg/mynewt-core/include/os/mynewt.h
+++ b/pkg/mynewt-core/include/os/mynewt.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_mynewt_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef OS_MYNEWT_H
-#define OS_MYNEWT_H
 
 #include <stdlib.h>
 #include "syscfg/syscfg.h"
@@ -32,5 +31,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* OS_MYNEWT_H */

--- a/pkg/mynewt-core/include/os/os.h
+++ b/pkg/mynewt-core/include/os/os.h
@@ -26,6 +26,8 @@
  * under the License.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_mynewt_core
  * @{
@@ -35,9 +37,6 @@
  *
  * @}
  */
-
-#ifndef OS_OS_H
-#define OS_OS_H
 
 #include <assert.h>
 #include <stdint.h>
@@ -142,5 +141,3 @@ static inline bool os_hw_is_in_critical(void)
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* OS_OS_H */

--- a/pkg/mynewt-core/include/os/os_dev.h
+++ b/pkg/mynewt-core/include/os/os_dev.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_mynewt_core
  * @{
@@ -16,8 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-#ifndef OS_OS_DEV_H
-#define OS_OS_DEV_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,5 +40,3 @@ struct os_dev {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* OS_OS_DEV_H */

--- a/pkg/mynewt-core/include/os/os_eventq.h
+++ b/pkg/mynewt-core/include/os/os_eventq.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_mynewt_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef OS_OS_EVENTQ_H
-#define OS_OS_EVENTQ_H
 
 #include <os/os_types.h>
 
@@ -232,5 +231,3 @@ static inline bool os_eventq_is_empty(struct os_eventq *evq)
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* OS_OS_EVENTQ_H */

--- a/pkg/mynewt-core/include/os/os_time.h
+++ b/pkg/mynewt-core/include/os/os_time.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_mynewt_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef OS_OS_TIME_H
-#define OS_OS_TIME_H
 
 #include "os/os_error.h"
 #include "ztimer.h"
@@ -112,5 +111,3 @@ static inline void os_time_delay(os_time_t ticks)
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* OS_OS_TIME_H */

--- a/pkg/mynewt-core/include/os/os_types.h
+++ b/pkg/mynewt-core/include/os/os_types.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_mynewt_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef OS_OS_TYPES_H
-#define OS_OS_TYPES_H
 
 #include <stdint.h>
 
@@ -55,5 +54,3 @@ typedef char os_stack_t;
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* OS_OS_TYPES_H */

--- a/pkg/mynewt-core/include/syscfg/syscfg.h
+++ b/pkg/mynewt-core/include/syscfg/syscfg.h
@@ -26,6 +26,8 @@
  * under the License.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_mynewt_core
  * @{
@@ -35,9 +37,6 @@
  *
  * @}
  */
-
-#ifndef SYSCFG_SYSCFG_H
-#define SYSCFG_SYSCFG_H
 
 #include "kernel_defines.h"
 
@@ -127,5 +126,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* SYSCFG_SYSCFG_H */

--- a/pkg/mynewt-core/include/sysinit/sysinit.h
+++ b/pkg/mynewt-core/include/sysinit/sysinit.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_mynewt_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef SYSINIT_SYSINIT_H
-#define SYSINIT_SYSINIT_H
 
 #include "assert.h"
 
@@ -39,5 +38,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* SYSINIT_SYSINIT_H */

--- a/pkg/nanocbor/include/nanocbor/config.h
+++ b/pkg/nanocbor/include/nanocbor/config.h
@@ -6,15 +6,14 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    nanocbor_config NanoCBOR configuration header
  * @ingroup     pkg_nanocbor
  * @ingroup     config
  * @brief       Provides compile-time configuration for nanocbor
  */
-
-#ifndef NANOCBOR_CONFIG_H
-#define NANOCBOR_CONFIG_H
 
 #include <stdint.h>
 
@@ -79,5 +78,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* NANOCBOR_CONFIG_H */

--- a/pkg/nimble/addr/include/nimble_addr.h
+++ b/pkg/nimble/addr/include/nimble_addr.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_nimble_addr Address Helper
  * @ingroup     pkg_nimble
@@ -17,9 +19,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NIMBLE_ADDR_H
-#define NIMBLE_ADDR_H
 
 #include "nimble/ble.h"
 
@@ -54,5 +53,4 @@ void nimble_addr_sprint(char *buf, const ble_addr_t *addr);
 }
 #endif
 
-#endif /* NIMBLE_ADDR_H */
 /** @} */

--- a/pkg/nimble/autoadv/include/nimble_autoadv.h
+++ b/pkg/nimble/autoadv/include/nimble_autoadv.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_nimble_autoadv Automated advertising
  * @ingroup     pkg_nimble
@@ -24,9 +26,6 @@
  *
  * @author      Hendrik van Essen <hendrik.ve@fu-berlin.de>
  */
-
-#ifndef NIMBLE_AUTOADV_H
-#define NIMBLE_AUTOADV_H
 
 #include "host/ble_gap.h"
 
@@ -191,4 +190,3 @@ int nimble_autoadv_get_adv_instance(void);
 }
 #endif
 /** @} */
-#endif /* NIMBLE_AUTOADV_H */

--- a/pkg/nimble/autoadv/include/nimble_autoadv_params.h
+++ b/pkg/nimble/autoadv/include/nimble_autoadv_params.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_nimble_autoadv
  *
@@ -15,9 +17,6 @@
  *
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  */
-
-#ifndef NIMBLE_AUTOADV_PARAMS_H
-#define NIMBLE_AUTOADV_PARAMS_H
 
 #include "nimble_autoadv.h"
 #include "nimble_riot.h"
@@ -80,5 +79,4 @@ static const nimble_autoadv_cfg_t nimble_autoadv_cfg =
 }
 #endif
 
-#endif /* NIMBLE_AUTOADV_PARAMS_H */
 /** @} */

--- a/pkg/nimble/autoconn/include/nimble_autoconn.h
+++ b/pkg/nimble/autoconn/include/nimble_autoconn.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_nimble_autoconn Autoconn
  * @ingroup     pkg_nimble
@@ -105,9 +107,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NIMBLE_AUTOCONN_H
-#define NIMBLE_AUTOCONN_H
 
 #include <stdint.h>
 
@@ -217,5 +216,4 @@ void nimble_autoconn_disable(void);
 }
 #endif
 
-#endif /* NIMBLE_AUTOCONN_H */
 /** @} */

--- a/pkg/nimble/autoconn/include/nimble_autoconn_params.h
+++ b/pkg/nimble/autoconn/include/nimble_autoconn_params.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_nimble_autoconn
  *
@@ -15,9 +17,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NIMBLE_AUTOCONN_PARAMS_H
-#define NIMBLE_AUTOCONN_PARAMS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -103,5 +102,4 @@ static const nimble_autoconn_params_t nimble_autoconn_params =
 }
 #endif
 
-#endif /* NIMBLE_AUTOCONN_PARAMS_H */
 /** @} */

--- a/pkg/nimble/contrib/include/nimble_riot.h
+++ b/pkg/nimble/contrib/include/nimble_riot.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_nimble_contrib RIOT Integration
  * @ingroup     pkg_nimble
@@ -18,9 +20,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NIMBLE_RIOT_H
-#define NIMBLE_RIOT_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -120,5 +119,4 @@ int nimble_riot_get_phy_hci(uint8_t mode);
 }
 #endif
 
-#endif /* NIMBLE_RIOT_H */
 /** @} */

--- a/pkg/nimble/netif/include/nimble_netif.h
+++ b/pkg/nimble/netif/include/nimble_netif.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_nimble_netif GNRC netif Implementation
  * @ingroup     pkg_nimble
@@ -62,9 +64,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NIMBLE_NETIF_H
-#define NIMBLE_NETIF_H
 
 #include <stdint.h>
 #include <errno.h>
@@ -336,5 +335,4 @@ int nimble_netif_used_chanmap(int handle, uint8_t map[5]);
 }
 #endif
 
-#endif /* NIMBLE_NETIF_H */
 /** @} */

--- a/pkg/nimble/netif/include/nimble_netif_conn.h
+++ b/pkg/nimble/netif/include/nimble_netif_conn.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_nimble_netif_conn Connection State Management for netif
  * @ingroup     pkg_nimble_netif
@@ -18,9 +20,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NIMBLE_NETIF_CONN_H
-#define NIMBLE_NETIF_CONN_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -287,5 +286,4 @@ static inline int nimble_netif_conn_is_adv(void)
 }
 #endif
 
-#endif /* NIMBLE_NETIF_CONN_H */
 /** @} */

--- a/pkg/nimble/npl/include/nimble/nimble_npl_os.h
+++ b/pkg/nimble/npl/include/nimble/nimble_npl_os.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_nimble
  * @{
@@ -16,9 +18,6 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @}
  */
-
-#ifndef NIMBLE_NIMBLE_NPL_OS_H
-#define NIMBLE_NIMBLE_NPL_OS_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -587,5 +586,3 @@ nrf52_clock_hfxo_release(void)
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* NIMBLE_NIMBLE_NPL_OS_H */

--- a/pkg/nimble/rpble/include/nimble_rpble.h
+++ b/pkg/nimble/rpble/include/nimble_rpble.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_nimble_rpble RPL-over-BLE for NimBLE
  * @ingroup     pkg_nimble
@@ -81,9 +83,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NIMBLE_RPBLE_H
-#define NIMBLE_RPBLE_H
 
 #include "nimble_netif.h"
 
@@ -178,5 +177,4 @@ int nimble_rpble_update(const nimble_rpble_ctx_t *ctx);
 }
 #endif
 
-#endif /* NIMBLE_RPBLE_H */
 /** @} */

--- a/pkg/nimble/rpble/include/nimble_rpble_params.h
+++ b/pkg/nimble/rpble/include/nimble_rpble_params.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_nimble_rpble
  *
@@ -15,9 +17,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NIMBLE_RPBLE_PARAMS_H
-#define NIMBLE_RPBLE_PARAMS_H
 
 #include "nimble_rpble.h"
 
@@ -103,5 +102,4 @@ static const nimble_rpble_cfg_t nimble_rpble_params = NIMBLE_RPBLE_PARAMS;
 }
 #endif
 
-#endif /* NIMBLE_RPBLE_PARAMS_H */
 /** @} */

--- a/pkg/nimble/scanlist/include/nimble_scanlist.h
+++ b/pkg/nimble/scanlist/include/nimble_scanlist.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_nimble_scanlist Scan Result Helper
  * @ingroup     pkg_nimble
@@ -21,9 +23,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NIMBLE_SCANLIST_H
-#define NIMBLE_SCANLIST_H
 
 #include "clist.h"
 #include "net/ble.h"
@@ -120,5 +119,4 @@ void nimble_scanlist_print_entry(nimble_scanlist_entry_t *e);
 }
 #endif
 
-#endif /* NIMBLE_SCANLIST_H */
 /** @} */

--- a/pkg/nimble/scanner/include/nimble_scanner.h
+++ b/pkg/nimble/scanner/include/nimble_scanner.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_nimble_scanner Scanner Helper
  * @ingroup     pkg_nimble
@@ -17,9 +19,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NIMBLE_SCANNER_H
-#define NIMBLE_SCANNER_H
 
 #include <errno.h>
 #include <stdint.h>
@@ -170,5 +169,4 @@ void nimble_scanner_set_scan_duration(int32_t duration_ms);
 }
 #endif
 
-#endif /* NIMBLE_SCANNER_H */
 /** @} */

--- a/pkg/nimble/statconn/include/nimble_statconn.h
+++ b/pkg/nimble/statconn/include/nimble_statconn.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_nimble_statconn Statconn
  * @ingroup     pkg_nimble
@@ -46,9 +48,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NIMBLE_STATCONN_H
-#define NIMBLE_STATCONN_H
 
 #include <errno.h>
 #include <stdint.h>
@@ -193,5 +192,4 @@ int nimble_statconn_rm(const uint8_t *addr);
 }
 #endif
 
-#endif /* NIMBLE_STATCONN_H */
 /** @} */

--- a/pkg/nrfx/include/nrfx_config.h
+++ b/pkg/nrfx/include/nrfx_config.h
@@ -31,6 +31,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_nrfx
  * @{
@@ -40,9 +42,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef NRFX_CONFIG_H
-#define NRFX_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -55,5 +54,4 @@ extern "C" {
 }
 #endif
 
-#endif /* NRFX_CONFIG_H */
 /** @} **/

--- a/pkg/nrfx/include/nrfx_glue.h
+++ b/pkg/nrfx/include/nrfx_glue.h
@@ -31,6 +31,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_nrfx
  * @{
@@ -42,9 +44,6 @@
  *
  * @author      Nordic Semiconductor ASA
  */
-
-#ifndef NRFX_GLUE_H
-#define NRFX_GLUE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -281,5 +280,4 @@ extern "C" {
 }
 #endif
 
-#endif /* NRFX_GLUE_H */
 /** @} */

--- a/pkg/opendsme/include/opendsme/DSMEMessage.h
+++ b/pkg/opendsme/include/opendsme/DSMEMessage.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_opendsme_dsmemessage DSME Message interface implementation.
  * @ingroup     pkg_opendsme
@@ -18,9 +20,6 @@
  *
  * @author  José I. Álamos <jose.alamos@haw-hamburg.de>
  */
-
-#ifndef OPENDSME_DSMEMESSAGE_H
-#define OPENDSME_DSMEMESSAGE_H
 
 #include <stdint.h>
 #include <string.h>
@@ -336,5 +335,4 @@ friend class DSMEMessageBuffer;
 }
 #endif
 
-#endif /* OPENDSME_DSMEMESSAGE_H */
 /** @} */

--- a/pkg/opendsme/include/opendsme/DSMEPlatform.h
+++ b/pkg/opendsme/include/opendsme/DSMEPlatform.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_opendsme_dsmeplatform DSME Platform interface implementation.
  * @ingroup     pkg_opendsme
@@ -18,9 +20,6 @@
  *
  * @author  José I. Álamos <jose.alamos@haw-hamburg.de>
  */
-
-#ifndef OPENDSME_DSMEPLATFORM_H
-#define OPENDSME_DSMEPLATFORM_H
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -542,5 +541,4 @@ protected:
 }
 #endif
 
-#endif /* OPENDSME_DSMEPLATFORM_H */
 /** @} */

--- a/pkg/opendsme/include/opendsme/dsme_atomic.h
+++ b/pkg/opendsme/include/opendsme/dsme_atomic.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_opendsme
  *
@@ -15,9 +17,6 @@
  *
  * @author      José I. Álamos <jose.alamos@haw-hamburg.de>
  */
-
-#ifndef OPENDSME_DSME_ATOMIC_H
-#define OPENDSME_DSME_ATOMIC_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,7 +36,6 @@ extern "C" {
  */
 #define dsme_atomicEnd()
 
-#endif /* OPENDSME_DSME_ATOMIC_H */
 
 #ifdef __cplusplus
 }

--- a/pkg/opendsme/include/opendsme/dsme_platform.h
+++ b/pkg/opendsme/include/opendsme/dsme_platform.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_opendsme
  *
@@ -15,9 +17,6 @@
  *
  * @author      José I. Álamos <jose.alamos@haw-hamburg.de>
  */
-
-#ifndef OPENDSME_DSME_PLATFORM_H
-#define OPENDSME_DSME_PLATFORM_H
 
 #include <assert.h>
 #include <stdio.h>
@@ -48,5 +47,4 @@ extern "C" {
 }
 #endif
 
-#endif /* OPENDSME_DSME_PLATFORM_H */
 /** @} */

--- a/pkg/opendsme/include/opendsme/dsme_settings.h
+++ b/pkg/opendsme/include/opendsme/dsme_settings.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_opendsme
  *
@@ -15,8 +17,6 @@
  *
  * @author      José I. Álamos <jose.alamos@haw-hamburg.de>
  */
-#ifndef OPENDSME_DSME_SETTINGS_H
-#define OPENDSME_DSME_SETTINGS_H
 
 #include <stdint.h>
 
@@ -162,5 +162,4 @@ constexpr uint8_t ADDITIONAL_ACK_WAIT_DURATION = 63;
 }
 #endif
 
-#endif /* OPENDSME_DSME_SETTINGS_H */
 /** @} */

--- a/pkg/opendsme/include/opendsme/opendsme.h
+++ b/pkg/opendsme/include/opendsme/opendsme.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_opendsme openDSME - IEEE 802.15.4 DSME
  * @ingroup     pkg
@@ -184,8 +186,6 @@
  * ## MAC configuration
  *
  */
-#ifndef OPENDSME_OPENDSME_H
-#define OPENDSME_OPENDSME_H
 
 #include <stdbool.h>
 #include "byteorder.h"
@@ -278,7 +278,5 @@ int gnrc_netif_opendsme_create(gnrc_netif_t *netif, char *stack, int stacksize,
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* OPENDSME_OPENDSME_H */
 
 /** @} */

--- a/pkg/openthread/include/ot.h
+++ b/pkg/openthread/include/ot.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_openthread_cli   OpenThread
  * @ingroup     pkg_openthread
@@ -49,9 +51,6 @@
  * @author      Jose Ignacio Alamos <jialamos@uc.cl>
  * @author      Baptiste Clenet <bapclenet@gmail.com>
  */
-
-#ifndef OT_H
-#define OT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -168,5 +167,4 @@ void ot_random_init(void);
 }
 #endif
 
-#endif /* OT_H */
 /** @} */

--- a/pkg/openthread/include/platform_config.h
+++ b/pkg/openthread/include/platform_config.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @{
  * @ingroup     net
@@ -15,9 +17,6 @@
  * @author      Baptiste Clenet <bapclenet@gmail.com>
  * @}
  */
-
-#ifndef PLATFORM_CONFIG_H
-#define PLATFORM_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,5 +45,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* PLATFORM_CONFIG_H */

--- a/pkg/openwsn/include/board_info.h
+++ b/pkg/openwsn/include/board_info.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_openwsn
  * @{
@@ -20,9 +22,6 @@
  *
  * @}
  */
-
-#ifndef BOARD_INFO_H
-#define BOARD_INFO_H
 
 #include <stdint.h>
 #include <string.h>
@@ -144,5 +143,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* BOARD_INFO_H */

--- a/pkg/openwsn/include/openwsn.h
+++ b/pkg/openwsn/include/openwsn.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_openwsn
  *
@@ -17,8 +19,6 @@
  * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  */
-#ifndef OPENWSN_H
-#define OPENWSN_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -61,5 +61,4 @@ kernel_pid_t openwsn_get_pid(void);
 }
 #endif
 
-#endif /* OPENWSN_H */
 /** @} */

--- a/pkg/openwsn/include/openwsn_board.h
+++ b/pkg/openwsn/include/openwsn_board.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_openwsn
  * @{
@@ -23,9 +25,6 @@
  *
  * @}
  */
-
-#ifndef OPENWSN_BOARD_H
-#define OPENWSN_BOARD_H
 
 #include "board_info.h"
 
@@ -67,5 +66,3 @@ void board_sleep(void);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* OPENWSN_BOARD_H */

--- a/pkg/openwsn/include/openwsn_debugpins.h
+++ b/pkg/openwsn/include/openwsn_debugpins.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_openwsn
  * @{
@@ -19,9 +21,6 @@
  *
  * @}
  */
-
-#ifndef OPENWSN_DEBUGPINS_H
-#define OPENWSN_DEBUGPINS_H
 
 #include "periph/gpio.h"
 
@@ -52,5 +51,3 @@ void openwsn_debugpins_init(const debugpins_config_t *user_config);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* OPENWSN_DEBUGPINS_H */

--- a/pkg/openwsn/include/openwsn_debugpins_params.h
+++ b/pkg/openwsn/include/openwsn_debugpins_params.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_openwsn
  * @{
@@ -18,9 +20,6 @@
  *
  * @}
  */
-
-#ifndef OPENWSN_DEBUGPINS_PARAMS_H
-#define OPENWSN_DEBUGPINS_PARAMS_H
 
 #include "board.h"
 #include "openwsn_debugpins.h"
@@ -77,5 +76,3 @@ static const debugpins_config_t openwsn_debugpins_params[] =
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* OPENWSN_DEBUGPINS_PARAMS_H */

--- a/pkg/openwsn/include/openwsn_leds.h
+++ b/pkg/openwsn/include/openwsn_leds.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_openwsn
  * @{
@@ -20,8 +22,6 @@
  *
  * @}
  */
-#ifndef OPENWSN_LEDS_H
-#define OPENWSN_LEDS_H
 
 #include "periph/gpio.h"
 
@@ -62,5 +62,3 @@ void ledpins_riot_init(const leds_config_t *user_config);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* OPENWSN_LEDS_H */

--- a/pkg/openwsn/include/openwsn_leds_params.h
+++ b/pkg/openwsn/include/openwsn_leds_params.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_openwsn
  * @{
@@ -17,8 +19,6 @@
  *
  * @}
  */
-#ifndef OPENWSN_LEDS_PARAMS_H
-#define OPENWSN_LEDS_PARAMS_H
 
 #include "board.h"
 
@@ -92,5 +92,3 @@ static const leds_config_t openwsn_leds_params[] =
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* OPENWSN_LEDS_PARAMS_H */

--- a/pkg/openwsn/include/openwsn_log.h
+++ b/pkg/openwsn/include/openwsn_log.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_openwsn
  * @{
@@ -18,9 +20,6 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
-
-#ifndef OPENWSN_LOG_H
-#define OPENWSN_LOG_H
 
 #include <stdio.h>
 
@@ -95,5 +94,4 @@ enum {
 }
 #endif
 
-#endif /* OPENWSN_LOG_H */
 /** @} */

--- a/pkg/openwsn/include/openwsn_radio.h
+++ b/pkg/openwsn/include/openwsn_radio.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_openwsn
  * @{
@@ -45,9 +47,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  */
 
-#ifndef OPENWSN_RADIO_H
-#define OPENWSN_RADIO_H
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -83,5 +82,4 @@ typedef struct {
 }
 #endif
 
-#endif /* OPENWSN_RADIO_H */
 /** @} */

--- a/pkg/openwsn/include/openwsn_uart.h
+++ b/pkg/openwsn/include/openwsn_uart.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_openwsn
  * @{
@@ -22,9 +24,6 @@
  *
  * @}
  */
-
-#ifndef OPENWSN_UART_H
-#define OPENWSN_UART_H
 
 #include "stdint.h"
 #include "board.h"
@@ -138,5 +137,3 @@ void    uart_clearTxInterrupts(void);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* OPENWSN_UART_H */

--- a/pkg/openwsn/scheduler/scheduler_types.h
+++ b/pkg/openwsn/scheduler/scheduler_types.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_openwsn
  * @{
@@ -18,9 +20,6 @@
  *
  * @}
  */
-
-#ifndef SCHEDULER_TYPES_H
-#define SCHEDULER_TYPES_H
 
 #include "opendefs.h"
 #include "scheduler.h"
@@ -52,5 +51,3 @@ typedef struct {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* SCHEDULER_TYPES_H */

--- a/pkg/openwsn/sock/sock_types.h
+++ b/pkg/openwsn/sock/sock_types.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup pkg_openwsn_sock OpenWSN-specific implementation of the sock API
  * @ingroup  pkg_openwsn
@@ -19,9 +21,6 @@
  * @author  Timothy Claeys <timothy.claeys@inria.fr>
  * @author  Francisco Molina <francois-xavier.molina@inria.fr>
  */
-
-#ifndef SOCK_TYPES_H
-#define SOCK_TYPES_H
 
 #include "mbox.h"
 #include "net/af.h"
@@ -94,5 +93,4 @@ struct sock_udp {
 }
 #endif
 
-#endif /* SOCK_TYPES_H */
 /** @} */

--- a/pkg/paho-mqtt/include/paho_mqtt.h
+++ b/pkg/paho-mqtt/include/paho_mqtt.h
@@ -7,6 +7,8 @@
  *
  */
 
+#pragma once
+
 /**
  * @addtogroup  pkg_paho_mqtt
  * @{
@@ -16,8 +18,6 @@
  *
  * @author      Javier FILEIV <javier.fileiv@gmail.com>
  */
-#ifndef PAHO_MQTT_H
-#define PAHO_MQTT_H
 
 #include "mutex.h"
 #include "thread.h"
@@ -193,5 +193,4 @@ int ThreadStart(Thread *thread, void (*fn)(void *), void *arg);
 }
 #endif
 
-#endif /* PAHO_MQTT_H */
 /** @} */

--- a/pkg/semtech-loramac/include/semtech-loramac/timer.h
+++ b/pkg/semtech-loramac/include/semtech-loramac/timer.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         pkg_semtech-loramac
  * @brief           Semtech LoRaMAC timer compatibility definitions
@@ -18,9 +20,6 @@
  * @author          Alexandre Abadie <alexandre.abadie@inria.fr>
  * @author          Francisco Molina <francisco.molina@inria.cl>
  */
-
-#ifndef SEMTECH_LORAMAC_TIMER_H
-#define SEMTECH_LORAMAC_TIMER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -126,5 +125,4 @@ void TimerLowPowerHandler(void);
 }
 #endif
 
-#endif /* SEMTECH_LORAMAC_TIMER_H */
 /** @} */

--- a/pkg/semtech-loramac/include/semtech_loramac.h
+++ b/pkg/semtech-loramac/include/semtech_loramac.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         pkg_semtech-loramac
  * @brief           Public API and definitions of the Semtech LoRaMAC
@@ -15,9 +17,6 @@
  *
  * @author          Alexandre Abadie <alexandre.abadie@inria.fr>
  */
-
-#ifndef SEMTECH_LORAMAC_H
-#define SEMTECH_LORAMAC_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -567,5 +566,4 @@ void semtech_loramac_erase_config(void);
 }
 #endif
 
-#endif /* SEMTECH_LORAMAC_H */
 /** @} */

--- a/pkg/spiffs/include/spiffs_config.h
+++ b/pkg/spiffs/include/spiffs_config.h
@@ -21,15 +21,14 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#pragma once
+
 /*
  * spiffs_config.h
  *
  *  Created on: Jul 3, 2013
  *      Author: petera
  */
-
-#ifndef SPIFFS_CONFIG_H
-#define SPIFFS_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -349,5 +348,3 @@ typedef int16_t s16_t;
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* SPIFFS_CONFIG_H */

--- a/pkg/tinydtls/include/sock_dtls_types.h
+++ b/pkg/tinydtls/include/sock_dtls_types.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @{
  *
@@ -15,9 +17,6 @@
  * @author  Aiman Ismail <muhammadaimanbin.ismail@haw-hamburg.de>
  * @author  Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-
-#ifndef SOCK_DTLS_TYPES_H
-#define SOCK_DTLS_TYPES_H
 
 #include "dtls.h"
 #include "net/sock/udp.h"
@@ -94,5 +93,4 @@ struct sock_dtls_session {
 }
 #endif
 
-#endif /* SOCK_DTLS_TYPES_H */
 /** @} */

--- a/pkg/tinyusb/contrib/include/tinyusb.h
+++ b/pkg/tinyusb/contrib/include/tinyusb.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_tinyusb
  * @{
@@ -15,9 +17,6 @@
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
-
-#ifndef TINYUSB_H
-#define TINYUSB_H
 
 #include "periph_conf.h"
 #include "tinyusb_hw_defaults.h"
@@ -63,5 +62,4 @@ int tinyusb_setup(void);
 }
 #endif
 
-#endif /* TINYUSB_H */
 /** @} */

--- a/pkg/tinyusb/contrib/include/tinyusb_descriptors.h
+++ b/pkg/tinyusb/contrib/include/tinyusb_descriptors.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_tinyusb
  * @{
@@ -15,9 +17,6 @@
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
-
-#ifndef TINYUSB_DESCRIPTORS_H
-#define TINYUSB_DESCRIPTORS_H
 
 #include "tusb_config.h"        /* defined by the application */
 #include "tinyusb.h"
@@ -205,5 +204,4 @@ enum {
 #endif
 
 #endif /* !DOXYGEN */
-#endif /* TINYUSB_DESCRIPTORS_H */
 /** @} */

--- a/pkg/tinyusb/contrib/include/tusb_config.h
+++ b/pkg/tinyusb/contrib/include/tusb_config.h
@@ -21,6 +21,8 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_tinyusb
  * @{
@@ -30,9 +32,6 @@
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
-
-#ifndef TUSB_CONFIG_H
-#define TUSB_CONFIG_H
 
 /* defined by the application */
 #if __has_include("tinyusb_app_config.h")
@@ -464,5 +463,4 @@ extern "C" {
 #endif
 
 #endif /* !DOXYGEN */
-#endif /* TUSB_CONFIG_H */
 /** @} */

--- a/pkg/tinyusb/contrib/include/tusb_os_custom.h
+++ b/pkg/tinyusb/contrib/include/tusb_os_custom.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_tinyusb
  * @{
@@ -15,9 +17,6 @@
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
-
-#ifndef TUSB_OS_CUSTOM_H
-#define TUSB_OS_CUSTOM_H
 
 #include "mutex.h"
 #include "sema.h"
@@ -252,5 +251,4 @@ TU_ATTR_ALWAYS_INLINE static inline bool osal_queue_empty(osal_queue_t qhdl)
 #endif
 
 #endif /* !DOXYGEN */
-#endif /* TUSB_OS_CUSTOM_H */
 /** @} */

--- a/pkg/tinyusb/dfu/include/tinyusb_dfu.h
+++ b/pkg/tinyusb/dfu/include/tinyusb_dfu.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_tinyusb_dfu
  * @{
@@ -14,9 +16,6 @@
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
-
-#ifndef TINYUSB_DFU_H
-#define TINYUSB_DFU_H
 
 #include "riotboot/flashwrite.h"
 
@@ -44,5 +43,4 @@ void tinyusb_dfu_init(void);
 }
 #endif
 
-#endif /* TINYUSB_DFU_H */
 /** @} */

--- a/pkg/tinyusb/hw/include/nrf52/nrf_clock.h
+++ b/pkg/tinyusb/hw/include/nrf52/nrf_clock.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_tinyusb
  * @brief
@@ -19,9 +21,6 @@
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
-
-#ifndef NRF52_NRF_CLOCK_H
-#define NRF52_NRF_CLOCK_H
 
 #include <stdbool.h>
 
@@ -105,5 +104,4 @@ static inline void nrf_clock_task_trigger(NRF_CLOCK_Type *reg,
 #endif
 
 #endif /* !DOXYGEN */
-#endif /* NRF52_NRF_CLOCK_H */
 /** @} */

--- a/pkg/tinyusb/hw/include/tinyusb_hw.h
+++ b/pkg/tinyusb/hw/include/tinyusb_hw.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_tinyusb
  * @{
@@ -15,9 +17,6 @@
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
-
-#ifndef TINYUSB_HW_H
-#define TINYUSB_HW_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,5 +36,4 @@ int tinyusb_hw_init(void);
 }
 #endif
 
-#endif /* TINYUSB_HW_H */
 /** @} */

--- a/pkg/tinyusb/hw/include/tinyusb_hw_defaults.h
+++ b/pkg/tinyusb/hw/include/tinyusb_hw_defaults.h
@@ -20,6 +20,8 @@
  * THE SOFTWARE.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_tinyusb
  * @{
@@ -36,9 +38,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef TINYUSB_HW_DEFAULTS_H
-#define TINYUSB_HW_DEFAULTS_H
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,5 +46,4 @@ extern "C" {
 }
 #endif
 
-#endif /* TINYUSB_HW_DEFAULTS_H */
 /** @} */

--- a/pkg/tinyusb/netdev/include/tinyusb_netdev.h
+++ b/pkg/tinyusb/netdev/include/tinyusb_netdev.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @defgroup    pkg_tinyusb_netdev TinyUSB netdev driver
  * @ingroup     pkg_tinyusb
@@ -56,9 +58,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifndef TINYUSB_NETDEV_H
-#define TINYUSB_NETDEV_H
-
 #include "net/ethernet.h"
 #include "net/netdev.h"
 #include "mutex.h"
@@ -88,5 +87,4 @@ typedef struct {
 }
 #endif
 
-#endif /* TINYUSB_NETDEV_H */
 /** @} */

--- a/pkg/tinyvcdiff/include/vcdiff_mtd.h
+++ b/pkg/tinyvcdiff/include/vcdiff_mtd.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @{
  *
@@ -14,9 +16,6 @@
  *
  * @author  Juergen Fitschen <me@jue.yt>
  */
-
-#ifndef VCDIFF_MTD_H
-#define VCDIFF_MTD_H
 
 #include "vcdiff.h"
 #include "mtd.h"
@@ -71,5 +70,4 @@ typedef struct {
 }
 #endif
 
-#endif /* VCDIFF_MTD_H */
 /** @} */

--- a/pkg/tinyvcdiff/include/vcdiff_vfs.h
+++ b/pkg/tinyvcdiff/include/vcdiff_vfs.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @{
  *
@@ -14,9 +16,6 @@
  *
  * @author  Juergen Fitschen <me@jue.yt>
  */
-
-#ifndef VCDIFF_VFS_H
-#define VCDIFF_VFS_H
 
 #include "vcdiff.h"
 #include "vfs.h"
@@ -52,5 +51,4 @@ typedef struct {
 }
 #endif
 
-#endif /* VCDIFF_VFS_H */
 /** @} */

--- a/pkg/tlsf/contrib/include/tlsf-malloc.h
+++ b/pkg/tlsf/contrib/include/tlsf-malloc.h
@@ -5,6 +5,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+
+#pragma once
+
 /**
  * @defgroup pkg_tlsf_malloc TLSF-based malloc.
  * @ingroup  pkg
@@ -32,9 +35,6 @@
  * @author  Juan I Carrano
  *
  */
-
-#ifndef TLSF_MALLOC_H
-#define TLSF_MALLOC_H
 
 #include <stddef.h>
 
@@ -92,8 +92,6 @@ tlsf_t _tlsf_get_global_control(void);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* TLSF_MALLOC_H */
 
 /**
  * @}

--- a/pkg/tlsf/contrib/tlsf-malloc-internal.h
+++ b/pkg/tlsf/contrib/tlsf-malloc-internal.h
@@ -5,6 +5,9 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+
+#pragma once
+
 /**
  * @ingroup  pkg_tlsf_malloc
  * @{
@@ -15,9 +18,6 @@
  * @author  Juan I Carrano
  *
  */
-
-#ifndef TLSF_MALLOC_INTERNAL_H
-#define TLSF_MALLOC_INTERNAL_H
 
 #include "tlsf.h"
 
@@ -31,5 +31,4 @@ extern tlsf_t tlsf_malloc_gheap;
 }
 #endif
 
-#endif /* TLSF_MALLOC_INTERNAL_H */
 /** @} */

--- a/pkg/u8g2/contrib/u8x8_riotos.h
+++ b/pkg/u8g2/contrib/u8x8_riotos.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_u8g2
  * @{
@@ -18,9 +20,6 @@
  *
  * @}
  */
-
-#ifndef U8X8_RIOTOS_H
-#define U8X8_RIOTOS_H
 
 #include "u8x8.h"
 
@@ -66,5 +65,3 @@ uint8_t u8x8_byte_hw_i2c_riotos(u8x8_t *u8g2, uint8_t msg, uint8_t arg_int, void
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* U8X8_RIOTOS_H */

--- a/pkg/ucglib/contrib/ucg_riotos.h
+++ b/pkg/ucglib/contrib/ucg_riotos.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_ucglib
  * @{
@@ -18,9 +20,6 @@
  *
  * @}
  */
-
-#ifndef UCG_RIOTOS_H
-#define UCG_RIOTOS_H
 
 #include "ucg.h"
 
@@ -61,5 +60,3 @@ ucg_int_t ucg_dev_dummy_riotos(ucg_t *ucg, ucg_int_t msg, void *data);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* UCG_RIOTOS_H */

--- a/pkg/uwb-core/include/dpl/dpl.h
+++ b/pkg/uwb-core/include/dpl/dpl.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_DPL_H
-#define DPL_DPL_H
 
 #include "syscfg/syscfg.h"
 #include "dpl/dpl_types.h"
@@ -35,5 +34,3 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#endif /* DPL_DPL_H */

--- a/pkg/uwb-core/include/dpl/dpl_callout.h
+++ b/pkg/uwb-core/include/dpl/dpl_callout.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -19,9 +21,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_DPL_CALLOUT_H
-#define DPL_DPL_CALLOUT_H
 
 #include "os/os_callout.h"
 
@@ -82,5 +81,3 @@ static inline void dpl_callout_stop(struct dpl_callout *c)
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_DPL_CALLOUT_H */

--- a/pkg/uwb-core/include/dpl/dpl_cputime.h
+++ b/pkg/uwb-core/include/dpl/dpl_cputime.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_DPL_CPUTIME_H
-#define DPL_DPL_CPUTIME_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -145,5 +144,3 @@ static inline void dpl_cputime_timer_stop(struct hal_timer *timer)
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_DPL_CPUTIME_H */

--- a/pkg/uwb-core/include/dpl/dpl_error.h
+++ b/pkg/uwb-core/include/dpl/dpl_error.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_DPL_ERROR_H
-#define DPL_DPL_ERROR_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,5 +52,3 @@ typedef os_error_t dpl_error_t;
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_DPL_ERROR_H */

--- a/pkg/uwb-core/include/dpl/dpl_eventq.h
+++ b/pkg/uwb-core/include/dpl/dpl_eventq.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_DPL_EVENTQ_H
-#define DPL_DPL_EVENTQ_H
 
 #include <dpl/dpl_types.h>
 
@@ -219,5 +218,3 @@ static inline struct dpl_eventq * dpl_eventq_dflt_get(void)
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_DPL_EVENTQ_H */

--- a/pkg/uwb-core/include/dpl/dpl_mutex.h
+++ b/pkg/uwb-core/include/dpl/dpl_mutex.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_DPL_MUTEX_H
-#define DPL_DPL_MUTEX_H
 
 #include "os/os_mutex.h"
 
@@ -76,5 +75,3 @@ static inline dpl_error_t dpl_mutex_release(struct dpl_mutex *mu)
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_DPL_MUTEX_H */

--- a/pkg/uwb-core/include/dpl/dpl_os.h
+++ b/pkg/uwb-core/include/dpl/dpl_os.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_DPL_OS_H
-#define DPL_DPL_OS_H
 
 #include "os/os.h"
 
@@ -73,5 +72,3 @@ static inline bool dpl_hw_is_in_critical(void)
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_DPL_OS_H */

--- a/pkg/uwb-core/include/dpl/dpl_sem.h
+++ b/pkg/uwb-core/include/dpl/dpl_sem.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_DPL_SEM_H
-#define DPL_DPL_SEM_H
 
 #include <stdint.h>
 
@@ -96,5 +95,3 @@ static inline int16_t dpl_sem_get_count(struct dpl_sem *sem)
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_DPL_SEM_H */

--- a/pkg/uwb-core/include/dpl/dpl_tasks.h
+++ b/pkg/uwb-core/include/dpl/dpl_tasks.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_DPL_TASKS_H
-#define DPL_DPL_TASKS_H
 
 #include "os/os_task.h"
 
@@ -94,5 +93,3 @@ static inline void dpl_task_yield(void)
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_DPL_TASKS_H */

--- a/pkg/uwb-core/include/dpl/dpl_time.h
+++ b/pkg/uwb-core/include/dpl/dpl_time.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_DPL_TIME_H
-#define DPL_DPL_TIME_H
 
 #include "os/os_time.h"
 
@@ -99,5 +98,3 @@ static inline void dpl_time_delay(dpl_time_t ticks)
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_DPL_TIME_H */

--- a/pkg/uwb-core/include/dpl/dpl_types.h
+++ b/pkg/uwb-core/include/dpl/dpl_types.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_DPL_TYPES_H
-#define DPL_DPL_TYPES_H
 
 #include <stdint.h>
 #include <math.h>
@@ -116,5 +115,3 @@ typedef double dpl_float64_t;
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_DPL_TYPES_H */

--- a/pkg/uwb-core/include/dpl/queue.h
+++ b/pkg/uwb-core/include/dpl/queue.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -17,9 +19,6 @@
  * @}
  */
 
-#ifndef DPL_QUEUE_H
-#define DPL_QUEUE_H
-
 #include "os/os_queue.h"
 
 #ifdef __cplusplus
@@ -29,5 +28,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_QUEUE_H */

--- a/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ds.h
+++ b/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ds.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -17,9 +19,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_SYSCFG_SYSCFG_TWR_DS_H
-#define DPL_SYSCFG_SYSCFG_TWR_DS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,5 +48,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_SYSCFG_SYSCFG_TWR_DS_H */

--- a/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ds_ext.h
+++ b/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ds_ext.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -17,9 +19,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_SYSCFG_SYSCFG_TWR_DS_EXT_H
-#define DPL_SYSCFG_SYSCFG_TWR_DS_EXT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,5 +48,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_SYSCFG_SYSCFG_TWR_DS_EXT_H */

--- a/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ss.h
+++ b/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ss.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -17,9 +19,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_SYSCFG_SYSCFG_TWR_SS_H
-#define DPL_SYSCFG_SYSCFG_TWR_SS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,5 +48,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_SYSCFG_SYSCFG_TWR_SS_H */

--- a/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ss_ack.h
+++ b/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ss_ack.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -17,9 +19,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_SYSCFG_SYSCFG_TWR_SS_ACK_H
-#define DPL_SYSCFG_SYSCFG_TWR_SS_ACK_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,5 +48,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_SYSCFG_SYSCFG_TWR_SS_ACK_H */

--- a/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ss_ext.h
+++ b/pkg/uwb-core/include/dpl_syscfg/syscfg_twr_ss_ext.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -17,9 +19,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_SYSCFG_SYSCFG_TWR_SS_EXT_H
-#define DPL_SYSCFG_SYSCFG_TWR_SS_EXT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,5 +48,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_SYSCFG_SYSCFG_TWR_SS_EXT_H */

--- a/pkg/uwb-core/include/dpl_syscfg/syscfg_uwb.h
+++ b/pkg/uwb-core/include/dpl_syscfg/syscfg_uwb.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -17,9 +19,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_SYSCFG_SYSCFG_UWB_H
-#define DPL_SYSCFG_SYSCFG_UWB_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -140,5 +139,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_SYSCFG_SYSCFG_UWB_H */

--- a/pkg/uwb-core/include/dpl_syscfg/syscfg_uwb_rng.h
+++ b/pkg/uwb-core/include/dpl_syscfg/syscfg_uwb_rng.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -17,9 +19,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef DPL_SYSCFG_SYSCFG_UWB_RNG_H
-#define DPL_SYSCFG_SYSCFG_UWB_RNG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -63,5 +62,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DPL_SYSCFG_SYSCFG_UWB_RNG_H */

--- a/pkg/uwb-core/include/uwb_core.h
+++ b/pkg/uwb-core/include/uwb_core.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  *
@@ -15,9 +17,6 @@
  *
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  */
-
-#ifndef UWB_CORE_H
-#define UWB_CORE_H
 
 #include <stdint.h>
 #include "event.h"
@@ -69,5 +68,4 @@ event_queue_t *uwb_core_get_eventq(void);
 }
 #endif
 
-#endif /* UWB_CORE_H */
 /** @} */

--- a/pkg/uwb-dw1000/include/syscfg_uwb_dw1000.h
+++ b/pkg/uwb-dw1000/include/syscfg_uwb_dw1000.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -17,9 +19,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef SYSCFG_UWB_DW1000_H
-#define SYSCFG_UWB_DW1000_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -116,5 +115,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* SYSCFG_UWB_DW1000_H */

--- a/pkg/uwb-dw1000/include/uwb_dw1000.h
+++ b/pkg/uwb-dw1000/include/uwb_dw1000.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_dw1000
  *
@@ -17,8 +19,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-#ifndef UWB_DW1000_H
-#define UWB_DW1000_H
 
 #include <stdint.h>
 
@@ -91,5 +91,3 @@ void uwb_dw1000_update_config_from_otp(dw1000_dev_instance_t* dev);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* UWB_DW1000_H */

--- a/pkg/uwb-dw1000/include/uwb_dw1000_config.h
+++ b/pkg/uwb-dw1000/include/uwb_dw1000_config.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_core
  * @{
@@ -16,9 +18,6 @@
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  * @}
  */
-
-#ifndef UWB_DW1000_CONFIG_H
-#define UWB_DW1000_CONFIG_H
 
 #include "dw1000/dw1000_regs.h"
 
@@ -269,5 +268,3 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* UWB_DW1000_CONFIG_H */

--- a/pkg/uwb-dw1000/include/uwb_dw1000_params.h
+++ b/pkg/uwb-dw1000/include/uwb_dw1000_params.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_uwb_dw1000
  *
@@ -15,9 +17,6 @@
  *
  * @author      Francisco Molina <francois-xavier.molina@inria.fr>
  */
-
-#ifndef UWB_DW1000_PARAMS_H
-#define UWB_DW1000_PARAMS_H
 
 #include "board.h"
 #include "uwb_dw1000.h"
@@ -92,5 +91,4 @@ static const dw1000_params_t dw1000_params[] =
 }
 #endif
 
-#endif /* UWB_DW1000_PARAMS_H */
 /** @} */

--- a/pkg/wakaama/include/lwm2m_client.h
+++ b/pkg/wakaama/include/lwm2m_client.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_wakaama
  * @defgroup    lwm2m_client LwM2M Client using Wakaama
@@ -16,9 +18,6 @@
  *
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-
-#ifndef LWM2M_CLIENT_H
-#define LWM2M_CLIENT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -163,5 +162,4 @@ void lwm2m_client_remove_credential(credman_tag_t tag);
 }
 #endif
 
-#endif /* LWM2M_CLIENT_H */
 /** @} */

--- a/pkg/wakaama/include/lwm2m_client_config.h
+++ b/pkg/wakaama/include/lwm2m_client_config.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup      pkg_wakaama
  * @ingroup      config
@@ -22,9 +24,6 @@
  * @author      Christian Manal <manal@uni-bremen.de>
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-
-#ifndef LWM2M_CLIENT_CONFIG_H
-#define LWM2M_CLIENT_CONFIG_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -109,5 +108,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#endif /* LWM2M_CLIENT_CONFIG_H */
 /** @} */

--- a/pkg/wakaama/include/lwm2m_client_connection.h
+++ b/pkg/wakaama/include/lwm2m_client_connection.h
@@ -16,6 +16,9 @@
 *    Christian Manal - Ported to RIOT OS
 *
 *******************************************************************************/
+
+#pragma once
+
 /*
  * Copyright (C) 2018 Beduino Master Projekt - University of Bremen
  * Copyright (C) 2019 HAW Hamburg
@@ -36,9 +39,6 @@
  * @author      Christian Manal <manal@uni-bremen.de>
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-
-#ifndef LWM2M_CLIENT_CONNECTION_H
-#define LWM2M_CLIENT_CONNECTION_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -86,5 +86,4 @@ int lwm2m_connection_handle_packet(lwm2m_client_connection_t *conn,
 }
 #endif
 
-#endif /* LWM2M_CLIENT_CONNECTION_H */
 /** @} */

--- a/pkg/wakaama/include/lwm2m_client_objects.h
+++ b/pkg/wakaama/include/lwm2m_client_objects.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup         lwm2m_client
  * @{
@@ -15,9 +17,6 @@
  * @file
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-
-#ifndef LWM2M_CLIENT_OBJECTS_H
-#define LWM2M_CLIENT_OBJECTS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,5 +67,4 @@ lwm2m_object_t *lwm2m_client_get_acc_ctrl_object(
 }
 #endif
 
-#endif /* LWM2M_CLIENT_OBJECTS_H */
 /** @} */

--- a/pkg/wakaama/include/lwm2m_platform.h
+++ b/pkg/wakaama/include/lwm2m_platform.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_wakaama
  * @defgroup    lwm2m_platform Platform adaption for Wakaama package
@@ -16,8 +18,6 @@
  *
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-#ifndef LWM2M_PLATFORM_H
-#define LWM2M_PLATFORM_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,5 +50,4 @@ void lwm2m_tlsf_status(void);
 }
 #endif
 
-#endif /* LWM2M_PLATFORM_H */
 /** @} */

--- a/pkg/wakaama/include/objects/barometer.h
+++ b/pkg/wakaama/include/objects/barometer.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     lwm2m_objects
  * @defgroup    lwm2m_objects_barometer Barometer
@@ -88,9 +90,6 @@
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
 
-#ifndef OBJECTS_BAROMETER_H
-#define OBJECTS_BAROMETER_H
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -157,5 +156,4 @@ void lwm2m_object_barometer_update_value(const lwm2m_client_data_t *client_data,
 }
 #endif
 
-#endif /* OBJECTS_BAROMETER_H */
 /** @} */

--- a/pkg/wakaama/include/objects/common.h
+++ b/pkg/wakaama/include/objects/common.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     pkg_wakaama
  * @defgroup    lwm2m_objects_common Common LwM2M Object functionalities
@@ -16,9 +18,6 @@
  *
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-
-#ifndef OBJECTS_COMMON_H
-#define OBJECTS_COMMON_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -511,5 +510,4 @@ int lwm2m_set_objlink_by_path(lwm2m_client_data_t *client_data, const char *path
 }
 #endif
 
-#endif /* OBJECTS_COMMON_H */
 /** @} */

--- a/pkg/wakaama/include/objects/current.h
+++ b/pkg/wakaama/include/objects/current.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     lwm2m_objects
  * @defgroup    lwm2m_objects_current Current
@@ -86,9 +88,6 @@
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
 
-#ifndef OBJECTS_CURRENT_H
-#define OBJECTS_CURRENT_H
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -155,5 +154,4 @@ void lwm2m_object_current_update_value(const lwm2m_client_data_t *client_data,
 }
 #endif
 
-#endif /* OBJECTS_CURRENT_H */
 /** @} */

--- a/pkg/wakaama/include/objects/device.h
+++ b/pkg/wakaama/include/objects/device.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     lwm2m_objects
  * @defgroup    lwm2m_objects_device Device LwM2M object
@@ -43,9 +45,6 @@
  *
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-
-#ifndef OBJECTS_DEVICE_H
-#define OBJECTS_DEVICE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -270,5 +269,4 @@ bool lwm2m_device_reboot_requested(void);
 }
 #endif
 
-#endif /* OBJECTS_DEVICE_H */
 /** @} */

--- a/pkg/wakaama/include/objects/humidity.h
+++ b/pkg/wakaama/include/objects/humidity.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     lwm2m_objects
  * @defgroup    lwm2m_objects_humidity Humidity
@@ -89,9 +91,6 @@
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
 
-#ifndef OBJECTS_HUMIDITY_H
-#define OBJECTS_HUMIDITY_H
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -158,5 +157,4 @@ void lwm2m_object_humidity_update_value(const lwm2m_client_data_t *client_data,
 }
 #endif
 
-#endif /* OBJECTS_HUMIDITY_H */
 /** @} */

--- a/pkg/wakaama/include/objects/illuminance.h
+++ b/pkg/wakaama/include/objects/illuminance.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     lwm2m_objects
  * @defgroup    lwm2m_objects_illuminance Illuminance
@@ -85,9 +87,6 @@
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
 
-#ifndef OBJECTS_ILLUMINANCE_H
-#define OBJECTS_ILLUMINANCE_H
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -154,5 +153,4 @@ void lwm2m_object_illuminance_update_value(const lwm2m_client_data_t *client_dat
 }
 #endif
 
-#endif /* OBJECTS_ILLUMINANCE_H */
 /** @} */

--- a/pkg/wakaama/include/objects/ipso_sensor_base.h
+++ b/pkg/wakaama/include/objects/ipso_sensor_base.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     lwm2m_objects
  * @defgroup    lwm2m_objects_ipso_sensor_base IPSO Sensor base object
@@ -39,9 +41,6 @@
  *
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-
-#ifndef OBJECTS_IPSO_SENSOR_BASE_H
-#define OBJECTS_IPSO_SENSOR_BASE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -198,5 +197,4 @@ void lwm2m_object_ipso_sensor_base_update_value(const lwm2m_client_data_t *clien
 }
 #endif
 
-#endif /* OBJECTS_IPSO_SENSOR_BASE_H */
 /** @} */

--- a/pkg/wakaama/include/objects/light_control.h
+++ b/pkg/wakaama/include/objects/light_control.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     lwm2m_objects
  * @defgroup    lwm2m_objects_light_control Light Control
@@ -104,9 +106,6 @@
  *
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-
-#ifndef OBJECTS_LIGHT_CONTROL_H
-#define OBJECTS_LIGHT_CONTROL_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -298,5 +297,4 @@ int lwm2m_object_light_control_update_app_type(uint16_t instance_id, const char 
 }
 #endif
 
-#endif /* OBJECTS_LIGHT_CONTROL_H */
 /** @} */

--- a/pkg/wakaama/include/objects/on_off_switch.h
+++ b/pkg/wakaama/include/objects/on_off_switch.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     lwm2m_objects
  * @defgroup    lwm2m_objects_on_off-switch On/Off Switch
@@ -77,9 +79,6 @@
  *
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-
-#ifndef OBJECTS_ON_OFF_SWITCH_H
-#define OBJECTS_ON_OFF_SWITCH_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -200,5 +199,4 @@ int lwm2m_object_on_off_switch_update_app_type(uint16_t instance_id, const char 
 }
 #endif
 
-#endif /* OBJECTS_ON_OFF_SWITCH_H */
 /** @} */

--- a/pkg/wakaama/include/objects/security.h
+++ b/pkg/wakaama/include/objects/security.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     lwm2m_objects
  * @defgroup    lwm2m_objects_security Security LwM2M object
@@ -154,9 +156,6 @@
  *
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
-
-#ifndef OBJECTS_SECURITY_H
-#define OBJECTS_SECURITY_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -429,5 +428,4 @@ credman_tag_t lwm2m_object_security_get_credential(uint16_t instance_id);
 }
 #endif
 
-#endif /* OBJECTS_SECURITY_H */
 /** @} */

--- a/pkg/wakaama/include/objects/temperature.h
+++ b/pkg/wakaama/include/objects/temperature.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     lwm2m_objects
  * @defgroup    lwm2m_objects_temperature Temperature
@@ -88,9 +90,6 @@
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
 
-#ifndef OBJECTS_TEMPERATURE_H
-#define OBJECTS_TEMPERATURE_H
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -157,5 +156,4 @@ void lwm2m_object_temperature_update_value(const lwm2m_client_data_t *client_dat
 }
 #endif
 
-#endif /* OBJECTS_TEMPERATURE_H */
 /** @} */

--- a/pkg/wakaama/include/objects/voltage.h
+++ b/pkg/wakaama/include/objects/voltage.h
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /**
  * @ingroup     lwm2m_objects
  * @defgroup    lwm2m_objects_voltage Voltage
@@ -90,9 +92,6 @@
  * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
  */
 
-#ifndef OBJECTS_VOLTAGE_H
-#define OBJECTS_VOLTAGE_H
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -159,5 +158,4 @@ void lwm2m_object_voltage_update_value(const lwm2m_client_data_t *client_data,
 }
 #endif
 
-#endif /* OBJECTS_VOLTAGE_H */
 /** @} */

--- a/pkg/wolfssl/include/user_settings.h
+++ b/pkg/wolfssl/include/user_settings.h
@@ -1,7 +1,6 @@
-/* user_settings.h : custom configuration for wolfcrypt/wolfSSL */
+#pragma once
 
-#ifndef USER_SETTINGS_H
-#define USER_SETTINGS_H
+/* user_settings.h : custom configuration for wolfcrypt/wolfSSL */
 
 #ifdef __cplusplus
 extern "C" {
@@ -340,5 +339,3 @@ int strncasecmp(const char *s1, const char * s2, size_t sz);
 #define _SAME51_AES_COMPONENT_
 #define _SAME54_AES_COMPONENT_
 #define _SAMR34_AES_COMPONENT_
-
-#endif /* USER_SETTINGS_H */

--- a/pkg/wolfssl/sock_tls/sock_tls.h
+++ b/pkg/wolfssl/sock_tls/sock_tls.h
@@ -7,6 +7,8 @@
  * directory for more details.
  */
 
+#pragma once
+
 /* @defgroup    module sock_tls
  * @ingroup     pkg_wolfssl
  * @brief       Sock submodule for TLS/DTLS sessions
@@ -227,8 +229,6 @@
 #include <net/sock.h>
 #include <wolfssl/ssl.h>
 
-#ifndef SOCK_TLS_H
-#define SOCK_TLS_H
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -337,5 +337,3 @@ void sock_dtls_close(sock_tls_t *sk);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* SOCK_TLS_H */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is part of a greater effort to replace all header guards in RIOT with `#pragma once`. This PR only affects all headers under `pkg/`, excluding those that have a path that contains `/vendor/`.

It should now remove double empty lines around the `#ifndef` block.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Tracking issue #21335

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
