### PR TITLE
gnrc/netif: don't re-append tx_sync snip if tx is done 

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1950,8 +1950,9 @@ static void _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt, bool push_back)
     int res = netif->ops->send(netif, pkt);
 
     /* For legacy netdevs (no confirm_send) TX is blocking, thus it is always
-     * completed. For new netdevs (with confirm_send), TX is async. It is only
-     * done if TX failed right away (res < 0).
+     * completed. For new netdevs (with confirm_send), TX is usually async (res == 0).
+     * It is only done if TX failed right away (res < 0) or if the driver signaled
+     * that the transmission already completed (res > 0).
      */
     if (gnrc_netif_netdev_legacy_api(netif) || (res != 0)) {
         _tx_done(netif, pkt, tx_sync, res, push_back);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

In the `gnrc_netif` `_send` function, if sending is blocking or sending failed, the pkt is freed in the call to `_tx_done`.
 Thus, the previously split-of `tx_sync` snip shouldn't be re-appended to the already freed pkt afterwards.
This PR moves the re-appending inside the `else` path that is only executed if tx is not done yet.

The same applies for setting the `GNRC_NETIF_FLAGS_TX_FROM_PKTQUEUE` flag.

Note: I am not very familiar with this part of the code, so I don't know if the re-appending of tx-sync was deliberately outside of the `else` path, and why.  cc @maribu  as author of #18139.

### Testing procedure

I tested it manually with host+6LBR+6LN and `benchmark_udp` (6LN as client, host as server). For `-i  <= 10000` on the benchmark server (-> client will send packets at a frequency of 10ms) the 6LBR was crashing non-deterministically because of  the use-after free. 
With this fix it is not crashing anymore.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
