### PR TITLE
drivers/abp2: faulty saul init for multiple abp2 devices

### DIFF
--- a/drivers/saul/init_devs/auto_init_abp2.c
+++ b/drivers/saul/init_devs/auto_init_abp2.c
@@ -60,7 +60,7 @@ void auto_init_abp2(void)
         saul_entries[(i * 2)].dev = &(abp2_devs[i]);
         saul_entries[(i * 2)].name = abp2_saul_info[i][0].name;
         saul_entries[(i * 2)].driver = &abp2_saul_driver_press;
-        saul_reg_add(&(saul_entries[i]));
+        saul_reg_add(&(saul_entries[(i * 2)]));
 
         /* temperature */
         saul_entries[(i * 2) + 1].dev = &(abp2_devs[i]);


### PR DESCRIPTION
### Contribution description

`abp2` device register two SAUL entries each. 
For all but the first `abp2` device the wrong SAUL info is added to the registry. 