### PR TITLE
cpu/esp_common: make Xtensa `ISR_STACKSIZE` conditional

### DIFF
--- a/cpu/esp_common/include/xtensa_conf.h
+++ b/cpu/esp_common/include/xtensa_conf.h
@@ -23,7 +23,9 @@ extern "C" {
  * @brief   Xtensa ASM code specific default stack sizes
  * @{
  */
-#define ISR_STACKSIZE                 (2048)
+#ifndef ISR_STACKSIZE
+#  define ISR_STACKSIZE               (2048)
+#endif
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

The `Xtensa` CPU architecture is currently the only one that defines the `ISR_STACKSIZE` unconditionally, which leads to issues when an application wants to define that stacksize.

### Testing procedure

This should not have any effects and the CI should build as expected.

### Issues/PRs references

Discovered in #21206.