### PR TITLE
posix/sockets: Prevent potentially long wait with multiple posix TCP sockets

### DIFF
--- a/sys/posix/sockets/posix_sockets.c
+++ b/sys/posix/sockets/posix_sockets.c
@@ -515,6 +515,7 @@ int accept(int socket, struct sockaddr *restrict address,
     switch (s->type) {
     case SOCK_STREAM:
         new_s = _get_free_socket();
+        mutex_unlock(&_socket_pool_mutex);
         if (new_s == NULL) {
             errno = ENFILE;
             res = -1;

--- a/sys/posix/sockets/posix_sockets.c
+++ b/sys/posix/sockets/posix_sockets.c
@@ -515,6 +515,7 @@ int accept(int socket, struct sockaddr *restrict address,
     switch (s->type) {
     case SOCK_STREAM:
         new_s = _get_free_socket();
+        mutex_unlock(&_socket_pool_mutex);
         if (new_s == NULL) {
             errno = ENFILE;
             res = -1;
@@ -567,6 +568,8 @@ int accept(int socket, struct sockaddr *restrict address,
         }
         break;
     default:
+        /* Each case needs to unlock the mutex individually */
+        mutex_unlock(&_socket_pool_mutex);
         errno = EOPNOTSUPP;
         res = -1;
         break;
@@ -574,7 +577,6 @@ int accept(int socket, struct sockaddr *restrict address,
     if ((res < 0) && (sock != NULL)) {
         sock_tcp_disconnect(sock);
     }
-    mutex_unlock(&_socket_pool_mutex);
     return res;
 #else
     (void)socket;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When 2 posix TCP sockets in different threads are open and the first one is in accept() the mutex of the socket pool was not unlocked until data was received. When another thread calls a function which needs the socket pool mutex there was a ~deadlock~ potentially long wait until such data is received. Unlocking the mutex after all operations on the socket pool are done, in particular BEFORE sock_tcp_accept() solves this.

I verified all function calls between my insertion and the later mutex unlock do not access the socket pool.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Since this change is small I hope it is sufficient to describe the problem:

In one thread open a posix socket and accept(), this blocks until data is received.
In another thread call any other socket pool dependent posix/socket function, like socket().

Expected:
Second thread can create/... sockets.

Actual:
Deadlock, as the socket pool is still locked.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

None, just found this without creating an issue, while porting posix dependent code.

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
