### PR TITLE
cpu/sam0_eth: disable interrupts during init

### DIFF
--- a/cpu/sam0_common/periph/eth.c
+++ b/cpu/sam0_common/periph/eth.c
@@ -355,6 +355,9 @@ bool sam0_eth_has_queued_pkt(void)
 
 int sam0_eth_init(void)
 {
+    /* HACK: interrupting the init sequence leads to strange hangs */
+    unsigned state = irq_disable();
+
     /* Enable clocks */
     _enable_clock();
     /* Initialize GPIOs */
@@ -412,6 +415,8 @@ int sam0_eth_init(void)
     NVIC_EnableIRQ(GMAC_IRQn);
     /* Enable both receiver and transmitter */
     GMAC->NCR.reg |= GMAC_NCR_TXEN | GMAC_NCR_RXEN;
+
+    irq_restore(state);
 
     return 0;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

With e.g. a `same54-xpro` with the ATREB215-XPRO module, enable the `at86rf215` driver in e.g.  `examples/networking/gnrc/networking`.

On `master` this will randomly hang during init when ethernet init is interrupted by a GPIO interrupt from `at86rf215`.

```
#0  event_post (queue=<optimized out>, event=0x200015b8 <_netif+272>) at /home/benjamin.valentin@ml-pa.com/dev/RIOT/sys/event/event.c:50
50	        thread_flags_set(waiter, THREAD_FLAG_EVENT);
(gdb) bt
#0  event_post (queue=<optimized out>, event=0x200015b8 <_netif+272>) at /home/benjamin.valentin@ml-pa.com/dev/RIOT/sys/event/event.c:50
#1  0x0000f32a in isr_eic14 () at /home/benjamin.valentin@ml-pa.com/dev/RIOT/cpu/sam0_common/periph/gpio.c:554
#2  <signal handler called>
#3  gpio_init_mux (pin=pin@entry=1090551822, mux=mux@entry=GPIO_MUX_L) at /home/benjamin.valentin@ml-pa.com/dev/RIOT/cpu/sam0_common/periph/gpio.c:148
#4  0x0000edc2 in sam0_eth_init () at /home/benjamin.valentin@ml-pa.com/dev/RIOT/cpu/sam0_common/periph/eth.c:361
#5  0x00010628 in _sam0_eth_init (netdev=0x20001c40 <sam0eth>) at /home/benjamin.valentin@ml-pa.com/dev/RIOT/cpu/sam0_common/sam0_eth/eth-netdev.c:159
#6  0x00008ae4 in gnrc_netif_default_init (netif=0x200016ec <_netif>) at /home/benjamin.valentin@ml-pa.com/dev/RIOT/sys/net/gnrc/netif/gnrc_netif.c:1663
#7  0x00008096 in _gnrc_netif_thread (args=0x200008a4 <main_stack+1380>) at /home/benjamin.valentin@ml-pa.com/dev/RIOT/sys/net/gnrc/netif/gnrc_netif.c:1997
#8  0x00002f58 in sched_switch (other_prio=0) at /home/benjamin.valentin@ml-pa.com/dev/RIOT/core/sched.c:303
```

With this patch applied, we do not get stuck in init, even after several `make reset`. 

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/21634#issuecomment-3469587892
~~Maybe we can even revert 54a744635c441d60a867ab392bd9627a84fe75e0 - will conduct some testing.~~ nope