### PR TITLE
rust: Update riot-sys selectively to fix C2Rust incompatibility

### DIFF
--- a/examples/lang_support/official/rust-async/Cargo.lock
+++ b/examples/lang_support/official/rust-async/Cargo.lock
@@ -553,7 +553,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "riot-sys"
 version = "0.7.15"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#4f83b534fee5e8d68881a79236e70fa38d313ee1"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#88d87768c8046878a927e792f0540f61f7acb999"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",

--- a/examples/lang_support/official/rust-gcoap/Cargo.lock
+++ b/examples/lang_support/official/rust-gcoap/Cargo.lock
@@ -767,7 +767,7 @@ dependencies = [
 [[package]]
 name = "riot-sys"
 version = "0.7.15"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#4f83b534fee5e8d68881a79236e70fa38d313ee1"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#88d87768c8046878a927e792f0540f61f7acb999"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",

--- a/examples/lang_support/official/rust-hello-world/Cargo.lock
+++ b/examples/lang_support/official/rust-hello-world/Cargo.lock
@@ -437,7 +437,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "riot-sys"
 version = "0.7.15"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#4f83b534fee5e8d68881a79236e70fa38d313ee1"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#88d87768c8046878a927e792f0540f61f7acb999"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",

--- a/sys/rust_riotmodules_standalone/Cargo.lock
+++ b/sys/rust_riotmodules_standalone/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "riot-sys"
 version = "0.7.15"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#4f83b534fee5e8d68881a79236e70fa38d313ee1"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#88d87768c8046878a927e792f0540f61f7acb999"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",

--- a/tests/rust_minimal/Cargo.lock
+++ b/tests/rust_minimal/Cargo.lock
@@ -437,7 +437,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "riot-sys"
 version = "0.7.15"
-source = "git+https://github.com/RIOT-OS/rust-riot-sys#4f83b534fee5e8d68881a79236e70fa38d313ee1"
+source = "git+https://github.com/RIOT-OS/rust-riot-sys#88d87768c8046878a927e792f0540f61f7acb999"
 dependencies = [
  "bindgen",
  "c2rust-asm-casts",


### PR DESCRIPTION
### Contribution description

This updates the package just so far that the changes from [60] (fixing compatibility with C2Rust 0.21) are in, but not [61] (which caused yet to be understood trouble on native32 builds).

[60]: https://github.com/RIOT-OS/rust-riot-sys/pull/60
[61]: https://github.com/RIOT-OS/rust-riot-sys/pull/61

In this, it is a subset of  https://github.com/RIOT-OS/RIOT/pull/21840, which will need to be re-run onto this later.

This PR is prioritized over 21840 because the fixes should be backportable to the upcoming release.

### Testing procedure

I'm tied up in other projects, and did not test this. In particular, I think that this will need a runtime testing on native32 (probably running all the examples once, and in gcoap running some CoAP request) because I have a hunch that the troubles in #21840 that require disabling native32 might not be bugs, but actually new checks that detect alignment or size issues. Testing should at least show if that is an acute problem.

### Issues/PRs references

Breaks: https://github.com/RIOT-OS/RIOT/pull/21840