### PR TITLE
doc/starlight: fix gitignore

### DIFF
--- a/doc/starlight/.gitignore
+++ b/doc/starlight/.gitignore
@@ -20,4 +20,4 @@ pnpm-debug.log*
 .DS_Store
 
 # Don't show copied files
-src/content/docs/**
+src/content


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Right now after running `make dev` in doc/starlight, the new generated symlink will be added to git. This fixes that.
