### PR TITLE
doc/starlight: Add link to RIOT forum

### DIFF
--- a/doc/starlight/astro.config.mjs
+++ b/doc/starlight/astro.config.mjs
@@ -24,6 +24,11 @@ export default defineConfig({
           label: "Matrix",
           href: "https://matrix.to/#/#riot-os:matrix.org",
         },
+        {
+          icon: "discourse",
+          label: "Forum",
+          href: "https://forum.riot-os.org",
+        },
       ],
       sidebar: [
         {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The guides page was already providing links (at the top right) to GitHub, Matrix and Mastodon, but not to the forum.
So I added a simple link to the RIOT discourse :)