### PR TITLE
.gitattributes: Treat SVG as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@ Cargo.lock binary
 # when the heading is exactly 7 characters long.
 *.md conflict-marker-size=100
 *.txt conflict-marker-size=100
+*.svg binary


### PR DESCRIPTION
### Contribution description

This may not be fully accurate. But changes to an SVG file are usually better viewed with a graphical tool than a `diff` and contributor stats are really messed up with svg files being treated as text files.

### Testing procedure

#### In `master`

```
git check-attr --all -- doc/doxygen/src/riot-logo.svg
# No output
```

#### This PR

```
git check-attr --all -- doc/doxygen/src/riot-logo.svg 
doc/doxygen/src/riot-logo.svg: binary: set
doc/doxygen/src/riot-logo.svg: diff: unset
doc/doxygen/src/riot-logo.svg: merge: unset
doc/doxygen/src/riot-logo.svg: text: unset
```

### Issues/PRs references

This hopefully fixes misleading contribution stats showing many thousand lines of code changes when adding a new SVG file to the doc.