### PR TITLE
cpu/sam0_common: clear tamper wake on `gpio_irq_disable()`

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -1353,9 +1353,25 @@ void rtc_tamper_init(void);
  * @param   pin     The GPIO pin to be used for tamper detection
  * @param   flank   The Flank to trigger the even
  *
- * @return  0 on success, -1 if pin is not RTC pin
+ * @return  0 on success, -1 if pin is not an RTC pin
  */
 int rtc_tamper_register(gpio_t pin, gpio_flank_t flank);
+
+/**
+ * @brief   (Re-)Enable Tamper Detection pin
+ *
+ * @param   pin     The GPIO pin to be used for tamper detection
+ *
+ * @return  0 on success, -1 if pin is not an RTC pin
+ */
+int rtc_tamper_pin_enable(gpio_t pin);
+
+/**
+ * @brief   Disable Tamper Detection pin
+ *
+ * @param   pin     The GPIO pin to no longer be used for tamper detection
+ */
+void rtc_tamper_pin_disable(gpio_t pin);
 
 /**
  * @brief   Enable Tamper Detection IRQs

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -481,6 +481,10 @@ void gpio_irq_enable(gpio_t pin)
 
     /* enable wake from deep sleep */
     _set_extwake(pin, true);
+
+    if (IS_ACTIVE(MODULE_PERIPH_GPIO_TAMPER_WAKE)) {
+        rtc_tamper_pin_enable(pin);
+    }
 }
 
 void gpio_irq_disable(gpio_t pin)
@@ -502,6 +506,10 @@ void gpio_irq_disable(gpio_t pin)
 
     /* disable wake from deep sleep */
     _set_extwake(pin, false);
+
+    if (IS_ACTIVE(MODULE_PERIPH_GPIO_TAMPER_WAKE)) {
+        rtc_tamper_pin_disable(pin);
+    }
 }
 
 #if defined(CPU_COMMON_SAML1X)

--- a/cpu/sam0_common/periph/rtc_rtt.c
+++ b/cpu/sam0_common/periph/rtc_rtt.c
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "atomic_utils.h"
 #include "pm_layered.h"
 #include "periph/rtc.h"
 #include "periph/rtt.h"
@@ -501,6 +502,30 @@ int rtc_tamper_register(gpio_t pin, gpio_flank_t flank)
     }
 
     return 0;
+}
+
+int rtc_tamper_pin_enable(gpio_t pin)
+{
+    int in = _rtc_pin(pin);
+
+    if (in < 0) {
+        return -1;
+    }
+
+    atomic_set_bit_u32(atomic_bit_u32(&tampctr, 2 * in));
+
+    return 0;
+}
+
+void rtc_tamper_pin_disable(gpio_t pin)
+{
+    int in = _rtc_pin(pin);
+
+    if (in < 0) {
+        return;
+    }
+
+    atomic_clear_bit_u32(atomic_bit_u32(&tampctr, 2 * in));
 }
 
 void rtc_tamper_enable(void)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We register the tamper pin in `gpio_init_int()`, so also disable it in `gpio_irq_disable()` (and re-enable it in `gpio_irq_enable()`).

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
