### PR TITLE
boards/seeedstudio-xiao-esp32s3: Add Initial Support [new PR]

### DIFF
--- a/boards/seeedstudio-xiao-esp32s3/Kconfig
+++ b/boards/seeedstudio-xiao-esp32s3/Kconfig
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2024 Technische Universität Dresden
+# SPDX-FileCopyrightText: 2024 Isikcan 'Jon' Yilmaz
+# SPDX-License-Identifier: LGPL-2.1-only
+
+config BOARD
+    default "seeedstudio-xiao-esp32s3" if BOARD_SEEEDSTUDIO_XIAO_ESP32S3
+
+config BOARD_SEEEDSTUDIO_XIAO_ESP32S3
+    bool
+    default y
+    select BOARD_COMMON_ESP32S3
+    select CPU_MODEL_ESP32S3_WROOM_1X_N8R8
+
+source "$(RIOTBOARD)/common/esp32s3/Kconfig"

--- a/boards/seeedstudio-xiao-esp32s3/Makefile
+++ b/boards/seeedstudio-xiao-esp32s3/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/esp32s3
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/seeedstudio-xiao-esp32s3/Makefile.dep
+++ b/boards/seeedstudio-xiao-esp32s3/Makefile.dep
@@ -1,0 +1,6 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+include $(RIOTBOARD)/common/esp32s3/stdio_esp32s3_default.dep.mk
+include $(RIOTBOARD)/common/esp32s3/Makefile.dep

--- a/boards/seeedstudio-xiao-esp32s3/Makefile.features
+++ b/boards/seeedstudio-xiao-esp32s3/Makefile.features
@@ -1,0 +1,18 @@
+# the board uses a ESP32-S3R8 with an 8MB QSPI Flash and an 8MB QSPI PSRAM
+CPU_MODEL = esp32s3_wroom_1x_n8r8
+
+# common board and CPU features
+include $(RIOTBOARD)/common/esp32s3/Makefile.features
+
+# peripherals provided by the board
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_usbdev
+
+# other features provided by the board
+FEATURES_PROVIDED += esp_jtag
+FEATURES_PROVIDED += highlevel_stdio
+FEATURES_PROVIDED += tinyusb_device
+FEATURES_PROVIDED += xiao_shield

--- a/boards/seeedstudio-xiao-esp32s3/Makefile.include
+++ b/boards/seeedstudio-xiao-esp32s3/Makefile.include
@@ -1,0 +1,5 @@
+PORT_LINUX ?= /dev/ttyACM0
+
+OPENOCD_CONFIG ?= board/esp32s3-builtin.cfg
+
+include $(RIOTBOARD)/common/esp32s3/Makefile.include

--- a/boards/seeedstudio-xiao-esp32s3/doc.md
+++ b/boards/seeedstudio-xiao-esp32s3/doc.md
@@ -1,0 +1,132 @@
+<!--
+SPDX-FileCopyrightText: 2024 Isikcan 'Jon' Yilmaz
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+
+@defgroup    boards_seeedstudio-xiao-esp32s3 Seeed Studio XIAO ESP32S3 Board
+@ingroup     boards_esp32s3
+@brief       Support for the Seeed Studio Xiao ESP32S3
+@author      Isikcan 'Jon' Yilmaz <can158@gmail.com>
+
+\section esp32s3_seeedstudio Seeed Studio Xiao ESP32S3
+
+## Table of Contents {#esp32s3_seeedstudio_toc}
+
+-# [Overview](#esp32s3_seeedstudio_overview)
+-# [Hardware](#esp32s3_seeedstudio_hardware)
+    -# [MCU](#esp32s3_seeedstudio_mcu)
+    -# [Board Configuration](#esp32s3_seeedstudio_board_configuration)
+    -# [Board Pinout](#esp32s3_seeedstudio_pinout)
+-# [Flashing the Device](#esp32s3_seeedstudio_flashing)
+-# [Using STDIO](#esp32s3_seeedstudio_stdio)
+
+## Overview {#esp32s3_seeedstudio_overview}
+
+The Seeed Studio Xiao ESP32S3 is one of the ESP32-S3 boards from Seeed Studio.
+\image html https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32S3/img/xiaoesp32s3.jpg "Seeed Studio ESP32S3" width=800px
+
+Vendor's info page for the board [here](https://wiki.seeedstudio.com/xiao_esp32s3_getting_started/)
+
+The main features of the board are:
+
+- ESP32-S3 SoC with 2.4 GHz WiFi 802.11b/g/n and Bluetooth5, BLE
+- 8 MByte Flash
+- 8 MByte QSPI RAM
+- Native USB and USB Serial JTAG
+- 21 x 17.8 mm footprint
+
+[Back to table of contents](#esp32s3_seeedstudio_toc)
+
+## Hardware {#esp32s3_seeedstudio_hardware}
+
+This section describes
+
+- the [MCU](#esp32s3_seeedstudio_mcu),
+- the default [board configuration](#esp32s3_seeedstudio_board_configuration),
+- the [board pinout](#esp32s3_seeedstudio_pinout).
+
+[Back to table of contents](#esp32s3_seeedstudio_toc)
+
+### MCU {#esp32s3_seeedstudio_mcu}
+
+Most features of the board are provided by the ESP32-S3 SoC. For detailed
+information about the ESP32-S3 SoC variant (family) and ESP32x SoCs,
+see section \ref esp32_mcu_esp32 "ESP32 SoC Series".
+
+[Back to table of contents](#esp32s3_seeedstudio_toc)
+
+### Board Configuration {#esp32s3_seeedstudio_board_configuration}
+
+Seeed Studio Xiao ESP32S3 boards have no special hardware on board,
+besides a yellow LED connected to GPIO21.
+
+The default board configuration provides:
+
+- 9 x ADC
+- 1 x SPI
+- 1 x I2C
+- 1 x UART
+- 10 x PWM, 4 channels each
+
+For detailed information about the peripheral configurations of ESP32-S3
+boards, see section \ref esp32_peripherals "Common Peripherals".
+
+[Back to table of contents](#esp32s3_seeedstudio_toc)
+
+### Board Pinout {#esp32s3_seeedstudio_pinout}
+
+The following figure shows the pinout as configured by board definition
+(excluding the camera module).
+
+@image html https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32S3/img/2.jpg "Seeed Studio Xiao ESP32S3 Pinout" width=900px
+
+The corresponding board schematic can be found
+[here](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32S3/res/XIAO_ESP32S3_SCH_v1.2.pdf)
+
+[Back to table of contents](#esp32s3_seeedstudio_toc)
+
+## Flashing the Device {#esp32s3_seeedstudio_flashing}
+
+Since the board does not have a USB-to-Serial chip, the easiest way to flash
+the board is using the USB Serial/JTAG interface. Just connect the board to
+your host computer and use the following command:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BOARD=seeedstudio-xiao-esp32s3 make flash ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+@note Usually the make system resets the board before flashing to enable the
+USB Serial/JTAG interface. In some special cases this reset does not work so
+that the programmer cannot connect to the board and the flashing is aborted
+with a timeout:
+```
+Serial port /dev/ttyACM0
+Connecting...
+...
+serial.serialutil.SerialTimeoutException: Write timeout
+```
+This can happen for example if the board is not yet flashed with RIOT or the
+USB interface is used for another purpose. In this case, restart the board
+manually in download mode by pressing and releasing the RESET button while
+holding down the BOOT button. In download mode, the USB Serial/JTAG interface is
+always available.
+
+For detailed information about ESP32-S3 as well as configuring and compiling
+RIOT for ESP32-S3 boards, see \ref esp32_riot.
+
+[Back to table of contents](#esp32s3_seeedstudio_toc)
+
+## Using STDIO {#esp32s3_seeedstudio_stdio}
+
+Since the board does not have a USB-to-Serial chip, the USB Serial/JTAG
+interface is used by default for the STDIO (module `stdio_usb_serial_jtag`)
+which provides an USB CDC ACM interface.
+
+If the USB port is used by the USBUS stack or the tinyUSB stack, implicitly
+the module `stdio_cdc_acm` or `stdio_tinyusb_cdc_acm` is used for the STDIO
+via the USB CDC ACM interface.
+
+Alternatively, the UART interface could be used with an external USB-to-Serial
+adapter. Simply add `stdio_uart` to the list of used modules for this purpose:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BOARD=seeedstudio-xiao-esp32s3 USEMODULE=stdio_uart make flash ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/boards/seeedstudio-xiao-esp32s3/include/board.h
+++ b/boards/seeedstudio-xiao-esp32s3/include/board.h
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Isikcan 'Jon' Yilmaz
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_seeedstudio-xiao-esp32s3
+ * @brief       Board definitions for Seeed Studio Xiao ESP32S3 board
+ * @{
+ *
+ * The board definitions in this file are valid for the Seeed Studio Xiao ESP32S3 board.
+ *
+ * Any modifications required for specific applications
+ * can be overridden by \ref esp32_application_specific_configurations
+ * "application-specific board configuration".
+ *
+ * @file
+ * @author      Isikcan 'Jon' Yilmaz <can158@gmail.com>
+ */
+
+#include <stdint.h>
+
+/**
+ * @name    Button pin definitions
+ * @{
+ */
+
+/**
+ * @brief   Default button GPIO pin definition
+ *
+ * Seeed Studio Xiao ESP32S3 boards have a BOOT button connected to GPIO0, which can be
+ * used as button during normal operation. Since the GPIO0 pin is pulled up,
+ * the button signal is inverted, i.e., pressing the button will give a
+ * low signal.
+ */
+#define BTN0_PIN        GPIO0
+
+/**
+ * @brief   Default button GPIO mode definition
+ *
+ * Since the GPIO of the button is pulled up with an external resistor, the
+ * mode for the GPIO pin has to be GPIO_IN.
+ */
+#define BTN0_MODE       GPIO_IN
+
+/**
+ * @brief   Default interrupt flank definition for the button GPIO
+ */
+#ifndef BTN0_INT_FLANK
+#  define BTN0_INT_FLANK    GPIO_FALLING
+#endif
+
+/**
+ * @brief   Definition for compatibility with previous versions
+ */
+#define BUTTON0_PIN     BTN0_PIN
+
+/** @} */
+
+/**
+ * @name    LED (on-board) configuration
+ *
+ * The Seeed Studio Xiao ESP32S3 board has one red LED connected to GPIO21.
+ * @{
+ */
+/** @} */
+#ifndef LED0_PIN
+#  define LED0_PIN      GPIO21
+#  define LED0_ACTIVE   (0)
+#endif
+
+/* include common board definitions as last step */
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+/** @} */

--- a/boards/seeedstudio-xiao-esp32s3/include/gpio_params.h
+++ b/boards/seeedstudio-xiao-esp32s3/include/gpio_params.h
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Isikcan 'Jon' Yilmaz
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_seeedstudio-xiao-esp32s3
+ * @brief       Board specific configuration of direct mapped GPIOs
+ * @file
+ * @author      Isikcan 'Jon' Yilmaz <can158@gmail.com>
+ * @{
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   LED and Button configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "BOOT",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+    {
+        .name = "LED",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INIT_CLEAR
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+/** @} */

--- a/boards/seeedstudio-xiao-esp32s3/include/periph_conf.h
+++ b/boards/seeedstudio-xiao-esp32s3/include/periph_conf.h
@@ -1,0 +1,153 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Isikcan 'Jon' Yilmaz
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_seeedstudio-xiao-esp32s3
+ * @brief       Peripheral configurations for Seeed Studio Xiao ESP32S3 boards
+ * @{
+ *
+ * Any modifications required for specific applications
+ * can be overridden by \ref esp32_application_specific_configurations
+ * "application-specific board configuration".
+ *
+ * For detailed information about the peripheral configuration for ESP32-S3
+ * boards, see section \ref esp32_peripherals "Common Peripherals".
+ *
+ * @file
+ * @author      Isikcan 'Jon' Yilmaz <can158@gmail.com>
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    ADC Channel Configuration
+ * @{
+ */
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ *
+ * All pins of ADC1 are declared as ADC channels. Keep in mind that GPIO10 is
+ * not broken out and used as VBAT signal. GPIO3 is a strapping pin if
+ * `EFUSE_STRAP_JTAG_SEL` is set, see \ref esp32_gpio_pins_esp32s3_strapping.
+ *
+ * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
+ * channels with the `adc_init` function, they can be used for other
+ * purposes.
+ */
+#ifndef ADC_GPIOS
+#  define ADC_GPIOS { GPIO1, GPIO2, GPIO3, GPIO4, GPIO5, GPIO6, GPIO7, GPIO8, GPIO9 }
+#endif
+/** @} */
+
+/**
+ * @name   I2C configuration
+ *
+ * For the Seeedstudio Xiao ESP32S3 board, only one I2C interface I2C_DEV(0)
+ * is defined.
+ *
+ * The GPIOs listed in the configuration are only initialized as I2C signals
+ * when module `periph_i2c` is used. Otherwise they are not allocated and
+ * can be used for other purposes.
+ *
+ * @{
+ */
+#ifndef I2C0_SPEED
+#  define I2C0_SPEED    I2C_SPEED_FAST  /**< I2C bus speed of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SCL
+#  define I2C0_SCL      GPIO6           /**< SCL signal of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SDA
+#  define I2C0_SDA      GPIO5           /**< SDA signal of I2C_DEV(0) */
+#endif
+/** @} */
+
+/**
+ * @name   PWM channel configuration
+ *
+ * Two PWM devices are configured. These devices can use all GPIOs that are not
+ * defined as I2C, SPI or UART for this board. Generally, all outputs pins
+ * could be used as PWM channels.
+ *
+ * @note As long as the according PWM device is not initialized with
+ * the `pwm_init`, the GPIOs declared for this device can be used
+ * for other purposes.
+ *
+ * @{
+ */
+
+/**
+ * @brief Declaration of the channels for device PWM_DEV(0),
+ *        at maximum PWM_CHANNEL_NUM_DEV_MAX.
+ */
+#ifndef PWM0_GPIOS
+#  define PWM0_GPIOS    { GPIO0, GPIO1, GPIO2 }
+#endif
+
+/**
+ * @brief Declaration of the channels for device PWM_DEV(1),
+ *        at maximum PWM_CHANNEL_NUM_DEV_MAX.
+ */
+#ifndef PWM1_GPIOS
+#  define PWM1_GPIOS    { GPIO21 }
+#endif
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * @note The GPIOs listed in the configuration are first initialized as SPI
+ * signals when the corresponding SPI interface is used for the first time
+ * by either calling the `spi_init_cs` function or the `spi_acquire`
+ * function. That is, they are not allocated as SPI signals before and can
+ * be used for other purposes as long as the SPI interface is not used.
+ * @{
+ */
+#ifndef SPI0_CTRL
+#  define SPI0_CTRL FSPI    /**< FSPI is used as SPI_DEV(0) */
+#endif
+#ifndef SPI0_SCK
+#  define SPI0_SCK  GPIO7   /**< FSPI SCK (pin FSPICLK) */
+#endif
+#ifndef SPI0_MISO
+#  define SPI0_MISO GPIO8   /**< FSPI MISO (pin FSPIQ) */
+#endif
+#ifndef SPI0_MOSI
+#  define SPI0_MOSI GPIO9   /**< FSPI MOSI (pin FSPID) */
+#endif
+#ifndef SPI0_CS0
+#  define SPI0_CS0  GPIO3   /**< FSPI CS0 (pin FSPICS0) */
+#endif
+/** @} */
+
+/**
+ * @name   UART configuration
+ *
+ * ESP32-S3 provides 3 UART interfaces at maximum:
+ *
+ * UART_DEV(0) uses fixed standard configuration.<br>
+ * UART_DEV(1) is not used.<br>
+ * UART_DEV(2) is not used.
+ *
+ * @{
+ */
+#define UART0_TXD   GPIO43  /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO44  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/* include common peripheral definitions as last step */
+#include "periph_conf_common.h"
+
+/** @} */


### PR DESCRIPTION
### Contribution description

This is a takeover from #20973 as the original author unfortunately did not address the review comments and did not move this forward :(

I applied the typical style comments and most of the review comments except for the GPIO stuff that is still commented out.
This will need a bit of a deeper dive into the datasheet/schematic which I did not do yet.


### Testing procedure

- [X] `tests/sys/shell` works (except for the known issue with the output being truncated)
- [X] `tests/periph/pwm` works
- [X] `tests/periph/adc` works
- [X] `tests/periph/i2c` scan works, I don't have any I2C devices around
- [X] `tests/periph/spi` benchmark appears to work
- [X] `tests/leds` works


### Issues/PRs references

This is a follow-up from #20973.