### PR TITLE
drivers/sx126x: fix misplaced endif _select_pa_cfg

### DIFF
--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -179,8 +179,8 @@ static int8_t _select_pa_cfg(sx126x_t *dev, int8_t tx_power_dbm,
             }
 #else
             *pa_cfg = &hpa_cfg[0];
-            return 14;
 #endif
+            return 14;
         }
         else if (tx_power_dbm <= 17) {
             *pa_cfg = &hpa_cfg[1];


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Fix misplaced `#endif` in `_select_pa_cfg()`
### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
