### PR TITLE
codeowner: remove inactive owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,8 +20,7 @@ Cargo.*                                     @chrysn
 /boards/common/slwstk6000b/                 @basilfx
 /boards/common/stm32/                       @aabadie
 /boards/e180-zg120b-tb/                     @basilfx
-/boards/esp*/                               @gschorcht @yegorich
-/boards/hamilton/                           @Hyungsin
+/boards/esp*/                               @gschorcht
 /boards/ikea-tradfri/                       @basilfx
 /boards/lobaro-lorabox/                     @leandrolanzieri
 /boards/nrf*/                               @aabadie
@@ -37,7 +36,6 @@ Cargo.*                                     @chrysn
 /boards/sodaq-sara-aff/                     @leandrolanzieri
 /boards/stk3*00/                            @basilfx
 /boards/openmote*/                          @MrKevinWeiss
-/boards/cc1352p-launchpad                   @luisan00
 /boards/atxmega*/                           @nandojve
 
 /core/                                      @kaspar030
@@ -71,18 +69,14 @@ Cargo.*                                     @chrysn
 /drivers/ad7746/                            @leandrolanzieri
 /drivers/at24mac/                           @benpicco
 /drivers/at86rf215/                         @benpicco
-/drivers/at86rf2xx/                         @daniel-k @Hyungsin @jia200x @miri64
-/drivers/bh1900nux/                         @wosym
+/drivers/at86rf2xx/                         @jia200x @miri64
 /drivers/bq2429x/                           @jeandudey
 /drivers/cc110x/                            @maribu
 /drivers/cc1xxx_common/                     @maribu
 /drivers/ccs811/                            @gschorcht
-/drivers/dcf77/                             @daexel
-/drivers/dht/                               @wosym
 /drivers/dose/                              @jue89
 /drivers/ds18/                              @leandrolanzieri
 /drivers/itg320x/                           @gschorcht
-/drivers/mcp2515/                           @wosym
 /drivers/mrf24j40/                          @bergzand
 /drivers/pca9685/                           @gschorcht
 /drivers/sht3x/                             @gschorcht
@@ -96,15 +90,14 @@ Cargo.*                                     @chrysn
 /drivers/include/periph/ptp.h               @maribu
 
 /pkg/cryptoauthlib/                         @Einhornhool
-/pkg/libschc/                               @bartmoons @miri64
-/pkg/lua/                                   @jcarrano
+/pkg/libschc/                               @miri64
 /pkg/lwip/                                  @miri64
 /pkg/gecko_sdk/                             @basilfx
 /pkg/lora-serialization/                    @leandrolanzieri
 /pkg/micropython/                           @bergzand @kaspar030
-/pkg/openthread/                            @Hyungsin @jia200x
+/pkg/openthread/                            @jia200x
 /pkg/semtech-loramac/                       @aabadie @jia200x
-/pkg/tinydtls/                              @rfuentess @leandrolanzieri
+/pkg/tinydtls/                              @leandrolanzieri
 /pkg/tinyvcdiff/                            @jue89
 /pkg/u8g2/                                  @basilfx
 /pkg/ucglib/                                @basilfx
@@ -119,7 +112,7 @@ Cargo.*                                     @chrysn
 /sys/include/net/sock*                      @maribu
 /sys/net/netif/                             @miri64 @jia200x
 /sys/net/gnrc/network_layer/                @miri64
-/sys/net/gnrc/transport_layer/tcp/          @brummer-simon @miri64
+/sys/net/gnrc/transport_layer/tcp/          @miri64
 /sys/net/gnrc/transport_layer/udp/          @miri64
 /sys/net/gnrc/link_layer/lorawan/           @jia200x
 /sys/net/gnrc/netif/                        @miri64 @jia200x
@@ -138,9 +131,7 @@ Cargo.*                                     @chrysn
 /sys/ztimer/                                @kaspar030 @bergzand
 
 /tests/                                     @leandrolanzieri @aabadie @MichelRottleuthner
-/tests/drivers/candev/                      @wosym
 /tests/drivers/bq2429x/                     @jeandudey
-/tests/drivers/dht/                         @wosym
 /tests/net/gnrc*                            @miri64
 /tests/pkg/lwip*                            @miri64
 /tests/pkg/libschc/                         @miri64


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hiiii 🐆

This clears all "bugs" in our `CODEOWNERS` file. These bugs are reported by github with this message:
```
Unknown owner on line XXX: make sure @<username> exists and has write access to the repository
/path/of/ownership                             @<username>
```
In our case, all erroneous users exist but don't have write access. 

This removes in-active owners. One single exception is `einhornhool` which does exists, does not have write access and as such is a "bug" in the file. I deliberately keep her in the file as she is still active and still reacts to pings.

"In-active" is defined as:
`"I looked at their online presence, e.g. on Github and the last time they contributed to RIOT and decided they are in-active"`. 

Follow-up for #21761 
