### PR TITLE
dist/tools/ci: include rust, node and git commit in print-version

### DIFF
--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -110,6 +110,21 @@ avr_libc_version() {
 }
 
 printf "\n"
+printf "%s\n" "RIOT version information"
+printf "%s\n" "----------------------------"
+if [ -d .git ]; then
+    RIOT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    RIOT_COMMIT_HASH=$(git rev-parse HEAD)
+    RIOT_COMMIT_DATE=$(git log -1 --format=%cd --date=short)
+else
+    RIOT_BRANCH="unknown (not a git repository)"
+    RIOT_COMMIT_HASH="unknown (not a git repository)"
+    RIOT_COMMIT_DATE="unknown (not a git repository)"
+fi
+printf "%25s: %s\n" "RIOT branch" "$RIOT_BRANCH"
+printf "%25s: %s\n" "RIOT commit hash" "$RIOT_COMMIT_HASH"
+printf "%25s: %s\n" "RIOT commit date" "$RIOT_COMMIT_DATE"
+printf "\n"
 # print operating system information
 printf "%s\n" "Operating System Environment"
 printf "%s\n" "----------------------------"
@@ -171,6 +186,12 @@ for c in \
          python \
          python2 \
          python3 \
+         rustup \
+         cargo \
+         rustc \
+         c2rust \
+         node \
+         npm \
          ; do
     printf "%25s: %s\n" "$c" "$(get_cmd_version "${c}")"
 done

--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -144,6 +144,7 @@ for p in \
          riscv-none-elf \
          riscv64-unknown-elf \
          riscv32-esp-elf \
+         riscv32-unknown-elf \
          xtensa-esp32-elf \
          xtensa-esp32s2-elf \
          xtensa-esp32s3-elf \
@@ -162,6 +163,7 @@ for p in \
          riscv-none-elf \
          riscv64-unknown-elf \
          riscv32-esp-elf \
+         riscv32-unknown-elf \
          xtensa-esp32-elf \
          xtensa-esp32s2-elf \
          xtensa-esp32s3-elf \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Currently the print-version script used for debugging does not include information about the Rust and Frontend environment. While at it I thought it might also make sense to include information about the exact state the RIOT repository is in, esp. to debug cases where the RIOT repository might simply be outdated.

#### Before:

```
[ann@computer RIOT]$ make print-versions 

Operating System Environment
----------------------------
         Operating System: "EndeavourOS" 
                   Kernel: Linux 6.16.5-arch1-1 x86_64 unknown
             System shell: GNU bash, version 5.3.3(1)-release (x86_64-pc-linux-gnu)
             make's shell: GNU bash, version 5.3.3(1)-release (x86_64-pc-linux-gnu)

Installed compiler toolchains
-----------------------------
               native gcc: gcc (GCC) 15.2.1 20250813
        arm-none-eabi-gcc: missing
                  avr-gcc: missing
           msp430-elf-gcc: missing
       riscv-none-elf-gcc: missing
  riscv64-unknown-elf-gcc: missing
      riscv32-esp-elf-gcc: missing
     xtensa-esp32-elf-gcc: missing
   xtensa-esp32s2-elf-gcc: missing
   xtensa-esp32s3-elf-gcc: missing
   xtensa-esp8266-elf-gcc: missing
                    clang: clang version 20.1.8

Installed compiler libs
-----------------------
     arm-none-eabi-newlib: missing
        msp430-elf-newlib: missing
    riscv-none-elf-newlib: missing
riscv64-unknown-elf-newlib: missing
   riscv32-esp-elf-newlib: missing
  xtensa-esp32-elf-newlib: missing
xtensa-esp32s2-elf-newlib: missing
xtensa-esp32s3-elf-newlib: missing
xtensa-esp8266-elf-newlib: missing
                 avr-libc: missing (missing)

Installed development tools
---------------------------
                   ccache: missing
                    cmake: cmake version 4.1.1
                 cppcheck: missing
                  doxygen: missing
                      git: git version 2.51.0
                     make: GNU Make 4.4.1
                  openocd: missing
                   python: Python 3.13.7
                  python2: missing
                  python3: Python 3.13.7
                   flake8: error: /usr/bin/python3: No module named flake8
               coccinelle: missing
```

#### After:

```
[ann@computer RIOT]$ make print-versions 

RIOT version information
----------------------------
              RIOT branch: extend_print_version
         RIOT commit hash: 5d52edeb57ef88c5435dbccd55c14cb93a31e236
         RIOT commit date: 2025-09-21

Operating System Environment
----------------------------
         Operating System: "EndeavourOS" 
                   Kernel: Linux 6.16.5-arch1-1 x86_64 unknown
             System shell: GNU bash, version 5.3.3(1)-release (x86_64-pc-linux-gnu)
             make's shell: GNU bash, version 5.3.3(1)-release (x86_64-pc-linux-gnu)

Installed compiler toolchains
-----------------------------
               native gcc: gcc (GCC) 15.2.1 20250813
        arm-none-eabi-gcc: missing
                  avr-gcc: missing
           msp430-elf-gcc: missing
       riscv-none-elf-gcc: missing
  riscv64-unknown-elf-gcc: missing
      riscv32-esp-elf-gcc: missing
     xtensa-esp32-elf-gcc: missing
   xtensa-esp32s2-elf-gcc: missing
   xtensa-esp32s3-elf-gcc: missing
   xtensa-esp8266-elf-gcc: missing
                    clang: clang version 20.1.8

Installed compiler libs
-----------------------
     arm-none-eabi-newlib: missing
        msp430-elf-newlib: missing
    riscv-none-elf-newlib: missing
riscv64-unknown-elf-newlib: missing
   riscv32-esp-elf-newlib: missing
  xtensa-esp32-elf-newlib: missing
xtensa-esp32s2-elf-newlib: missing
xtensa-esp32s3-elf-newlib: missing
xtensa-esp8266-elf-newlib: missing
                 avr-libc: missing (missing)

Installed development tools
---------------------------
                   ccache: missing
                    cmake: cmake version 4.1.1
                 cppcheck: missing
                  doxygen: missing
                      git: git version 2.51.0
                     make: GNU Make 4.4.1
                  openocd: missing
                   python: Python 3.13.7
                  python2: missing
                  python3: Python 3.13.7
                    cargo: cargo 1.84.0 (66221abde 2024-11-19)
                    rustc: rustc 1.84.0 (9fc6b4312 2025-01-07)
                     node: v22.13.0
                      npm: 10.9.2
                   flake8: error: /usr/bin/python3: No module named flake8
               coccinelle: missing
```


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`make print-version`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
