### PR TITLE
cpu/stm32: fix `_ccmram_length` name, make names consistent

### DIFF
--- a/cpu/stm32/Makefile.include
+++ b/cpu/stm32/Makefile.include
@@ -69,7 +69,7 @@ endif
 ifneq (,$(filter periph_fmc_sdram periph_fmc_nor_sram,$(USEMODULE)))
   ifneq (,$(FMC_RAM_LEN))
     LINKFLAGS += $(LINKFLAGPREFIX)--defsym=_fmc_ram_addr=$(FMC_RAM_ADDR)
-    LINKFLAGS += $(LINKFLAGPREFIX)--defsym=_fmc_ram_len=$(FMC_RAM_LEN)
+    LINKFLAGS += $(LINKFLAGPREFIX)--defsym=_fmc_ram_length=$(FMC_RAM_LEN)
     CFLAGS += -DCPU_HAS_FMC_RAM=1
     CFLAGS += -DNUM_HEAPS=4
   endif

--- a/cpu/stm32/ldscripts/stm32.ld
+++ b/cpu/stm32/ldscripts/stm32.ld
@@ -18,19 +18,19 @@
  * @}
  */
 
-ccmram_length = DEFINED( _ccmram_len ) ? _ccmram_len : 0x0 ;
+ccmram_length = DEFINED( _ccmram_length ) ? _ccmram_length : 0x0 ;
 
 sram4_addr = DEFINED( _sram4_length ) ? 0x28000000 : 0x0 ;
 sram4_length = DEFINED( _sram4_length ) ? _sram4_length : 0x0 ;
 
 fmc_ram_addr = DEFINED( _fmc_ram_addr ) ? _fmc_ram_addr : 0x0 ;
-fmc_ram_len = DEFINED( _fmc_ram_len ) ? _fmc_ram_len : 0x0 ;
+fmc_ram_length = DEFINED( _fmc_ram_length ) ? _fmc_ram_length : 0x0 ;
 
 MEMORY
 {
     ccmram  : ORIGIN = 0x10000000, LENGTH = ccmram_length
     sram4   : ORIGIN = sram4_addr, LENGTH = sram4_length
-    fmcram  : ORIGIN = fmc_ram_addr, LENGTH = fmc_ram_len
+    fmcram  : ORIGIN = fmc_ram_addr, LENGTH = fmc_ram_length
 }
 
 SECTIONS


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The Linkerscript used a variable called `_ccmram_len`, while the Makefile defined it as `_ccmram_length`, therefore it was never actually used.

I also renamed `fmc_ram_len` to `fmc_ram_length` to make it consistent with the other two.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Honstly I'm not sure how to test that?

I checked that no old names are left in the codebase:
```
RIOT$ grep -Rnw . -e fmc_ram_len
RIOT$ grep -Rnw . -e _ccmram_len
```

Will test it with real hardware

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Closes #21698.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
