### PR TITLE
makefiles: remove `DOWNLOAD_TO_STDOUT`

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -333,28 +333,7 @@ APPLICATION := $(strip $(APPLICATION))
 
 # provide common external programs for `Makefile.include`s
 
-ifeq (,$(and $(DOWNLOAD_TO_STDOUT),$(DOWNLOAD_TO_FILE)))
-  ifeq (,$(WGET))
-    ifeq (0,$(shell which wget > /dev/null 2>&1 ; echo $$?))
-      WGET = $(call memoized,WGET,$(shell which wget))
-    endif
-  endif
-  ifeq (,$(CURL))
-    ifeq (0,$(shell which curl > /dev/null 2>&1 ; echo $$?))
-      CURL = $(call memoized,CURL,$(shell which curl))
-    endif
-  endif
-  ifeq (,$(WGET)$(CURL))
-    $(warning Neither wget nor curl is installed!)
-  endif
-
-  ifeq (,$(DOWNLOAD_TO_STDOUT))
-    DOWNLOAD_TO_STDOUT ?= $(if $(CURL),$(CURL) -s,$(WGET) -q -O-)
-  endif
-  ifeq (,$(DOWNLOAD_TO_FILE))
-    DOWNLOAD_TO_FILE ?= $(DLCACHE)
-  endif
-endif
+DOWNLOAD_TO_FILE ?= $(DLCACHE)
 
 ifeq (,$(UNZIP_HERE))
   ifeq (0,$(shell which unzip > /dev/null 2>&1 ; echo $$?))

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -110,8 +110,9 @@ info-build:
 	@echo 'DEBUGGER:       $(DEBUGGER)'
 	@echo 'DEBUGGER_FLAGS: $(DEBUGGER_FLAGS)'
 	@echo
+	@echo 'DLCACHE:            $(DLCACHE)'
+	@echo 'DLCACHE_DIR:        $(DLCACHE_DIR)'
 	@echo 'DOWNLOAD_TO_FILE:   $(DOWNLOAD_TO_FILE)'
-	@echo 'DOWNLOAD_TO_STDOUT: $(DOWNLOAD_TO_STDOUT)'
 	@echo 'UNZIP_HERE:         $(UNZIP_HERE)'
 	@echo ''
 	@echo 'DEBUGSERVER:       $(DEBUGSERVER)'

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -128,10 +128,14 @@ export DEVELHELP             # Set to 1 to spend ROM, RAM and CPU time for help 
 # USE_PROGRAMMER_WRAPPER_SCRIPT     # Use the programmer wrapper Python script. Default is 0 (wrapper not used).
 
 
-export DLCACHE               # directory used to cache http downloads
-export DOWNLOAD_TO_FILE      # Use `$(DOWNLOAD_TO_FILE) $(DESTINATION) $(URL)` to download `$(URL)` to `$(DESTINATION)`.
-export DOWNLOAD_TO_STDOUT    # Use `$(DOWNLOAD_TO_STDOUT) $(URL)` to download `$(URL)` output `$(URL)` to stdout, e.g. to be piped into `tar xz`.
-export UNZIP_HERE            # Use `cd $(SOME_FOLDER) && $(UNZIP_HERE) $(SOME_FILE)` to extract the contents of the zip file `$(SOME_FILE)` into `$(SOME_FOLDER)`.
+export DLCACHE               # Use `$(DLCACHE) $(DESTINATION) $(URL) [$(SHA512)]` to
+                             # download `$(URL)` to `$(DESTINATION)` but keep a copy in cache
+                             # with an `$(SHA512)` checksum. If no checksum is given, the
+                             # URL will just be downloaded, not cached.
+export DOWNLOAD_TO_FILE      # Use `$(DOWNLOAD_TO_FILE) $(DESTINATION) $(URL) [$(SHA512)]` to
+                             # download `$(URL)` to `$(DESTINATION)`. Alias for $(DLCACHE).
+export UNZIP_HERE            # Use `cd $(SOME_FOLDER) && $(UNZIP_HERE) $(SOME_FILE)` to extract
+                             # the contents of the zip file `$(SOME_FILE)` into `$(SOME_FOLDER)`.
 
 export LAZYSPONGE            # Command saving stdin to a file only on content update.
 export LAZYSPONGE_FLAGS      # Parameters supplied to LAZYSPONGE.


### PR DESCRIPTION
### Contribution description

While working on #21813 I noticed that there is a big blob of Makefile magic in `$(RIOTBASE)/Makefile.include` that defines `DOWNLOAD_TO_FILE` and `DOWNLOAD_TO_STDOUT`. Both were introduced in #1431, but so far there is no use of `DOWNLOAD_TO_STDOUT` in our sources. Even `DOWNLOAD_TO_FILE` was/is only used by two instances.

Since `DOWNLOAD_TO_FILE` is now essentially an Alias for `DLCACHE` and `dlcache.sh` does all the "finding out whether to use curl or wget"-magic, the code in the `Makefile.include` is essentially obsolete.

Therefore I'd like to remove the `DOWNLOAD_TO_STDOUT` as well, considering the only use would be to pipe something to something like `tar`. This conflicts with the idea of caching and reducing traffic though.

Furthermore I took the opportunity to correct the documentation of `DLCACHE` in `makefile/vars.inc.mk` and add the information about the SHA512 checksums.

### Testing procedure

Check the sourcetree that no instances of `DOWNLOAD_TO_STDOUT` are left. CI should also still be happy when building `pkg/c25519` and `pkg/cryptocell_...`.


### Issues/PRs references

Discovered in #21813.
