### PR TITLE
makefiles/tools/openocd-adapters: let OpenOCD auto-select transport

### DIFF
--- a/makefiles/tools/openocd-adapters/stlink.inc.mk
+++ b/makefiles/tools/openocd-adapters/stlink.inc.mk
@@ -7,13 +7,9 @@ STLINK_VERSION ?= 2-1
 # Also pass the correct version of the ST-Link adapter to the script.
 OPENOCD_ADAPTER_INIT ?= -c 'set stlink_version $(STLINK_VERSION);source $(RIOTBASE)/dist/tools/openocd/adapters/stlink.cfg'
 
-# If swd / jtag is selected by the board, prefix it with hla_
-ifneq (,$(filter swd jtag,$(OPENOCD_TRANSPORT)))
-  OPENOCD_TRANSPORT := hla_$(OPENOCD_TRANSPORT)
-endif
-
-# All ST-Link adapters support hla_swd, so use that for simplicity
-OPENOCD_TRANSPORT ?= hla_swd
+# Let OpenOCD decide which transport to select, as there is
+# an incompatibility with different versions of OpenOCD
+OPENOCD_TRANSPORT ?=
 
 # Add serial matching command, only if DEBUG_ADAPTER_ID was specified
 ifneq (,$(DEBUG_ADAPTER_ID))


### PR DESCRIPTION
### Contribution description

As described in #21781, different OpenOCD versions require different transport protocols for the ST-Link and there is no common ground except for "let OpenOCD decide".

Therefore we do exactly that and let OpenOCD decide.

This PR also removes the forced prefixing, because perhaps we *want* to select `swd` and not `hla_swd` and the current code does not allow it.

### Testing procedure

Flash an STM32 based board with OpenOCD 0.11, 0.12 Release and 0.12 Upstream, preferrably one based on an ST-Link V2 and ST-Link V3, also one with a new(ish) microcontroller such as the STM32C0.

*Insert Test Traces here*

### Issues/PRs references

Fixes #21781.
Partly reverts #14480.