### PR TITLE
boards: don't show pin conflict warnings for info and generate targets

### DIFF
--- a/boards/common/nucleo64/Makefile.dep
+++ b/boards/common/nucleo64/Makefile.dep
@@ -2,13 +2,16 @@
 include $(RIOTMAKE)/utils/ansi.mk
 include $(RIOTMAKE)/color.inc.mk
 
-ifneq (,$(filter periph_spi,$(USEMODULE)))
-  # The LED pin is also used for SPI, disable the LED0 module (once)
-  ifeq (,$(filter periph_init_led0,$(DISABLE_MODULE)))
-    DISABLE_MODULE += periph_init_led0
+# Don't show warnings for info and generate targets
+ifeq (,$(filter info-% generate-%,$(MAKECMDGOALS)))
+  ifneq (,$(filter periph_spi,$(USEMODULE)))
+    # The LED pin is also used for SPI, disable the LED0 module (once)
+    ifeq (,$(filter periph_init_led0,$(DISABLE_MODULE)))
+      DISABLE_MODULE += periph_init_led0
 
-    MSG="Warning: Using periph_spi on Nucleo64 boards will disable LED0 due to pin conflicts."
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)$(MSG)$(COLOR_RESET)" 1>&2)
+      MSG="Warning: Using periph_spi on Nucleo64 boards will disable LED0 due to pin conflicts."
+      $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)$(MSG)$(COLOR_RESET)" 1>&2)
+    endif
   endif
 endif
 

--- a/boards/seeedstudio-xiao-esp32c3/Makefile.dep
+++ b/boards/seeedstudio-xiao-esp32c3/Makefile.dep
@@ -1,13 +1,16 @@
-ifneq (,$(filter periph_spi, $(USEMODULE)))
-  ifeq (,$(filter periph_init_buttons, $(DISABLE_MODULE)))
-    DISABLE_MODULE += periph_init_buttons
+# Don't show warnings for info and generate targets
+ifeq (,$(filter info-% generate-%,$(MAKECMDGOALS)))
+  ifneq (,$(filter periph_spi, $(USEMODULE)))
+    ifeq (,$(filter periph_init_buttons, $(DISABLE_MODULE)))
+      DISABLE_MODULE += periph_init_buttons
 
-    MSG="Warning: Using periph_spi on Seeed Studio Xiao ESP32C3 board will disable BUTTON0 due to pin conflict."
-    $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)$(MSG)$(COLOR_RESET)" 1>&2)
+      MSG="Warning: Using periph_spi on Seeed Studio Xiao ESP32C3 board will disable BUTTON0 due to pin conflict."
+      $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)$(MSG)$(COLOR_RESET)" 1>&2)
+    endif
+  else ifneq (,$(filter saul_default,$(USEMODULE)))
+    # The button is the only SAUL device. Enable it only when SPI is not enabled.
+    USEMODULE += saul_gpio
   endif
-else ifneq (,$(filter saul_default,$(USEMODULE)))
-  # The button is the only SAUL device. Enable it only when SPI is not enabled.
-  USEMODULE += saul_gpio
 endif
 
 ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))


### PR DESCRIPTION
### Contribution description

Inspired by https://github.com/RIOT-OS/RIOT/pull/20430/commits/ecc8bda62f456b1f572fce7ccbcb78f98845b603, I disabled the pin conflict warnings for the Nucleo64 and Seeedstudio Xiao ESP32C3 for `info-*` and `generate-*` targets to avoid useless spamming.

Also I changed the warning color from red to yellow, following a comment from Gunar: https://github.com/RIOT-OS/RIOT/pull/21463#discussion_r2092845065

### Testing procedure

Current behavior:
<img width="951" height="1044" alt="image" src="https://github.com/user-attachments/assets/a2fbb615-e1d2-49d7-b198-9a7c3441aae6" />



With this PR:
```
buechse@skyleaf:~/RIOTstuff/riot-vanillaice/RIOT$ make -C tests/drivers/paa5100je/ generate-Makefile.ci
make: Entering directory '/home/buechse/RIOTstuff/riot-vanillaice/RIOT/tests/drivers/paa5100je'
acd52832                                OK
adafruit-clue                           OK
adafruit-feather-nrf52840-express       OK
adafruit-feather-nrf52840-sense         OK
adafruit-grand-central-m4-express       OK
adafruit-itsybitsy-m4                   OK
...
```

### Issues/PRs references
None.

