### PR TITLE
boards/nucleo-l031k6: improve board doc

### DIFF
--- a/boards/nucleo-l031k6/doc.md
+++ b/boards/nucleo-l031k6/doc.md
@@ -7,16 +7,35 @@
 The Nucleo-L031K6 is a board from ST's Nucleo family supporting ARM Cortex-M0
 STM32L031K6T6 microcontroller with 8KiB of RAM and 32KiB of Flash.
 
+## Pinout
 
-## Flashing the Board Using ST-LINK Removable Media
+@image html pinouts/nucleo-l432kc-and-more.svg "Pinout for the Nucleo-L031K6 (from STM user manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 32)" width=25%
 
-On-board ST-LINK programmer provides via composite USB device removable media.
-Copying the HEX file causes reprogramming of the board. This task
-could be performed manually; however, the cpy2remed (copy to removable
-media) PROGRAMMER script does this automatically. To program board in
-this manner, use the command:
-```
-make BOARD=nucleo-l031k6 PROGRAMMER=cpy2remed flash
-```
-@note This PROGRAMMER was tested using ST-LINK firmware 2.37.26. Firmware updates
-      can be found on [this STM webpage](https://www.st.com/en/development-tools/stsw-link007.html).
+### MCU
+
+| MCU        |    STM32L031K6      |
+|:---------- |:------------------- |
+| Family     | ARM Cortex-M0+      |
+| Vendor     | ST Microelectronics |
+| RAM        | 8KiB                |
+| Flash      | 32KiB               |
+| Frequency  | up to 32MHz         |
+| FPU        | no                  |
+| Timers     | 8 (4x 16-bit, 1x RTC, 1x Systick, 2x Watchdog) |
+| ADC        | 1x 12-bit (10 channels) |
+| UARTs      | 2 (one USART and one Low-Power UART) |
+| SPIs       | 2                   |
+| CANs       | 0                   |
+| RTC        | 1                   |
+| I2Cs       | 1                   |
+| Vcc        | 1.65V - 3.6V        |
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32l031k6.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0377-ultralowpower-stm32l0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) |
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0223-stm32-cortexm0-mcus-programming-manual-stmicroelectronics.pdf) |
+| Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf) |
+
+## Flashing the Board
+
+A detailed description about the flashing process can be found on the
+[guides page](https://guide.riot-os.org/board_specific/stm32/).
+The board name for the Nucleo-L031K6 is `nucleo-l031k6`.


### PR DESCRIPTION
### Contribution description

This PR updates `nucleo-l031k6` board doc page, by:
- adding board pinout,
- adding MCU table,
- moving flashing info accordingly to PR https://github.com/RIOT-OS/RIOT/pull/21337 .

### Testing procedure

Generate doc and check if everything looks good:

```
make doc
xdg-open ./doc/doxygen/html/group__boards__nucleo-l031k6.html 
```

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/21337
