### PR TITLE
kinetis/bme: temp disable `BITBAND_FUNCTIONS_PROVIDED`

### DIFF
--- a/cpu/kinetis/include/bme.h
+++ b/cpu/kinetis/include/bme.h
@@ -28,7 +28,7 @@ extern "C"
 /**
  * @brief Tell bit.h that we provide CPU specific bit manipulation functions
  */
-#define BITBAND_FUNCTIONS_PROVIDED 1
+#define BITBAND_FUNCTIONS_PROVIDED 0
 
 #define BME_AND_MASK        (1 << 26) /**< AND decoration bitmask */
 #define BME_OR_MASK         (1 << 27) /**< OR decoration bitmask */
@@ -121,6 +121,7 @@ static inline volatile uint8_t *bme_bitfield8(volatile uint8_t *ptr, uint8_t bit
     return (volatile uint8_t *)(bme_bf_addr(ptr, bit, width));
 }
 
+#if BITBAND_FUNCTIONS_PROVIDED
 /* For compatibility with the M3/M4 bitbanding macros: */
 
 /**
@@ -242,6 +243,8 @@ static inline void bit_clear8(volatile uint8_t *ptr, uint8_t bit)
 {
     *((volatile uint8_t *)(((uintptr_t)ptr) | BME_AND_MASK)) = (uint8_t)(~(1ul << bit));
 }
+
+#endif /* BITBAND_FUNCTIONS_PROVIDED */
 
 #ifdef __cplusplus
 }

--- a/drivers/kw41zrf/kw41zrf.c
+++ b/drivers/kw41zrf/kw41zrf.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <errno.h>
 
+#include "bit.h"
 #include "log.h"
 #include "msg.h"
 #include "net/gnrc.h"

--- a/drivers/kw41zrf/kw41zrf_getset.c
+++ b/drivers/kw41zrf/kw41zrf_getset.c
@@ -20,6 +20,7 @@
 #include <errno.h>
 #include <string.h>
 #include "log.h"
+#include "bit.h"
 #include "cpu.h"
 #include "byteorder.h"
 #include "kw41zrf.h"

--- a/drivers/kw41zrf/kw41zrf_netdev.c
+++ b/drivers/kw41zrf/kw41zrf_netdev.c
@@ -22,6 +22,7 @@
 #include <assert.h>
 #include <stdatomic.h>
 
+#include "bit.h"
 #include "log.h"
 #include "random.h"
 #include "thread_flags.h"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The kinetis bme implementation currently doesn't work proberly, see https://github.com/RIOT-OS/RIOT/pull/21705#discussion_r2389433571.
This PR temporarily sets `BITBAND_FUNCTIONS_PROVIDED` to false so that the default `sys/bit` implementation for bit manipulation is used instead. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Came up while extending the `bme` implementation in #21705.  
Unblocks #21577.
