### PR TITLE
drivers/periph/i2c: Replace LaTeX formula with static SVG file in documentation

### DIFF
--- a/doc/doxygen/src/periph_i2c_bus_equations.svg
+++ b/doc/doxygen/src/periph_i2c_bus_equations.svg
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="460.8pt"
+   height="236.16pt"
+   viewBox="0 0 460.8 236.16"
+   version="1.1"
+   id="svg27"
+   sodipodi:docname="periph_i2c_bus_equations.svg"
+   inkscape:export-filename="periph_i2c_bus_equations.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview27"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="pt"
+     inkscape:zoom="0.2445376"
+     inkscape:cx="308.74598"
+     inkscape:cy="155.39533"
+     inkscape:window-width="937"
+     inkscape:window-height="981"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg27" />
+  <metadata
+     id="metadata1">
+    <rdf:RDF>
+      <cc:Work>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:date>2025-11-12T23:37:48.638870</dc:date>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Matplotlib v3.6.3, https://matplotlib.org/</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs1">
+    <style
+       type="text/css"
+       id="style1">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+  </defs>
+  <g
+     id="figure_1">
+    <g
+       id="axes_1">
+      <g
+         id="text_1">
+        <g
+           transform="translate(140.96 46.728)"
+           id="g6">
+          <text
+             stroke="white"
+             stroke-width="0.8"
+             paint-order="stroke fill"
+             fill="black"
+             id="text6"><tspan
+               style="font: italic 26px 'STIXGeneral'"
+               x="0"
+               y="-0.6157812500000048"
+               id="tspan1">R</tspan><tspan
+               style="font: italic 18.2px 'STIXGeneral'"
+               x="15.885986 29.026378 34.085976 69.651617 110.651617 117.694313"
+               y="2.824843749999996 2.824843749999996 2.824843749999996 -15.1109375 9.570156249999997 -15.1109375"
+               id="tspan2">minVIV</tspan><tspan
+               style="font: 26px 'STIXGeneral'"
+               x="48.087238"
+               y="-0.6157812500000048"
+               id="tspan3">=</tspan><tspan
+               style="font: italic 12.74px 'STIXGeneral'"
+               x="80.771808 89.970082 116.71221 125.910484 128.814503 138.012777 149.338629 158.536903 164.919636"
+               y="-12.7025 -12.7025 11.978593750000002 11.978593750000002 -12.7025 -12.7025 -12.7025 -12.7025 -12.7025"
+               id="tspan4">DDOLOLmax</tspan><tspan
+               style="font: 18.2px 'STIXGeneral'"
+               x="102.599247"
+               y="-15.1109375"
+               id="tspan5">−</tspan><tspan
+               style="font: 12.74px 'STIXGeneral'"
+               x="145.096214 170.576192"
+               y="-12.7025"
+               id="tspan6">()</tspan></text>
+          <rect
+             x="69.651617"
+             y="-4.943906"
+             width="105.969802"
+             height="1.625"
+             id="rect6" />
+        </g>
+        <g
+           transform="translate(146.42 91.032)"
+           id="g11">
+          <text
+             stroke="white"
+             stroke-width="0.8"
+             paint-order="stroke fill"
+             fill="black"
+             id="text11"><tspan
+               style="font: italic 26px 'STIXGeneral'"
+               x="0"
+               y="-0.8212499999999991"
+               id="tspan7">R</tspan><tspan
+               style="font: italic 18.2px 'STIXGeneral'"
+               x="15.885986 29.026378 38.144568 113.691014 139.262892"
+               y="2.6193750000000016 2.6193750000000016 2.6193750000000016 -13.0578125 9.7803125"
+               id="tspan8">maxtC</tspan><tspan
+               style="font: 26px 'STIXGeneral'"
+               x="51.126634"
+               y="-0.8212499999999991"
+               id="tspan9">=</tspan><tspan
+               style="font: italic 12.74px 'STIXGeneral'"
+               x="118.750612 151.402289"
+               y="-10.649375000000001 12.188749999999999"
+               id="tspan10">rb</tspan><tspan
+               style="font: 18.2px 'STIXGeneral'"
+               x="72.691014 78.751607 87.851596 92.401585 101.501575 110.601564 119.701553 131.429621 158.575094"
+               y="9.7803125"
+               id="tspan11">(0.8473⋅)</tspan></text>
+          <rect
+             x="72.691014"
+             y="-5.149375"
+             width="91.944672"
+             height="1.625"
+             id="rect11" />
+        </g>
+      </g>
+      <g
+         id="text_2">
+        <g
+           transform="translate(161.045 145.36332)"
+           id="g14">
+          <text
+             stroke="white"
+             stroke-width="0.8"
+             paint-order="stroke fill"
+             fill="black"
+             id="text14"><tspan
+               style="font: italic 13px 'STIXGeneral'"
+               x="0"
+               y="-0.125"
+               id="tspan12">V</tspan><tspan
+               style="font: italic 9.1px 'STIXGeneral'"
+               x="7.942993 14.513194"
+               y="1.5953125000000004"
+               id="tspan13">DD</tspan><tspan
+               style="font: 13px 'DejaVu Serif'"
+               x="21.656833 25.789157 36.681735 40.814059 49.719821 58.09238 66.414157 74.735934 78.893649 86.237888 90.370212 97.71445 105.54111 109.698825 114.922946 122.673434 130.995212"
+               y="-0.125"
+               id="tspan14"> = Supply voltage</tspan></text>
+        </g>
+        <g
+           transform="translate(142.52 161.19732)"
+           id="g18">
+          <text
+             stroke="white"
+             stroke-width="0.8"
+             paint-order="stroke fill"
+             fill="black"
+             id="text18"><tspan
+               style="font: italic 13px 'STIXGeneral'"
+               x="0"
+               y="-0.125"
+               id="tspan15">V</tspan><tspan
+               style="font: italic 9.1px 'STIXGeneral'"
+               x="7.942993 14.513194 22.603088 29.173289 33.73239"
+               y="1.5953125000000004"
+               id="tspan16">OLmax</tspan><tspan
+               style="font: 9.1px 'STIXGeneral'"
+               x="19.572792 37.772792"
+               y="1.5953125000000004"
+               id="tspan17">()</tspan><tspan
+               style="font: 13px 'DejaVu Serif'"
+               x="41.376526 45.50885 56.401428 60.533752 69.166565 76.993225 88.120667 92.252991 96.410706 104.104065 111.448303 119.141663 123.299377 127.431702 134.77594 142.6026 146.760315 151.984436 159.734924 168.056702"
+               y="-0.125"
+               id="tspan18"> = Low level voltage</tspan></text>
+        </g>
+        <g
+           transform="translate(130.625 177.42132)"
+           id="g21">
+          <text
+             stroke="white"
+             stroke-width="0.8"
+             paint-order="stroke fill"
+             fill="black"
+             id="text21"><tspan
+               style="font: italic 13px 'STIXGeneral'"
+               x="0"
+               y="-0.125"
+               id="tspan19">I</tspan><tspan
+               style="font: italic 9.1px 'STIXGeneral'"
+               x="4.328995 10.899196"
+               y="1.5953125000000004"
+               id="tspan20">OL</tspan><tspan
+               style="font: 13px 'DejaVu Serif'"
+               x="16.532231 20.664555 31.557133 35.689458 44.32227 52.14893 63.276372 67.408696 71.566411 79.25977 86.604008 94.297368 98.455083 102.587407 110.414067 118.786626 124.010747 132.332524 140.705083 145.929204 150.061528 157.34229 165.714848 171.929204 178.143559 185.836919 194.209477"
+               y="-0.125"
+               id="tspan21"> = Low level output current</tspan></text>
+        </g>
+        <g
+           transform="translate(164.88 192.99532)"
+           id="g24">
+          <text
+             stroke="white"
+             stroke-width="0.8"
+             paint-order="stroke fill"
+             fill="black"
+             id="text24"><tspan
+               style="font: italic 13px 'STIXGeneral'"
+               x="0"
+               y="-0.125"
+               id="tspan22">t</tspan><tspan
+               style="font: italic 9.1px 'STIXGeneral'"
+               x="3.613998"
+               y="1.5953125000000004"
+               id="tspan23">r</tspan><tspan
+               style="font: 13px 'DejaVu Serif'"
+               x="7.72733 11.859654 22.752232 26.884557 35.790318 39.948033 48.26981 56.642369 64.392857 68.550572 72.682896 78.897252 83.054967 89.726353 97.419713 101.552037 106.776158 110.933873 123.261021"
+               y="-0.125"
+               id="tspan24"> = Signal rise time</tspan></text>
+        </g>
+        <g
+           transform="translate(160.07 208.82668)"
+           id="g27">
+          <text
+             stroke="white"
+             stroke-width="0.8"
+             paint-order="stroke fill"
+             fill="black"
+             id="text27"><tspan
+               style="font: italic 13px 'STIXGeneral'"
+               x="0"
+               y="-0.4375"
+               id="tspan25">C</tspan><tspan
+               style="font: italic 9.1px 'STIXGeneral'"
+               x="8.671005"
+               y="1.2828125000000004"
+               id="tspan26">b</tspan><tspan
+               style="font: 13px 'DejaVu Serif'"
+               x="13.794443 17.926767 28.819345 32.951669 42.504892 50.877451 57.548837 61.681161 68.961923 76.712411 85.034189 92.784677 100.065439 104.223154 109.447275 117.197763 125.570322 132.851083"
+               y="-0.4375"
+               id="tspan27"> = Bus capacitance</tspan></text>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -24,7 +24,7 @@
  * address and 8-bit register addresses and using a RESTART condition (CAUTION:
  * this example does not check any return values...):
  *
- * @code{c}
+ * ```c
  * // before accessing the bus, we need to acquire it
  * i2c_acquire(dev);
  * // next we write the register address, but create no STOP condition when done
@@ -33,12 +33,12 @@
  * i2c_read_byte(dev, device_addr, &reg_value, I2C_ADDR10);
  * // finally we have to release the bus
  * i2c_release(dev);
- * @endcode
+ * ```
  *
  * Example for writing a 16-bit register with 16-bit register addressing and
  * 7-bit device addressing:
  *
- * @code{c}
+ * ```c
  * // first, acquire the shared bus again
  * i2c_acquire(dev);
  * // write the 16-bit register address to the device and prevent STOP condition
@@ -47,7 +47,7 @@
  * i2c_write_bytes(dev, device_addr, reg_data, 2, 0);
  * // and finally free the bus again
  * i2c_release(dev);
- * @endcode
+ * ```
  *
  *
  * @section   sec_i2c_pull Pull Resistors
@@ -62,16 +62,7 @@
  * I2C bus lines.
  *
  * The minimum and maximum resistances are computed by:
- * \f{eqnarray*}{
- * R_{min} &=& \frac{V_{DD} - V_{OL(max)}} {I_{OL}}\\
- * R_{max} &=& \frac{t_r} {(0.8473 \cdot C_b)}
- * \f}<br>
- * where:<br>
- * \f$ V_{DD} =\f$ Supply voltage,
- * \f$ V_{OL(max)} =\f$ Low level voltage,
- * \f$ I_{OL} =\f$ Low level output current,
- * \f$ t_r =\f$ Signal rise time,
- * \f$ C_b =\f$ Bus capacitance <br>
+ * @image html periph_i2c_bus_equations.svg
  * <br>The pull-up resistors depend on the bus speed.
  * Some typical values are:<br>
  * Normal mode:       10k&Omega;<br>


### PR DESCRIPTION
### Contribution description

I started adding the MathJax support as discussed in #21490 but then I realized that it is somewhat stupid to add such a big dependency for static LaTeX formulas and instead asked ChatGPT to generate SVG files from said LaTeX formulas.

~~Also I changed the comments from `//` to `/* */` to stay consistent with our Coding Convention.~~
This breaks things when not inside a `doc.md` file.

### Testing procedure

Check the generated Doxygen documentation in the subpage `group__drivers__periph__i2c.html`.

### Issues/PRs references

Fixes #21490.
Depends on (and currently includes) #21372.