### PR TITLE
boards/{cc2538dk,cc2650stk}: Fix Dead Links in Documentation

### DIFF
--- a/boards/cc2538dk/doc.md
+++ b/boards/cc2538dk/doc.md
@@ -43,7 +43,7 @@ Activating this bootloader is NOT enabled if the flash content is in factory
 default state (e.g. after unboxing). To set the bits in the CCA accordingly you
 have to follow the guidelines found [here](https://web.archive.org/web/20170610111337/http://processors.wiki.ti.com/index.php/CC2538_Bootloader_Backdoor).
 To manage this first time access you have to download the
-["Uniflash"](http://processors.wiki.ti.com/index.php/Category:CCS_UniFlash) tool
+["Uniflash"](https://web.archive.org/web/20201215123705/https://processors.wiki.ti.com/index.php/Category:CCS_UniFlash) tool
 at TI's website.
 
 Some Linux machines may not recognize the CC2538DK's vendor and product ID

--- a/boards/cc2650stk/doc.md
+++ b/boards/cc2650stk/doc.md
@@ -53,8 +53,8 @@ The arm-none-eabi toolchain works fine. You can get it
 
 ## Programming and Debugging
 
-You'll need [debugging hardware](https://processors.wiki.ti.com/index.php?title=CC13xx_CC26xx_Tools_Overview#Debuggers).
-So far, the [XDS110 debug probe](https://www.ti.com/tool/CC-DEVPACK-DEBUG) has
+You'll need [debugging hardware](https://web.archive.org/web/20180920132949/http://processors.wiki.ti.com/index.php/CC13xx_CC26xx_Tools_Overview#Debuggers).
+So far, the [XDS110 debug probe](https://web.archive.org/web/20180919044431/http://www.ti.com/tool/cc-devpack-debug) has
 been tested. That bugger requires you to load a firmware onto it each time it
 powers up. The tool is contained in the Uniflash utility or the `CodeComposer
 Studio` from TI. Look for a folder called `uscif` in the installation directory,


### PR DESCRIPTION
### Contribution description

@chrysn discoverd in 2019 that some links are broken, this PR fixes that with Web Archive links.

Unfortunately TI disabled that Wiki entirely, so the Web Archive is the way to go apparently. I don't know anything about the TI chips, so idk if there are better resources available nowadays.

### Testing procedure

Check that the links work.

### Issues/PRs references

Fixes #12889.