### PR TITLE
dist/tools: fix no-merge-keywords of pr_check (fix regression from #21803)

### DIFF
--- a/dist/tools/pr_check/no_merge_keywords
+++ b/dist/tools/pr_check/no_merge_keywords
@@ -1,12 +1,12 @@
-[0-9a-f]\+ SQUASH
-[0-9a-f]\+ FIX
-[0-9a-f]\+ REMOVE *ME
-[0-9a-f]\+ Update
-[0-9a-f]\+ \<DONOTMERGE\>
-[0-9a-f]\+ \<DO NOT MERGE\>
-[0-9a-f]\+ \<DON'T MERGE\>
-[0-9a-f]\+ \<NO MERGE\>
-[0-9a-f]\+ \<DELETE ME\>
-[0-9a-f]\+ \<DELETEME\>
-[0-9a-f]\+ \<WIP\>
-[0-9a-f]\+ \<TEMP\>
+^[0-9a-f]\+ SQUASH
+^[0-9a-f]\+ FIX
+^[0-9a-f]\+ REMOVE *ME
+^[0-9a-f]\+ Update
+^[0-9a-f]\+ \<DONOTMERGE\>
+^[0-9a-f]\+ \<DO NOT MERGE\>
+^[0-9a-f]\+ \<DON'T MERGE\>
+^[0-9a-f]\+ \<NO MERGE\>
+^[0-9a-f]\+ \<DELETE ME\>
+^[0-9a-f]\+ \<DELETEME\>
+^[0-9a-f]\+ \<WIP\>
+^[0-9a-f]\+ \<TEMP\>


### PR DESCRIPTION
### Contribution description

The no-merge-keyword expressions were prone to false positives, because in #21803 I removed the `^` of the regex, that tells it to only match from the line beginning.


### Testing procedure

Current `master` matches to `e update` and therefore causes a false positive.
```
cbuec@W11nMate:~/RIOTstuff/riot-guides/RIOT$ echo "cpu/stm32: style update of rtc_all.c" | grep -i -f dist/tools/pr_check/no_merge_keywords
cpu/stm32: style update of rtc_all.c
```

This PR does not.
```
cbuec@W11nMate:~/RIOTstuff/riot-guides/RIOT$ echo "cpu/stm32: style update of rtc_all.c" | grep -i -f dist/tools/pr_check/no_merge_keywords
```


### Issues/PRs references

Fixes regression introduced in #21803.
