### PR TITLE
doc/doxygen: deprecate governance page

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -866,7 +866,7 @@ INPUT                  = ../../doc.txt \
                          src/ \
                          src/mainpage.md \
                          src/vision.md \
-                         src/governance.md \
+                         src/governance-info.md \
                          src/roadmap.md \
                          src/coc-info.md \
                          src/coc.md \

--- a/doc/doxygen/src/governance-info.md
+++ b/doc/doxygen/src/governance-info.md
@@ -1,0 +1,5 @@
+Governance of the RIOT Community (Deprecated)                                    {#governance}
+================================
+
+@deprecated Guides have moved to the [Guide Site](https://guide.riot-os.org/general/governance/).
+This page will be removed after release 2026.04.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The governance page was already migrated to the guides site in a previous PR, so I deprecated it also now.

One question that remains is if we want to keep it inside of the man pages and the latex target??
If we can remove it from these pages than I would change the implementation of this PR and just stop the makefile from copying the code_of_conduct.md file