### PR TITLE
pkg/cn-cbor: fix unaligned access

### DIFF
--- a/pkg/cn-cbor/Makefile
+++ b/pkg/cn-cbor/Makefile
@@ -9,7 +9,6 @@ include $(RIOTBASE)/pkg/pkg.mk
 # Enable code forcing aligned reads
 CFLAGS += -DCBOR_ALIGN_READS
 CFLAGS += -Wno-return-local-addr
-CFLAGS += -Wno-cast-align
 
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)

--- a/pkg/cn-cbor/patches/0001-Use-unaligned-access-and-endian-helpers.patch
+++ b/pkg/cn-cbor/patches/0001-Use-unaligned-access-and-endian-helpers.patch
@@ -1,0 +1,40 @@
+From b0200fe47803508dffd5ef08989a0b0a6f14a41b Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
+Date: Sat, 15 Nov 2025 23:52:14 +0100
+Subject: [PATCH] Use unaligned access and endian helpers.
+
+This makes the code readable and correct.
+---
+ src/cn-encoder.c | 15 ++++++---------
+ 1 file changed, 6 insertions(+), 9 deletions(-)
+
+diff --git a/src/cn-encoder.c b/src/cn-encoder.c
+index d5b5bf0..e4c3a15 100644
+--- a/src/cn-encoder.c
++++ b/src/cn-encoder.c
+@@ -29,16 +29,13 @@ extern "C" {
+ #include "cn-cbor/cn-cbor.h"
+ #include "cbor.h"
+ 
++#include "endian.h"
++#include "unaligned.h"
++
+ #define hton8p(p) (*(uint8_t*)(p))
+-#define hton16p(p) (htons(*(uint16_t*)(p)))
+-#define hton32p(p) (htonl(*(uint32_t*)(p)))
+-static uint64_t hton64p(const uint8_t *p) {
+-  /* TODO: does this work on both BE and LE systems? */
+-  uint64_t ret = hton32p(p);
+-  ret <<= 32;
+-  ret |= hton32p(p+4);
+-  return ret;
+-}
++#define hton16p(p) (htobe16(unaligned_get_u16(p)))
++#define hton32p(p) (htobe32(unaligned_get_u32(p)))
++#define hton64p(p) (htobe64(unaligned_get_u64(p)))
+ 
+ typedef struct _write_state
+ {
+-- 
+2.51.2
+


### PR DESCRIPTION
### Contribution description

With GCC 15.2.0, the self test of cn-cbor fails. Using safe unaligned access and standard endian conversions fixes the issue.

### Testing procedure

#### In `master`

```
git:(master) ~/Repos/software/RIOT/master ➜ make BOARD=nrf52840dk -C tests/pkg/cn-cbor flash test
make: Entering directory '/home/maribu/Repos/software/RIOT/master/tests/pkg/cn-cbor'
Building application "tests_cn-cbor" for "nrf52840dk" with CPU "nrf52".
[...]
   text	   data	    bss	    dec	    hex	filename
  17696	    132	   3076	  20904	   51a8	/home/maribu/Repos/software/RIOT/master/tests/pkg/cn-cbor/bin/nrf52840dk/tests_cn-cbor.elf
[...]
READY
s
START
main(): This is RIOT! (Version: 2026.01-devel-120-g490b5)
.
tests_cn_cbor.test_parse (tests/pkg/cn-cbor/main.c 150) exp 63 was 0
.
run 2 failures 1
{ "threads": [{ "name": "main", "stack_size": 1536, "stack_used": 768}]}
```

#### This PR

```
git:(pkg/cn-cbor/fix-failing-test) ~/Repos/software/RIOT/master ➜ make BOARD=nrf52840dk -C tests/pkg/cn-cbor flash test
[...]
   text	   data	    bss	    dec	    hex	filename
  17728	    132	   3076	  20936	   51c8	/home/maribu/Repos/software/RIOT/master/tests/pkg/cn-cbor/bin/nrf52840dk/tests_cn-cbor.elf
[...]
READY
s
START
main(): This is RIOT! (Version: 2026.01-devel-121-g6510c62-pkg/cn-cbor/fix-failing-test)
..
OK (2 tests)
```

> [!NOTE]
> It seems that our build system does not properly update the checked out git repo when the custom patches change. As a result `$(BUILD_DIR)/pkg/cn-cbor` needs to be removed by hand between builds to have correct test results.

### Issues/PRs references

None