### PR TITLE
makefiles/tools/openocd: Do not require openocd.cfg for STM32 boards

### DIFF
--- a/makefiles/tools/openocd-adapters/stlink.inc.mk
+++ b/makefiles/tools/openocd-adapters/stlink.inc.mk
@@ -28,14 +28,3 @@ ifneq (,$(SRST))
   OPENOCD_ADAPTER_INIT += \
     -c 'set SRST_OPT $(SRST)'
 endif
-
-# if no openocd specific configuration file, check for default locations:
-# 1. Using the default dist/openocd.cfg (automatically set by openocd.sh)
-# 2. Using the common cpu specific config file
-ifeq (,$(OPENOCD_CONFIG))
-  # if no openocd default configuration is provided by the board,
-  # use the STM32 common one
-  ifeq (0,$(words $(wildcard $(BOARDDIR)/dist/openocd.cfg)))
-    OPENOCD_CONFIG = $(RIOTBASE)/boards/common/stm32/dist/stm32$(CPU_FAM).cfg
-  endif
-endif

--- a/makefiles/tools/openocd.inc.mk
+++ b/makefiles/tools/openocd.inc.mk
@@ -18,7 +18,19 @@ ifneq (,$(OPENOCD_DEBUG_ADAPTER))
   endif
 endif
 
-OPENOCD_CONFIG ?= $(BOARDDIR)/dist/openocd.cfg
+# Use the board's custom OpenOCD by default, if present in the file system.
+OPENOCD_CONFIG ?= $(wildcard $(BOARDDIR)/dist/openocd.cfg)
+
+# Still no config?
+ifeq (,$(OPENOCD_CONFIG))
+  # MCU is STM32 based?
+  ifeq (stm32,$(CPU))
+    # Then use the common OpenOCD config for the STM32 family in use
+    OPENOCD_CONFIG := $(RIOTBASE)/boards/common/stm32/dist/stm32$(CPU_FAM).cfg
+  else
+    $(warning "Even though PROGRAMMER is openocd, no OPENOCD_CONFIG is specified. Flashing and debugging won't work.")
+  endif
+endif
 
 OPENOCD_TARGETS = debug% flash% reset
 


### PR DESCRIPTION
### Contribution description

When `OPENOCD_DEBUG_ADAPTER` was set to `stlink`, no `openocd.cfg` was needed for most STM32 boards. (But one could still be provided if special handling was needed.) However, for any other debug adapter this was not the case.

This moves the handling for when no custom `openocd.cfg` is provided from the `stlink.inc.mk` to `openocd.inc.mk`, so that most boards now work out of the box with other debuggers.

### Testing procedure

Tested with `OPENOCD_DEBUG_ADAPTER=jlink` with a yet to be upstreamed STM32 board. B

### Issues/PRs references

Fixes one of the issues we ran into on the RIOT summit Hackathon when adding the Olimexino-STM32F3 board definition