### PR TITLE
build system: Fix regression from #21752

### DIFF
--- a/makefiles/tests/tests.inc.mk
+++ b/makefiles/tests/tests.inc.mk
@@ -23,7 +23,7 @@ TEST_EXECUTOR ?=
 TEST_EXECUTOR_FLAGS ?=
 
 # Are tests going to be run in docker and we are not yet in docker?
-ifeq (0-test,$(INSIDE_DOCKER)-$(filter test,$(DOCKER_MAKECMDGOALS)))
+ifeq (1-0-test,$(BUILD_IN_DOCKER)-$(INSIDE_DOCKER)-$(filter test,$(DOCKER_MAKECMDGOALS)))
 # Yes --> defer test execution to docker
 test: ..in-docker-container
 else


### PR DESCRIPTION
### Contribution description

Fixes https://github.com/RIOT-OS/RIOT/pull/21752#issuecomment-3398008963

### Testing procedure

1. `make -C tests/sys/fmt_print all test BOARD=native64 BUILD_IN_DOCKER=1`
    - Build should be run in docker
    - Test should be run in docker
2. `make -C tests/sys/fmt_print all test BOARD=native BUILD_IN_DOCKER=1`
    - Build should be run in docker
    - Test should be run in docker
3. `make -C tests/sys/fmt_print all test BOARD=native64`
    - Build should **NOT** be run in docker
    - Test should **NOT** be run in docker
4. `make -C tests/sys/fmt_print all test BOARD=samr21-xpro`
    - Build should **NOT** be run in docker
    - Test should **NOT** be run in docker
5. `make -C tests/sys/fmt_print all test BOARD=samr21-xpro BUILD_IN_DOCKER=1`
    - Build should be run in docker
    - Test should **NOT** be run in docker

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/pull/21752#issuecomment-3398008963