### PR TITLE
doc/starlight: rename guides title from Riot to RIOT

### DIFF
--- a/doc/starlight/astro.config.mjs
+++ b/doc/starlight/astro.config.mjs
@@ -7,7 +7,7 @@ export default defineConfig({
   site: "https://guide.riot-os.org",
   integrations: [
     starlight({
-      title: "Riot Documentation",
+      title: "RIOT Documentation",
       social: [
         {
           icon: "github",


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

I renamed the title tag of the RIOT guides website to write `RIOT` instead of `Riot`.
We always write RIOT's name as `RIOT` and not as `Riot` in all places I checked.
E.g.:
 - https://www.riot-os.org/
 - https://doc.riot-os.org/
 - main readme.md


