### PR TITLE
gnrc/rpl: float DODAG during local repair

### DIFF
--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -151,6 +151,7 @@
 #include "net/gnrc/rpl/dodag.h"
 #include "net/gnrc/rpl/of_manager.h"
 #include "net/fib.h"
+#include "time_units.h"
 #include "trickle.h"
 
 #ifdef MODULE_NETSTATS_RPL
@@ -625,6 +626,19 @@ extern netstats_rpl_t gnrc_rpl_netstats;
  */
 #ifndef CONFIG_GNRC_RPL_PARENT_TIMEOUT_DIS_RETRIES
 #define CONFIG_GNRC_RPL_PARENT_TIMEOUT_DIS_RETRIES (3)
+#endif
+
+/**
+ * @brief   Timeout for floating DODAGs in milliseconds.
+ *
+ * @details While a DODOAG is floating, it has no uplink but maintains
+ *          connectivity in the subtree. After the timeout, the DODAG will be
+ *          deconstructed and cleared.
+ *          Nodes will always switch to grounded (i.e., non-floating) DODAGs if
+ *          one becomes available in the meantime.
+ */
+#ifndef CONFIG_GNRC_RPL_DODAG_FLOAT_TIMEOUT
+#  define CONFIG_GNRC_RPL_DODAG_FLOAT_TIMEOUT (15 * MS_PER_SEC * SEC_PER_MIN)
 #endif
 
 /**

--- a/sys/include/net/gnrc/rpl/dodag.h
+++ b/sys/include/net/gnrc/rpl/dodag.h
@@ -179,6 +179,15 @@ void gnrc_rpl_parent_update(gnrc_rpl_dodag_t *dodag, gnrc_rpl_parent_t *parent);
 void gnrc_rpl_cleanup_start(gnrc_rpl_dodag_t *dodag);
 
 /**
+ * @brief Poison all routes of @p dodag by setting an infinite rank, and schedule
+ * a cleanup for the @p dodag.
+ *
+ * @param[in] dodag     Pointer to the DODAG
+ *
+ */
+void gnrc_rpl_poison_routes(gnrc_rpl_dodag_t *dodag);
+
+/**
  * @brief   Start a local repair.
  *
  * @param[in] dodag     Pointer to the DODAG

--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -330,6 +330,10 @@ struct gnrc_rpl_dodag {
     uint8_t dio_opts;               /**< options in the next DIO
                                          (see @ref GNRC_RPL_REQ_DIO_OPTS "DIO Options") */
     evtimer_msg_event_t dao_event;  /**< DAO TX events (see @ref GNRC_RPL_MSG_TYPE_DODAG_DAO_TX) */
+    /**
+     * floating dodag timeout events (see @ref GNRC_RPL_MSG_TYPE_DODAG_FLOAT_TIMEOUT)
+     */
+    evtimer_msg_event_t float_timeout_event;
     trickle_t trickle;              /**< trickle representation */
 };
 

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -77,6 +77,18 @@ static uint16_t _dflt_route_lifetime_sec(gnrc_rpl_dodag_t *dodag)
             (GNRC_RPL_PARENT_PROBE_INTERVAL / MS_PER_SEC));
 }
 
+void gnrc_rpl_poison_routes(gnrc_rpl_dodag_t *dodag)
+{
+    if (dodag->my_rank != GNRC_RPL_INFINITE_RANK) {
+        DEBUG("RPL: Poison all children routes in DODAG.\n");
+
+        /* Poison routes by advertising infinity rank */
+        dodag->my_rank = GNRC_RPL_INFINITE_RANK;
+        trickle_reset_timer(&dodag->trickle);
+        gnrc_rpl_cleanup_start(dodag);
+    }
+}
+
 bool gnrc_rpl_instance_add(uint8_t instance_id, gnrc_rpl_instance_t **inst)
 {
     *inst = NULL;
@@ -130,8 +142,9 @@ void gnrc_rpl_dodag_remove(gnrc_rpl_dodag_t *dodag)
     gnrc_rpl_dodag_remove_all_parents(dodag);
     trickle_stop(&dodag->trickle);
     evtimer_del(&gnrc_rpl_evtimer, (evtimer_event_t *)&dodag->dao_event);
+    evtimer_del(&gnrc_rpl_evtimer, (evtimer_event_t *)&dodag->float_timeout_event);
     evtimer_del(&gnrc_rpl_evtimer, (evtimer_event_t *)&dodag->instance->cleanup_event);
-
+    memset(dodag, 0, sizeof(gnrc_rpl_dodag_t));
 }
 
 void gnrc_rpl_instance_remove(gnrc_rpl_instance_t *inst)
@@ -164,6 +177,7 @@ void gnrc_rpl_dodag_root_init(gnrc_rpl_dodag_t *dodag)
     dodag->node_status = GNRC_RPL_ROOT_NODE;
     dodag->my_rank = GNRC_RPL_ROOT_RANK;
     dodag->dio_opts |= GNRC_RPL_REQ_DIO_OPT_DODAG_CONF;
+    dodag->parents = NULL;
 
     if (!IS_ACTIVE(CONFIG_GNRC_RPL_WITHOUT_PIO)) {
         dodag->dio_opts |= GNRC_RPL_REQ_DIO_OPT_PREFIX_INFO;
@@ -200,6 +214,8 @@ bool gnrc_rpl_dodag_init(gnrc_rpl_instance_t *instance, const ipv6_addr_t *dodag
     dodag->iface = iface;
     dodag->dao_event.msg.content.ptr = instance;
     dodag->dao_event.msg.type = GNRC_RPL_MSG_TYPE_DODAG_DAO_TX;
+    dodag->float_timeout_event.msg.content.ptr = instance;
+    dodag->float_timeout_event.msg.type = GNRC_RPL_MSG_TYPE_DODAG_FLOAT_TIMEOUT;
 
     if ((netif != NULL) && !(netif->flags & GNRC_NETIF_FLAGS_IPV6_FORWARDING)) {
         gnrc_rpl_leaf_operation(dodag);
@@ -211,6 +227,50 @@ bool gnrc_rpl_dodag_init(gnrc_rpl_instance_t *instance, const ipv6_addr_t *dodag
         return false;
     }
 #endif
+
+    return true;
+}
+
+/**
+ * @brief   Configures the local node as root for a new floating DODAG.
+ *          The DODAG retains the prefix of the @p dodag old ID.
+ *
+ * @param[in, out] dodag    Pointer to the new dodag.
+ *
+ * @retval  True on success.
+ * @retval  False if no address was found that can be used as ID for the new
+ *          DODAG.
+ * @retval  If @p dodag is null.
+ */
+static bool _float_dodag(gnrc_rpl_dodag_t *dodag)
+{
+    evtimer_event_t *float_event;
+
+    if (!dodag) {
+        return false;
+    }
+
+    DEBUG("RPL: Set local node as root for floating DODAG.\n");
+
+    float_event = (evtimer_event_t *)&dodag->float_timeout_event;
+    evtimer_del(&gnrc_rpl_evtimer, float_event);
+
+    /* Find address on interface that matches the prefix of the old dodag. */
+    gnrc_netif_t *netif = gnrc_netif_get_by_pid(dodag->iface);
+    int idx = gnrc_netif_ipv6_addr_match(netif, &dodag->dodag_id);
+    if (idx < 0) {
+        DEBUG("RPL: could not find address to use as DODAGID.");
+        return false;
+    }
+
+    /* Configure node as root. */
+    gnrc_rpl_dodag_root_init(dodag);
+    dodag->dodag_id = netif->ipv6.addrs[idx];
+    dodag->grounded &= !GNRC_RPL_GROUNDED;
+
+    /* Floating dodag should timeout eventually if no new grounded dodag is found. */
+    float_event->offset = CONFIG_GNRC_RPL_DODAG_FLOAT_TIMEOUT;
+    evtimer_add_msg(&gnrc_rpl_evtimer, &dodag->float_timeout_event, gnrc_rpl_pid);
 
     return true;
 }
@@ -313,10 +373,8 @@ void gnrc_rpl_local_repair(gnrc_rpl_dodag_t *dodag)
 
     dodag->dtsn++;
 
-    if (dodag->my_rank != GNRC_RPL_INFINITE_RANK) {
-        dodag->my_rank = GNRC_RPL_INFINITE_RANK;
-        trickle_reset_timer(&dodag->trickle);
-        gnrc_rpl_cleanup_start(dodag);
+    if ((CONFIG_GNRC_RPL_DODAG_FLOAT_TIMEOUT <= 0) || !_float_dodag(dodag)) {
+        gnrc_rpl_poison_routes(dodag);
     }
 
     if (dodag->parents) {

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_internal/globals.h
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_internal/globals.h
@@ -45,6 +45,10 @@ extern evtimer_msg_t gnrc_rpl_evtimer;
  * @brief   Message type for DAO transmissions.
  */
 #define GNRC_RPL_MSG_TYPE_DODAG_DAO_TX        (0x0906)
+/**
+ * @brief   Message type for floating DODAG timeouts.
+ */
+#define GNRC_RPL_MSG_TYPE_DODAG_FLOAT_TIMEOUT  (0x0907)
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Add the option to create a temporary floating DODAG if the parent set of a node becomes empty and a local repair is started. This allows to maintain connectivity within the sub-tree, even if the uplink is temporarily gone (e.g., because a BLE connection broke). See [RFC6550#Section18.2.4](https://www.rfc-editor.org/rfc/rfc6550#section-18.2.4).

With #21759 merged, we now support switching between DODAGs. So as soon as the parent node (or any other node in the subtree) receives a DIO again from the original, grounded (i.e., non-floating) DODAG, it will switch back to that one. Children will furthermore not join the new floating DODAG in the first place, if they are still connected to the grounded DODAG through another parent.

A floating DODAG has a configurable timeout after which the DODAG will be cleaned up. If the timeout is set to 0, then the old logic for `gnrc_rpl_local_repair` is retained. It just immediately poisons all routes (causing the local node to be cleared from the children's parent set) and cleans up the DODAG.


### Testing procedure

Can be tested with min. 3 nodes and the `gnrc_networking` example with a BLE capable board.
Set `CONFIG_GNRC_RPL_DEFAULT_LIFETIME=1` (=1min). Until #21608 is merged, we can only detect a lost parent through a timeout mechanism.

- Start 3 nodes `N{0..1}` and connect them in a line
- Init `N0` as RPL root for `2001:db8::1` => `N1` and `N2` will join the DODAG
- Disconnect `N0` and `N1`. After the 1min timeout, `N1` will set itself to be the root of a new floating DODAG. The DODAG ID is the public IP of `N1`.
  - => `N2` will join the new floating DODAG
  - => `N1` and `N2` can still ping each other
- Connect `N1` or `N2` again to `N0` and call `rpl send dis`
  - => both nodes will switch back to the original DODAG of `N0` 


### Issues/PRs references

Part of #21574.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
