### PR TITLE
cpu/sam0_common: init: remove superflous reads

### DIFF
--- a/cpu/sam0_common/periph/usbdev.c
+++ b/cpu/sam0_common/periph/usbdev.c
@@ -332,12 +332,12 @@ static void _usbdev_init(usbdev_t *dev)
     _poweron(usbdev);
 
     /* Reset peripheral */
-    usbdev->config->device->CTRLA.reg |= USB_CTRLA_SWRST;
+    usbdev->config->device->CTRLA.reg = USB_CTRLA_SWRST;
     while (_syncbusy_swrst(usbdev)) {}
 
     /* Enable USB device */
     usbdev->config->device->DESCADD.reg = (uint32_t)&usbdev->banks;
-    usbdev->config->device->CTRLA.reg |= USB_CTRLA_ENABLE;
+    usbdev->config->device->CTRLA.reg = USB_CTRLA_ENABLE;
     while (_syncbusy_enable(usbdev)) {}
 
     /* Calibration values */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

reset take precedence over everything else in the same write an will reset all bits to their default value. 

after the reset finished ( ensured by the loop) we know the register value of CTRLA to be 0x00.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
