### PR TITLE
pkg/flashdb: Bump to v2.1.1

### DIFF
--- a/pkg/flashdb/Makefile
+++ b/pkg/flashdb/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=flashdb
 PKG_URL=https://github.com/armink/FlashDB.git
-# 2.1.0 + patches
-PKG_VERSION=0594fdc95700745ee8b26f43a9a28f3dba8407bb
+# 2.1.1
+PKG_VERSION=714d6159e7e6afb267a3953756abca445c350e61
 PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This bumps the FlashDB from 2.1.0+ to 2.1.1, which includes various bugfixes. You can check the changes in the [release notes](https://github.com/armink/FlashDB/releases/tag/2.1.1).


### Testing procedure
Tests should work as usual.


### Issues/PRs references
None
