### PR TITLE
drivers/at86rf215: re-enable RPC when TX is done

### DIFF
--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -226,6 +226,9 @@ void at86rf215_tx_done(at86rf215_t *dev)
     }
 
     at86rf215_reg_write(dev, dev->BBC->RG_AMCS, amcs);
+
+    /* re-enable reduced power consumption */
+    at86rf215_enable_rpc(dev);
 }
 
 static bool _tx_ongoing(at86rf215_t *dev)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We disable reduced power consumption during CCA in `at86rf215_netdev.c:1115` but don't re-enable it.

Let's do so in `at86rf215_tx_done()`


### Testing procedure

Reduces idle power consumption with MR-O-QPSK by ~3.5 mA per transceiver with `CFLAGS += -DCONFIG_AT86RF215_RPC_EN=1`



### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
