### PR TITLE
pkg/mplaland-printf: Use buffered output

### DIFF
--- a/pkg/mpaland-printf/patches/0006-use-buffered-output.patch
+++ b/pkg/mpaland-printf/patches/0006-use-buffered-output.patch
@@ -1,0 +1,131 @@
+From 1070ce82390a7ca9bdaef52f106488ac7ef99645 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
+Date: Sun, 19 Oct 2025 16:58:11 +0200
+Subject: [PATCH] use buffered output
+
+---
+ printf.c | 63 +++++++++++++++++++++++++++++++++++++++++---------------
+ 1 file changed, 46 insertions(+), 17 deletions(-)
+
+diff --git a/printf.c b/printf.c
+index 33fd8a6..756fd12 100644
+--- a/printf.c
++++ b/printf.c
+@@ -133,6 +133,27 @@ typedef struct {
+ } out_fct_wrap_type;
+ 
+ 
++typedef struct {
++  char buf[64];
++  uint8_t fill;
++} output_buffer_type;
++
++
++/* RIOT integration: Use stdio_write for output and loop until all output is
++ * flushed. */
++static void write_all(const char *buf, size_t len)
++{
++  const char *end = buf + len;
++  while (buf < end) {
++    int res = stdio_write(buf, (size_t)end-(size_t)buf);
++    if (res < 0) {
++      return;
++    }
++    buf += res;
++  }
++}
++
++
+ // internal buffer output
+ static inline void _out_buffer(char character, void* buffer, size_t idx, size_t maxlen)
+ {
+@@ -150,15 +171,19 @@ static inline void _out_null(char character, void* buffer, size_t idx, size_t ma
+ 
+ 
+ // internal _putchar wrapper
+-static inline void _out_char(char character, void* buffer, size_t idx, size_t maxlen)
++static inline void _out_char(char character, void* _buffer, size_t idx, size_t maxlen)
+ {
+-  (void)buffer; (void)idx; (void)maxlen;
+-  if (character) {
+-    _putchar(character);
+-  }
+-}
+-
+-
++  (void)idx; (void)maxlen;
++  output_buffer_type *buffer = _buffer;
++  if (buffer->fill == sizeof(buffer->buf)) {
++    write_all(buffer->buf, sizeof(buffer->buf));
++    buffer->fill = 0;
++  }
++  if (character) {
++    buffer->buf[buffer->fill++] = character;
++  }
++}
++
+ // internal output function wrapper
+ static inline void _out_fct(char character, void* buffer, size_t idx, size_t maxlen)
+ {
+@@ -578,7 +603,7 @@ static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
+ 
+ 
+ // internal vsnprintf
+-static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const char* format, va_list va)
++static int _vsnprintf(out_fct_type out, void* buffer, const size_t maxlen, const char* format, va_list va)
+ {
+   unsigned int flags, width, precision, n;
+   size_t idx = 0U;
+@@ -873,8 +898,10 @@ int printf_(const char* format, ...)
+ {
+   va_list va;
+   va_start(va, format);
+-  char buffer[1];
+-  const int ret = _vsnprintf(_out_char, buffer, (size_t)-1, format, va);
++  output_buffer_type buffer;
++  buffer.fill = 0;
++  const int ret = _vsnprintf(_out_char, &buffer, (size_t)-1, format, va);
++  write_all(buffer.buf, buffer.fill);
+   va_end(va);
+   return ret;
+ }
+@@ -902,8 +929,11 @@ int snprintf_(char* buffer, size_t count, const char* format, ...)
+ 
+ int vprintf_(const char* format, va_list va)
+ {
+-  char buffer[1];
+-  return _vsnprintf(_out_char, buffer, (size_t)-1, format, va);
++  output_buffer_type buffer;
++  buffer.fill = 0;
++  int result = _vsnprintf(_out_char, &buffer, (size_t)-1, format, va);
++  write_all(buffer.buf, buffer.fill);
++  return result;
+ }
+ 
+ 
+@@ -924,10 +954,9 @@ int fctprintf(void (*out)(char character, void* arg), void* arg, const char* for
+ }
+ 
+ 
+-/* RIOT integration: Use stdio_write for output */
+ static void _putchar(char character)
+ {
+-  stdio_write(&character, sizeof(character));
++  write_all(&character, sizeof(character));
+ }
+ 
+ 
+@@ -962,8 +991,8 @@ int __wrap_putchar(int c)
+ int __wrap_puts(const char *s)
+ {
+   size_t len = strlen(s);
+-  stdio_write(s, len);
+-  stdio_write("\n", 1);
++  write_all(s, len);
++  write_all("\n", 1);
+   return len + 1;
+ }
+ 
+-- 
+2.43.0
+


### PR DESCRIPTION
### Contribution description

With this patch a small (64 byte) on-stack is buffer is used. On stdio transports with extremely high overhead per call of `stdio_write()` (like e.g. telnet or semihosting), this will make the stdio usable again.

Compared to e.g. the stdio from newlib, the increased stack requirements are still modest.

### Testing procedure

Run e.g. an app with lots of stdio output with an stdio transport that has a lot of overhead per `stdio_write()` call. E.g.

```
USEMODULE=stdio_semihosting make BOAD=<board_with_many_timers> -C tests/periph/timer RIOT_TERMINAL=semihosting flash term
```

In `master`, this will be unusable. (About two chars per second on for semihosting on `master`). With this PR, this should be faster.

### Issues/PRs references

Fixes a regression from https://github.com/RIOT-OS/RIOT/pull/21438