### PR TITLE
codeowner: Remove PeterKietzmann and add Teufelchen

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -95,7 +95,7 @@ Cargo.*                                     @chrysn
 /drivers/periph_common/                     @MrKevinWeiss
 /drivers/include/periph/ptp.h               @maribu
 
-/pkg/cryptoauthlib/                         @Einhornhool @PeterKietzmann
+/pkg/cryptoauthlib/                         @Einhornhool
 /pkg/libschc/                               @bartmoons @miri64
 /pkg/lua/                                   @jcarrano
 /pkg/lwip/                                  @miri64
@@ -124,7 +124,7 @@ Cargo.*                                     @chrysn
 /sys/net/gnrc/link_layer/lorawan/           @jia200x
 /sys/net/gnrc/netif/                        @miri64 @jia200x
 /sys/net/gnrc/routing/rpl/                  @emmanuelsearch
-/sys/net/                                   @miri64 @PeterKietzmann
+/sys/net/                                   @miri64
 /sys/pm_layered/                            @kaspar030
 /sys/random/fortuna/                        @basilfx
 /sys/riotboot/                              @kaspar030

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -145,7 +145,7 @@ Cargo.*                                     @chrysn
 /tests/pkg/lwip*                            @miri64
 /tests/pkg/libschc/                         @miri64
 /tests/net/slip/                            @miri64
-/tests/unittests                            @miri64
+/tests/unittests                            @miri64 @teufelchen1
 /tests/*/tests/*.py                         @miri64
 /tests/cpu/efm32_features/                  @basilfx
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hello! 🐸

This removes @PeterKietzmann as code owner. I asked him out of band, he was a bit hesitant which I interpreted as "I would like to remain a maintainer" but okay with the code owner cleanup.

In addition, I add myself to the unittests. Unittests have always been one of my favorite topics. 
