### PR TITLE
cpu: move licenses from comments to SPDX format (part5)

### DIFF
--- a/cpu/Kconfig
+++ b/cpu/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
+
 #   +-----------+
 #   | CPU_MODEL |
 #   +-----------+

--- a/cpu/doc.md
+++ b/cpu/doc.md
@@ -1,9 +1,6 @@
 <!--
-Copyright (C) 2013 Freie Universität Berlin
-
-This file is subject to the terms and conditions of the GNU Lesser
-General Public License v2.1. See the file LICENSE in the top level
-directory for more details.
+SPDX-FileCopyrightText: 2013 Freie Universität Berlin
+SPDX-License-Identifier: LGPL-2.1-only
 -->
 
 @defgroup   cpu CPU

--- a/cpu/sam3/Kconfig
+++ b/cpu/sam3/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_SAM3
     bool

--- a/cpu/sam3/cpu.c
+++ b/cpu/sam3/cpu.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam3/include/periph_cpu.h
+++ b/cpu/sam3/include/periph_cpu.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *               2015 Hamburg University of Applied Sciences
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Hamburg University of Applied Sciences
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/sam3/periph/adc.c
+++ b/cpu/sam3/periph/adc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam3/periph/cpuid.c
+++ b/cpu/sam3/periph/cpuid.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 <nqdinhddt@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 <nqdinhddt@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam3/periph/dac.c
+++ b/cpu/sam3/periph/dac.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam3/periph/hwrng.c
+++ b/cpu/sam3/periph/hwrng.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam3/periph/pwm.c
+++ b/cpu/sam3/periph/pwm.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Hamburg University of Applied Sciences
- *               2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Hamburg University of Applied Sciences
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam3/periph/rtt.c
+++ b/cpu/sam3/periph/rtt.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017,2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017, 2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam3/periph/spi.c
+++ b/cpu/sam3/periph/spi.c
@@ -1,11 +1,8 @@
 /*
-* Copyright (C) 2014 Hamburg University of Applied Sciences
-*               2016-2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
-*/
+ * SPDX-FileCopyrightText: 2014 Hamburg University of Applied Sciences
+ * SPDX-FileCopyrightText: 2016-2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
 
 /**
  * @ingroup     cpu_sam3

--- a/cpu/sam3/vectors.c
+++ b/cpu/sam3/vectors.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam4s/Kconfig
+++ b/cpu/sam4s/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2025 Mesotic SAS
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2025 Mesotic SAS
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_SAM4S
     bool

--- a/cpu/sam4s/cpu.c
+++ b/cpu/sam4s/cpu.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam4s/include/periph_cpu.h
+++ b/cpu/sam4s/include/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/sam4s/vectors.c
+++ b/cpu/sam4s/vectors.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam_common/include/cpu_conf.h
+++ b/cpu/sam_common/include/cpu_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C)    2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/sam_common/include/periph_cpu_common.h
+++ b/cpu/sam_common/include/periph_cpu_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025   Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/sam_common/periph/gpio.c
+++ b/cpu/sam_common/periph/gpio.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2014 Hauke Petersen <devel@haukepetersen.de>
- *               2015 Hamburg University of Applied Sciences
- *               2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Hauke Petersen <devel@haukepetersen.de>
+ * SPDX-FileCopyrightText: 2015 Hamburg University of Applied Sciences
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam_common/periph/timer.c
+++ b/cpu/sam_common/periph/timer.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/sam_common/periph/uart.c
+++ b/cpu/sam_common/periph/uart.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/samd21/Kconfig
+++ b/cpu/samd21/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_COMMON_SAMD21
     bool

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/samd21/periph/pm.c
+++ b/cpu/samd21/periph/pm.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
- * Copyright (C) 2014 Freie Universität Berlin
- * Copyright (C) 2015 Saurabh Singh
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Saurabh Singh
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/samd21/vectors/vectors_samd1x.c
+++ b/cpu/samd21/vectors/vectors_samd1x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/samd21/vectors/vectors_samd2x.c
+++ b/cpu/samd21/vectors/vectors_samd2x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/samd5x/Kconfig
+++ b/cpu/samd5x/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_COMMON_SAMD5X
     bool

--- a/cpu/samd5x/cpu.c
+++ b/cpu/samd5x/cpu.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/samd5x/include/can_params.h
+++ b/cpu/samd5x/include/can_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/samd5x/include/candev_samd5x.h
+++ b/cpu/samd5x/include/candev_samd5x.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/samd5x/periph/can.c
+++ b/cpu/samd5x/periph/can.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/samd5x/periph/pm.c
+++ b/cpu/samd5x/periph/pm.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/samd5x/vectors.c
+++ b/cpu/samd5x/vectors.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/saml1x/Kconfig
+++ b/cpu/saml1x/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_COMMON_SAML1X
     bool

--- a/cpu/saml1x/cpu.c
+++ b/cpu/saml1x/cpu.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/saml1x/include/periph_cpu.h
+++ b/cpu/saml1x/include/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/saml1x/periph/pm.c
+++ b/cpu/saml1x/periph/pm.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/saml1x/vectors.c
+++ b/cpu/saml1x/vectors.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2018 Mesotic SAS
- *
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/saml21/Kconfig
+++ b/cpu/saml21/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_COMMON_SAML21
     bool

--- a/cpu/saml21/cpu.c
+++ b/cpu/saml21/cpu.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- *               2015 FreshTemp, LLC.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2015 FreshTemp, LLC.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/saml21/periph/pm.c
+++ b/cpu/saml21/periph/pm.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/saml21/vectors.c
+++ b/cpu/saml21/vectors.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- *               2015 FreshTemp, LLC.
- *               2014-2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2015 FreshTemp, LLC.
+ * SPDX-FileCopyrightText: 2014-2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/Kconfig
+++ b/cpu/stm32/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_STM32
     bool

--- a/cpu/stm32/bootloader/reset.c
+++ b/cpu/stm32/bootloader/reset.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/cpu_common.c
+++ b/cpu/stm32/cpu_common.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/cpu_init.c
+++ b/cpu/stm32/cpu_init.c
@@ -1,14 +1,10 @@
 /*
- * Copyright (C) 2013 INRIA
- *               2014 Freie Universität Berlin
- *               2016 TriaGnoSys GmbH
- *               2018 Kaspar Schleiser <kaspar@schleiser.de>
- *               2018 OTA keys S.A.
- *
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2013 INRIA
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016 TriaGnoSys GmbH
+ * SPDX-FileCopyrightText: 2018 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2018 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/dist/clk_conf/clk_conf.c
+++ b/cpu/stm32/dist/clk_conf/clk_conf.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/dist/clk_conf/clk_conf.h
+++ b/cpu/stm32/dist/clk_conf/clk_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/can_params.h
+++ b/cpu/stm32/include/can_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/candev_stm32.h
+++ b/cpu/stm32/include/candev_stm32.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/clk/c0/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/c0/cfg_clock_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 BISSELL Homecare, Inc.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 BISSELL Homecare, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/clk/cfg_clock_common_fx_gx_mp1_c0.h
+++ b/cpu/stm32/include/clk/cfg_clock_common_fx_gx_mp1_c0.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *               2018-2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2018-2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/clk/cfg_clock_common_lx_u5_wx.h
+++ b/cpu/stm32/include/clk/cfg_clock_common_lx_u5_wx.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *               2018-2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2018-2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/clk/clk_conf.h
+++ b/cpu/stm32/include/clk/clk_conf.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/clk/f0f1f3/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/f0f1f3/cfg_clock_default.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2015 TriaGnoSys GmbH
- *               2017 Alexander Kurth, Sören Tempel, Tristan Bruns
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 TriaGnoSys GmbH
+ * SPDX-FileCopyrightText: 2017 Alexander Kurth, Sören Tempel, Tristan Bruns
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_100.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_100.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *               2018-2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2018-2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_120.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_120.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *               2018-2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2018-2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_180.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_180.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *               2018-2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2018-2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_216.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_216.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *               2018-2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2018-2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_84.h
+++ b/cpu/stm32/include/clk/f2f4f7/cfg_clock_default_84.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *               2018-2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2018-2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/clk/g0g4/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/g0g4/cfg_clock_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/clk/l0l1/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/l0l1/cfg_clock_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018-2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/clk/l4l5wx/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/l4l5wx/cfg_clock_default.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *               2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/clk/mp1/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/mp1/cfg_clock_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Savoir-faire Linux
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Savoir-faire Linux
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/clk/u5/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/u5/cfg_clock_default.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/cpu_conf.h
+++ b/cpu/stm32/include/cpu_conf.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/fdcandev_stm32.h
+++ b/cpu/stm32/include/fdcandev_stm32.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 COGIP Robotics association
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 COGIP Robotics association
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/gpio_ll_arch.h
+++ b/cpu/stm32/include/gpio_ll_arch.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/lcd_fmc.h
+++ b/cpu/stm32/include/lcd_fmc.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/c0/periph_cpu.h
+++ b/cpu/stm32/include/periph/c0/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 BISSELL Homecare, Inc.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 BISSELL Homecare, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_backup_ram.h
+++ b/cpu/stm32/include/periph/cpu_backup_ram.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_common.h
+++ b/cpu/stm32/include/periph/cpu_common.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_dma.h
+++ b/cpu/stm32/include/periph/cpu_dma.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_eth.h
+++ b/cpu/stm32/include/periph/cpu_eth.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_fmc.h
+++ b/cpu/stm32/include/periph/cpu_fmc.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_gpio.h
+++ b/cpu/stm32/include/periph/cpu_gpio.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_gpio_ll.h
+++ b/cpu/stm32/include/periph/cpu_gpio_ll.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_i2c.h
+++ b/cpu/stm32/include/periph/cpu_i2c.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_ltdc.h
+++ b/cpu/stm32/include/periph/cpu_ltdc.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_pm.h
+++ b/cpu/stm32/include/periph/cpu_pm.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_pwm.h
+++ b/cpu/stm32/include/periph/cpu_pwm.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_qdec.h
+++ b/cpu/stm32/include/periph/cpu_qdec.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_sdmmc.h
+++ b/cpu/stm32/include/periph/cpu_sdmmc.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_spi.h
+++ b/cpu/stm32/include/periph/cpu_spi.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_timer.h
+++ b/cpu/stm32/include/periph/cpu_timer.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_uart.h
+++ b/cpu/stm32/include/periph/cpu_uart.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_usbdev.h
+++ b/cpu/stm32/include/periph/cpu_usbdev.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_vbat.h
+++ b/cpu/stm32/include/periph/cpu_vbat.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/cpu_wdt.h
+++ b/cpu/stm32/include/periph/cpu_wdt.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/f0/periph_cpu.h
+++ b/cpu/stm32/include/periph/f0/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/f1/periph_cpu.h
+++ b/cpu/stm32/include/periph/f1/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/f2/periph_cpu.h
+++ b/cpu/stm32/include/periph/f2/periph_cpu.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Engineering-Spirit
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Engineering-Spirit
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/f3/periph_cpu.h
+++ b/cpu/stm32/include/periph/f3/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/f4/periph_cpu.h
+++ b/cpu/stm32/include/periph/f4/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/f7/periph_cpu.h
+++ b/cpu/stm32/include/periph/f7/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/g0/periph_cpu.h
+++ b/cpu/stm32/include/periph/g0/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/g4/periph_cpu.h
+++ b/cpu/stm32/include/periph/g4/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/l0/periph_cpu.h
+++ b/cpu/stm32/include/periph/l0/periph_cpu.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015-2017 Freie Universität Berlin
- *               2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/l1/periph_cpu.h
+++ b/cpu/stm32/include/periph/l1/periph_cpu.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015-2016 Freie Universität Berlin
- * Copyright (C) 2015 Hamburg University of Applied Sciences
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Hamburg University of Applied Sciences
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/l4/periph_cpu.h
+++ b/cpu/stm32/include/periph/l4/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/l5/periph_cpu.h
+++ b/cpu/stm32/include/periph/l5/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/u5/periph_cpu.h
+++ b/cpu/stm32/include/periph/u5/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/wb/periph_cpu.h
+++ b/cpu/stm32/include/periph/wb/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph/wl/periph_cpu.h
+++ b/cpu/stm32/include/periph/wl/periph_cpu.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/stmclk.h
+++ b/cpu/stm32/include/stmclk.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/include/usbdev_stm32.h
+++ b/cpu/stm32/include/usbdev_stm32.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/cpu/stm32/kconfigs/Kconfig.clk
+++ b/cpu/stm32/kconfigs/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CLOCK_HAS_NO_MCO_PRE
     bool

--- a/cpu/stm32/kconfigs/c0/Kconfig
+++ b/cpu/stm32/kconfigs/c0/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (C) 2024 BISSELL Homecare, Inc.
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2024 BISSELL Homecare, Inc.
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_C0
     bool

--- a/cpu/stm32/kconfigs/c0/Kconfig.clk
+++ b/cpu/stm32/kconfigs/c0/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (C) 2024 BISSELL Homecare, Inc.
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2024 BISSELL Homecare, Inc.
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if CPU_FAM_C0
 

--- a/cpu/stm32/kconfigs/c0/Kconfig.lines
+++ b/cpu/stm32/kconfigs/c0/Kconfig.lines
@@ -1,9 +1,5 @@
-# Copyright (C) 2024 BISSELL Homecare, Inc.
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2024 BISSELL Homecare, Inc.
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/c0/Kconfig.models
+++ b/cpu/stm32/kconfigs/c0/Kconfig.models
@@ -1,9 +1,5 @@
-# Copyright (C) 2024 BISSELL Homecare, Inc.
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2024 BISSELL Homecare, Inc.
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/f0/Kconfig
+++ b/cpu/stm32/kconfigs/f0/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM
     default "f0" if CPU_FAM_F0

--- a/cpu/stm32/kconfigs/f0/Kconfig.clk
+++ b/cpu/stm32/kconfigs/f0/Kconfig.clk
@@ -1,8 +1,4 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource '../f0f1f3/Kconfig.clk'

--- a/cpu/stm32/kconfigs/f0/Kconfig.lines
+++ b/cpu/stm32/kconfigs/f0/Kconfig.lines
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/f0/Kconfig.models
+++ b/cpu/stm32/kconfigs/f0/Kconfig.models
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/f0f1f3/Kconfig.clk
+++ b/cpu/stm32/kconfigs/f0f1f3/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3
 

--- a/cpu/stm32/kconfigs/f0f1f3g0g4l0l1l4wbwl/Kconfig.clk
+++ b/cpu/stm32/kconfigs/f0f1f3g0g4l0l1l4wbwl/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3 || CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L4 || CPU_FAM_WB || CPU_FAM_WL
 

--- a/cpu/stm32/kconfigs/f1/Kconfig
+++ b/cpu/stm32/kconfigs/f1/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_F1
     bool

--- a/cpu/stm32/kconfigs/f1/Kconfig.clk
+++ b/cpu/stm32/kconfigs/f1/Kconfig.clk
@@ -1,8 +1,4 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource '../f0f1f3/Kconfig.clk'

--- a/cpu/stm32/kconfigs/f1/Kconfig.lines
+++ b/cpu/stm32/kconfigs/f1/Kconfig.lines
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/f1/Kconfig.models
+++ b/cpu/stm32/kconfigs/f1/Kconfig.models
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/f2/Kconfig
+++ b/cpu/stm32/kconfigs/f2/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_F2
     bool

--- a/cpu/stm32/kconfigs/f2/Kconfig.clk
+++ b/cpu/stm32/kconfigs/f2/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource '../f2f4f7mp1/Kconfig.clk'
 

--- a/cpu/stm32/kconfigs/f2/Kconfig.lines
+++ b/cpu/stm32/kconfigs/f2/Kconfig.lines
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/f2/Kconfig.models
+++ b/cpu/stm32/kconfigs/f2/Kconfig.models
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/f2f4f7mp1/Kconfig.clk
+++ b/cpu/stm32/kconfigs/f2f4f7mp1/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if CPU_FAM_F2 || CPU_FAM_F4 || CPU_FAM_F7 || CPU_FAM_MP1
 

--- a/cpu/stm32/kconfigs/f3/Kconfig
+++ b/cpu/stm32/kconfigs/f3/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_F3
     bool

--- a/cpu/stm32/kconfigs/f3/Kconfig.clk
+++ b/cpu/stm32/kconfigs/f3/Kconfig.clk
@@ -1,8 +1,4 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource '../f0f1f3/Kconfig.clk'

--- a/cpu/stm32/kconfigs/f3/Kconfig.lines
+++ b/cpu/stm32/kconfigs/f3/Kconfig.lines
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/f3/Kconfig.models
+++ b/cpu/stm32/kconfigs/f3/Kconfig.models
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/f4/Kconfig
+++ b/cpu/stm32/kconfigs/f4/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_F4
     bool

--- a/cpu/stm32/kconfigs/f4/Kconfig.clk
+++ b/cpu/stm32/kconfigs/f4/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource '../f2f4f7mp1/Kconfig.clk'
 

--- a/cpu/stm32/kconfigs/f4/Kconfig.lines
+++ b/cpu/stm32/kconfigs/f4/Kconfig.lines
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/f4/Kconfig.models
+++ b/cpu/stm32/kconfigs/f4/Kconfig.models
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/f7/Kconfig
+++ b/cpu/stm32/kconfigs/f7/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_F7
     bool

--- a/cpu/stm32/kconfigs/f7/Kconfig.clk
+++ b/cpu/stm32/kconfigs/f7/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource '../f2f4f7mp1/Kconfig.clk'
 

--- a/cpu/stm32/kconfigs/f7/Kconfig.lines
+++ b/cpu/stm32/kconfigs/f7/Kconfig.lines
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/f7/Kconfig.models
+++ b/cpu/stm32/kconfigs/f7/Kconfig.models
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/g0/Kconfig
+++ b/cpu/stm32/kconfigs/g0/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_G0
     bool

--- a/cpu/stm32/kconfigs/g0/Kconfig.clk
+++ b/cpu/stm32/kconfigs/g0/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource '../g0wxmp1/Kconfig.clk'
 

--- a/cpu/stm32/kconfigs/g0/Kconfig.lines
+++ b/cpu/stm32/kconfigs/g0/Kconfig.lines
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/g0/Kconfig.models
+++ b/cpu/stm32/kconfigs/g0/Kconfig.models
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/g0wxmp1/Kconfig.clk
+++ b/cpu/stm32/kconfigs/g0wxmp1/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if CPU_FAM_G0 || CPU_FAM_WB || CPU_FAM_WL || CPU_FAM_MP1
 

--- a/cpu/stm32/kconfigs/g4/Kconfig
+++ b/cpu/stm32/kconfigs/g4/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_G4
     bool

--- a/cpu/stm32/kconfigs/g4/Kconfig.clk
+++ b/cpu/stm32/kconfigs/g4/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource '../g4l4l5/Kconfig.clk'
 

--- a/cpu/stm32/kconfigs/g4/Kconfig.lines
+++ b/cpu/stm32/kconfigs/g4/Kconfig.lines
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/g4/Kconfig.models
+++ b/cpu/stm32/kconfigs/g4/Kconfig.models
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/g4l4l5/Kconfig.clk
+++ b/cpu/stm32/kconfigs/g4l4l5/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if CPU_FAM_G4 || CPU_FAM_L4 || CPU_FAM_L5
 

--- a/cpu/stm32/kconfigs/l0/Kconfig
+++ b/cpu/stm32/kconfigs/l0/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_L0
     bool

--- a/cpu/stm32/kconfigs/l0/Kconfig.clk
+++ b/cpu/stm32/kconfigs/l0/Kconfig.clk
@@ -1,8 +1,4 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource '../l0l1/Kconfig.clk'

--- a/cpu/stm32/kconfigs/l0/Kconfig.lines
+++ b/cpu/stm32/kconfigs/l0/Kconfig.lines
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/l0/Kconfig.models
+++ b/cpu/stm32/kconfigs/l0/Kconfig.models
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/l0l1/Kconfig.clk
+++ b/cpu/stm32/kconfigs/l0l1/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if CPU_FAM_L0 || CPU_FAM_L1
 

--- a/cpu/stm32/kconfigs/l1/Kconfig
+++ b/cpu/stm32/kconfigs/l1/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_L1
     bool

--- a/cpu/stm32/kconfigs/l1/Kconfig.clk
+++ b/cpu/stm32/kconfigs/l1/Kconfig.clk
@@ -1,8 +1,4 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource '../l0l1/Kconfig.clk'

--- a/cpu/stm32/kconfigs/l1/Kconfig.lines
+++ b/cpu/stm32/kconfigs/l1/Kconfig.lines
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/l1/Kconfig.models
+++ b/cpu/stm32/kconfigs/l1/Kconfig.models
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/l4/Kconfig
+++ b/cpu/stm32/kconfigs/l4/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_L4
     bool

--- a/cpu/stm32/kconfigs/l4/Kconfig.clk
+++ b/cpu/stm32/kconfigs/l4/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource '../g4l4l5/Kconfig.clk'
 rsource '../l4l5wx/Kconfig.clk'

--- a/cpu/stm32/kconfigs/l4/Kconfig.lines
+++ b/cpu/stm32/kconfigs/l4/Kconfig.lines
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/l4/Kconfig.models
+++ b/cpu/stm32/kconfigs/l4/Kconfig.models
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/l4l5wx/Kconfig.clk
+++ b/cpu/stm32/kconfigs/l4l5wx/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB || CPU_FAM_WL
 

--- a/cpu/stm32/kconfigs/l5/Kconfig
+++ b/cpu/stm32/kconfigs/l5/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_L5
     bool

--- a/cpu/stm32/kconfigs/l5/Kconfig.clk
+++ b/cpu/stm32/kconfigs/l5/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource '../g4l4l5/Kconfig.clk'
 rsource '../l4l5wx/Kconfig.clk'

--- a/cpu/stm32/kconfigs/l5/Kconfig.lines
+++ b/cpu/stm32/kconfigs/l5/Kconfig.lines
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # CPU lines
 config CPU_LINE_STM32L552XX

--- a/cpu/stm32/kconfigs/l5/Kconfig.models
+++ b/cpu/stm32/kconfigs/l5/Kconfig.models
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/mp1/Kconfig
+++ b/cpu/stm32/kconfigs/mp1/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (C) 2020 Savoir-faire Linux
-#
-# This file is subject to the terms and conditions of the GNU Lesser General
-# Public License v2.1. See the file LICENSE in the top level directory for more
-# details.
+# SPDX-FileCopyrightText: 2020 Savoir-faire Linux
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_MP1
     bool

--- a/cpu/stm32/kconfigs/mp1/Kconfig.clk
+++ b/cpu/stm32/kconfigs/mp1/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource '../f2f4f7mp1/Kconfig.clk'
 rsource '../g0wxmp1/Kconfig.clk'

--- a/cpu/stm32/kconfigs/mp1/Kconfig.lines
+++ b/cpu/stm32/kconfigs/mp1/Kconfig.lines
@@ -1,8 +1,5 @@
-# Copyright (C) 2020 Savoir-faire Linux
-#
-# This file is subject to the terms and conditions of the GNU Lesser General
-# Public License v2.1. See the file LICENSE in the top level directory for more
-# details.
+# SPDX-FileCopyrightText: 2020 Savoir-faire Linux
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # CPU lines
 config CPU_LINE_STM32MP157CXX

--- a/cpu/stm32/kconfigs/mp1/Kconfig.models
+++ b/cpu/stm32/kconfigs/mp1/Kconfig.models
@@ -1,8 +1,5 @@
-# Copyright (C) 2020 Savoir-faire Linux
-#
-# This file is subject to the terms and conditions of the GNU Lesser General
-# Public License v2.1. See the file LICENSE in the top level directory for more
-# details.
+# SPDX-FileCopyrightText: 2020 Savoir-faire Linux
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # CPU models
 config CPU_MODEL_STM32MP157CAC

--- a/cpu/stm32/kconfigs/u5/Kconfig
+++ b/cpu/stm32/kconfigs/u5/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_U5
     bool

--- a/cpu/stm32/kconfigs/u5/Kconfig.lines
+++ b/cpu/stm32/kconfigs/u5/Kconfig.lines
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/u5/Kconfig.models
+++ b/cpu/stm32/kconfigs/u5/Kconfig.models
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/wb/Kconfig
+++ b/cpu/stm32/kconfigs/wb/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_WB
     bool

--- a/cpu/stm32/kconfigs/wb/Kconfig.clk
+++ b/cpu/stm32/kconfigs/wb/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource '../l4l5wx/Kconfig.clk'
 rsource '../g0wxmp1/Kconfig.clk'

--- a/cpu/stm32/kconfigs/wb/Kconfig.lines
+++ b/cpu/stm32/kconfigs/wb/Kconfig.lines
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/wb/Kconfig.models
+++ b/cpu/stm32/kconfigs/wb/Kconfig.models
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/wl/Kconfig
+++ b/cpu/stm32/kconfigs/wl/Kconfig
@@ -1,10 +1,6 @@
-# Copyright (c) 2021 Inria
-# Copyright (c) 2021 Freie Universitaet Berlin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CPU_FAM_WL
     bool

--- a/cpu/stm32/kconfigs/wl/Kconfig.clk
+++ b/cpu/stm32/kconfigs/wl/Kconfig.clk
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource '../l4l5wx/Kconfig.clk'
 rsource '../g0wxmp1/Kconfig.clk'

--- a/cpu/stm32/kconfigs/wl/Kconfig.lines
+++ b/cpu/stm32/kconfigs/wl/Kconfig.lines
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/kconfigs/wl/Kconfig.models
+++ b/cpu/stm32/kconfigs/wl/Kconfig.models
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/lcd_fmc/lcd_fmc.c
+++ b/cpu/stm32/lcd_fmc/lcd_fmc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/adc_f0_g0_c0.c
+++ b/cpu/stm32/periph/adc_f0_g0_c0.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/adc_f1.c
+++ b/cpu/stm32/periph/adc_f1.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Engineering-Spirit
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 Engineering-Spirit
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/adc_f2.c
+++ b/cpu/stm32/periph/adc_f2.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Engineering-Spirit
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 Engineering-Spirit
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/adc_f3.c
+++ b/cpu/stm32/periph/adc_f3.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 LAAS-CNRS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 LAAS-CNRS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/adc_f4_f7.c
+++ b/cpu/stm32/periph/adc_f4_f7.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/adc_l0.c
+++ b/cpu/stm32/periph/adc_l0.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/adc_l1.c
+++ b/cpu/stm32/periph/adc_l1.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Fundacion Inria Chile
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 Fundacion Inria Chile
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/adc_l4_wb.c
+++ b/cpu/stm32/periph/adc_l4_wb.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- * Copyright (C) 2018 HAW-Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 HAW-Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/adc_wl.c
+++ b/cpu/stm32/periph/adc_wl.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- * Copyright (C) 2018 HAW-Hamburg
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 HAW-Hamburg
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/classiccan.c
+++ b/cpu/stm32/periph/classiccan.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2018 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016-2018 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/dac.c
+++ b/cpu/stm32/periph/dac.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 Simon Brummer
- *               2015-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Simon Brummer
+ * SPDX-FileCopyrightText: 2015-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/dma.c
+++ b/cpu/stm32/periph/dma.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/eeprom.c
+++ b/cpu/stm32/periph/eeprom.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/eth.c
+++ b/cpu/stm32/periph/eth.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 TriaGnoSys GmbH
- *               2020 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 TriaGnoSys GmbH
+ * SPDX-FileCopyrightText: 2020 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/eth_common.c
+++ b/cpu/stm32/periph/eth_common.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 TriaGnoSys GmbH
- *               2020 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 TriaGnoSys GmbH
+ * SPDX-FileCopyrightText: 2020 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/fdcan.c
+++ b/cpu/stm32/periph/fdcan.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 COGIP Robotics association
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 COGIP Robotics association
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/flash_common.c
+++ b/cpu/stm32/periph/flash_common.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/flashpage.c
+++ b/cpu/stm32/periph/flashpage.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/fmc.c
+++ b/cpu/stm32/periph/fmc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/gpio_all.c
+++ b/cpu/stm32/periph/gpio_all.c
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2014-2015 Freie Universität Berlin
- *               2015 Hamburg University of Applied Sciences
- *               2017-2020 Inria
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014-2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Hamburg University of Applied Sciences
+ * SPDX-FileCopyrightText: 2017-2020 Inria
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/gpio_f1.c
+++ b/cpu/stm32/periph/gpio_f1.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014-2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/gpio_ll.c
+++ b/cpu/stm32/periph/gpio_ll.c
@@ -1,13 +1,10 @@
 /*
- * Copyright (C) 2014-2015 Freie Universität Berlin
- *               2015 Hamburg University of Applied Sciences
- *               2017-2020 Inria
- *               2017 OTA keys S.A.
- *               2021 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014-2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Hamburg University of Applied Sciences
+ * SPDX-FileCopyrightText: 2017-2020 Inria
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/gpio_ll_irq.c
+++ b/cpu/stm32/periph/gpio_ll_irq.c
@@ -1,13 +1,10 @@
 /*
- * Copyright (C) 2014-2015 Freie Universität Berlin
- *               2015 Hamburg University of Applied Sciences
- *               2017-2020 Inria
- *               2017 OTA keys S.A.
- *               2021 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014-2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Hamburg University of Applied Sciences
+ * SPDX-FileCopyrightText: 2017-2020 Inria
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/hwrng.c
+++ b/cpu/stm32/periph/hwrng.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014-2017 Freie Universität Berlin
- *               2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/i2c_1.c
+++ b/cpu/stm32/periph/i2c_1.c
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2015 Jan Pohlmann <jan-pohlmann@gmx.de>
- *               2017 we-sens.com
- *               2018 Inria
- *               2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Jan Pohlmann <jan-pohlmann@gmx.de>
+ * SPDX-FileCopyrightText: 2017 we-sens.com
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/i2c_2.c
+++ b/cpu/stm32/periph/i2c_2.c
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
- *               2014 FU Berlin
- *               2018 Inria
- *               2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/ltdc.c
+++ b/cpu/stm32/periph/ltdc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/pm.c
+++ b/cpu/stm32/periph/pm.c
@@ -1,13 +1,10 @@
 /*
- * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
- *               2015 Freie Universität Berlin
- *               2015 Engineering-Spirit
- *               2017-2019 OTA keys S.A.
- *               2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Engineering-Spirit
+ * SPDX-FileCopyrightText: 2017-2019 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/ptp.c
+++ b/cpu/stm32/periph/ptp.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/pwm.c
+++ b/cpu/stm32/periph/pwm.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *               2015 Engineering-Spirit
- *               2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Engineering-Spirit
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/qdec.c
+++ b/cpu/stm32/periph/qdec.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Gilles DOFFE <gdoffe@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Gilles DOFFE <gdoffe@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/rtc_all.c
+++ b/cpu/stm32/periph/rtc_all.c
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2015 Lari Lehtomäki
- *               2016 Laksh Bhatia
- *               2016-2017 OTA keys S.A.
- *               2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Lari Lehtomäki
+ * SPDX-FileCopyrightText: 2016 Laksh Bhatia
+ * SPDX-FileCopyrightText: 2016-2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/rtc_f1.c
+++ b/cpu/stm32/periph/rtc_f1.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Alexei Bezborodov
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Alexei Bezborodov
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/rtc_mem.c
+++ b/cpu/stm32/periph/rtc_mem.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/rtt_all.c
+++ b/cpu/stm32/periph/rtt_all.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/rtt_f1.c
+++ b/cpu/stm32/periph/rtt_f1.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/sdmmc.c
+++ b/cpu/stm32/periph/sdmmc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/spi.c
+++ b/cpu/stm32/periph/spi.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2014 Hamburg University of Applied Sciences
- *               2014-2017 Freie Universität Berlin
- *               2016-2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Hamburg University of Applied Sciences
+ * SPDX-FileCopyrightText: 2014-2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016-2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/timer.c
+++ b/cpu/stm32/periph/timer.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/uart.c
+++ b/cpu/stm32/periph/uart.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2014-2017 Freie Universität Berlin
- * Copyright (C) 2016 OTA keys
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014-2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016 OTA keys
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/usbdev_fs.c
+++ b/cpu/stm32/periph/usbdev_fs.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/vbat.c
+++ b/cpu/stm32/periph/vbat.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/periph/wdt.c
+++ b/cpu/stm32/periph/wdt.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/stmclk/stmclk_c0.c
+++ b/cpu/stm32/stmclk/stmclk_c0.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 BISSELL Homecare, Inc.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 BISSELL Homecare, Inc.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/stmclk/stmclk_common.c
+++ b/cpu/stm32/stmclk/stmclk_common.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/stmclk/stmclk_f0f1f3.c
+++ b/cpu/stm32/stmclk/stmclk_f0f1f3.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/stmclk/stmclk_f2f4f7.c
+++ b/cpu/stm32/stmclk/stmclk_f2f4f7.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/stmclk/stmclk_gx.c
+++ b/cpu/stm32/stmclk/stmclk_gx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/stmclk/stmclk_l0l1.c
+++ b/cpu/stm32/stmclk/stmclk_l0l1.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *               2017-2020 Inria
- *               2018 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017-2020 Inria
+ * SPDX-FileCopyrightText: 2018 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/stmclk/stmclk_l4wx.c
+++ b/cpu/stm32/stmclk/stmclk_l4wx.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *               2017 HAW-Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2017 HAW-Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/stmclk/stmclk_l5.c
+++ b/cpu/stm32/stmclk/stmclk_l5.c
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *               2017 OTA keys S.A.
- *               2017 HAW-Hamburg
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2017 HAW-Hamburg
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/stmclk/stmclk_mp1.c
+++ b/cpu/stm32/stmclk/stmclk_mp1.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Savoir-faire Linux
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Savoir-faire Linux
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/cpu/stm32/stmclk/stmclk_u5.c
+++ b/cpu/stm32/stmclk/stmclk_u5.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**


### PR DESCRIPTION
### Contribution description

This PR moves license information from headers to SPDX format for cpu directory.
In this PR following cpu's are processed:
- sam,
- stm32,
-  ... plus two files in the main directory.

This is final PR for this directory.

### Testing procedure

Review changed files.

### Issues/PRs references

Track https://github.com/RIOT-OS/RIOT/issues/21515
Part 1 https://github.com/RIOT-OS/RIOT/pull/21704
Part 2 https://github.com/RIOT-OS/RIOT/pull/21715
Part 3 https://github.com/RIOT-OS/RIOT/pull/21732
Part 4 https://github.com/RIOT-OS/RIOT/pull/21747