### PR TITLE
drivers/ethos: implement netdev API async

### DIFF
--- a/drivers/include/ethos.h
+++ b/drivers/include/ethos.h
@@ -116,6 +116,7 @@ typedef struct {
     line_state_t state;     /**< Line status variable */
     unsigned frametype;     /**< type of currently incoming frame */
     mutex_t out_mutex;      /**< mutex used for locking concurrent sends */
+    int tx_result;          /**< result to report in confirm_send() */
 } ethos_t;
 
 /**


### PR DESCRIPTION
### Contribution description

This changes the behavior of the netdev implementation to match what async drivers do. The current implementation is synchronous, but that can be fixed once an async UART API is available.

In any case, we rather should not complicate testing of the network stack by having network devices come in different flavors.

### Testing procedure

Ethos should still work correctly.

### Issues/PRs references

Same as: https://github.com/RIOT-OS/RIOT/pull/21719