### PR TITLE
makefiles/docker: add support for tinybuild and smallbuild

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -401,6 +401,10 @@ $(HOME)/.cargo/registry:
 # Tinybuild is the default choice, smallbuild is selected when C++ or Rust are
 # used and the legacy riotbuild is the fallback for anything not covered by
 # the former two.
+#
+# REMOVE WHEN FIXED: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119953
+# The upstream g++ currently does not support MSP430, so we fallback to
+# riotbuild if C++ is used.
 ..in-docker-container: $(DEPS_FOR_RUNNING_DOCKER)
 	@mkdir -p $(HOME)/.cargo/git
 	@mkdir -p $(HOME)/.cargo/registry
@@ -435,7 +439,11 @@ $(HOME)/.cargo/registry:
 	      echo "riotbuild"; \
 	      ;; \
 	    "msp430") \
-	      echo "$${DOCKER_IMAGE_VARIANT}-msp430"; \
+	      if echo "$${USEMODULE}" | grep -q "cpp"; then \
+	        echo "riotbuild"; \
+	      else \
+	        echo "$${DOCKER_IMAGE_VARIANT}-msp430"; \
+	      fi; \
 	      ;; \
 	    "armv6m"|"armv7m"|"armv8m") \
 	      echo "$${DOCKER_IMAGE_VARIANT}-arm"; \


### PR DESCRIPTION
### Contribution description

This PR is a first draft to add support for tinybuild and smallbuild in the RIOT build system and automagically selects the right image to use depending on the featureset.

Doing this as a bash-script inside of the make recipe isn't super nice, but I couldn't come up with anything better tbh. 

The better solution would be to craft a Dockerfile that distinguishes between the platforms and possibly also gets `$(CPU_ARCH)` and `$(USEMODULE)` as parameters. Then it would be easier to keep the platforms in sync, because it's in the `riotdocker` repository and not here. Something like `build-dispatcher`.

There is Multi-Stage building in Docker, but I have no experience with that and for the `build-dispatcher` image, we'd have to pull Alpine Linux again I guess? So there would be a size penalty.

### Testing procedure

To test whether the switch-case distinguishes correctly between the variants, I just replaced the `docker` command with `echo`:

```
cbuec@W11nMate:~/RIOTstuff/riot-guides/RIOT$ BUILD_IN_DOCKER=1 DOCKER=echo BOARD=nrf52840dk make -C examples/basic/hello-world/
make: Entering directory '/home/cbuec/RIOTstuff/riot-guides/RIOT/examples/basic/hello-world'
Launching build container using image "docker.io/riot/tinybuild-arm@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736".
run --rm --tty --user 1000 --platform linux/amd64 -v /usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro -v /home/cbuec/RIOTstuff/riot-guides/RIOT:/data/riotbuild/riotbase:delegated -v /home/cbuec/.cargo/registry:/data/riotbuild/.cargo/registry:delegated -v /home/cbuec/.cargo/git:/data/riotbuild/.cargo/git:delegated -e RIOTBASE=/data/riotbuild/riotbase -e CCACHE_BASEDIR=/data/riotbuild/riotbase -e BUILD_DIR=/data/riotbuild/riotbase/build -e BUILD_IN_DOCKER=/data/riotbuild/riotbase/examples/basic/hello-world/1 -e RIOTPROJECT=/data/riotbuild/riotbase -e RIOTCPU=/data/riotbuild/riotbase/cpu -e RIOTBOARD=/data/riotbuild/riotbase/boards -e RIOTMAKE=/data/riotbuild/riotbase/makefiles -e BOARD=nrf52840dk -e DISABLE_MODULE= -e DEFAULT_MODULE= -e FEATURES_REQUIRED= -e FEATURES_BLACKLIST= -e FEATURES_OPTIONAL= -e USEMODULE= -e USEPKG= -w /data/riotbuild/riotbase/examples/basic/hello-world/ docker.io/riot/tinybuild-arm@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736 make
make: Leaving directory '/home/cbuec/RIOTstuff/riot-guides/RIOT/examples/basic/hello-world'
```

```
cbuec@W11nMate:~/RIOTstuff/riot-guides/RIOT$ BUILD_IN_DOCKER=1 DOCKER=echo BOARD=nrf52840dk make -C examples/lang_support/official/riot_and_cpp/
make: Entering directory '/home/cbuec/RIOTstuff/riot-guides/RIOT/examples/lang_support/official/riot_and_cpp'
Launching build container using image "docker.io/riot/smallbuild-arm@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736".
run --rm --tty --user 1000 --platform linux/amd64 -v /usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro -v /home/cbuec/RIOTstuff/riot-guides/RIOT:/data/riotbuild/riotbase:delegated -v /home/cbuec/.cargo/registry:/data/riotbuild/.cargo/registry:delegated -v /home/cbuec/.cargo/git:/data/riotbuild/.cargo/git:delegated -e RIOTBASE=/data/riotbuild/riotbase -e CCACHE_BASEDIR=/data/riotbuild/riotbase -e BUILD_DIR=/data/riotbuild/riotbase/build -e BUILD_IN_DOCKER=/data/riotbuild/riotbase/examples/lang_support/official/riot_and_cpp/1 -e RIOTPROJECT=/data/riotbuild/riotbase -e RIOTCPU=/data/riotbuild/riotbase/cpu -e RIOTBOARD=/data/riotbuild/riotbase/boards -e RIOTMAKE=/data/riotbuild/riotbase/makefiles -e BOARD=nrf52840dk -e DISABLE_MODULE= -e DEFAULT_MODULE= -e FEATURES_REQUIRED=cpp libstdcpp -e FEATURES_BLACKLIST= -e FEATURES_OPTIONAL= -e USEMODULE= -e USEPKG= -w /data/riotbuild/riotbase/examples/lang_support/official/riot_and_cpp/ docker.io/riot/smallbuild-arm@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736 make
make: Leaving directory '/home/cbuec/RIOTstuff/riot-guides/RIOT/examples/lang_support/official/riot_and_cpp'
```

Select the legacy `riotbuild`:
```
cbuec@W11nMate:~/RIOTstuff/riot-guides/RIOT$ BUILD_IN_DOCKER=1 DOCKER=echo DOCKER_IMAGE_VARIANT=riotbuild  B
OARD=nrf52840dk make -C examples/basic/hello-world/
make: Entering directory '/home/cbuec/RIOTstuff/riot-guides/RIOT/examples/basic/hello-world'
Launching build container using image "docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736".
run --rm --tty --user 1000 --platform linux/amd64 -v /usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro -v /home/cbuec/RIOTstuff/riot-guides/RIOT:/data/riotbuild/riotbase:delegated -v /home/cbuec/.cargo/registry:/data/riotbuild/.cargo/registry:delegated -v /home/cbuec/.cargo/git:/data/riotbuild/.cargo/git:delegated -e RIOTBASE=/data/riotbuild/riotbase -e CCACHE_BASEDIR=/data/riotbuild/riotbase -e BUILD_DIR=/data/riotbuild/riotbase/build -e BUILD_IN_DOCKER=/data/riotbuild/riotbase/examples/basic/hello-world/1 -e RIOTPROJECT=/data/riotbuild/riotbase -e RIOTCPU=/data/riotbuild/riotbase/cpu -e RIOTBOARD=/data/riotbuild/riotbase/boards -e RIOTMAKE=/data/riotbuild/riotbase/makefiles -e BOARD=nrf52840dk -e DISABLE_MODULE= -e DEFAULT_MODULE= -e FEATURES_REQUIRED= -e FEATURES_BLACKLIST= -e FEATURES_OPTIONAL= -e USEMODULE= -e USEPKG= -w /data/riotbuild/riotbase/examples/basic/hello-world/ docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736 make
make: Leaving directory '/home/cbuec/RIOTstuff/riot-guides/RIOT/examples/basic/hello-world'
```

### Issues/PRs references

Depends on https://github.com/RIOT-OS/riotdocker/pull/259.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
