### PR TITLE
drivers/atwinc15x0: implement netdev API async

### DIFF
--- a/drivers/include/atwinc15x0.h
+++ b/drivers/include/atwinc15x0.h
@@ -92,6 +92,7 @@ typedef struct atwinc15x0 {
     int8_t rssi;                /**< RSSI last measured by the WiFi module */
 
     uint8_t* rx_buf;            /**< Incoming packet in receive buffer */
+    int tx_result;              /**< value to resturn in confirm_send() */
     uint16_t rx_len;            /**< Length of an incoming packet, if there
                                      is no packet in the buffer, it is 0 */
 


### PR DESCRIPTION
### Contribution description

This changes the behavior of the netdev implementation to match what async drivers do. The current implementation is synchronous, but that can be fixed once an async UART API is available.

In any case, we rather should not complicate testing of the network stack by having network devices come in different flavors.

### Testing procedure

The atwinc15x0 should still work as before

### Issues/PRs references

Same as: https://github.com/RIOT-OS/RIOT/pull/21719 and https://github.com/RIOT-OS/RIOT/pull/21720