### PR TITLE
dist/tools/edbg: bump version

### DIFF
--- a/dist/tools/edbg/Makefile
+++ b/dist/tools/edbg/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=edbg
 PKG_URL=https://github.com/ataradov/edbg
-PKG_VERSION=7bde7a4168c801746941f8df2fe5849823085545
+PKG_VERSION=7d0626dfa5c359a6dcd8406c8c1259b74b2b2ebd
 PKG_LICENSE=BSD-3-Clause
 
 # manually set some RIOT env vars, so this Makefile can be called stand-alone


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`make flash` still works on e.g. `same54-xpro`

```
[INFO] edbg binary successfully built!
/home/benjamin.valentin@ml-pa.com/dev/RIOT/dist/tools/edbg/edbg.sh flash /home/benjamin.valentin@ml-pa.com/dev/RIOT/examples/basic/hello-world/bin/same54-xpro/hello-world.bin
### Flashing Target ###
Debugger: ATMEL EDBG CMSIS-DAP ATML2748101800008783 03.25.01B6 (S)
Clock frequency: 16.0 MHz
Target: SAM E54P20A (Rev D)
Verification...
at address 0x4 expected 0xf9, read 0x0d
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML2748101800008783 03.25.01B6 (S)
Clock frequency: 16.0 MHz
Target: SAM E54P20A (Rev D)
Programming..... done.
Verification.................... done.
Done flashing

```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
