### PR TITLE
pkg: Add `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` to cmake flags [backport 2025.10]

### DIFF
--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -27,9 +27,12 @@ $(BINDIR)/ccn-lite.a: $(PKG_BUILD_DIR)/lib/libccnl-riot.a
 $(PKG_BUILD_DIR)/lib/libccnl-riot.a: $(PKG_BUILD_DIR)/Makefile
 	$(MAKE) -C $(PKG_BUILD_DIR)
 
+# TODO: Drop `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` once upstream is compatible
+#       with newer cmake (e.g. compilation still succeeds with cmake 4.x)
 $(PKG_BUILD_DIR)/Makefile: $(PKG_PREPARED) $(TOOLCHAIN_FILE) | ..cmake_version_supported
 	cmake -B$(PKG_BUILD_DIR) -H$(PKG_SOURCE_DIR)/src \
 	      -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE) \
+	      -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 	      -DCCNL_RIOT=1 -DRIOT_CFLAGS="$(RIOT_CFLAGS)" -DBUILD_TESTING=OFF
 
 $(TOOLCHAIN_FILE): FORCE

--- a/pkg/cryptoauthlib/Makefile
+++ b/pkg/cryptoauthlib/Makefile
@@ -36,8 +36,11 @@ cryptoauth: $(PKG_BUILD_DIR)/Makefile
 	$(MAKE) -C $(PKG_BUILD_DIR)
 	cp $(PKG_BUILD_DIR)/libcryptoauth.a $(BINDIR)/$(PKG_NAME).a
 
+# TODO: Drop `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` once upstream is compatible
+#       with newer cmake (e.g. compilation still succeeds with cmake 4.x)
 $(PKG_BUILD_DIR)/Makefile: $(TOOLCHAIN_FILE)
 	cmake -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE) \
+		  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 		  -Wno-dev \
 		  -DATCA_NO_HEAP:BOOL=TRUE \
 		  -B$(PKG_BUILD_DIR) \

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -46,12 +46,15 @@ $(BINDIR)/jerryscript.a: $(PKG_BUILD_DIR)/Makefile
 	@cp $(PKG_BUILD_DIR)/lib/libjerry-ext.a $(BINDIR)/jerryscript-ext.a
 	@cp $(PKG_BUILD_DIR)/lib/libjerry-port-default.a $(BINDIR)/jerryscript-port-default.a
 
+# TODO: Drop `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` once upstream is compatible
+#       with newer cmake (e.g. compilation still succeeds with cmake 4.x)
 $(PKG_BUILD_DIR)/Makefile:
 	cmake -B$(PKG_BUILD_DIR) -H$(PKG_SOURCE_DIR) \
 	 -DCMAKE_SYSTEM_NAME=RIOT \
 	 -DCMAKE_SYSTEM_PROCESSOR="$(MCPU)" \
 	 -DCMAKE_C_COMPILER=$(CC) \
 	 -DCMAKE_C_COMPILER_WORKS=TRUE \
+	 -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 	 -DENABLE_LTO=OFF \
 	 -DENABLE_AMALGAM=OFF \
 	 -DHAVE_TIME_H=0 \

--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -64,6 +64,8 @@ $(BINDIR)/openthread-$(TD).a: $(OT_CORE_LIB_DIR)/libopenthread-$(TD).a
 $(OT_CORE_LIB_DIR)/libopenthread-$(TD).a: $(PKG_BUILD_DIR)/Makefile
 	$(QQ)"$(MAKE)" -C $(PKG_BUILD_DIR) $(OT_MODULES)
 
+# TODO: Drop `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` once upstream is compatible
+#       with newer cmake (e.g. compilation still succeeds with cmake 4.x)
 $(PKG_BUILD_DIR)/Makefile:
 	cmake -Wno-dev -B$(PKG_BUILD_DIR) -H$(PKG_SOURCE_DIR) \
 	 -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY \
@@ -75,6 +77,7 @@ $(PKG_BUILD_DIR)/Makefile:
 	 -DCMAKE_CXX_FLAGS="$(OT_C_FLAGS) $(OT_CXXFLAGS) -fno-exceptions -fno-rtti" \
 	 -DCMAKE_NM="$(NM)" \
 	 -DCMAKE_STRIP="$(STRIP)" \
+	 -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 	 -DOT_PLATFORM=NO \
 	 -DOT_CONFIG="$(RIOTBASE)/pkg/openthread/include/platform_config.h" \
 	 -DOT_APP_CLI=$(OT_APP_CLI) \


### PR DESCRIPTION
# Backport of #21839

### Contribution description

This disable policy enforcement of newer cmake 4.1.2 on older cmake projects. The flags can be removed once the upstream projects are compatible with newer versions of cmake.

### Testing procedure

- Green CI
- Compilation with cmake 4.1.2 (e.g. Alpine Edge) no longer fails for the following apps
	- examples/lang_support/community/javascript
	- tests/pkg/nimble_autoconn_ccnl
	- tests/pkg/cryptoauthlib_internal-tests
	- tests/pkg/cryptoauthlib_compare_sha256
	- examples/networking/misc/openthread
	- examples/networking/misc/ccn-lite-relay

### Issues/PRs references

None