### PR TITLE
drivers/sx126x: configure tx clamp for sx1262

### DIFF
--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -359,6 +359,13 @@ int sx126x_init(sx126x_t *dev)
         return -ENODEV;
     }
 
+    if (sx126x_is_sx1262(dev)) {
+        /*  Workaround for SX1262, during the chip initialization.
+            Calling this function optimizes the PA clamping threshold.
+            The call must be done after a Power On Reset or a wake-up from cold start */
+        sx126x_cfg_tx_clamp(dev);
+    }
+
     /* Configure the power regulator mode */
     sx126x_set_reg_mode(dev, dev->params->regulator);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

[15.2.2 Workaround](https://cdn.sparkfun.com/assets/6/b/5/1/4/SX1262_datasheet.pdf#G19.2122720)
On the SX1262, during the chip initialization, the register TxClampConfig should be modified to optimize the PA clamping
threshold. Bits 4-1 must be set to “1111” (default value “0100”).
This register modification must be done after a Power On Reset, or a wake-up from cold Start

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

#21675 