### PR TITLE
gnrc/lorawan: define gnrc_lorawan_mcps_confirm as weak function

### DIFF
--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -160,6 +160,7 @@ release:
     gnrc_pktbuf_release(pkt);
 }
 
+__attribute__((weak))
 void gnrc_lorawan_mlme_indication(gnrc_lorawan_t *mac, mlme_indication_t *ind)
 {
     (void)mac;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Added `__attribute__((weak))` to `gnrc_lorawan_mcps_confirm` to enable usage as stated in the documentation [ "Supposed to be implemented by the user of GNRC LoRaWAN"](https://doc.riot-os.org/group__net__gnrc__lorawan.html#ga5bbef9c9c22db8945b1ecb93a9a5c405)

The weak attributes allows the user to actually define the function.

### Testing procedure

Successfully build Lorawan example 
```make -C examples/networking/gnrc/lorawan/```

With the following in `main.c`

```
void gnrc_lorawan_mcps_confirm(gnrc_lorawan_t *mac, mcps_confirm_t *confirm) {
    (void) mac;
    (void) confirm;
    puts("received ack");
}
```
