### PR TITLE
sys/psa_crypto: unify buffer size size handling for ed25519 backends

### DIFF
--- a/pkg/c25519/psa_c25519/edsign.c
+++ b/pkg/c25519/psa_c25519/edsign.c
@@ -22,13 +22,10 @@
 #include "edsign.h"
 #include "random.h"
 
-psa_status_t psa_generate_ecc_ed25519_key_pair( uint8_t *priv_key_buffer, uint8_t *pub_key_buffer,
-                                                size_t *priv_key_buffer_length,
-                                                size_t *pub_key_buffer_length)
+psa_status_t psa_generate_ecc_ed25519_key_pair( uint8_t *priv_key_buffer,
+                                                uint8_t *pub_key_buffer)
 {
-    *priv_key_buffer_length = EDSIGN_SECRET_KEY_SIZE;
-    *pub_key_buffer_length = EDSIGN_PUBLIC_KEY_SIZE;
-
+    /* todo: maybe this should usa psa_random instead */
     random_bytes(priv_key_buffer, EDSIGN_SECRET_KEY_SIZE);
     ed25519_prepare(priv_key_buffer);
     edsign_sec_to_pub(pub_key_buffer, priv_key_buffer);
@@ -36,58 +33,31 @@ psa_status_t psa_generate_ecc_ed25519_key_pair( uint8_t *priv_key_buffer, uint8_
     return PSA_SUCCESS;
 }
 
-psa_status_t psa_derive_ecc_ed25519_public_key( const uint8_t *priv_key_buffer, uint8_t *pub_key_buffer,
-                                                size_t priv_key_buffer_length,
-                                                size_t *pub_key_buffer_length)
+psa_status_t psa_derive_ecc_ed25519_public_key( const uint8_t *priv_key_buffer,
+                                                uint8_t *pub_key_buffer)
 {
-    *pub_key_buffer_length = EDSIGN_PUBLIC_KEY_SIZE;
-
     edsign_sec_to_pub(pub_key_buffer, priv_key_buffer);
 
-    (void)priv_key_buffer_length;
     return PSA_SUCCESS;
 }
 
-psa_status_t psa_ecc_ed25519_sign_message(  const uint8_t *priv_key_buffer,
-                                            size_t priv_key_buffer_size,
-                                            const uint8_t *pub_key_buffer,
-                                            size_t pub_key_buffer_size,
-                                            const uint8_t *input,
-                                            size_t input_length,
-                                            uint8_t *signature,
-                                            size_t signature_size,
-                                            size_t *signature_length)
+psa_status_t psa_ecc_ed25519_sign_message(const uint8_t *priv_key_buffer,
+                                        const uint8_t *pub_key_buffer,
+                                        const uint8_t *input, size_t input_length,
+                                        uint8_t *signature)
 {
-    if (signature_size < EDSIGN_SIGNATURE_SIZE) {
-        return PSA_ERROR_BUFFER_TOO_SMALL;
-    }
-
-    *signature_length = EDSIGN_SIGNATURE_SIZE;
     edsign_sign(signature, pub_key_buffer, priv_key_buffer, input, input_length);
 
-    (void)priv_key_buffer_size;
-    (void)pub_key_buffer_size;
     return PSA_SUCCESS;
 }
 
-psa_status_t psa_ecc_ed25519_verify_message(const uint8_t *key_buffer,
-                                            size_t key_buffer_size,
-                                            const uint8_t *input,
-                                            size_t input_length,
-                                            const uint8_t *signature,
-                                            size_t signature_length)
+psa_status_t psa_ecc_ed25519_verify_message(const uint8_t *pub_key_buffer,
+                                            const uint8_t *input, size_t input_length,
+                                            const uint8_t *signature)
 {
-    uint8_t ret = 0;
-
-    if (signature_length < EDSIGN_SIGNATURE_SIZE) {
+    if (!edsign_verify(signature, pub_key_buffer, input, input_length)) {
         return PSA_ERROR_INVALID_SIGNATURE;
     }
 
-    ret = edsign_verify(signature, key_buffer, input, input_length);
-    if (!ret) {
-        return PSA_ERROR_INVALID_SIGNATURE;
-    }
-
-    (void)key_buffer_size;
     return PSA_SUCCESS;
 }

--- a/pkg/driver_cryptocell_310/psa_cryptocell_310/ecc_ed25519.c
+++ b/pkg/driver_cryptocell_310/psa_cryptocell_310/ecc_ed25519.c
@@ -29,9 +29,7 @@
 extern CRYS_RND_State_t *rndState_ptr;
 
 psa_status_t psa_generate_ecc_ed25519_key_pair( uint8_t *priv_key_buffer,
-                                                uint8_t *pub_key_buffer,
-                                                size_t *priv_key_buffer_length,
-                                                size_t *pub_key_buffer_length)
+                                                uint8_t *pub_key_buffer)
 {
     CRYS_ECEDW_TempBuff_t tmp;
     CRYSError_t ret;
@@ -40,12 +38,11 @@ psa_status_t psa_generate_ecc_ed25519_key_pair( uint8_t *priv_key_buffer,
     uint8_t secret_key[CRYS_ECEDW_ORD_SIZE_IN_BYTES + CRYS_ECEDW_MOD_SIZE_IN_BYTES] = { 0x0 };
     size_t secret_key_size = sizeof(secret_key);
 
-    *priv_key_buffer_length = CRYS_ECEDW_ORD_SIZE_IN_BYTES;
-    *pub_key_buffer_length = CRYS_ECEDW_MOD_SIZE_IN_BYTES;
+    size_t pub_key_size = 32;
 
     cryptocell_310_enable();
     ret = CRYS_ECEDW_KeyPair(secret_key, &secret_key_size,
-                                        pub_key_buffer, pub_key_buffer_length,
+                                        pub_key_buffer, &pub_key_size,
                                         rndState_ptr, CRYS_RND_GenerateVector, &tmp);
     cryptocell_310_disable();
     if (ret != CRYS_OK) {
@@ -60,9 +57,8 @@ done:
     return CRYS_to_psa_error(ret);
 }
 
-psa_status_t psa_derive_ecc_ed25519_public_key( const uint8_t *priv_key_buffer, uint8_t *pub_key_buffer,
-                                                size_t priv_key_buffer_length,
-                                                size_t *pub_key_buffer_length)
+psa_status_t psa_derive_ecc_ed25519_public_key( const uint8_t *priv_key_buffer,
+                                                uint8_t *pub_key_buffer)
 {
     CRYS_ECEDW_TempBuff_t tmp;
     CRYSError_t ret;
@@ -76,14 +72,15 @@ psa_status_t psa_derive_ecc_ed25519_public_key( const uint8_t *priv_key_buffer, 
     uint8_t secret_key[CRYS_ECEDW_ORD_SIZE_IN_BYTES + CRYS_ECEDW_MOD_SIZE_IN_BYTES] = { 0x0 };
     size_t secret_key_size = sizeof(secret_key);
 
-    *pub_key_buffer_length = CRYS_ECEDW_MOD_SIZE_IN_BYTES;
+    size_t pub_key_size = 32;
 
     cryptocell_310_enable();
-    ret = CRYS_ECEDW_SeedKeyPair(priv_key_buffer, priv_key_buffer_length, secret_key, &secret_key_size,
-                                            pub_key_buffer, pub_key_buffer_length, &tmp);
+    ret = CRYS_ECEDW_SeedKeyPair(priv_key_buffer, 32, secret_key, &secret_key_size,
+                                            pub_key_buffer, &pub_key_size, &tmp);
     cryptocell_310_disable();
     if (ret != CRYS_OK) {
-        DEBUG("CRYS_ECEDW_SeedKeyPair failed with %s\n", cryptocell310_status_to_humanly_readable(ret));
+        DEBUG("CRYS_ECEDW_SeedKeyPair failed with %s\n",
+            cryptocell310_status_to_humanly_readable(ret));
         goto done;
     }
 
@@ -93,14 +90,9 @@ done:
 }
 
 psa_status_t psa_ecc_ed25519_sign_message(const uint8_t *priv_key_buffer,
-                                        size_t priv_key_buffer_size,
                                         const uint8_t *pub_key_buffer,
-                                        size_t pub_key_buffer_size,
-                                        const uint8_t *input,
-                                        size_t input_length,
-                                        uint8_t *signature,
-                                        size_t signature_size,
-                                        size_t *signature_length)
+                                        const uint8_t *input, size_t input_length,
+                                        uint8_t *signature)
 {
     CRYS_ECEDW_TempBuff_t tmp;
     CRYSError_t ret;
@@ -119,16 +111,14 @@ psa_status_t psa_ecc_ed25519_sign_message(const uint8_t *priv_key_buffer,
     /* contains seed (private key), concatenated with public key */
     uint8_t secret_key[CRYS_ECEDW_ORD_SIZE_IN_BYTES + CRYS_ECEDW_MOD_SIZE_IN_BYTES] = { 0x0 };
 
-    if (priv_key_buffer_size != CRYS_ECEDW_ORD_SIZE_IN_BYTES || pub_key_buffer_size != CRYS_ECEDW_MOD_SIZE_IN_BYTES) {
-        return PSA_ERROR_INVALID_ARGUMENT;
-    }
-
-    memcpy(secret_key, priv_key_buffer, CRYS_ECEDW_ORD_SIZE_IN_BYTES);
+    memcpy(&secret_key[0], priv_key_buffer, CRYS_ECEDW_ORD_SIZE_IN_BYTES);
     memcpy(&secret_key[CRYS_ECEDW_ORD_SIZE_IN_BYTES], pub_key_buffer, CRYS_ECEDW_MOD_SIZE_IN_BYTES);
-    *signature_length = signature_size;
+
+    size_t signature_size = 64;
 
     cryptocell_310_enable();
-    ret = CRYS_ECEDW_Sign(signature, signature_length, input, input_length, secret_key, sizeof(secret_key), &tmp);
+    ret = CRYS_ECEDW_Sign(signature, &signature_size, input, input_length,
+                          secret_key, sizeof(secret_key), &tmp);
     cryptocell_310_disable();
     if (ret != CRYS_OK) {
         DEBUG("CRYS_ECEDW_Sign failed with %s\n", cryptocell310_status_to_humanly_readable(ret));
@@ -138,21 +128,16 @@ psa_status_t psa_ecc_ed25519_sign_message(const uint8_t *priv_key_buffer,
 done:
     explicit_bzero(&secret_key, sizeof(secret_key));
     return CRYS_to_psa_error(ret);
-
-    (void)signature_size;
 }
 
-psa_status_t psa_ecc_ed25519_verify_message(const uint8_t *key_buffer,
-                                            size_t key_buffer_size,
-                                            const uint8_t *input,
-                                            size_t input_length,
-                                            const uint8_t *signature,
-                                            size_t signature_length)
+psa_status_t psa_ecc_ed25519_verify_message(const uint8_t *pub_key_buffer,
+                                            const uint8_t *input, size_t input_length,
+                                            const uint8_t *signature)
 {
     CRYS_ECEDW_TempBuff_t tmp;
     CRYSError_t ret;
 
-    if (!cryptocell_310_data_within_ram(key_buffer) ||
+    if (!cryptocell_310_data_within_ram(pub_key_buffer) ||
         !cryptocell_310_data_within_ram(input) ||
         !cryptocell_310_data_within_ram(signature)) {
         DEBUG("%s : cryptocell_310 data required to be in RAM.\n", __FILE__);
@@ -164,7 +149,8 @@ psa_status_t psa_ecc_ed25519_verify_message(const uint8_t *key_buffer,
     }
 
     cryptocell_310_enable();
-    ret = CRYS_ECEDW_Verify(signature, signature_length, key_buffer, key_buffer_size, (uint8_t *)input, input_length, &tmp);
+    ret = CRYS_ECEDW_Verify(signature, 64, pub_key_buffer, 32,
+                            (uint8_t *)input, input_length, &tmp);
     cryptocell_310_disable();
     if (ret != CRYS_OK) {
         DEBUG("CRYS_ECEDW_Verify failed with %s\n", cryptocell310_status_to_humanly_readable(ret));

--- a/sys/psa_crypto/include/psa_ecc.h
+++ b/sys/psa_crypto/include/psa_ecc.h
@@ -148,41 +148,49 @@ psa_status_t psa_ecc_p256r1_verify_message(const psa_key_attributes_t *attribute
 /**
  * @brief   Low level wrapper function to call a driver for an ECC key generation
  *          with an ed25519 key.
- *          See @ref psa_generate_key()
+ *
+ * @param[out]  priv_key_buffer         buffer of size 32B to write the private key to
+ * @param[out]  pub_key_buffer          buffer of size 32B to write the public key to
  */
-psa_status_t psa_generate_ecc_ed25519_key_pair( uint8_t *priv_key_buffer, uint8_t *pub_key_buffer,
-                                                size_t *priv_key_buffer_length,
-                                                size_t *pub_key_buffer_length);
+psa_status_t psa_generate_ecc_ed25519_key_pair( uint8_t *priv_key_buffer,
+                                                uint8_t *pub_key_buffer);
 
 /**
  * @brief   Low level wrapper function for deriving an ed25519 public key from the private key.
+ *
+ * @param[in]   priv_key_buffer         buffer of size 32B containing the private key
+ * @param[out]  pub_key_buffer          buffer of size 32B to write the public key to
  */
 psa_status_t psa_derive_ecc_ed25519_public_key( const uint8_t *priv_key_buffer,
-                                                uint8_t *pub_key_buffer,
-                                                size_t priv_key_buffer_length,
-                                                size_t *pub_key_buffer_length);
+                                                uint8_t *pub_key_buffer);
 
 /**
  * @brief   Low level wrapper function to call a driver for an ECC hash signature
  *          with an ed25519 key.
- *          See @ref psa_sign_message()
+ *
+ * @param[in]   priv_key_buffer         buffer of size 32B containing the private key
+ * @param[in]   pub_key_buffer          buffer of size 32B containing the public key
+ * @param[in]   input                   input message to be signed
+ * @param[in]   input_length            length of @p input in bytes
+ * @param[out]  signature               buffer of size 64 to write the signature to
  */
 psa_status_t psa_ecc_ed25519_sign_message(const uint8_t *priv_key_buffer,
-                                        size_t priv_key_buffer_size,
                                         const uint8_t *pub_key_buffer,
-                                        size_t pub_key_buffer_size,
                                         const uint8_t *input, size_t input_length,
-                                        uint8_t *signature, size_t signature_size,
-                                        size_t *signature_length);
+                                        uint8_t *signature);
 
 /**
  * @brief   Low level wrapper function to call a driver for an ECC hash verification
  *          with a ed25519 key.
- *          See @ref psa_verify_message()
+ *
+ * @param[in]   pub_key_buffer          buffer of size 32B containing the public key
+ * @param[in]   input                   input message whose signature should be checked
+ * @param[in]   input_length            length of @p input in bytes
+ * @param[in]   signature               buffer of size 64 containing the signature
  */
-psa_status_t psa_ecc_ed25519_verify_message(const uint8_t *key_buffer, size_t key_buffer_size,
+psa_status_t psa_ecc_ed25519_verify_message(const uint8_t *pub_key_buffer,
                                             const uint8_t *input, size_t input_length,
-                                            const uint8_t *signature, size_t signature_length);
+                                            const uint8_t *signature);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Contribution description

Ed25519 has fixed sizes for private keys, public keys, and signatures. Those can be checked on the algorithm dispatch layer once instead of duplicating code in the backends.

Additionally, we now consistently zero out key-material buffers on the stack in both the hardware and software backend.


### Testing procedure

`make -C tests/sys/psa_crypto_eddsa all flash test` still succeeds for `BOARD=native` (automatically using `c25519` as software backend) and for `BOARD=nrf52840dk` (automatically using `driver_cryptocell_310` as HW backend).
