### PR TITLE
doc: fix outdated links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,9 @@ As a reminder, all contributors are expected to follow our
 If you are just beginning to work with RIOT you might first want to read our
 [documentation]. Especially the following sections might be of interest to you
 
-- [Getting Started](https://doc.riot-os.org/getting-started.html)
-- [Creating modules](https://doc.riot-os.org/creating-modules.html)
-- [Creating an application](https://doc.riot-os.org/creating-an-application.html)
+- [Getting Started](https://guide.riot-os.org/getting-started/installing/)
+- [Creating modules](https://guide.riot-os.org/advanced_tutorials/creating_modules/)
+- [Creating an application](https://guide.riot-os.org/advanced_tutorials/creating_application/)
 
 [documentation]: https://doc.riot-os.org
 
@@ -234,7 +234,7 @@ In this section, we give the bare minimum for a better experience with our
 development workflow on GitHub.
 
 [try-github-io]: https://try.github.io/
-[git-scm-getting-started]: https://git-scm.com/book/en/v2/Getting-Started-Git-Basics
+[git-scm-getting-started]: https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository
 
 ### Setup your local RIOT repository
 


### PR DESCRIPTION
### Contribution description

This PR updates outdated/deprecated links in `CONTRIBUTING.md` to ensure new contributors are redirected to the correct resources.

Changes made:
- Updated old GitHub links pointing to deprecated documentation pages.
- Replaced invalid GitHub URLs with current links.
- Improved clarity of instructions by fixing formatting inconsistencies.

This improves documentation quality and reduces friction for new contributors.

### Testing procedure

1. Open the modified `CONTRIBUTING.md` file in the browser or markdown preview.
2. Click on each link that was changed.
3. Verify that all links correctly redirect to the intended, current documentation pages (no 404 / deprecated pages).

No code execution needed — documentation only.

### Issues/PRs references

None.
