### PR TITLE
sys/psa_crypto: add monocypher as ed25519 software backend

### DIFF
--- a/pkg/monocypher/Makefile.include
+++ b/pkg/monocypher/Makefile.include
@@ -1,2 +1,8 @@
 INCLUDES += -I$(PKGDIRBASE)/monocypher/src
 INCLUDES += -I$(PKGDIRBASE)/monocypher/src/optional
+
+ifneq (,$(filter psa_monocypher_%, $(USEMODULE)))
+  PSEUDOMODULES += psa_monocypher_ed25519
+  DIRS += $(RIOTPKG)/monocypher/psa_monocypher
+  INCLUDES += -I$(RIOTBASE)/sys/psa_crypto/include
+endif

--- a/pkg/monocypher/psa_monocypher/Makefile
+++ b/pkg/monocypher/psa_monocypher/Makefile
@@ -1,0 +1,4 @@
+BASE_MODULE := psa_monocypher
+SUBMODULES := 1
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/monocypher/psa_monocypher/Makefile.dep
+++ b/pkg/monocypher/psa_monocypher/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += random

--- a/pkg/monocypher/psa_monocypher/ed25519.c
+++ b/pkg/monocypher/psa_monocypher/ed25519.c
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: 2025 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     sys_psa_crypto pkg_monocypher
+ * @{
+ *
+ * @brief       Glue code translating between PSA Crypto and the Monocypher EdDSA APIs
+ *
+ * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
+ *
+ * @}
+ */
+
+#include "string_utils.h"
+
+#include "psa/crypto.h"
+#include "psa_ecc.h"
+#include "monocypher-ed25519.h"
+#include "random.h"
+
+psa_status_t psa_generate_ecc_ed25519_key_pair( uint8_t *priv_key_buffer,
+                                                uint8_t *pub_key_buffer)
+{
+    /* todo: maybe this should use psa_random instead */
+    random_bytes(priv_key_buffer, 32);
+
+    return psa_derive_ecc_ed25519_public_key(priv_key_buffer, pub_key_buffer);
+}
+
+psa_status_t psa_derive_ecc_ed25519_public_key( const uint8_t *priv_key_buffer,
+                                                uint8_t *pub_key_buffer)
+{
+    uint8_t priv_and_pub_key[64] = { 0 };
+
+    memcpy(&priv_and_pub_key[0], priv_key_buffer, 32);
+    crypto_ed25519_key_pair(priv_and_pub_key, pub_key_buffer, priv_and_pub_key);
+
+    explicit_bzero(priv_and_pub_key, 64);
+
+    return PSA_SUCCESS;
+}
+
+psa_status_t psa_ecc_ed25519_sign_message(const uint8_t *priv_key_buffer,
+                                        const uint8_t *pub_key_buffer,
+                                        const uint8_t *input, size_t input_length,
+                                        uint8_t *signature)
+{
+    uint8_t priv_and_pub_key[64];
+    memcpy(&priv_and_pub_key[0], priv_key_buffer, 32);
+    memcpy(&priv_and_pub_key[32], pub_key_buffer, 32);
+
+    crypto_ed25519_sign(signature, priv_and_pub_key, input, input_length);
+
+    explicit_bzero(priv_and_pub_key, 64);
+
+    return PSA_SUCCESS;
+}
+
+psa_status_t psa_ecc_ed25519_verify_message(const uint8_t *pub_key_buffer,
+                                            const uint8_t *input, size_t input_length,
+                                            const uint8_t *signature)
+{
+    if (crypto_ed25519_check(signature, pub_key_buffer, input, input_length) != 0) {
+        return PSA_ERROR_INVALID_SIGNATURE;
+    }
+
+    return PSA_SUCCESS;
+}

--- a/sys/psa_crypto/Makefile.dep
+++ b/sys/psa_crypto/Makefile.dep
@@ -74,7 +74,7 @@ ifneq (,$(filter psa_asymmetric_ecc_ed25519,$(USEMODULE)))
     ifneq (,$(filter periph_ecc_ed25519,$(FEATURES_USED)))
       USEMODULE += psa_asymmetric_ecc_ed25519_backend_periph
     else
-      USEMODULE += psa_asymmetric_ecc_ed25519_backend_c25519
+      USEMODULE += psa_asymmetric_ecc_ed25519_backend_monocypher
     endif
   endif
 endif
@@ -83,6 +83,12 @@ ifneq (,$(filter psa_asymmetric_ecc_ed25519_backend_c25519,$(USEMODULE)))
   USEPKG += c25519
   USEMODULE += psa_c25519
   USEMODULE += psa_c25519_edsign
+endif
+
+ifneq (,$(filter psa_asymmetric_ecc_ed25519_backend_monocypher,$(USEMODULE)))
+  USEPKG += monocypher
+  USEMODULE += psa_monocypher
+  USEMODULE += psa_monocypher_ed25519
 endif
 
 ifneq (,$(filter psa_asymmetric_ecc_ed25519_backend_periph,$(USEMODULE)))

--- a/sys/psa_crypto/Makefile.include
+++ b/sys/psa_crypto/Makefile.include
@@ -37,6 +37,7 @@ endif
 PSEUDOMODULES += psa_asymmetric_ecc_ed25519
 PSEUDOMODULES += psa_asymmetric_ecc_ed25519_backend_periph
 PSEUDOMODULES += psa_asymmetric_ecc_ed25519_backend_c25519
+PSEUDOMODULES += psa_asymmetric_ecc_ed25519_backend_monocypher
 PSEUDOMODULES += psa_asymmetric_ecc_ed25519_custom_backend
 
 # check that one and only one backend has been selected

--- a/tests/sys/psa_crypto/Makefile.ci
+++ b/tests/sys/psa_crypto/Makefile.ci
@@ -1,14 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    arduino-duemilanove \
-    arduino-leonardo \
-    arduino-mega2560 \
-    arduino-nano \
-    arduino-uno \
-    atmega328p \
-    atmega328p-xplained-mini \
-    atmega8 \
     bluepill-stm32f030c8 \
     i-nucleo-lrwan1 \
+    nucleo-c031c6 \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
@@ -19,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     slstk3400a \
     stk3200 \
     stm32c0116-dk \
+    stm32c0316-dk \
     stm32f030f4-demo \
     stm32f0discovery \
     stm32g0316-disco \

--- a/tests/sys/psa_crypto_eddsa/Makefile.ci
+++ b/tests/sys/psa_crypto_eddsa/Makefile.ci
@@ -1,14 +1,14 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    arduino-duemilanove \
-    arduino-leonardo \
-    arduino-nano \
-    arduino-uno \
-    atmega328p \
-    atmega328p-xplained-mini \
-    atmega8 \
+    nucleo-c031c6 \
     nucleo-f031k6 \
+    nucleo-f042k6 \
     nucleo-l011k4 \
+    nucleo-l031k6 \
     samd10-xmini \
     stk3200 \
+    stm32c0116-dk \
+    stm32c0316-dk \
     stm32f030f4-demo \
+    stm32g0316-disco \
+    weact-g030f6 \
     #


### PR DESCRIPTION
### Contribution description

Monocypher offers an [implementation of Ed25519](https://monocypher.org/manual/ed25519) that is much faster than the `c25519` implementation, at the cost of higher flash consumption: See Table 4 of https://arxiv.org/pdf/2106.05577

This PR adds monocypher as a PSA Crypto API backend and enables it as default software backend.


### Testing procedure

`make -C tests/sys/psa_crypto_eddsa all flash test` should select `monocypher` as default on `BOARD=native` and complete successfully.

On a `BOARD=nrf52840dk`, we get the following numbers:

```sh
$ USEMODULE="psa_asymmetric_ecc_ed25519_custom_backend psa_asymmetric_ecc_ed25519_backend_c25519" make -C tests/sys/psa_crypto_eddsa BOARD=nrf52840dk flash test
...
   text    data     bss     dec     hex
  24052     176    5348   29576    7388
...
EdDSA took 4295262 us
All Done
[TEST PASSED]
$ make -C tests/sys/psa_crypto_eddsa BOARD=nrf52840dk flash test
...
   text    data     bss     dec     hex
  32648     176    5348   38172    951c
...
EdDSA took 73349 us
All Done
[TEST PASSED]
```


### Issues/PRs references

Builds on and includes https://github.com/RIOT-OS/RIOT/pull/21821