### PR TITLE
doc/guides: fix wrong script name in Porting Boards

### DIFF
--- a/doc/guides/advanced_tutorials/porting_boards.md
+++ b/doc/guides/advanced_tutorials/porting_boards.md
@@ -541,10 +541,12 @@ depending on the host architecture.
 
 Some scripts and tools available to ease `BOARD` porting and testing:
 
-  - Run `dist/tools/insufficient_memory/add_insufficient_memory_board.sh <board>`
+  - Run `dist/tools/insufficient_memory/update_insufficient_memory_board.sh <board>`
     if your board has little memory. This updates the `Makefile.ci` lists to
     exclude the `BOARD` from automated compile-tests of applications that do
     not fit on the `BOARD`s `CPU`.
+    Please keep in mind that this will take quite a while depending on your
+    system!
 
   - Run `dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . <board> --with-test-only`
     to run all automated tests on the new board.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The script for updating the Makefile.ci files is actually called `update_insufficient_memory_board.sh`, not `add_insufficient_memory_board.sh`. Also I added a small sentence about the fact that running that script might take some time.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Look at the guide and see that it's still beautiful.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
