### PR TITLE
pkg/lwip: fix dependencies when LWIP IPv4 and LWIP_DHCP is used

### DIFF
--- a/pkg/lwip/Makefile.dep
+++ b/pkg/lwip/Makefile.dep
@@ -111,13 +111,17 @@ endif
 
 # Addition of missing modules for boards that do not have physical network
 # module - a dirty hack when lwip_dhcp is used for IPv4 (use of lwip_ipv4 module)
-# on such boards (lack of netdev_new_api module)
+# on such boards (lack of netdev_eth module)
+#
+# This is dirty-hack" to solve compilation problem
+# TODO:
+# Find the root cause of the problem. PR #17174 and PR #17162 could be a good
+# starting point.
 ifneq (,$(filter lwip_dhcp,$(USEMODULE)))
   ifneq (,$(filter lwip_ipv4,$(USEMODULE)))
-    ifeq (,$(filter netdev_new_api,$(USEMODULE)))
+    ifeq (,$(filter netdev_eth,$(USEMODULE)))
       USEMODULE += netdev_eth
-      USEMODULE += netdev_new_api
-   endif
+    endif
   endif
 endif
 


### PR DESCRIPTION
### Contribution description

When LWIP IPv4 and LWIP DHCP is used, in file `build/pkg/lwip/src/include/lwip/acd.h` (Address Conflict Detection)
definition of `struct etharp_hdr` is needed. This definition is available in the module `netdev_eth`. 

In [link](https://github.com/RIOT-OS/RIOT/pull/21342#discussion_r2487082601) @mguetschow reported that previous solution from PR #21342 did not work for `nrf52840dk`.

This PR is some "dirty-hack" to solve this problem.

**_TODO:_**
Find the root cause of the problem. PR #17174 and PR #17162 could be a good starting point.

### Testing procedure

Without this PR on current master `LWIP_IPV4=1 make -C examples/networking/coap/gcoap_dtls BOARD=nrf52840dk` ends with error:

```
"make" -C /data/RIOT/RIOT/build/pkg/lwip/src/api -f /data/RIOT/RIOT/Makefile.base MODULE=lwip_api
In file included from /data/RIOT/RIOT/build/pkg/lwip/src/include/lwip/dhcp.h:49,
                 from /data/RIOT/RIOT/build/pkg/lwip/src/include/lwip/netifapi.h:41,
                 from /data/RIOT/RIOT/build/pkg/lwip/src/api/netifapi.c:46:
/data/RIOT/RIOT/build/pkg/lwip/src/include/lwip/acd.h:97:48: error: 'struct etharp_hdr' declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
   97 | void acd_arp_reply(struct netif *netif, struct etharp_hdr *hdr);
      |                                                ^~~~~~~~~~
```

With this PR, everything works well. 
I tested this for `nrf52840dk` (lack of Ethernet interface but radio interface), `nucleo-f439zi` (with Ethernet interface), `native` (lack of any network interface).

### Issues/PRs references

Fixes PR #21342