### PR TITLE
dist/tools: add knob for docker pinning test

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -13,6 +13,8 @@
 #
 #
 
+export ENABLE_DOCKER_PINNING_TEST=${ENABLE_DOCKER_PINNING_TEST:-1}
+
 : "${RIOTBASE:="$(cd "$(dirname "$0")/../../../" || exit; pwd)"}"
 
 : "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
@@ -382,6 +384,10 @@ check_tests_application_path() {
 }
 
 check_pinned_docker_version_is_up_to_date() {
+    if [ "$ENABLE_DOCKER_PINNING_TEST" != "1" ]; then
+        # Skipping docker version test as requested
+        return
+    fi
     local pinned_repo_digest
     local upstream_repo_digest
     pinned_repo_digest="$(awk '/^DOCKER_TESTED_IMAGE_REPO_DIGEST := (.*)$/ { print substr($0, index($0, $3)); exit }' "$RIOTMAKE/docker.inc.mk")"


### PR DESCRIPTION
### Contribution description

Allow to opt out of the docker pinning test using

    ENABLE_DOCKER_PINNING_TEST=0 make static-test

The intended user is the CI for the docker image test.

### Testing procedure

Mess up the docker image digit, e.g.

```diff
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -5,7 +5,7 @@
 # When the docker image is updated, checks at
 # dist/tools/buildsystem_sanity_check/check.sh start complaining in CI, and
 # provide the latest values to verify and fill in.
-DOCKER_TESTED_IMAGE_REPO_DIGEST := 21c416fbbb94a99c3d9c76341baf5a9740608b1d1af89967127c7a171248fd7b
+DOCKER_TESTED_IMAGE_REPO_DIGEST := 21c416fbbb94a99c3d9c76341baf5a9740608b1d1af89967127c7a171248fd7c
 
 DOCKER_PULL_IDENTIFIER := docker.io/riot/riotbuild@sha256:$(DOCKER_TESTED_IMAGE_REPO_DIGEST)
 export DOCKER_IMAGE ?= $(DOCKER_PULL_IDENTIFIER)
```

The static tests should fail if invoked via:

- `ENABLE_DOCKER_PINNING_TEST=1 make static-test`
- `make static test`

And should pass despite the incorrect digit when invoked via

- `ENABLE_DOCKER_PINNING_TEST=0 make static-test`

### Issues/PRs references

None
