### PR TITLE
cpu/esp32/esp-idf-rmt: fix compilation together with Nimble and WiFi

### DIFF
--- a/cpu/esp32/esp-idf/rmt/Makefile
+++ b/cpu/esp32/esp-idf/rmt/Makefile
@@ -11,7 +11,11 @@ ESP32_SDK_SRC = \
   #
 
 ifeq (esp32s3,$(CPU_FAM))
-  ESP32_SDK_SRC += components/bootloader_support/src/flash_encrypt.c
+  ifeq (,$(filter esp_idf_nvs_flash,$(USEMODULE)))
+    # this file is already compiled in `esp_idf_nvs_flash`
+    # don't compile it again if `esp_idf_nvs_flash` is used
+    ESP32_SDK_SRC += components/bootloader_support/src/flash_encrypt.c
+  endif
   ESP32_SDK_SRC += components/esp_hw_support/dma/gdma.c
   ESP32_SDK_SRC += components/hal/gdma_hal_ahb_v1.c
   ESP32_SDK_SRC += components/hal/gdma_hal_top.c


### PR DESCRIPTION
### Contribution description

The RMT driver module `esp_idf_rmt` uses GDMA on ESP32-S3, which in turn requires the activation and deactivation of flash encryption. Therefore, when the RMT driver module `esp_idf_rmt` is used, the function `gdma_disconnect` is used, which in turn requires the function `esp_flash_encryption_enabled`.

However, if the NVS flash module `esp_idf_nvs_flash` is also used for some reason, e.g. because WiFi or BLE is used, the function `esp_flash_encryption_enabled` is already compiled in the module `esp_idf_nvs_flash` and must not be compiled again in the module `esp_idf_rmt`.

### Testing procedure

Use the following command to test the compilation with and w/o this PR:

```
USEMODULE=ws281x BOARD=esp32s3-pros3 make -j4 -C examples/networking/ble/nimble/nimble_scanner
```

Without the PR, a multiple defintion errors occurs:
```
xtensa-esp-elf/bin/ld: examples/networking/ble/nimble/nimble_scanner/bin/esp32s3-pros3/esp_idf_rmt/components/bootloader_support/src/flash_encrypt.o: in function `esp_flash_encryption_enabled':
build/pkg/esp32_sdk/components/bootloader_support/src/flash_encrypt.c:84: multiple definition of `esp_flash_encryption_enabled'; examples/networking/ble/nimble/nimble_scanner/bin/esp32s3-pros3/esp_idf_common/components/bootloader_support/src/flash_encrypt.o:build/pkg/esp32_sdk/components/bootloader_support/src/flash_encrypt.c:84: first defined here
```

With the PR, the compilation should succeed.

### Issues/PRs references

Fixes #21690