### PR TITLE
tests/unittests: add test for bit.h

### DIFF
--- a/sys/include/bit.h
+++ b/sys/include/bit.h
@@ -18,6 +18,7 @@
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 #include "cpu.h"
 

--- a/tests/unittests/tests-bit/Makefile
+++ b/tests/unittests/tests-bit/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-bit/tests-bit.c
+++ b/tests/unittests/tests-bit/tests-bit.c
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: 2025 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include <errno.h>
+#include "embUnit.h"
+
+#include "bit.h"
+
+static void test_bit8(void)
+{
+    uint8_t tmp, word = UINT8_MAX;
+
+    for (unsigned i = 0; i < sizeof(word) * 8; ++i) {
+        TEST_ASSERT_EQUAL_INT(1, bit_check8(&word, i));
+    }
+
+    tmp = word;
+    for (unsigned i = 0; i < sizeof(word) * 8; i += 2) {
+        bit_clear8(&word, i);
+        tmp &= ~(1UL << i);
+        TEST_ASSERT_EQUAL_INT(tmp, word);
+    }
+
+    word <<= 1;
+    tmp = word;
+    for (unsigned i = 1; i < sizeof(word) * 8; i += 2) {
+        bit_set8(&word, i);
+        tmp |= 1UL << i;
+        TEST_ASSERT_EQUAL_INT(tmp, word);
+    }
+}
+
+static void test_bit16(void)
+{
+    uint16_t tmp, word = UINT16_MAX;
+
+    for (unsigned i = 0; i < sizeof(word) * 8; ++i) {
+        TEST_ASSERT_EQUAL_INT(1, bit_check16(&word, i));
+    }
+
+    tmp = word;
+    for (unsigned i = 0; i < sizeof(word) * 8; i += 2) {
+        bit_clear16(&word, i);
+        tmp &= ~(1UL << i);
+        TEST_ASSERT_EQUAL_INT(tmp, word);
+    }
+
+    word <<= 1;
+    tmp = word;
+    for (unsigned i = 1; i < sizeof(word) * 8; i += 2) {
+        bit_set16(&word, i);
+        tmp |= 1UL << i;
+        TEST_ASSERT_EQUAL_INT(tmp, word);
+    }
+}
+
+static void test_bit32(void)
+{
+    uint32_t tmp, word = UINT32_MAX;
+
+    for (unsigned i = 0; i < sizeof(word) * 8; ++i) {
+        TEST_ASSERT_EQUAL_INT(1, bit_check32(&word, i));
+    }
+
+    tmp = word;
+    for (unsigned i = 0; i < sizeof(word) * 8; i += 2) {
+        bit_clear32(&word, i);
+        tmp &= ~(1UL << i);
+        TEST_ASSERT_EQUAL_INT(tmp, word);
+    }
+
+    word <<= 1;
+    tmp = word;
+    for (unsigned i = 1; i < sizeof(word) * 8; i += 2) {
+        bit_set32(&word, i);
+        tmp |= 1UL << i;
+        TEST_ASSERT_EQUAL_INT(tmp, word);
+    }
+}
+
+Test *tests_bit_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_bit8),
+        new_TestFixture(test_bit16),
+        new_TestFixture(test_bit32),
+    };
+
+    EMB_UNIT_TESTCALLER(bit_tests, NULL, NULL, fixtures);
+
+    return (Test *)&bit_tests;
+}
+
+void tests_bit(void)
+{
+    TESTS_RUN(tests_bit_tests());
+}

--- a/tests/unittests/tests-bit/tests-bit.h
+++ b/tests/unittests/tests-bit/tests-bit.h
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2025 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief   Unittests for the `bit` header
+ *
+ *          This verifies that the functions to test/set/clear individual bits
+ *          (which may use hardware specific instructions to do so) work.
+ *
+ * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#include "embUnit/embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+*  @brief   The entry point of this test suite.
+*/
+void tests_bit(void);
+
+/**
+ * @brief   Generates tests for bit header
+ *
+ * @return  embUnit tests if successful, NULL if not.
+ */
+Test *tests_bit_tests(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds unit tests for the functions from `bit.h`


### Testing procedure

Just run `make -C tests/unittests tests-bit`


### Issues/PRs references

depends on #21705
