### PR TITLE
drivers/motor_driver: fix accidental braking

### DIFF
--- a/drivers/include/motor_driver.h
+++ b/drivers/include/motor_driver.h
@@ -68,12 +68,9 @@
  * - CCW (Counter ClockWise)
  * and a brake capability
  *
- * BRAKE LOW is functionally the same than BRAKE HIGH but some H-bridge only
- * brake on BRAKE HIGH due to hardware.
- * In case of single direction GPIO, there is no BRAKE.
- *
- * In case of brake, PWM duty cycle is always set to 0.
-
+ * Most H-bridges brake in both BRAKE HIGH and BRAKE LOW states,
+ * but some only support BRAKE HIGH due to hardware
+ * When breaking the PWM duty cycle is set to 0.
  * @{
  * @file
  * @brief       High-level driver for DC motors

--- a/drivers/motor_driver/motor_driver.c
+++ b/drivers/motor_driver/motor_driver.c
@@ -168,7 +168,6 @@ int motor_set(const motor_driver_t *motor_driver, uint8_t motor_id, \
     switch (motor_driver->params->mode) {
     /* Two direction GPIO, handling brake */
     case MOTOR_DRIVER_2_DIRS:
-        _motor_brake_two_dirs(motor, motor_driver->params->brake_inverted);
         break;
     case MOTOR_DRIVER_1_DIR:
         break;


### PR DESCRIPTION
### Contribution description

When the motor driver mode is set to `MOTOR_DRIVER_2_DIRS`, the states of the `DIR0` and `DIR1` pins encode both the rotation direction and whether the motor should brake. 
"Removing" the brakes causes both pins to be set to the inverse of the braking state. So, if the driver is configured to brake high, both pins will be set low, and vice versa. Most H-bridges will break both in the low and high state.

I also adjusted the phrasing in the documentation a bit.