### PR TITLE
cpu/nrf5x_common: copy vendor files only when newer

### DIFF
--- a/cpu/nrf5x_common/Makefile.nrfx
+++ b/cpu/nrf5x_common/Makefile.nrfx
@@ -65,4 +65,4 @@ include $(RIOTBASE)/pkg/pkg.mk
 # subfolder called "vendor".
 all:
 	@mkdir -p $(VENDOR_FOLDER)
-	@cp $(addprefix $(PKG_SOURCE_DIR)/, $(PKG_SPARSE_PATHS)) $(VENDOR_FOLDER)
+	@cp -u $(addprefix $(PKG_SOURCE_DIR)/, $(PKG_SPARSE_PATHS)) $(VENDOR_FOLDER)


### PR DESCRIPTION
### Contribution description
With #21800, nrf5x_common pull vendor files from an external repo. The issue is that the target that copies the vendor files does so unconditionally, resulting in an update of the vendor files on every compilation, forcing `make` to rebuild mostly everything every time.

This adds a flag to the `cp` command to only copy the files over when the vendor ones are indeed newer.

### Testing procedure

Using some nrf-based board, compile some application (e.g., `hello-world`) twice using `QUIET=0`. You should see that without this patch many objects are recompiled every time.

### Issues/PRs references
#21800