### PR TITLE
boards/nucleo-f303k8: add board pinout

### DIFF
--- a/boards/nucleo-f303k8/doc.md
+++ b/boards/nucleo-f303k8/doc.md
@@ -10,6 +10,10 @@ STM32F303K8 microcontroller with 12KiB of RAM and 64KiB of ROM.
 You can find general information about the Nucleo32 boards on the
 @ref boards_common_nucleo32 page.
 
+## Pinout
+
+@image html pinouts/nucleo-f031k6-and-more.svg "Pinout for the Nucleo-F303K8 (from ST User Manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 31)" width=25%
+
 ## Hardware
 
 ![nucleo image](https://www.st.com/bin/ecommerce/api/image.PF262496.en.feature-description-include-personalized-no-cpn-medium.jpg)


### PR DESCRIPTION
### Contribution description

This PR adds missing pinout to the `nucleo-f303k8` .

### Testing procedure

Generate doc and check if everything looks good:

```
make doc
xdg-open ./doc/doxygen/html/group__boards__nucleo-f303k8.html 
```

### Issues/PRs references

None