### PR TITLE
pkg/lvgl: support monochrome displays via u8g2

### DIFF
--- a/pkg/lvgl/contrib/lvgl.c
+++ b/pkg/lvgl/contrib/lvgl.c
@@ -39,7 +39,11 @@
 #endif
 
 #ifndef LVGL_COLOR_BUF_SIZE
-#define LVGL_COLOR_BUF_SIZE                 (LV_HOR_RES_MAX * 10)
+#  if IS_USED(MODULE_U8G2_DISP_DEV)
+#    define LVGL_COLOR_BUF_SIZE                 (LV_HOR_RES_MAX * 10 * 8)
+#  else
+#    define LVGL_COLOR_BUF_SIZE                 (LV_HOR_RES_MAX * 10)
+#  endif
 #endif
 
 #ifndef CONFIG_LVGL_INACTIVITY_PERIOD_MS
@@ -134,6 +138,23 @@ static void _touch_read(lv_indev_drv_t *indev_driver, lv_indev_data_t *data)
 }
 #endif
 
+/* Pixel placement for monochrome displays where color depth is 1 bit, and each bit represents
+   a pixel */
+static void _monochrome_1bit_set_px_cb(lv_disp_drv_t *disp_drv, uint8_t *buf, lv_coord_t buf_w,
+                                       lv_coord_t x, lv_coord_t y, lv_color_t color, lv_opa_t opa)
+{
+    (void)disp_drv;
+    (void)opa;
+
+    uint16_t byte = (y * buf_w / 8) + (x / 8);
+    if (lv_color_brightness(color) > 128) {
+        (buf[byte]) |= (1 << (x % 8));
+    }
+    else {
+        (buf[byte]) &= ~(1 << (x % 8));
+    }
+}
+
 void lvgl_init(screen_dev_t *screen_dev)
 {
     lv_init();
@@ -163,6 +184,11 @@ void lvgl_init(screen_dev_t *screen_dev)
     disp_drv.hor_res = disp_dev_width(screen_dev->display);
     disp_drv.ver_res = disp_dev_height(screen_dev->display);
 #endif
+
+    if (disp_dev_color_depth(screen_dev->display) == 1) {
+        disp_drv.full_refresh = 1;
+        disp_drv.set_px_cb = _monochrome_1bit_set_px_cb;
+    }
 
     lv_disp_drv_register(&disp_drv);
 
@@ -208,5 +234,6 @@ void lvgl_run(void)
 void lvgl_wakeup(void)
 {
     thread_t *tcb = thread_get(_task_thread_pid);
+
     thread_flags_set(tcb, LVGL_THREAD_FLAG);
 }

--- a/pkg/lvgl/include/lv_conf.h
+++ b/pkg/lvgl/include/lv_conf.h
@@ -30,7 +30,7 @@ extern "C" {
  *====================*/
 
 /* Color depth:
- * - 1:  1 byte per pixel
+ * - 1:  1 bit per pixel
  * - 8:  RGB233
  * - 16: RGB565
  * - 32: ARGB8888

--- a/pkg/lvgl/include/lv_conf.h
+++ b/pkg/lvgl/include/lv_conf.h
@@ -36,7 +36,11 @@ extern "C" {
  * - 32: ARGB8888
  */
 #ifndef LV_COLOR_DEPTH
-#define LV_COLOR_DEPTH     16
+#  if IS_USED(MODULE_U8G2_DISP_DEV)
+#    define LV_COLOR_DEPTH     1
+#  else
+#    define LV_COLOR_DEPTH     16
+#  endif
 #endif
 
 /* Swap the 2 bytes of RGB565 color.

--- a/sys/auto_init/screen/auto_init_lvgl.c
+++ b/sys/auto_init/screen/auto_init_lvgl.c
@@ -50,6 +50,10 @@ void auto_init_lvgl(void)
     /* Only a single screen is supported by lvgl */
 #if !IS_USED(MODULE_LV_DRIVERS_SDL)
     disp_dev_reg_t *disp_dev = disp_dev_reg_find_screen(CONFIG_LVGL_SCREEN_DEFAULT);
+    if (disp_dev == NULL) {
+        puts("[auto_init_screen] error: no display device found\n");
+        return;
+    }
     s_screen.display = disp_dev->dev;
 #endif
 


### PR DESCRIPTION
### Contribution description
This enables using monochrome displays via the [Display Device Generic API](https://doc.riot-os.org/group__drivers__disp__dev.html) and the [u8g2](https://github.com/olikraus/u8g2/) package.

I've tested this on two displays with the 1306 driver. In the examples below there's a random counter that updates a label and a line plot on the left.

#### I2C

[i2c.webm](https://github.com/user-attachments/assets/3b90795c-55be-4122-8eaa-ae02923a5085)

#### SPI

(ignore PCB marking, connection is a 4-wire SPI :)

[spi.webm](https://github.com/user-attachments/assets/6c13c2f9-2b62-4ef4-802a-2b239c54aec1)

### Testing procedure

The test application `tests/pkg/lvgl` should work after adapting it to the correct resolution.

### Issues/PRs references
Depends on #21725
