### PR TITLE
cpu/stm32/periph/fdcan: reread bittiming max values

### DIFF
--- a/cpu/stm32/periph/fdcan.c
+++ b/cpu/stm32/periph/fdcan.c
@@ -80,19 +80,19 @@ static const struct can_bittiming_const bittiming_const = {
     .tseg1_max = 256,
     .tseg2_min = 1,
     .tseg2_max = 128,
-    .sjw_max = 1,
+    .sjw_max = 128,
     .brp_min = 1,
-    .brp_max = 1024,
+    .brp_max = 512,
     .brp_inc = 1,
 };
 
 /* FDCAN data bittiming */
 static const struct can_bittiming_const fd_data_bittiming_const = {
     .tseg1_min = 1,
-    .tseg1_max = 16,
+    .tseg1_max = 31,
     .tseg2_min = 1,
-    .tseg2_max = 8,
-    .sjw_max = 1,
+    .tseg2_max = 16,
+    .sjw_max = 16,
     .brp_min = 1,
     .brp_max = 32,
     .brp_inc = 1,


### PR DESCRIPTION
 <!--
-->
since the stm32 fdcan is quiet similar to the samd5 can (same ip core bosch mcan).  i had a look at its configurartion and found the values quiet strage  i reread them from the manual of stm32g0 and g4 (same) chapter 36 and 44 register (FDCAN_NBTP) and (FDCAN_DBTP)

especially the SJW values where strange.

### Contribution description

update the bittiming max values to the values actually found in the manual 

### Testing procedure

read and compare 

test with hardware 

i do not have a test system with that cpu at the moment  (g4 would use fdcan  if asked for perpih_can)

especially unfit sjw values might work for some time unless clocks drift or other 

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
