### PR TITLE
doc/starlight: add Bluesky and YouTube social link

### DIFF
--- a/doc/starlight/astro.config.mjs
+++ b/doc/starlight/astro.config.mjs
@@ -20,14 +20,24 @@ export default defineConfig({
           href: "https://floss.social/@RIOT_OS",
         },
         {
-          icon: "matrix",
-          label: "Matrix",
-          href: "https://matrix.to/#/#riot-os:matrix.org",
+          icon: "blueSky",
+          label: "Bluesky",
+          href: "https://bsky.app/profile/riot-os.org",
+        },
+        {
+          icon: "youtube",
+          label: "YouTube",
+          href: "https://www.youtube.com/c/RIOT-IoT",
         },
         {
           icon: "discourse",
           label: "Forum",
           href: "https://forum.riot-os.org",
+        },
+        {
+          icon: "matrix",
+          label: "Matrix",
+          href: "https://matrix.to/#/#riot-os:matrix.org",
         },
       ],
       sidebar: [


### PR DESCRIPTION
### Contribution description

I just realized that we also have youtube and bluesky, so I also added them.
I also rearranged the icon order to follow the order on the https://riot-os.org website in the footer.

### Guides:
<img width="281" height="66" alt="image" src="https://github.com/user-attachments/assets/16735450-4d6a-43d2-863d-5ac0be4f8658" />

### riot-os.org:
<img width="293" height="63" alt="image" src="https://github.com/user-attachments/assets/d6a43c78-d0c1-45c1-af1b-6653818316d1" />
