### PR TITLE
boards: migrate ESP32 based boards to common board module system

### DIFF
--- a/boards/Makefile
+++ b/boards/Makefile
@@ -6,6 +6,27 @@ DIRS += $(RIOTBOARD)/common/init
 ifneq (,$(filter boards_common_adafruit-nrf52-bootloader,$(USEMODULE)))
   DIRS += $(RIOTBOARD)/common/adafruit-nrf52-bootloader
 endif
+ifneq (,$(filter boards_common_esp32,$(USEMODULE)))
+  DIRS += $(RIOTBOARD)/common/esp32
+endif
+ifneq (,$(filter boards_common_esp32c3,$(USEMODULE)))
+  DIRS += $(RIOTBOARD)/common/esp32c3
+endif
+ifneq (,$(filter boards_common_esp32c6,$(USEMODULE)))
+  DIRS += $(RIOTBOARD)/common/esp32c6
+endif
+ifneq (,$(filter boards_common_esp32h2,$(USEMODULE)))
+  DIRS += $(RIOTBOARD)/common/esp32h2
+endif
+ifneq (,$(filter boards_common_esp32s2,$(USEMODULE)))
+  DIRS += $(RIOTBOARD)/common/esp32s2
+endif
+ifneq (,$(filter boards_common_esp32s3,$(USEMODULE)))
+  DIRS += $(RIOTBOARD)/common/esp32s3
+endif
+ifneq (,$(filter boards_common_esp32x,$(USEMODULE)))
+  DIRS += $(RIOTBOARD)/common/esp32x
+endif
 ifneq (,$(filter boards_common_seeedstudio-xiao-nrf52840,$(USEMODULE)))
   DIRS += $(RIOTBOARD)/common/seeedstudio-xiao-nrf52840
 endif

--- a/boards/Makefile.dep
+++ b/boards/Makefile.dep
@@ -2,6 +2,27 @@
 ifneq (,$(filter boards_common_adafruit-nrf52-bootloader,$(USEMODULE)))
   include $(RIOTBOARD)/common/adafruit-nrf52-bootloader/Makefile.dep
 endif
+ifneq (,$(filter boards_common_esp32,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32/Makefile.dep
+endif
+ifneq (,$(filter boards_common_esp32c3,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32c3/Makefile.dep
+endif
+ifneq (,$(filter boards_common_esp32c6,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32c6/Makefile.dep
+endif
+ifneq (,$(filter boards_common_esp32h2,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32h2/Makefile.dep
+endif
+ifneq (,$(filter boards_common_esp32s2,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32s2/Makefile.dep
+endif
+ifneq (,$(filter boards_common_esp32s3,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32s3/Makefile.dep
+endif
+ifneq (,$(filter boards_common_esp32x,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32x/Makefile.dep
+endif
 ifneq (,$(filter boards_common_seeedstudio-xiao-nrf52840,$(USEMODULE)))
   include $(RIOTBOARD)/common/seeedstudio-xiao-nrf52840/Makefile.dep
 endif

--- a/boards/Makefile.features
+++ b/boards/Makefile.features
@@ -1,4 +1,25 @@
 # SORT THIS ALPHABETICALLY BY COMMON BOARD NAME!
+ifneq (,$(filter boards_common_esp32,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32/Makefile.features
+endif
+ifneq (,$(filter boards_common_esp32c3,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32c3/Makefile.features
+endif
+ifneq (,$(filter boards_common_esp32c6,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32c6/Makefile.features
+endif
+ifneq (,$(filter boards_common_esp32h2,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32h2/Makefile.features
+endif
+ifneq (,$(filter boards_common_esp32s2,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32s2/Makefile.features
+endif
+ifneq (,$(filter boards_common_esp32s3,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32s3/Makefile.features
+endif
+ifneq (,$(filter boards_common_esp32x,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32x/Makefile.features
+endif
 ifneq (,$(filter boards_common_seeedstudio-xiao-nrf52840,$(USEMODULE)))
   include $(RIOTBOARD)/common/seeedstudio-xiao-nrf52840/Makefile.features
 endif

--- a/boards/Makefile.include
+++ b/boards/Makefile.include
@@ -2,6 +2,27 @@
 ifneq (,$(filter boards_common_adafruit-nrf52-bootloader,$(USEMODULE)))
   include $(RIOTBOARD)/common/adafruit-nrf52-bootloader/Makefile.include
 endif
+ifneq (,$(filter boards_common_esp32,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32/Makefile.include
+endif
+ifneq (,$(filter boards_common_esp32c3,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32c3/Makefile.include
+endif
+ifneq (,$(filter boards_common_esp32c6,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32c6/Makefile.include
+endif
+ifneq (,$(filter boards_common_esp32h2,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32h2/Makefile.include
+endif
+ifneq (,$(filter boards_common_esp32s2,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32s2/Makefile.include
+endif
+ifneq (,$(filter boards_common_esp32s3,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32s3/Makefile.include
+endif
+ifneq (,$(filter boards_common_esp32x,$(USEMODULE)))
+  include $(RIOTBOARD)/common/esp32x/Makefile.include
+endif
 ifneq (,$(filter boards_common_seeedstudio-xiao-nrf52840,$(USEMODULE)))
   include $(RIOTBOARD)/common/seeedstudio-xiao-nrf52840/Makefile.include
 endif

--- a/boards/arduino-nano-esp32/Makefile
+++ b/boards/arduino-nano-esp32/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32s3
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/arduino-nano-esp32/Makefile.dep
+++ b/boards/arduino-nano-esp32/Makefile.dep
@@ -2,5 +2,6 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
+USEMODULE += boards_common_esp32s3
+
 include $(RIOTBOARD)/common/esp32s3/stdio_esp32s3_default.dep.mk
-include $(RIOTBOARD)/common/esp32s3/Makefile.dep

--- a/boards/arduino-nano-esp32/Makefile.include
+++ b/boards/arduino-nano-esp32/Makefile.include
@@ -4,5 +4,3 @@ FLASH_SIZE ?= 16
 PORT_LINUX ?= /dev/ttyACM0
 
 OPENOCD_CONFIG ?= board/esp32s3-builtin.cfg
-
-include $(RIOTBOARD)/common/esp32s3/Makefile.include

--- a/boards/common/esp32/Makefile
+++ b/boards/common/esp32/Makefile
@@ -1,5 +1,3 @@
 MODULE = boards_common_esp32
 
-DIRS = $(RIOTBOARD)/common/esp32x
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/common/esp32/Makefile.dep
+++ b/boards/common/esp32/Makefile.dep
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_esp32
-
-include $(RIOTBOARD)/common/esp32x/Makefile.dep
+USEMODULE += boards_common_esp32x

--- a/boards/common/esp32/Makefile.include
+++ b/boards/common/esp32/Makefile.include
@@ -1,3 +1,1 @@
 INCLUDES += -I$(RIOTBOARD)/common/esp32/include
-
-include $(RIOTBOARD)/common/esp32x/Makefile.include

--- a/boards/common/esp32c3/Makefile
+++ b/boards/common/esp32c3/Makefile
@@ -1,5 +1,3 @@
 MODULE = boards_common_esp32c3
 
-DIRS = $(RIOTBOARD)/common/esp32x
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/common/esp32c3/Makefile.dep
+++ b/boards/common/esp32c3/Makefile.dep
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_esp32c3
-
-include $(RIOTBOARD)/common/esp32x/Makefile.dep
+USEMODULE += boards_common_esp32x

--- a/boards/common/esp32c3/Makefile.include
+++ b/boards/common/esp32c3/Makefile.include
@@ -1,3 +1,1 @@
 INCLUDES += -I$(RIOTBOARD)/common/esp32c3/include
-
-include $(RIOTBOARD)/common/esp32x/Makefile.include

--- a/boards/common/esp32c6/Makefile
+++ b/boards/common/esp32c6/Makefile
@@ -1,5 +1,3 @@
 MODULE = boards_common_esp32c6
 
-DIRS = $(RIOTBOARD)/common/esp32x
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/common/esp32c6/Makefile.dep
+++ b/boards/common/esp32c6/Makefile.dep
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_esp32c6
-
-include $(RIOTBOARD)/common/esp32x/Makefile.dep
+USEMODULE += boards_common_esp32x

--- a/boards/common/esp32c6/Makefile.include
+++ b/boards/common/esp32c6/Makefile.include
@@ -1,3 +1,1 @@
 INCLUDES += -I$(RIOTBOARD)/common/esp32c6/include
-
-include $(RIOTBOARD)/common/esp32x/Makefile.include

--- a/boards/common/esp32h2/Makefile
+++ b/boards/common/esp32h2/Makefile
@@ -1,5 +1,3 @@
 MODULE = boards_common_esp32h2
 
-DIRS = $(RIOTBOARD)/common/esp32x
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/common/esp32h2/Makefile.dep
+++ b/boards/common/esp32h2/Makefile.dep
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_esp32h2
-
-include $(RIOTBOARD)/common/esp32x/Makefile.dep
+USEMODULE += boards_common_esp32x

--- a/boards/common/esp32h2/Makefile.include
+++ b/boards/common/esp32h2/Makefile.include
@@ -1,3 +1,1 @@
 INCLUDES += -I$(RIOTBOARD)/common/esp32h2/include
-
-include $(RIOTBOARD)/common/esp32x/Makefile.include

--- a/boards/common/esp32s2/Makefile
+++ b/boards/common/esp32s2/Makefile
@@ -1,5 +1,3 @@
 MODULE = boards_common_esp32s2
 
-DIRS = $(RIOTBOARD)/common/esp32x
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/common/esp32s2/Makefile.dep
+++ b/boards/common/esp32s2/Makefile.dep
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_esp32s2
-
-include $(RIOTBOARD)/common/esp32x/Makefile.dep
+USEMODULE += boards_common_esp32x

--- a/boards/common/esp32s2/Makefile.include
+++ b/boards/common/esp32s2/Makefile.include
@@ -1,3 +1,1 @@
 INCLUDES += -I$(RIOTBOARD)/common/esp32s2/include
-
-include $(RIOTBOARD)/common/esp32x/Makefile.include

--- a/boards/common/esp32s3/Makefile
+++ b/boards/common/esp32s3/Makefile
@@ -1,5 +1,3 @@
 MODULE = boards_common_esp32s3
 
-DIRS = $(RIOTBOARD)/common/esp32x
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/common/esp32s3/Makefile.dep
+++ b/boards/common/esp32s3/Makefile.dep
@@ -1,3 +1,1 @@
-USEMODULE += boards_common_esp32s3
-
-include $(RIOTBOARD)/common/esp32x/Makefile.dep
+USEMODULE += boards_common_esp32x

--- a/boards/common/esp32s3/Makefile.include
+++ b/boards/common/esp32s3/Makefile.include
@@ -1,3 +1,1 @@
 INCLUDES += -I$(RIOTBOARD)/common/esp32s3/include
-
-include $(RIOTBOARD)/common/esp32x/Makefile.include

--- a/boards/common/esp32x/Makefile.dep
+++ b/boards/common/esp32x/Makefile.dep
@@ -1,1 +1,0 @@
-USEMODULE += boards_common_esp32x

--- a/boards/esp32-ethernet-kit-v1_0/Makefile
+++ b/boards/esp32-ethernet-kit-v1_0/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32-ethernet-kit-v1_0/Makefile.dep
+++ b/boards/esp32-ethernet-kit-v1_0/Makefile.dep
@@ -1,4 +1,4 @@
-include $(RIOTBOARD)/common/esp32/Makefile.dep
+USEMODULE += boards_common_esp32
 
 # enables esp_eth as default network device
 ifneq (,$(filter netdev_default,$(USEMODULE)))

--- a/boards/esp32-ethernet-kit-v1_0/Makefile.include
+++ b/boards/esp32-ethernet-kit-v1_0/Makefile.include
@@ -1,4 +1,3 @@
-
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB1
 
@@ -9,5 +8,3 @@ endif
 # Only consider TTYs matching the following filter when auto-selecting the TTY
 # with `MOST_RECENT_PORT=1`.
 TTY_BOARD_FILTER := --driver 'ftdi_sio' --vendor FTDI --model 'Dual RS232-HS' --iface-num 1
-
-include $(RIOTBOARD)/common/esp32/Makefile.include

--- a/boards/esp32-ethernet-kit-v1_1/Makefile
+++ b/boards/esp32-ethernet-kit-v1_1/Makefile
@@ -1,2 +1,4 @@
+MODULE = board
+
 DIRS = $(RIOTBOARD)/esp32-ethernet-kit-v1_0
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32-ethernet-kit-v1_2/Makefile
+++ b/boards/esp32-ethernet-kit-v1_2/Makefile
@@ -1,2 +1,4 @@
+MODULE = board
+
 DIRS = $(RIOTBOARD)/esp32-ethernet-kit-v1_0
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32-heltec-lora32-v2/Makefile
+++ b/boards/esp32-heltec-lora32-v2/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32-heltec-lora32-v2/Makefile.dep
+++ b/boards/esp32-heltec-lora32-v2/Makefile.dep
@@ -6,4 +6,4 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
-include $(RIOTBOARD)/common/esp32/Makefile.dep
+USEMODULE += boards_common_esp32

--- a/boards/esp32-heltec-lora32-v2/Makefile.include
+++ b/boards/esp32-heltec-lora32-v2/Makefile.include
@@ -1,1 +1,0 @@
-include $(RIOTBOARD)/common/esp32/Makefile.include

--- a/boards/esp32-mh-et-live-minikit/Makefile
+++ b/boards/esp32-mh-et-live-minikit/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32-mh-et-live-minikit/Makefile.dep
+++ b/boards/esp32-mh-et-live-minikit/Makefile.dep
@@ -14,4 +14,4 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
-include $(RIOTBOARD)/common/esp32/Makefile.dep
+USEMODULE += boards_common_esp32

--- a/boards/esp32-mh-et-live-minikit/Makefile.include
+++ b/boards/esp32-mh-et-live-minikit/Makefile.include
@@ -1,5 +1,3 @@
-include $(RIOTBOARD)/common/esp32/Makefile.include
-
 # Only consider TTYs matching the following filter when auto-selecting the TTY
 # with `MOST_RECENT_PORT=1`.
 TTY_BOARD_FILTER := --driver 'cp210x' --vendor 'Silicon Labs' --model 'CP2104 USB to UART Bridge Controller'

--- a/boards/esp32-olimex-evb/Makefile
+++ b/boards/esp32-olimex-evb/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32-olimex-evb/Makefile.dep
+++ b/boards/esp32-olimex-evb/Makefile.dep
@@ -1,5 +1,3 @@
-include $(RIOTBOARD)/common/esp32/Makefile.dep
-
 # enables esp_eth as default network device
 ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += esp_eth
@@ -14,3 +12,5 @@ endif
 ifneq (,$(filter mtd,$(USEMODULE)))
   USEMODULE += mtd_sdmmc_default
 endif
+
+USEMODULE += boards_common_esp32

--- a/boards/esp32-olimex-evb/Makefile.include
+++ b/boards/esp32-olimex-evb/Makefile.include
@@ -1,7 +1,5 @@
 PSEUDOMODULES += olimex_esp32_gateway
 
-include $(RIOTBOARD)/common/esp32/Makefile.include
-
 # Only consider TTYs matching the following filter when auto-selecting the TTY
 # with `MOST_RECENT_PORT=1`.
 TTY_BOARD_FILTER := --driver 'ch341' --vendor '1a86' --model 'USB2.0-Serial'

--- a/boards/esp32-ttgo-t-beam/Makefile
+++ b/boards/esp32-ttgo-t-beam/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32-ttgo-t-beam/Makefile.dep
+++ b/boards/esp32-ttgo-t-beam/Makefile.dep
@@ -6,4 +6,4 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
-include $(RIOTBOARD)/common/esp32/Makefile.dep
+USEMODULE += boards_common_esp32

--- a/boards/esp32-ttgo-t-beam/Makefile.include
+++ b/boards/esp32-ttgo-t-beam/Makefile.include
@@ -1,7 +1,5 @@
 PSEUDOMODULES += esp32_ttgo_t_beam_v1_0
 
-include $(RIOTBOARD)/common/esp32/Makefile.include
-
 # Only consider TTYs matching the following filter when auto-selecting the TTY
 # with `MOST_RECENT_PORT=1`.
 TTY_BOARD_FILTER := --driver 'cp210x' --vendor 'Silicon Labs' --model 'CP2104 USB to UART Bridge Controller'

--- a/boards/esp32-wemos-d1-r32/Makefile
+++ b/boards/esp32-wemos-d1-r32/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32-wemos-d1-r32/Makefile.dep
+++ b/boards/esp32-wemos-d1-r32/Makefile.dep
@@ -1,5 +1,5 @@
-include $(RIOTBOARD)/common/esp32/Makefile.dep
-
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+USEMODULE += boards_common_esp32

--- a/boards/esp32-wemos-d1-r32/Makefile.include
+++ b/boards/esp32-wemos-d1-r32/Makefile.include
@@ -1,5 +1,3 @@
-include $(RIOTBOARD)/common/esp32/Makefile.include
-
 # Only consider TTYs matching the following filter when auto-selecting the TTY
 # with `MOST_RECENT_PORT=1`.
 TTY_BOARD_FILTER := --driver 'cp210x' --vendor 'Silicon Labs' --model 'CP2102 USB to UART Bridge Controller'

--- a/boards/esp32-wemos-lolin-d32-pro/Makefile
+++ b/boards/esp32-wemos-lolin-d32-pro/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32-wemos-lolin-d32-pro/Makefile.dep
+++ b/boards/esp32-wemos-lolin-d32-pro/Makefile.dep
@@ -12,4 +12,4 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
-include $(RIOTBOARD)/common/esp32/Makefile.dep
+USEMODULE += boards_common_esp32

--- a/boards/esp32-wemos-lolin-d32-pro/Makefile.include
+++ b/boards/esp32-wemos-lolin-d32-pro/Makefile.include
@@ -1,7 +1,5 @@
 PSEUDOMODULES += esp_lolin_tft
 
-include $(RIOTBOARD)/common/esp32/Makefile.include
-
 # Only consider TTYs matching the following filter when auto-selecting the TTY
 # with `MOST_RECENT_PORT=1`.
 TTY_BOARD_FILTER := --driver 'ch341' --vendor '1a86' --model 'USB2.0-Serial'

--- a/boards/esp32-wroom-32/Makefile
+++ b/boards/esp32-wroom-32/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32-wroom-32/Makefile.dep
+++ b/boards/esp32-wroom-32/Makefile.dep
@@ -1,5 +1,5 @@
-include $(RIOTBOARD)/common/esp32/Makefile.dep
-
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+USEMODULE += boards_common_esp32

--- a/boards/esp32-wroom-32/Makefile.include
+++ b/boards/esp32-wroom-32/Makefile.include
@@ -1,5 +1,3 @@
-include $(RIOTBOARD)/common/esp32/Makefile.include
-
 # Only consider TTYs matching the following filter when auto-selecting the TTY
 # with `MOST_RECENT_PORT=1`.
 TTY_BOARD_FILTER := --driver 'cp210x' --vendor 'Silicon Labs' --model 'CP2102 USB to UART Bridge Controller'

--- a/boards/esp32-wrover-kit/Makefile
+++ b/boards/esp32-wrover-kit/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32-wrover-kit/Makefile.dep
+++ b/boards/esp32-wrover-kit/Makefile.dep
@@ -25,4 +25,4 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
-include $(RIOTBOARD)/common/esp32/Makefile.dep
+USEMODULE += boards_common_esp32

--- a/boards/esp32-wrover-kit/Makefile.include
+++ b/boards/esp32-wrover-kit/Makefile.include
@@ -10,5 +10,3 @@ TTY_BOARD_FILTER := --driver 'ftdi_sio' --vendor FTDI --model 'Dual RS232-HS' --
 ifneq (,$(filter esp_jtag,$(USEMODULE)))
   OPENOCD_CONFIG ?= board/esp32-wrover-kit-3.3v.cfg
 endif
-
-include $(RIOTBOARD)/common/esp32/Makefile.include

--- a/boards/esp32c3-devkit/Makefile
+++ b/boards/esp32c3-devkit/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32c3
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32c3-devkit/Makefile.dep
+++ b/boards/esp32c3-devkit/Makefile.dep
@@ -1,5 +1,5 @@
-include $(RIOTBOARD)/common/esp32c3/Makefile.dep
-
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+USEMODULE += boards_common_esp32c3

--- a/boards/esp32c3-devkit/Makefile.include
+++ b/boards/esp32c3-devkit/Makefile.include
@@ -1,5 +1,3 @@
-include $(RIOTBOARD)/common/esp32c3/Makefile.include
-
 # Only consider TTYs matching the following filter when auto-selecting the TTY
 # with `MOST_RECENT_PORT=1`.
 TTY_BOARD_FILTER := --driver 'cp210x' --vendor 'Silicon Labs' --model 'CP2102N USB to UART Bridge Controller'

--- a/boards/esp32c3-wemos-mini/Makefile
+++ b/boards/esp32c3-wemos-mini/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32c3
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32c3-wemos-mini/Makefile.dep
+++ b/boards/esp32c3-wemos-mini/Makefile.dep
@@ -11,4 +11,4 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
-include $(RIOTBOARD)/common/esp32c3/Makefile.dep
+USEMODULE += boards_common_esp32c3

--- a/boards/esp32c3-wemos-mini/Makefile.include
+++ b/boards/esp32c3-wemos-mini/Makefile.include
@@ -2,5 +2,3 @@ PORT_LINUX ?= /dev/ttyACM0
 
 PSEUDOMODULES += esp32c3_wemos_mini_v1_0_0
 PSEUDOMODULES += esp32c3_wemos_mini_v2_1_0
-
-include $(RIOTBOARD)/common/esp32c3/Makefile.include

--- a/boards/esp32c6-devkit/Makefile
+++ b/boards/esp32c6-devkit/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32c6
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32c6-devkit/Makefile.dep
+++ b/boards/esp32c6-devkit/Makefile.dep
@@ -1,5 +1,5 @@
-include $(RIOTBOARD)/common/esp32c6/Makefile.dep
-
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+USEMODULE += boards_common_esp32c6

--- a/boards/esp32c6-devkit/Makefile.include
+++ b/boards/esp32c6-devkit/Makefile.include
@@ -1,5 +1,3 @@
-include $(RIOTBOARD)/common/esp32c6/Makefile.include
-
 # Only consider TTYs matching the following filter when auto-selecting the TTY
 # with `MOST_RECENT_PORT=1`.
 TTY_BOARD_FILTER := --driver 'cp210x' --vendor 'Silicon Labs' --model 'CP2102N USB to UART Bridge Controller'

--- a/boards/esp32h2-devkit/Makefile
+++ b/boards/esp32h2-devkit/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32h2
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32h2-devkit/Makefile.dep
+++ b/boards/esp32h2-devkit/Makefile.dep
@@ -1,5 +1,5 @@
-include $(RIOTBOARD)/common/esp32h2/Makefile.dep
-
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+USEMODULE += boards_common_esp32h2

--- a/boards/esp32h2-devkit/Makefile.include
+++ b/boards/esp32h2-devkit/Makefile.include
@@ -1,5 +1,3 @@
-include $(RIOTBOARD)/common/esp32h2/Makefile.include
-
 # Only consider TTYs matching the following filter when auto-selecting the TTY
 # with `MOST_RECENT_PORT=1`.
 TTY_BOARD_FILTER := --driver 'cp210x' --vendor 'Silicon Labs' --model 'CP2102N USB to UART Bridge Controller'

--- a/boards/esp32s2-devkit/Makefile
+++ b/boards/esp32s2-devkit/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32s2
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32s2-devkit/Makefile.dep
+++ b/boards/esp32s2-devkit/Makefile.dep
@@ -1,5 +1,5 @@
-include $(RIOTBOARD)/common/esp32s2/Makefile.dep
-
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+USEMODULE += boards_common_esp32s2

--- a/boards/esp32s2-devkit/Makefile.include
+++ b/boards/esp32s2-devkit/Makefile.include
@@ -5,8 +5,6 @@ PSEUDOMODULES += esp32s2_devkitc_1r
 PSEUDOMODULES += esp32s2_saola_1
 PSEUDOMODULES += esp32s2_saola_1r
 
-include $(RIOTBOARD)/common/esp32s2/Makefile.include
-
 # Only consider TTYs matching the following filter when auto-selecting the TTY
 # with `MOST_RECENT_PORT=1`.
 TTY_BOARD_FILTER := --driver 'cp210x' --vendor 'Silicon Labs' --model 'CP2102N USB to UART Bridge Controller'

--- a/boards/esp32s2-lilygo-ttgo-t8/Makefile
+++ b/boards/esp32s2-lilygo-ttgo-t8/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32s2
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32s2-lilygo-ttgo-t8/Makefile.dep
+++ b/boards/esp32s2-lilygo-ttgo-t8/Makefile.dep
@@ -20,4 +20,4 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
-include $(RIOTBOARD)/common/esp32s2/Makefile.dep
+USEMODULE += boards_common_esp32s2

--- a/boards/esp32s2-lilygo-ttgo-t8/Makefile.include
+++ b/boards/esp32s2-lilygo-ttgo-t8/Makefile.include
@@ -4,8 +4,6 @@ ifneq (,$(filter esp32s2-lilygo-ttgo-t8-usb,$(USEMODULE)))
   PORT_LINUX ?= /dev/ttyACM0
 endif
 
-include $(RIOTBOARD)/common/esp32s2/Makefile.include
-
 # Only consider TTYs matching the following filter when auto-selecting the TTY
 # with `MOST_RECENT_PORT=1`.
 TTY_BOARD_FILTER := --driver 'ch341' --vendor '1a86' --model 'USB Serial'

--- a/boards/esp32s2-wemos-mini/Makefile
+++ b/boards/esp32s2-wemos-mini/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32s2
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32s2-wemos-mini/Makefile.dep
+++ b/boards/esp32s2-wemos-mini/Makefile.dep
@@ -1,6 +1,7 @@
 include $(RIOTBOARD)/common/makefiles/stdio_tinyusb_cdc_acm.dep.mk
-include $(RIOTBOARD)/common/esp32s2/Makefile.dep
 
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+USEMODULE += boards_common_esp32s2

--- a/boards/esp32s2-wemos-mini/Makefile.include
+++ b/boards/esp32s2-wemos-mini/Makefile.include
@@ -2,5 +2,3 @@ PORT_LINUX ?= /dev/ttyACM0
 
 CFLAGS += -DCONFIG_CONSOLE_UART_TX=39
 CFLAGS += -DCONFIG_CONSOLE_UART_RX=37
-
-include $(RIOTBOARD)/common/esp32s2/Makefile.include

--- a/boards/esp32s3-box/Makefile
+++ b/boards/esp32s3-box/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32s3
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32s3-box/Makefile.dep
+++ b/boards/esp32s3-box/Makefile.dep
@@ -7,4 +7,5 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
 endif
 
 include $(RIOTBOARD)/common/esp32s3/stdio_esp32s3_default.dep.mk
-include $(RIOTBOARD)/common/esp32s3/Makefile.dep
+
+USEMODULE += boards_common_esp32s3

--- a/boards/esp32s3-box/Makefile.include
+++ b/boards/esp32s3-box/Makefile.include
@@ -1,5 +1,3 @@
 PORT_LINUX ?= /dev/ttyACM0
 
 OPENOCD_CONFIG ?= board/esp32s3-builtin.cfg
-
-include $(RIOTBOARD)/common/esp32s3/Makefile.include

--- a/boards/esp32s3-devkit/Makefile
+++ b/boards/esp32s3-devkit/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32s3
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32s3-devkit/Makefile.dep
+++ b/boards/esp32s3-devkit/Makefile.dep
@@ -1,5 +1,5 @@
-include $(RIOTBOARD)/common/esp32s3/Makefile.dep
-
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+USEMODULE += boards_common_esp32s3

--- a/boards/esp32s3-devkit/Makefile.include
+++ b/boards/esp32s3-devkit/Makefile.include
@@ -9,8 +9,6 @@ PSEUDOMODULES += esp32s3_devkitc_1u_n8r8
 PSEUDOMODULES += esp32s3_devkitm_1_n8r8
 PSEUDOMODULES += esp32s3_devkitm_1u_n8r8
 
-include $(RIOTBOARD)/common/esp32s3/Makefile.include
-
 # Only consider TTYs matching the following filter when auto-selecting the TTY
 # with `MOST_RECENT_PORT=1`.
 TTY_BOARD_FILTER := --driver 'cp210x' --vendor 'Silicon Labs' --model 'CP2102N USB to UART Bridge Controller'

--- a/boards/esp32s3-pros3/Makefile
+++ b/boards/esp32s3-pros3/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32s3
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32s3-pros3/Makefile.dep
+++ b/boards/esp32s3-pros3/Makefile.dep
@@ -3,4 +3,5 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
 endif
 
 include $(RIOTBOARD)/common/esp32s3/stdio_esp32s3_default.dep.mk
-include $(RIOTBOARD)/common/esp32s3/Makefile.dep
+
+USEMODULE += boards_common_esp32s3

--- a/boards/esp32s3-pros3/Makefile.include
+++ b/boards/esp32s3-pros3/Makefile.include
@@ -4,5 +4,3 @@ FLASH_SIZE ?= 16
 PORT_LINUX ?= /dev/ttyACM0
 
 OPENOCD_CONFIG ?= board/esp32s3-builtin.cfg
-
-include $(RIOTBOARD)/common/esp32s3/Makefile.include

--- a/boards/esp32s3-usb-otg/Makefile
+++ b/boards/esp32s3-usb-otg/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32s3
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32s3-usb-otg/Makefile.dep
+++ b/boards/esp32s3-usb-otg/Makefile.dep
@@ -1,5 +1,4 @@
 include $(RIOTBOARD)/common/esp32s3/stdio_esp32s3_default.dep.mk
-include $(RIOTBOARD)/common/esp32s3/Makefile.dep
 
 # default to using fatfs on SD card
 ifneq (,$(filter vfs_default,$(USEMODULE)))
@@ -24,3 +23,5 @@ endif
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+USEMODULE += boards_common_esp32s3

--- a/boards/esp32s3-usb-otg/Makefile.include
+++ b/boards/esp32s3-usb-otg/Makefile.include
@@ -1,5 +1,3 @@
 PORT_LINUX ?= /dev/ttyACM0
 
 OPENOCD_CONFIG ?= board/esp32s3-builtin.cfg
-
-include $(RIOTBOARD)/common/esp32s3/Makefile.include

--- a/boards/esp32s3-wt32-sc01-plus/Makefile
+++ b/boards/esp32s3-wt32-sc01-plus/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32s3
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/esp32s3-wt32-sc01-plus/Makefile.dep
+++ b/boards/esp32s3-wt32-sc01-plus/Makefile.dep
@@ -1,5 +1,4 @@
 include $(RIOTBOARD)/common/esp32s3/stdio_esp32s3_default.dep.mk
-include $(RIOTBOARD)/common/esp32s3/Makefile.dep
 
 # default to using fatfs on SD card
 ifneq (,$(filter vfs_default,$(USEMODULE)))
@@ -31,3 +30,5 @@ endif
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+USEMODULE += boards_common_esp32s3

--- a/boards/esp32s3-wt32-sc01-plus/Makefile.include
+++ b/boards/esp32s3-wt32-sc01-plus/Makefile.include
@@ -1,5 +1,3 @@
 PORT_LINUX ?= /dev/ttyACM0
 
 OPENOCD_CONFIG ?= board/esp32s3-builtin.cfg
-
-include $(RIOTBOARD)/common/esp32s3/Makefile.include

--- a/boards/seeedstudio-xiao-esp32c3/Makefile
+++ b/boards/seeedstudio-xiao-esp32c3/Makefile
@@ -1,5 +1,3 @@
 MODULE = board
 
-DIRS = $(RIOTBOARD)/common/esp32c3
-
 include $(RIOTBASE)/Makefile.base

--- a/boards/seeedstudio-xiao-esp32c3/Makefile.dep
+++ b/boards/seeedstudio-xiao-esp32c3/Makefile.dep
@@ -14,4 +14,4 @@ ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
   USEMODULE += stdio_usb_serial_jtag
 endif
 
-include $(RIOTBOARD)/common/esp32c3/Makefile.dep
+USEMODULE += boards_common_esp32c3

--- a/boards/seeedstudio-xiao-esp32c3/Makefile.include
+++ b/boards/seeedstudio-xiao-esp32c3/Makefile.include
@@ -1,3 +1,1 @@
 PORT_LINUX ?= /dev/ttyACM0
-
-include $(RIOTBOARD)/common/esp32c3/Makefile.include


### PR DESCRIPTION
### Contribution description

This adapts the ESP32 based boards to the common boards system introduced in #21327, where only the `USEMODULE` has to be specified instead of manually adding the directory and including the Makefiles. (Well, `Makefile.features` still has to be included, as explained in #21334).

### Testing procedure

All boards should still build and work as before.

### Issues/PRs references

Tracking Issue: #21331