### PR TITLE
drivers/ds18: move to ztimer

### DIFF
--- a/drivers/ds18/Makefile.dep
+++ b/drivers/ds18/Makefile.dep
@@ -1,2 +1,2 @@
-USEMODULE += xtimer
+USEMODULE += ztimer_usec
 FEATURES_REQUIRED += periph_gpio

--- a/drivers/ds18/ds18.c
+++ b/drivers/ds18/ds18.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Frits Kuipers
- *               2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Frits Kuipers
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**
@@ -25,7 +22,7 @@
 
 #include "log.h"
 #include "periph/gpio.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -54,9 +51,9 @@ static void ds18_write_bit(const ds18_t *dev, uint8_t bit)
     }
 
     /* Wait for slot to end */
-    xtimer_usleep(DS18_DELAY_SLOT);
+    ztimer_sleep(ZTIMER_USEC, DS18_DELAY_SLOT);
     ds18_release(dev);
-    xtimer_usleep(1);
+    ztimer_sleep(ZTIMER_USEC, 1);
 }
 
 static int ds18_read_bit(const ds18_t *dev, uint8_t *bit)
@@ -66,17 +63,17 @@ static int ds18_read_bit(const ds18_t *dev, uint8_t *bit)
     ds18_release(dev);
 
 #if defined(MODULE_DS18_OPTIMIZED)
-    xtimer_usleep(DS18_SAMPLE_TIME);
+    ztimer_sleep(ZTIMER_USEC, DS18_SAMPLE_TIME);
     *bit = gpio_read(dev->params.pin);
-    xtimer_usleep(DS18_DELAY_R_RECOVER);
+    ztimer_sleep(ZTIMER_USEC, DS18_DELAY_R_RECOVER);
     return DS18_OK;
 #else
     uint32_t start, measurement = 0;
 
     /* Measure time low of device pin, timeout after slot time*/
-    start = xtimer_now_usec();
+    start = ztimer_now(ZTIMER_USEC);
     while (!gpio_read(dev->params.pin) && measurement < DS18_DELAY_SLOT) {
-        measurement = xtimer_now_usec() - start;
+        measurement = ztimer_now(ZTIMER_USEC) - start;
     }
 
     /* If there was a timeout return error */
@@ -88,7 +85,7 @@ static int ds18_read_bit(const ds18_t *dev, uint8_t *bit)
     *bit = measurement < DS18_SAMPLE_TIME;
 
     /* Wait for slot to end */
-    xtimer_usleep(DS18_DELAY_SLOT - measurement);
+    ztimer_sleep(ZTIMER_USEC, DS18_DELAY_SLOT - measurement);
 
     return DS18_OK;
 #endif
@@ -124,17 +121,17 @@ static int ds18_reset(const ds18_t *dev)
 
     /* Line low and sleep the reset delay */
     ds18_low(dev);
-    xtimer_usleep(DS18_DELAY_RESET);
+    ztimer_sleep(ZTIMER_USEC, DS18_DELAY_RESET);
 
     /* Release and wait for the presence response */
     ds18_release(dev);
-    xtimer_usleep(DS18_DELAY_PRESENCE);
+    ztimer_sleep(ZTIMER_USEC, DS18_DELAY_PRESENCE);
 
     /* Check device presence */
     res = gpio_read(dev->params.pin);
 
     /* Sleep for reset delay */
-    xtimer_usleep(DS18_DELAY_RESET);
+    ztimer_sleep(ZTIMER_USEC, DS18_DELAY_RESET);
 
     return res;
 }
@@ -199,7 +196,7 @@ int ds18_get_temperature(const ds18_t *dev, int16_t *temperature)
     }
 
     DEBUG("[DS18] Wait for convert T\n");
-    xtimer_usleep(DS18_DELAY_CONVERT);
+    ztimer_sleep(ZTIMER_USEC, DS18_DELAY_CONVERT);
 
     return ds18_read(dev, temperature);
 }

--- a/drivers/ds18/ds18_internal.h
+++ b/drivers/ds18/ds18_internal.h
@@ -1,13 +1,12 @@
 /*
- * Copyright (C) 2017 Frits Kuipers
- *               2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Frits Kuipers
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once
+
+#include "time_units.h"
 
 /**
  * @ingroup     drivers_ds18

--- a/drivers/ds18/ds18_saul.c
+++ b/drivers/ds18/ds18_saul.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Frits Kuipers
- *               2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Frits Kuipers
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/tests/drivers/ds18/Makefile
+++ b/tests/drivers/ds18/Makefile
@@ -3,9 +3,9 @@ include ../Makefile.drivers_common
 BOARD_WHITELIST := sensebox_samd21 samr21-xpro nucleo-l152re nucleo-l432kc nucleo-l073rz b-l072z-lrwan arduino-nano
 
 USEMODULE += ds18
-USEMODULE += xtimer
+USEMODULE += ztimer_sec
 USEMODULE += printf_float
-# Use the module if you have an accurate sleep with xtimer (~3us)
+# Use the module if you have an accurate sleep with ztimer (~3us)
 #USEMODULE += ds18_optimized
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/drivers/ds18/README.md
+++ b/tests/drivers/ds18/README.md
@@ -1,0 +1,15 @@
+## About
+
+This is a test application for the Maxim
+[DS18B20](https://datasheets.maximintegrated.com/en/ds/DS18B20.pdf)
+1-Wire temperature sensor.
+
+## Usage
+
+The application will initialize the DS18B20 sensor, read
+the temperature and print the measurement to STDOUT every two seconds.
+
+The default GPIO pin is (0,0), which equates for example to PA0 for STM32s.
+If you connected sensor to other pin you should set `DS18_PARAM_PIN` accordingly.
+Guide showing how to change default driver configuration is provided by
+[link](https://guide.riot-os.org/advanced_tutorials/device_drivers/#default-device-configuration) .

--- a/tests/drivers/ds18/Readme.md
+++ b/tests/drivers/ds18/Readme.md
@@ -1,7 +1,0 @@
-## About
-This is a test application for the Maxime [DS18B20](https://datasheets.maximintegrated.com/en/ds/DS18B20.pdf) 1-Wire temperature
-sensor.
-
-## Usage
-The application will initialize the DS18B20 sensor and every 2 seconds will read
-the temperature and print the measurement to STDOUT.

--- a/tests/drivers/ds18/main.c
+++ b/tests/drivers/ds18/main.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**
@@ -24,7 +21,7 @@
 #include "board.h"
 #include "ds18.h"
 #include "ds18_params.h"
-#include "xtimer.h"
+#include "ztimer.h"
 
 #define SAMPLING_PERIOD     2
 
@@ -63,7 +60,7 @@ int main(void)
             puts("[Error] Could not read temperature");
         }
 
-        xtimer_sleep(SAMPLING_PERIOD);
+        ztimer_sleep(ZTIMER_SEC, SAMPLING_PERIOD);
     }
 
     return 0;


### PR DESCRIPTION
### Contribution description

This PR moves in the `drivers/ds18` and `tests/drivers/ds18` deprecated `xtimer` to `ztimer`.
Moreover, it moves licenses to SPDX format. 

### Testing procedure

I tested working code on `nucleo-f439zi` using `tests/drivers/ds18`.
Observed output, each new reading appears in 2 seconds, when I touched ds18 sensor:

```
Temperature [ºC]:  23.12
+-------------------------------------+
Temperature [ºC]:  25.93
+-------------------------------------+
Temperature [ºC]:  27.68
+-------------------------------------+
Temperature [ºC]:  28.62
+-------------------------------------+
Temperature [ºC]:  29.18
+-------------------------------------+
Temperature [ºC]:  29.56
+-------------------------------------+
Temperature [ºC]:  29.75
+-------------------------------------+
Temperature [ºC]:  29.93
+-------------------------------------+
Temperature [ºC]:  30.00
+-------------------------------------+
Temperature [ºC]:  30.12
+-------------------------------------+
Temperature [ºC]:  31.00
+-------------------------------------+
Temperature [ºC]:  30.43
+-------------------------------------+
```

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/18560