### PR TITLE
doc/starlight: add route middleware to fix edit link

### DIFF
--- a/doc/starlight/astro.config.mjs
+++ b/doc/starlight/astro.config.mjs
@@ -177,6 +177,7 @@ export default defineConfig({
         replacesTitle: true,
       },
       plugins: [starlightImageZoom()],
+      routeMiddleware: "./src/routeData.ts",
       editLink: {
         baseUrl: "https://github.com/RIOT-OS/RIOT/tree/master/doc/guides",
       },

--- a/doc/starlight/src/routeData.ts
+++ b/doc/starlight/src/routeData.ts
@@ -1,0 +1,23 @@
+import { defineRouteMiddleware } from "@astrojs/starlight/route-data";
+
+/**
+ * Since we currently use a symlink to comply with the (broken)
+ * docs folder scanning of starlight, this will break the edit
+ * link since, while technically correct, our symlink will be
+ * shown as github.com/RIOT-OS/RIOT/doc/guides/src/content/docs/foobar
+ * Since github can't parse symlinks, we need to modify the editUrl
+ * through a route middleware in order for the edit link to still function
+ *
+ * As soon as base directory changes get fixed, this should be removed
+ * again! See: https://github.com/withastro/starlight/pull/3332
+ */
+export const onRequest = defineRouteMiddleware((context) => {
+  const { starlightRoute } = context.locals;
+
+  if (starlightRoute.editUrl) {
+    starlightRoute.editUrl = new URL(
+      starlightRoute.editUrl.href.replace("src/content/docs/", ""),
+      starlightRoute.editUrl,
+    );
+  }
+});


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Since we currently use a symlink (as introduced in https://github.com/RIOT-OS/RIOT/commit/bcd9fbe46751f30463b064ffd239fc86c70e63ae to comply with the (broken) docs folder scanning of starlight, this will break the edit link since, while technically correct, our symlink will be shown as github.com/RIOT-OS/RIOT/doc/guides/src/content/docs/foobar.md.

Since github can't parse symlinks, we need to modify the editUrl through a route middleware in order for the edit link to still function.
As soon as base directory changes get fixed, this should be removed again!

(Ty to @LasseRosenow for noticing that)

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
