### PR TITLE
cpu/stm32/genkconfig: move script licence and templates to SPDX

### DIFF
--- a/cpu/stm32/dist/kconfig/Kconfig.lines.j2
+++ b/cpu/stm32/dist/kconfig/Kconfig.lines.j2
@@ -1,9 +1,5 @@
-# Copyright (c) {{ year }} Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: {{ year }} Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/dist/kconfig/Kconfig.models.j2
+++ b/cpu/stm32/dist/kconfig/Kconfig.models.j2
@@ -1,9 +1,5 @@
-# Copyright (c) {{ year }} Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: {{ year }} Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # This file was auto-generated from ST ProductsList.xlsx sheet using the
 # script in cpu/stm32/dist/kconfig/gen_kconfig.py

--- a/cpu/stm32/dist/kconfig/gen_kconfig.py
+++ b/cpu/stm32/dist/kconfig/gen_kconfig.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 import os
 import argparse


### PR DESCRIPTION
### Contribution description

In https://github.com/RIOT-OS/RIOT/pull/21758#discussion_r2405762997 @crasbe spotted that in `cpu/stm32/dist/kconfig` directory there is a little utility tool `genkconfig` which generates Kconfig files with old style licenses. This PR fix this issue, plus move license of the script to SPDX, too.

### Testing procedure

Review changed files.

### Issues/PRs references

Track https://github.com/RIOT-OS/RIOT/issues/21515