### PR TITLE
cpu/sam0_common: rmw init gpio mux

### DIFF
--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -141,8 +141,11 @@ void gpio_init_mux(gpio_t pin, gpio_mux_t mux)
     int pin_pos = _pin_pos(pin);
 
     port->PINCFG[pin_pos].reg |= PORT_PINCFG_PMUXEN;
-    port->PMUX[pin_pos >> 1].reg &= ~(0xf << (4 * (pin_pos & 0x1)));
-    port->PMUX[pin_pos >> 1].reg |=  (mux << (4 * (pin_pos & 0x1)));
+
+    uint8_t pmux = port->PMUX[pin_pos >> 1].reg;
+    pmux &= ~(0xf << (4 * (pin_pos & 0x1)));
+    pmux |= (mux << (4 * (pin_pos & 0x1)));
+    port->PMUX[pin_pos >> 1].reg = pmux;
 }
 
 void gpio_disable_mux(gpio_t pin)


### PR DESCRIPTION
### Contribution description

reduce the number of rmw when initializing a gpio with mux

### Testing procedure

check if muxed pins are still working

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
