### PR TITLE
boards/nucleo-l011k4: improve board doc

### DIFF
--- a/boards/nucleo-l011k4/doc.md
+++ b/boards/nucleo-l011k4/doc.md
@@ -7,15 +7,35 @@
 The Nucleo-L011K4 is a board from ST's Nucleo family supporting ARM-Cortex-M0+
 STM32L011K4 microcontroller with 2KiB of RAM and 16KiB of Flash.
 
-## Flashing the Board Using ST-LINK Removable Media
+## Pinout
 
-On-board ST-LINK programmer provides via composite USB device removable media.
-Copying the HEX file causes reprogramming of the board. This task
-could be performed manually; however, the cpy2remed (copy to removable
-media) PROGRAMMER script does this automatically. To program board in
-this manner, use the command:
-```
-make BOARD=nucleo-l011k4 PROGRAMMER=cpy2remed flash
-```
-@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
-      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
+@image html pinouts/nucleo-l432kc-and-more.svg "Pinout for the Nucleo-L011K4 (from STM user manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 32)" width=25%
+
+### MCU
+
+| MCU        |    STM32L011K4      |
+|:---------- |:------------------- |
+| Family     | ARM Cortex-M0+      |
+| Vendor     | ST Microelectronics |
+| RAM        | 2KiB                |
+| Flash      | 16KiB               |
+| Frequency  | up to 32MHz         |
+| FPU        | no                  |
+| Timers     | 7 (3x 16-bit, 1x RTC, 1x Systick, 2x Watchdog) |
+| ADC        | 1x 12-bit (10 channels) |
+| UARTs      | 2 (one USART and one Low-Power UART) |
+| SPIs       | 1                   |
+| CANs       | 0                   |
+| RTC        | 1                   |
+| I2Cs       | 1                   |
+| Vcc        | 1.65V - 3.6V        |
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32l011k4.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0377-ultralowpower-stm32l0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) |
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0223-stm32-cortexm0-mcus-programming-manual-stmicroelectronics.pdf) |
+| Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf) |
+
+## Flashing the Board
+
+A detailed description about the flashing process can be found on the
+[guides page](https://guide.riot-os.org/board_specific/stm32/).
+The board name for the Nucleo-L011K4 is `nucleo-l011k4`.


### PR DESCRIPTION
### Contribution description

This PR updates `nucleo-l011k41` board doc page, by:
- adding board pinout,
- adding MCU table.

### Testing procedure

Generate doc and check if everything looks good:

```
make doc
xdg-open ./doc/doxygen/html/group__boards__nucleo-l011k4.html 
```

### Issues/PRs references

None