### PR TITLE
nrf52/cfg_rtt_default: fix rtt min offset

### DIFF
--- a/boards/common/nrf52/include/cfg_rtt_default.h
+++ b/boards/common/nrf52/include/cfg_rtt_default.h
@@ -36,6 +36,11 @@ extern "C" {
 #define RTT_MAX_FREQUENCY   (32768U)             /* in Hz */
 #define RTT_MIN_FREQUENCY   (8U)                 /* in Hz */
 #define RTT_CLOCK_FREQUENCY (32768U)             /* in Hz, LFCLK*/
+/**
+ * Default offset of 2 ticks is not enough, see figures 8 and 9 in
+ * https://docs.nordicsemi.com/bundle/ps_nrf52840/page/rtc.html.
+ */
+#define RTT_MIN_OFFSET      (3U)
 
 #ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (1024U)              /* in Hz */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

By default, RTT_MIN_OFFSET is 2. According to figures 8 and 9 in the [nrf52840 documentation](https://docs.nordicsemi.com/bundle/ps_nrf52840/page/rtc.html), the RTT_MIN_OFFSET should be set to this 2, because the RTC of nrf52 hardware requires a synchronization delay of at least 2 ticks after writing to the compare register.
However, this comparison is racy because it can happen that between reading and writing the register again, another tick happens. In that case, the actual offset in the end would only be 1, and the compare register wouldn't trigger and the event would be lost.
To avoid this, the RTT_MIN_OFFSET should be set to 3.

cc @mguetschow 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
The attached `makefile` and `main.c` can reproduce the problem.
[ztimer_test001.zip](https://github.com/user-attachments/files/22538237/ztimer_test001.zip)

The phenomenon is that after runing the code for a random amount of time, all the threads will stop printing their stack information. However, after 512 seconds (no idea why this number, maybe because 2^24 / 32768 = 512?), all the threads will restart to print again.
By uncommenting `CFLAGS += -DRTT_MIN_OFFSET=3` in the `makefile`, the problem can be solved. All the threads should keep printing without stopping randomly.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
