### PR TITLE
pkg: Always add mandatory GITAMFLAGS

### DIFF
--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -63,7 +63,8 @@ ifeq ($(QUIET),1)
 endif
 
 GITFLAGS ?= -c user.email=buildsystem@riot -c user.name="RIOT buildsystem"
-GITAMFLAGS ?= $(GIT_QUIET) --no-gpg-sign --ignore-whitespace --whitespace=nowarn
+GITAMFLAGS ?= $(GIT_QUIET)
+GITAMFLAGS += --no-gpg-sign --ignore-whitespace --whitespace=nowarn
 
 .PHONY: all prepare clean distclean FORCE
 


### PR DESCRIPTION
### Contribution description

We really don't want a `make BOARD=some-board -C some/app` to ask for a password to unlock a GPG key. That is more than confusing on a desktop machine and a real pain on a headless device.

Hence, this adds the mandatory part of `GITAMFLAGS` with a `+=` rather than a `?=`.

### Testing procedure

E.g. remove `pkg/arduino_api` from your `$(BUILD_DIR)`, run `make BOARD=nucleo-f767zi -C tests/pkg/arduino_sdi_12 -j`. Then inside `$(BUILD_DIR)/pkg/arduino_api` run `git verify-commit HEAD`.

In `master`, this will state a valid signature, with this PR it will fail due to absense of a signature.

### Issues/PRs references

None