### PR TITLE
drivers/sx126x add optional CONFIG_SX126X_DEFAULT_SYNC_WORD

### DIFF
--- a/drivers/include/sx126x.h
+++ b/drivers/include/sx126x.h
@@ -33,6 +33,22 @@
 extern "C" {
 #endif
 
+#if defined(DOXYGEN)
+/**
+ * @brief   Configure the LoRa sync word
+ *
+ * The sync word for sx126x is 16 bits long.
+ * Private networks should use 0x1424.
+ * Public networks should use 0x3444.
+ * Using the driver API you only configure 2 nibbles Y and Z to form a sync word 0xY4Z4.
+ * The default chip value is 0x12 (0x1424).
+ *
+ * See https://blog.classycode.com/lora-sync-word-compatibility-between-sx127x-and-sx126x-460324d1787a
+ * for more information and a comparison with sx127x.
+ */
+#  define CONFIG_SX126X_DEFAULT_SYNC_WORD       0x12
+#endif
+
 /**
  * * @note Forward declaration of the SX126x device descriptor
  */

--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -291,6 +291,9 @@ static void sx126x_init_default_config(sx126x_t *dev)
     sx126x_set_pkt_type(dev, SX126X_PKT_TYPE_LORA);
     sx126x_set_channel(dev, CONFIG_SX126X_CHANNEL_DEFAULT);
     sx126x_set_tx_power(dev,  CONFIG_SX126X_TX_POWER_DEFAULT, CONFIG_SX126X_RAMP_TIME_DEFAULT);
+#ifdef CONFIG_SX126X_DEFAULT_SYNC_WORD
+    sx126x_set_lora_sync_word(dev, CONFIG_SX126X_DEFAULT_SYNC_WORD);
+#endif
 
     dev->mod_params.bw = (sx126x_lora_bw_t)(CONFIG_LORA_BW_DEFAULT + SX126X_LORA_BW_125);
     dev->mod_params.sf = (sx126x_lora_sf_t)CONFIG_LORA_SF_DEFAULT;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Configure a LoRa sync word if `CONFIG_SX126X_DEFAULT_SYNC_WORD` is defined

Alternatively, should it be in `params`, in case 2 LoRa on a board should use different sync words?

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

#21675