### PR TITLE
drivers/dose: implement netdev API async

### DIFF
--- a/drivers/include/dose.h
+++ b/drivers/include/dose.h
@@ -204,6 +204,7 @@ typedef struct {
     ztimer_t timeout;                       /**< Timeout timer ensuring always to get back to IDLE state */
     uint32_t timeout_base;                  /**< Base timeout in us */
     uart_t uart;                            /**< UART device to use */
+    int tx_result;                          /**< return code for confirm_send() */
     uint8_t uart_octet;                     /**< Last received octet */
     uint8_t flags;                          /**< Several flags */
 } dose_t;


### PR DESCRIPTION
### Contribution description

This changes the behavior of the netdev implementation to match what async drivers do. The current implementation is synchronous, but that can be fixed once an async UART API is available.

In any case, we rather should not complicate testing of the network stack by having network devices come in different flavors.

### Testing procedure

No regressions in DOSE

### Issues/PRs references

None