### PR TITLE
cpu: move licenses from comments to SPDX format (part4)

### DIFF
--- a/cpu/native/Kconfig
+++ b/cpu/native/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_ARCH_NATIVE
     bool

--- a/cpu/native/async_read.c
+++ b/cpu/native/async_read.c
@@ -1,13 +1,10 @@
 /*
- * Copyright (C) 2015 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>,
- *                    Martine Lenders <mlenders@inf.fu-berlin.de>
- *                    Kaspar Schleiser <kaspar@schleiser.de>
- *                    Ell-i open source co-operative
- *                    Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>,
+ * SPDX-FileCopyrightText: 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2015 Ell-i open source co-operative
+ * SPDX-FileCopyrightText: 2015 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/backtrace/backtrace.c
+++ b/cpu/native/backtrace/backtrace.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/cli_eui_provider/eui_provider.c
+++ b/cpu/native/cli_eui_provider/eui_provider.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/cpu.c
+++ b/cpu/native/cpu.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
- *               2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/fs/native_fs.c
+++ b/cpu/native/fs/native_fs.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/include/architecture_arch.h
+++ b/cpu/native/include/architecture_arch.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/async_read.h
+++ b/cpu/native/include/async_read.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2015 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/atomic_utils_arch.h
+++ b/cpu/native/include/atomic_utils_arch.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/backtrace.h
+++ b/cpu/native/include/backtrace.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/can_params.h
+++ b/cpu/native/include/can_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/candev_linux.h
+++ b/cpu/native/include/candev_linux.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/cpu.h
+++ b/cpu/native/include/cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 - 2016 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013-2016 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/cpu_conf.h
+++ b/cpu/native/include/cpu_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/eeprom_native.h
+++ b/cpu/native/include/eeprom_native.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/gpiodev_linux.h
+++ b/cpu/native/include/gpiodev_linux.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2019 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/mtd_native.h
+++ b/cpu/native/include/mtd_native.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016  OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/native_cli_eui_provider.h
+++ b/cpu/native/include/native_cli_eui_provider.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2013, 2014 Ludwig Knüpfer
- * Copyright (C) 2025 carl-tud
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013-2014 Ludwig Knüpfer
+ * SPDX-FileCopyrightText: 2025 carl-tud
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/netdev_tap.h
+++ b/cpu/native/include/netdev_tap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/netdev_tap_params.h
+++ b/cpu/native/include/netdev_tap_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/periph_conf.h
+++ b/cpu/native/include/periph_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/periph_cpu.h
+++ b/cpu/native/include/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/socket_zep.h
+++ b/cpu/native/include/socket_zep.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/socket_zep_params.h
+++ b/cpu/native/include/socket_zep_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/spidev_linux.h
+++ b/cpu/native/include/spidev_linux.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Frank Hessel <frank@fhessel.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Frank Hessel <frank@fhessel.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/syscalls.h
+++ b/cpu/native/include/syscalls.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/thread_arch.h
+++ b/cpu/native/include/thread_arch.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2021 Koen Zandberg <koen@bergzand.net>
- *               2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2021 Koen Zandberg <koen@bergzand.net>
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/tty_uart.h
+++ b/cpu/native/include/tty_uart.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2015 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/util/ucontext.h
+++ b/cpu/native/include/util/ucontext.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2013 - 2016 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- * Copyright (C) 2025 carl-tud
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013-2016 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-FileCopyrightText: 2025 carl-tud
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/include/util/valgrind.h
+++ b/cpu/native/include/util/valgrind.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 carl-tud
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 carl-tud
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/native/irq.c
+++ b/cpu/native/irq.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/mtd/mtd_native.c
+++ b/cpu/native/mtd/mtd_native.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016  OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2015 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>,
- *                    Martine Lenders <mlenders@inf.fu-berlin.de>
- *                    Kaspar Schleiser <kaspar@schleiser.de>
- *                    Ell-i open source co-operative
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2015 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>,
+ * SPDX-FileCopyrightText: 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2015 Ell-i open source co-operative
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/panic.c
+++ b/cpu/native/panic.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014, 2015 Freie Universitaet Berlin (FUB) and INRIA
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2015 Freie Universität Berlin (FUB) and INRIA
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/periph/can.c
+++ b/cpu/native/periph/can.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/periph/cpuid.c
+++ b/cpu/native/periph/cpuid.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Martine Lenders <mlenders@inf.fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Martine Lenders <mlenders@inf.fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/periph/eeprom.c
+++ b/cpu/native/periph/eeprom.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/periph/flashpage.c
+++ b/cpu/native/periph/flashpage.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/periph/gpio_linux.c
+++ b/cpu/native/periph/gpio_linux.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2019 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/periph/gpio_mock.c
+++ b/cpu/native/periph/gpio_mock.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2015 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/periph/hwrng.c
+++ b/cpu/native/periph/hwrng.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *               2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/periph/pm.c
+++ b/cpu/native/periph/pm.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/periph/pwm.c
+++ b/cpu/native/periph/pwm.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gilles DOFFE <g.doffe@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gilles DOFFE <g.doffe@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/periph/qdec.c
+++ b/cpu/native/periph/qdec.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Gilles DOFFE <g.doffe@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Gilles DOFFE <g.doffe@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/periph/rtc.c
+++ b/cpu/native/periph/rtc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013, 2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013-2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/periph/spidev_linux.c
+++ b/cpu/native/periph/spidev_linux.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Frank Hessel <frank@fhessel.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Frank Hessel <frank@fhessel.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *               2015 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/periph/uart.c
+++ b/cpu/native/periph/uart.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2015 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *               2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/stdio_native/stdio_native.c
+++ b/cpu/native/stdio_native/stdio_native.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/native/vfs/native_vfs.c
+++ b/cpu/native/vfs/native_vfs.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf51/Kconfig
+++ b/cpu/nrf51/Kconfig
@@ -1,10 +1,6 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#               2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_NRF51
     bool

--- a/cpu/nrf51/cpu.c
+++ b/cpu/nrf51/cpu.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf51/include/cpu_conf.h
+++ b/cpu/nrf51/include/cpu_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf51/include/periph_cpu.h
+++ b/cpu/nrf51/include/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015-2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf51/periph/adc.c
+++ b/cpu/nrf51/periph/adc.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *               2015 Ludwig Knüpfer
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Ludwig Knüpfer
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf51/periph/i2c.c
+++ b/cpu/nrf51/periph/i2c.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf51/periph/pwm.c
+++ b/cpu/nrf51/periph/pwm.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf51/periph/spi.c
+++ b/cpu/nrf51/periph/spi.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf51/vectors.c
+++ b/cpu/nrf51/vectors.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014-2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf52/Kconfig
+++ b/cpu/nrf52/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_NRF52
     bool

--- a/cpu/nrf52/cpu.c
+++ b/cpu/nrf52/cpu.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Jan Wagner <mail@jwagner.eu>
- *               2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Jan Wagner <mail@jwagner.eu>
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf52/include/cpu_conf.h
+++ b/cpu/nrf52/include/cpu_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2020 Philipp-Alexander Blum <philipp-blum@jakiku.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Philipp-Alexander Blum <philipp-blum@jakiku.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf52/include/nrf802154.h
+++ b/cpu/nrf52/include/nrf802154.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf52/include/openwsn_defs.h
+++ b/cpu/nrf52/include/openwsn_defs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
- *               2020 Philipp-Alexander Blum <philipp-blum@jakiku.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2018 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Philipp-Alexander Blum <philipp-blum@jakiku.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf52/periph/adc.c
+++ b/cpu/nrf52/periph/adc.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *               2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf52/radio/nrf802154/Kconfig
+++ b/cpu/nrf52/radio/nrf802154/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "nRF802154"
     depends on USEMODULE_NRF802154

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf52/spi_twi_irq.c
+++ b/cpu/nrf52/spi_twi_irq.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf52/vectors/vectors_nrf52805xxaa.c
+++ b/cpu/nrf52/vectors/vectors_nrf52805xxaa.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf52/vectors/vectors_nrf52810xxaa.c
+++ b/cpu/nrf52/vectors/vectors_nrf52810xxaa.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2020 Philipp-Alexander Blum <philipp-blum@jakiku.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Philipp-Alexander Blum <philipp-blum@jakiku.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf52/vectors/vectors_nrf52811xxaa.c
+++ b/cpu/nrf52/vectors/vectors_nrf52811xxaa.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2020 Philipp-Alexander Blum <philipp-blum@jakiku.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Philipp-Alexander Blum <philipp-blum@jakiku.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf52/vectors/vectors_nrf52820xxaa.c
+++ b/cpu/nrf52/vectors/vectors_nrf52820xxaa.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf52/vectors/vectors_nrf52832xxaa.c
+++ b/cpu/nrf52/vectors/vectors_nrf52832xxaa.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf52/vectors/vectors_nrf52833xxaa.c
+++ b/cpu/nrf52/vectors/vectors_nrf52833xxaa.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf52/vectors/vectors_nrf52840xxaa.c
+++ b/cpu/nrf52/vectors/vectors_nrf52840xxaa.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf53/Kconfig
+++ b/cpu/nrf53/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2023 Mesotic SAS
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2023 Mesotic SAS
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # For now, define all features here
 # We will rely on nrf5x_common later when we support more peripherals

--- a/cpu/nrf53/cpu.c
+++ b/cpu/nrf53/cpu.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf53/include/cpu_conf.h
+++ b/cpu/nrf53/include/cpu_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf53/include/periph_cpu.h
+++ b/cpu/nrf53/include/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf53/vectors/vectors_nrf5340_app.c
+++ b/cpu/nrf53/vectors/vectors_nrf5340_app.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/Kconfig
+++ b/cpu/nrf5x_common/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_COMMON_NRF5X
 depends on !CPU_FAM_NRF53

--- a/cpu/nrf5x_common/clock.c
+++ b/cpu/nrf5x_common/clock.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/include/gpio_ll_arch.h
+++ b/cpu/nrf5x_common/include/gpio_ll_arch.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2015 Jan Wagner <mail@jwagner.eu>
- *               2015-2016 Freie Universität Berlin
- *               2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Jan Wagner <mail@jwagner.eu>
+ * SPDX-FileCopyrightText: 2015-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf5x_common/include/nrf_clock.h
+++ b/cpu/nrf5x_common/include/nrf_clock.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf5x_common/include/nrfble.h
+++ b/cpu/nrf5x_common/include/nrfble.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017-2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017-2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf5x_common/include/nrfmin.h
+++ b/cpu/nrf5x_common/include/nrfmin.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015-2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf5x_common/include/nrfmin_gnrc.h
+++ b/cpu/nrf5x_common/include/nrfmin_gnrc.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf5x_common/include/nrfusb.h
+++ b/cpu/nrf5x_common/include/nrfusb.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf5x_common/include/nrfx_riot.h
+++ b/cpu/nrf5x_common/include/nrfx_riot.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- * Copyright (C) 2020 Inria
- * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf5x_common/include/periph_cpu_common.h
+++ b/cpu/nrf5x_common/include/periph_cpu_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015-2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf5x_common/include/timer_arch.h
+++ b/cpu/nrf5x_common/include/timer_arch.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2015 Jan Wagner <mail@jwagner.eu>
- *               2015-2016 Freie Universität Berlin
- *               2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Jan Wagner <mail@jwagner.eu>
+ * SPDX-FileCopyrightText: 2015-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf5x_common/periph/flashpage.c
+++ b/cpu/nrf5x_common/periph/flashpage.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2015 Jan Wagner <mail@jwagner.eu>
- *               2015-2016 Freie Universität Berlin
- *               2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Jan Wagner <mail@jwagner.eu>
+ * SPDX-FileCopyrightText: 2015-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/periph/gpio_ll.c
+++ b/cpu/nrf5x_common/periph/gpio_ll.c
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2015 Jan Wagner <mail@jwagner.eu>
- *               2015-2016 Freie Universität Berlin
- *               2019 Inria
- *               2021 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Jan Wagner <mail@jwagner.eu>
+ * SPDX-FileCopyrightText: 2015-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/periph/gpio_ll_irq.c
+++ b/cpu/nrf5x_common/periph/gpio_ll_irq.c
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2015 Jan Wagner <mail@jwagner.eu>
- *               2015-2016 Freie Universität Berlin
- *               2019 Inria
- *               2021 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Jan Wagner <mail@jwagner.eu>
+ * SPDX-FileCopyrightText: 2015-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/periph/hwrng.c
+++ b/cpu/nrf5x_common/periph/hwrng.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *               2015 Jan Wagner <mail@jwagner.eu>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Jan Wagner <mail@jwagner.eu>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/periph/i2c_nrf52_nrf9160.c
+++ b/cpu/nrf5x_common/periph/i2c_nrf52_nrf9160.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *               2018 Freie Universität Berlin
- *               2018 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/periph/pm.c
+++ b/cpu/nrf5x_common/periph/pm.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
- *               2014-2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2014-2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/periph/pwm_nrfxx.c
+++ b/cpu/nrf5x_common/periph/pwm_nrfxx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/periph/qdec.c
+++ b/cpu/nrf5x_common/periph/qdec.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/periph/rtt.c
+++ b/cpu/nrf5x_common/periph/rtt.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014-2017 Freie Universität Berlin
- *               2015 Jan Wagner <mail@jwagner.eu>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Jan Wagner <mail@jwagner.eu>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/periph/spi_nrf52_nrf9160.c
+++ b/cpu/nrf5x_common/periph/spi_nrf52_nrf9160.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- * Copyright (C) 2020 Inria
- * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/periph/temperature.c
+++ b/cpu/nrf5x_common/periph/temperature.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/periph/timer.c
+++ b/cpu/nrf5x_common/periph/timer.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *               2015 Jan Wagner <mail@jwagner.eu>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Jan Wagner <mail@jwagner.eu>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/periph/uart.c
+++ b/cpu/nrf5x_common/periph/uart.c
@@ -1,13 +1,9 @@
 /*
- * Copyright (C) 2014-2017 Freie Universität Berlin
- *               2015 Jan Wagner <mail@jwagner.eu>
- *               2018 Inria
- *               2020 Philipp-Alexander Blum <philipp-blum@jakiku.de>
- *
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Jan Wagner <mail@jwagner.eu>
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-FileCopyrightText: 2020 Philipp-Alexander Blum <philipp-blum@jakiku.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/periph/usbdev.c
+++ b/cpu/nrf5x_common/periph/usbdev.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/periph/wdt.c
+++ b/cpu/nrf5x_common/periph/wdt.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/radio/nrfble/nrfble.c
+++ b/cpu/nrf5x_common/radio/nrfble/nrfble.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017-2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017-2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015-2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf5x_common/shared_irq/shared_serial_irq.c
+++ b/cpu/nrf5x_common/shared_irq/shared_serial_irq.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf9160/Kconfig
+++ b/cpu/nrf9160/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2021 Mesotic SAS
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2021 Mesotic SAS
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_NRF9160
     bool

--- a/cpu/nrf9160/cpu.c
+++ b/cpu/nrf9160/cpu.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/nrf9160/include/cpu_conf.h
+++ b/cpu/nrf9160/include/cpu_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf9160/include/periph_cpu.h
+++ b/cpu/nrf9160/include/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/nrf9160/vectors/vectors_nrf9160.c
+++ b/cpu/nrf9160/vectors/vectors_nrf9160.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/qn908x/Kconfig
+++ b/cpu/qn908x/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 iosabi
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 iosabi
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_QN908X
     bool

--- a/cpu/qn908x/cpu.c
+++ b/cpu/qn908x/cpu.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/qn908x/include/cpu_conf.h
+++ b/cpu/qn908x/include/cpu_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/qn908x/include/flexcomm.h
+++ b/cpu/qn908x/include/flexcomm.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/qn908x/include/gpio_mux.h
+++ b/cpu/qn908x/include/gpio_mux.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/qn908x/include/periph_cpu.h
+++ b/cpu/qn908x/include/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/qn908x/include/vectors_qn908x.h
+++ b/cpu/qn908x/include/vectors_qn908x.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/qn908x/isr_qn908x.c
+++ b/cpu/qn908x/isr_qn908x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/qn908x/periph/adc.c
+++ b/cpu/qn908x/periph/adc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/qn908x/periph/flexcomm.c
+++ b/cpu/qn908x/periph/flexcomm.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/qn908x/periph/gpio.c
+++ b/cpu/qn908x/periph/gpio.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/qn908x/periph/gpio_mux.c
+++ b/cpu/qn908x/periph/gpio_mux.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/qn908x/periph/i2c.c
+++ b/cpu/qn908x/periph/i2c.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/qn908x/periph/rtc.c
+++ b/cpu/qn908x/periph/rtc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/qn908x/periph/spi.c
+++ b/cpu/qn908x/periph/spi.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/qn908x/periph/timer.c
+++ b/cpu/qn908x/periph/timer.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/qn908x/periph/uart.c
+++ b/cpu/qn908x/periph/uart.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/qn908x/periph/wdt.c
+++ b/cpu/qn908x/periph/wdt.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/qn908x/system.c
+++ b/cpu/qn908x/system.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/qn908x/vectors.c
+++ b/cpu/qn908x/vectors.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/riscv_common/Kconfig
+++ b/cpu/riscv_common/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_ARCH_RISCV
     bool

--- a/cpu/riscv_common/context_frame.c
+++ b/cpu/riscv_common/context_frame.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017, 2019 JP Bonn, Ken Rabold
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017, 2019 JP Bonn, Ken Rabold
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/riscv_common/include/architecture_arch.h
+++ b/cpu/riscv_common/include/architecture_arch.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/riscv_common/include/atomic_utils_arch.h
+++ b/cpu/riscv_common/include/atomic_utils_arch.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/riscv_common/include/clic.h
+++ b/cpu/riscv_common/include/clic.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/riscv_common/include/context_frame.h
+++ b/cpu/riscv_common/include/context_frame.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017, 2019 JP Bonn, Ken Rabold
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017, 2019 JP Bonn, Ken Rabold
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/riscv_common/include/cpu_common.h
+++ b/cpu/riscv_common/include/cpu_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020, Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/riscv_common/include/cpu_conf_common.h
+++ b/cpu/riscv_common/include/cpu_conf_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/riscv_common/include/cpucycle.h
+++ b/cpu/riscv_common/include/cpucycle.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 JP Bonn
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 JP Bonn
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/riscv_common/include/irq_arch.h
+++ b/cpu/riscv_common/include/irq_arch.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2017 Ken Rabold
- *               2020 Inria
- *               2020 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Ken Rabold
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-FileCopyrightText: 2020 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/riscv_common/include/periph_cpu_common.h
+++ b/cpu/riscv_common/include/periph_cpu_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/riscv_common/include/plic.h
+++ b/cpu/riscv_common/include/plic.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/riscv_common/include/pmp.h
+++ b/cpu/riscv_common/include/pmp.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Bennet Blischke <bennet.blischke@haw-hamburg.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2023 Bennet Blischke <bennet.blischke@haw-hamburg.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/riscv_common/include/thread_arch.h
+++ b/cpu/riscv_common/include/thread_arch.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2021 Koen Zandberg <koen@bergzand.net>
- *               2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2021 Koen Zandberg <koen@bergzand.net>
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/riscv_common/irq_arch.c
+++ b/cpu/riscv_common/irq_arch.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017, 2019 Ken Rabold, JP Bonn
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017, 2019 Ken Rabold, JP Bonn
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/riscv_common/panic.c
+++ b/cpu/riscv_common/panic.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017, 2019 Ken Rabold, JP Bonn
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017, 2019 Ken Rabold, JP Bonn
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/riscv_common/periph/clic.c
+++ b/cpu/riscv_common/periph/clic.c
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup         cpu_riscv_common
  * @{

--- a/cpu/riscv_common/periph/coretimer.c
+++ b/cpu/riscv_common/periph/coretimer.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2017 Ken Rabold
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Ken Rabold
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/riscv_common/periph/plic.c
+++ b/cpu/riscv_common/periph/plic.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/riscv_common/periph/pmp.c
+++ b/cpu/riscv_common/periph/pmp.c
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2023 Bennet Blischke <bennet.blischke@haw-hamburg.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2023 Bennet Blischke <bennet.blischke@haw-hamburg.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup         cpu_riscv_common
  * @{

--- a/cpu/riscv_common/riscv_init.c
+++ b/cpu/riscv_common/riscv_init.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020, Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/riscv_common/thread_arch.c
+++ b/cpu/riscv_common/thread_arch.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017, 2019 Ken Rabold, JP Bonn
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017, 2019 Ken Rabold, JP Bonn
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/rpx0xx/Kconfig
+++ b/cpu/rpx0xx/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (C) 2021 Otto-von-Guericke-Universität Magdeburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Otto-von-Guericke-Universität Magdeburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_RPX0XX
     bool

--- a/cpu/rpx0xx/clock.c
+++ b/cpu/rpx0xx/clock.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/rpx0xx/cpu.c
+++ b/cpu/rpx0xx/cpu.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/rpx0xx/include/cpu_conf.h
+++ b/cpu/rpx0xx/include/cpu_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/rpx0xx/include/io_reg.h
+++ b/cpu/rpx0xx/include/io_reg.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/rpx0xx/include/periph_cpu.h
+++ b/cpu/rpx0xx/include/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/rpx0xx/include/pio/pio.h
+++ b/cpu/rpx0xx/include/pio/pio.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/rpx0xx/periph/adc.c
+++ b/cpu/rpx0xx/periph/adc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/rpx0xx/periph/gpio.c
+++ b/cpu/rpx0xx/periph/gpio.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/rpx0xx/periph/i2c.c
+++ b/cpu/rpx0xx/periph/i2c.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/rpx0xx/periph/pio.c
+++ b/cpu/rpx0xx/periph/pio.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/rpx0xx/periph/pwm.c
+++ b/cpu/rpx0xx/periph/pwm.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023-2024 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023-2024 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/rpx0xx/periph/spi.c
+++ b/cpu/rpx0xx/periph/spi.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Frank Engelhardt
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Frank Engelhardt
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/rpx0xx/periph/timer.c
+++ b/cpu/rpx0xx/periph/timer.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/rpx0xx/periph/uart.c
+++ b/cpu/rpx0xx/periph/uart.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2021 Nick Weiler, Justus Krebs, Franz Freitag
- * Copyright (C) 2021 Otto-von-Guericke Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Nick Weiler, Justus Krebs, Franz Freitag
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/rpx0xx/pio/i2c/i2c.c
+++ b/cpu/rpx0xx/pio/i2c/i2c.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/rpx0xx/pll.c
+++ b/cpu/rpx0xx/pll.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/rpx0xx/rosc.c
+++ b/cpu/rpx0xx/rosc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/rpx0xx/vectors.c
+++ b/cpu/rpx0xx/vectors.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/rpx0xx/xosc.c
+++ b/cpu/rpx0xx/xosc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/Kconfig
+++ b/cpu/sam0_common/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_COMMON_SAM0
     bool

--- a/cpu/sam0_common/include/cpu_conf.h
+++ b/cpu/sam0_common/include/cpu_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/sam0_common/include/exti_config.h
+++ b/cpu/sam0_common/include/exti_config.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/sam0_common/include/gpio_ll_arch.h
+++ b/cpu/sam0_common/include/gpio_ll_arch.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *               2023 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2023 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/sam0_common/include/mtd_sam0_sdhc.h
+++ b/cpu/sam0_common/include/mtd_sam0_sdhc.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/sam0_common/include/sam_usb.h
+++ b/cpu/sam0_common/include/sam_usb.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/sam0_common/include/sdhc.h
+++ b/cpu/sam0_common/include/sdhc.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Alkgrove
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Alkgrove
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/sam0_common/include/timer_config.h
+++ b/cpu/sam0_common/include/timer_config.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2017 Dan Evans <photonthunder@gmail.com>
- * Copyright (C) 2017 Travis Griggs <travisgriggs@gmail.com>
- * Copyright (C) 2017 Dylan Laduranty <dylanladuranty@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Dan Evans <photonthunder@gmail.com>
+ * SPDX-FileCopyrightText: 2017 Travis Griggs <travisgriggs@gmail.com>
+ * SPDX-FileCopyrightText: 2017 Dylan Laduranty <dylanladuranty@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/cpuid.c
+++ b/cpu/sam0_common/periph/cpuid.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/dac.c
+++ b/cpu/sam0_common/periph/dac.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Beuth Hochschule für Technik Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Beuth Hochschule für Technik Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/dma.c
+++ b/cpu/sam0_common/periph/dma.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/eth.c
+++ b/cpu/sam0_common/periph/eth.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/freqm.c
+++ b/cpu/sam0_common/periph/freqm.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2014-2015 Freie Universität Berlin
- *               2015 Kaspar Schleiser <kaspar@schleiser.de>
- *               2015 FreshTemp, LLC.
- *               2022 SSV Software Systems GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2015 FreshTemp, LLC.
+ * SPDX-FileCopyrightText: 2022 SSV Software Systems GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/gpio_ll.c
+++ b/cpu/sam0_common/periph/gpio_ll.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/gpio_ll_irq.c
+++ b/cpu/sam0_common/periph/gpio_ll_irq.c
@@ -1,13 +1,10 @@
 /*
- * Copyright (C) 2015 HAW Hamburg
- *               2016 INRIA
- *               2023 Gerson Fernando Budke
- *               2023 Hugues Larrive
- *               2023 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2015 HAW Hamburg
+ * SPDX-FileCopyrightText: 2016 INRIA
+ * SPDX-FileCopyrightText: 2023 Gerson Fernando Budke
+ * SPDX-FileCopyrightText: 2023 Hugues Larrive
+ * SPDX-FileCopyrightText: 2023 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/hwrng.c
+++ b/cpu/sam0_common/periph/hwrng.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 CLENET Baptiste
- * Copyright (C) 2018 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 CLENET Baptiste
+ * SPDX-FileCopyrightText: 2018 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/pwm.c
+++ b/cpu/sam0_common/periph/pwm.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 Hamburg University of Applied Sciences
- *               2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Hamburg University of Applied Sciences
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/rtc_rtt.c
+++ b/cpu/sam0_common/periph/rtc_rtt.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- *               2015 FreshTemp, LLC.
- *               2022 SSV Software Systems GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2015 FreshTemp, LLC.
+ * SPDX-FileCopyrightText: 2022 SSV Software Systems GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *               2015 Kaspar Schleiser <kaspar@schleiser.de>
- *               2015 FreshTemp, LLC.
- *               2022 SSV Software Systems GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2015 FreshTemp, LLC.
+ * SPDX-FileCopyrightText: 2022 SSV Software Systems GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/timer.c
+++ b/cpu/sam0_common/periph/timer.c
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *               2022 SSV Software Systems GmbH
- *
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-FileCopyrightText: 2022 SSV Software Systems GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *               2015 FreshTemp, LLC.
- *               2022 SSV Software Systems GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 FreshTemp, LLC.
+ * SPDX-FileCopyrightText: 2022 SSV Software Systems GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/usbdev.c
+++ b/cpu/sam0_common/periph/usbdev.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *               2022 SSV Software Systems GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-FileCopyrightText: 2022 SSV Software Systems GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/periph/wdt.c
+++ b/cpu/sam0_common/periph/wdt.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/sam0_eth/eth-netdev.c
+++ b/cpu/sam0_common/sam0_eth/eth-netdev.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam0_common/sam0_eth/sam0_eth_netdev.h
+++ b/cpu/sam0_common/sam0_eth/sam0_eth_netdev.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Dylan Laduranty
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Dylan Laduranty
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/sam0_common/sam0_sdhc/mtd_sdhc.c
+++ b/cpu/sam0_common/sam0_sdhc/mtd_sdhc.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2022 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2022 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**


### PR DESCRIPTION
### Contribution description

This PR moves license information from headers to SPDX format for cpu directory.
In this PR following cpu's are processed:
- native,
- nrf,
- qn908x,
- riscv,
- rpx0xx
- sam0 (common directory).

### Testing procedure

Review changed files.

### Issues/PRs references

Track https://github.com/RIOT-OS/RIOT/issues/21515
Part 1 https://github.com/RIOT-OS/RIOT/pull/21704
Part 2 https://github.com/RIOT-OS/RIOT/pull/21715
Part 3 https://github.com/RIOT-OS/RIOT/pull/21732