### PR TITLE
build system: Allow running tests in docker

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -19,13 +19,20 @@ DEPS_FOR_RUNNING_DOCKER :=
 DOCKER ?= docker
 
 # List of Docker-enabled make goals
-export DOCKER_MAKECMDGOALS_POSSIBLE = \
+DOCKER_MAKECMDGOALS_POSSIBLE := \
   all \
   scan-build \
   scan-build-analyze \
   tests-% \
   #
-export DOCKER_MAKECMDGOALS = $(filter $(DOCKER_MAKECMDGOALS_POSSIBLE),$(MAKECMDGOALS))
+
+# On native, we also can run the test in docker
+ifneq (, $(filter native%,$(BOARD)))
+  DOCKER_MAKECMDGOALS_POSSIBLE += test
+endif
+
+export DOCKER_MAKECMDGOALS_POSSIBLE
+export DOCKER_MAKECMDGOALS := $(filter $(DOCKER_MAKECMDGOALS_POSSIBLE),$(MAKECMDGOALS))
 
 # Docker creates the files .dockerinit and .dockerenv in the root directory of
 # the container, we check for the files to determine if we are inside a container.

--- a/makefiles/tests/tests.inc.mk
+++ b/makefiles/tests/tests.inc.mk
@@ -22,10 +22,17 @@ TEST_DEPS += $(TERMDEPS)
 TEST_EXECUTOR ?=
 TEST_EXECUTOR_FLAGS ?=
 
+# Are tests going to be run in docker and we are not yet in docker?
+ifeq (0-test,$(INSIDE_DOCKER)-$(filter test,$(DOCKER_MAKECMDGOALS)))
+# Yes --> defer test execution to docker
+test: ..in-docker-container
+else
+# No --> run test in this context
 test: $(TEST_DEPS)
 	$(Q) for t in $(TESTS); do \
 		$(TEST_EXECUTOR) $(TEST_EXECUTOR_FLAGS) $$t || exit 1; \
 	done
+endif
 
 test/available:
 ifneq (,$(TEST_ON_CI_WHITELIST))


### PR DESCRIPTION
### Contribution description

When building for native with `BUILD_IN_DOCKER=1`, the created elf file may not be compatible with the host system if:

- The container used is using glibc and the host system is using another C lib
- Both container and host are using glibc, but the container is using a more recent one than the host

To avoid these issues, this commit changes behavior to just run the `test` goal inside the docker image as well when the board is `native%`.

### Testing procedure

Run the following commands:

1. `make -C tests/sys/fmt_print all test BOARD=native64 BUILD_IN_DOCKER=1`
    - Build should be run in docker
    - Test should be run in docker
2. `make -C tests/sys/fmt_print all test BOARD=native BUILD_IN_DOCKER=1`
    - Build should be run in docker
    - Test should be run in docker
3. `make -C tests/sys/fmt_print all test BOARD=native64`
    - Build should **NOT** be run in docker
    - Test should **NOT** be run in docker
4. `make -C tests/sys/fmt_print all test BOARD=samr21-xpro`
    - Build should **NOT** be run in docker
    - Test should **NOT** be run in docker
5. `make -C tests/sys/fmt_print all test BOARD=samr21-xpro BUILD_IN_DOCKER=1`
    - Build should be run in docker
    - Test should **NOT** be run in docker

### Issues/PRs references

None