### PR TITLE
doc/guides: disable npm funding message

### DIFF
--- a/doc/starlight/Makefile
+++ b/doc/starlight/Makefile
@@ -5,8 +5,8 @@ RIOTTOOLS ?= $(RIOTBASE)/dist/tools
 .PHONY: install
 install: integrate_outside_files
 	@echo "Installing starlight..."
-	@npm ci --prefix $(CURDIR) --prefer-offline
-	@echo "Starlight installed successfully."
+	@npm ci --prefix $(CURDIR) --prefer-offline --no-fund --no-audit
+	@echo "\nStarlight installed successfully."
 
 .PHONY: build
 build: install


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The Make output for `make doc-starlight` is quite spammy due to `npm`. This PR disables the `xxx projects are looking for funding` and (optionally) the audit message.

The latter is up for discussion, but since `make doc-starlight` is creating a local instance, the security impact is low anyways and there are *always* security messages popping up, except you have updated everything 30 seconds ago.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Current `master`:
```
cbuec@W11nMate:~/RIOTstuff/riot-guides/RIOT$ make doc-starlight
"make" -C doc/starlight dev
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-guides/RIOT/doc/starlight'
Generating Code of Conduct documentation...
Generating Governance documentation...
Generating Lost and Found documentation...
Generating Coding Conventions documentation...
Generating C++ Coding Conventions documentation...
Installing starlight...

added 453 packages, and audited 454 packages in 6s

224 packages are looking for funding
  run `npm fund` for details

5 moderate severity vulnerabilities

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
Starlight installed successfully.
Linking RIOT documentation source files...
Starting starlight live server...

> guide@0.0.1 dev
> astro dev

13:29:14 [types] Generated 1ms
13:29:14 [content] Syncing content
13:29:17 [content] Synced content

 astro  v5.14.1 ready in 4643 ms

┃ Local    http://localhost:4321/
┃ Network  use --host to expose

13:29:17 watching for file changes...
```

This PR:
```
cbuec@W11nMate:~/RIOTstuff/riot-guides/RIOT$ make doc-starlight
"make" -C doc/starlight dev
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-guides/RIOT/doc/starlight'
Generating Code of Conduct documentation...
Generating Governance documentation...
Generating Lost and Found documentation...
Generating Coding Conventions documentation...
Generating C++ Coding Conventions documentation...
Installing starlight...

added 453 packages, and audited 454 packages in 6s

5 moderate severity vulnerabilities

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.

Starlight installed successfully.
Linking RIOT documentation source files...
Starting starlight live server...

> guide@0.0.1 dev
> astro dev

13:30:46 [types] Generated 0ms
13:30:47 [content] Syncing content
13:30:50 [content] Synced content

 astro  v5.14.1 ready in 4695 ms

┃ Local    http://localhost:4321/
┃ Network  use --host to expose

13:30:50 watching for file changes...
```



This PR (with disabled audit messages):
```
cbuec@W11nMate:~/RIOTstuff/riot-guides/RIOT$ make doc-starlight
"make" -C doc/starlight dev
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-guides/RIOT/doc/starlight'
Generating Code of Conduct documentation...
Generating Governance documentation...
Generating Lost and Found documentation...
Generating Coding Conventions documentation...
Generating C++ Coding Conventions documentation...
Installing starlight...

added 453 packages in 6s

Starlight installed successfully.
Linking RIOT documentation source files...
Starting starlight live server...

> guide@0.0.1 dev
> astro dev

13:29:56 [types] Generated 0ms
13:29:57 [content] Syncing content
13:30:00 [content] Synced content

 astro  v5.14.1 ready in 4730 ms

┃ Local    http://localhost:4321/
┃ Network  use --host to expose

13:30:00 watching for file changes...
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
