### PR TITLE
core/lib/atomic_c11: Add __atomic_test_and_set()

### DIFF
--- a/core/lib/atomic_c11.c
+++ b/core/lib/atomic_c11.c
@@ -261,15 +261,6 @@ TEMPLATE_ATOMIC_OP_FETCH_N(nand, &, 8, ~) /* __atomic_nand_fetch_8 */
 
 /* ***** Generic versions below ***** */
 
-/* Clang objects if you redefine a builtin.  This little hack allows us to
- * define a function with the same name as an intrinsic. */
-/* Hack origin: http://llvm.org/svn/llvm-project/compiler-rt/trunk/lib/builtins/atomic.c */
-#pragma redefine_extname __atomic_load_c __atomic_load
-#pragma redefine_extname __atomic_store_c __atomic_store
-#pragma redefine_extname __atomic_exchange_c __atomic_exchange
-#pragma redefine_extname __atomic_compare_exchange_c __atomic_compare_exchange
-#pragma redefine_extname __atomic_test_and_set_c __atomic_test_and_set
-
 /**
  * @brief Atomic generic load
  *
@@ -382,8 +373,7 @@ bool __atomic_compare_exchange_c(size_t len, void *ptr, void *expected,
  * This built-in function performs an atomic test-and-set operation on the byte
  * at *ptr. The byte is set to some implementation defined nonzero “set” value
  * and the return value is true if and only if the previous contents were “set”.
- * It should be only used for operands of type bool or char. For other types
- * only part of the value may be set.
+ * It should be only used for operands of type bool.
  *
  * All memory orders are valid.
  *
@@ -420,4 +410,15 @@ void __sync_synchronize(void)
     __asm__ volatile ("" : : : "memory");
 }
 #endif
+
+/* Clang objects if you redefine a builtin. This little hack allows us to
+ * define a function with the same name as an intrinsic. */
+/* Hack origin: http://llvm.org/svn/llvm-project/compiler-rt/trunk/lib/builtins/atomic.c */
+/* Note: The rename must come *after* the declaration of the symbol to work in
+ *       GCC. */
+#pragma redefine_extname __atomic_load_c __atomic_load
+#pragma redefine_extname __atomic_store_c __atomic_store
+#pragma redefine_extname __atomic_exchange_c __atomic_exchange
+#pragma redefine_extname __atomic_compare_exchange_c __atomic_compare_exchange
+#pragma redefine_extname __atomic_test_and_set_c __atomic_test_and_set
 /** @} */


### PR DESCRIPTION
### Contribution description

This adds a previously missing library implementation for `__atomic_test_and_set()`.

### Testing procedure

#### In `master`:

<details><summary><code>undefined reference to `__atomic_test_and_set'</code></summary>

```
 make BOARD=arduino-mega2560 -C tests/bench/msg_pingpong
make: Entering directory '/home/maribu/Repos/software/RIOT/master/tests/bench/msg_pingpong'
Building application "tests_msg_pingpong" for "arduino-mega2560" with CPU "atmega2560".

"make" -C /home/maribu/Repos/software/RIOT/master/boards
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/master/boards/arduino-mega2560
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/arduino-atmega
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/atmega
"make" -C /home/maribu/Repos/software/RIOT/master/core
"make" -C /home/maribu/Repos/software/RIOT/master/core/lib
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/atmega2560
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/atmega_common
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/atmega_common/periph
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/avr8_common
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/avr8_common/avr_libc_extra
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/avr8_common/periph
"make" -C /home/maribu/Repos/software/RIOT/master/drivers
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/periph_common
"make" -C /home/maribu/Repos/software/RIOT/master/sys
"make" -C /home/maribu/Repos/software/RIOT/master/sys/auto_init
"make" -C /home/maribu/Repos/software/RIOT/master/sys/div
"make" -C /home/maribu/Repos/software/RIOT/master/sys/frac
"make" -C /home/maribu/Repos/software/RIOT/master/sys/isrpipe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/libc
"make" -C /home/maribu/Repos/software/RIOT/master/sys/malloc_thread_safe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/pm_layered
"make" -C /home/maribu/Repos/software/RIOT/master/sys/preprocessor
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio_uart
"make" -C /home/maribu/Repos/software/RIOT/master/sys/test_utils/interactive_sync
"make" -C /home/maribu/Repos/software/RIOT/master/sys/test_utils/print_stack_usage
"make" -C /home/maribu/Repos/software/RIOT/master/sys/tiny_strerror
"make" -C /home/maribu/Repos/software/RIOT/master/sys/tsrb
"make" -C /home/maribu/Repos/software/RIOT/master/sys/ztimer
/usr/lib/gcc/avr/15.2.0/../../../../avr/bin/ld: /home/maribu/Repos/software/RIOT/master/tests/bench/msg_pingpong/bin/arduino-mega2560/application_tests_msg_pingpong/main.o: in function `main':
/home/maribu/Repos/software/RIOT/master/tests/bench/msg_pingpong/main.c:75:(.text.startup.main+0x68): undefined reference to `__atomic_test_and_set'
/usr/lib/gcc/avr/15.2.0/../../../../avr/bin/ld: /home/maribu/Repos/software/RIOT/master/tests/bench/msg_pingpong/main.c:78:(.text.startup.main+0x8e): undefined reference to `__atomic_test_and_set'
collect2: error: ld returned 1 exit status
make: *** [/home/maribu/Repos/software/RIOT/master/tests/bench/msg_pingpong/../../../Makefile.include:734: /home/maribu/Repos/software/RIOT/master/tests/bench/msg_pingpong/bin/arduino-mega2560/tests_msg_pingpong.elf] Error 1
make: Leaving directory '/home/maribu/Repos/software/RIOT/master/tests/bench/msg_pingpong'
```

</details>

#### In this PR

<details><summary><code>{ "result" : 12302, "ticks" : 1300 }</code></summary>

```
make BOARD=arduino-mega2560 -C tests/bench/msg_pingpong flash test       
make: Entering directory '/home/maribu/Repos/software/RIOT/master/tests/bench/msg_pingpong'
Building application "tests_msg_pingpong" for "arduino-mega2560" with CPU "atmega2560".

"make" -C /home/maribu/Repos/software/RIOT/master/boards
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/master/boards/arduino-mega2560
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/arduino-atmega
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/atmega
"make" -C /home/maribu/Repos/software/RIOT/master/core
"make" -C /home/maribu/Repos/software/RIOT/master/core/lib
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/atmega2560
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/atmega_common
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/atmega_common/periph
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/avr8_common
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/avr8_common/avr_libc_extra
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/avr8_common/periph
"make" -C /home/maribu/Repos/software/RIOT/master/drivers
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/periph_common
"make" -C /home/maribu/Repos/software/RIOT/master/sys
"make" -C /home/maribu/Repos/software/RIOT/master/sys/auto_init
"make" -C /home/maribu/Repos/software/RIOT/master/sys/div
"make" -C /home/maribu/Repos/software/RIOT/master/sys/frac
"make" -C /home/maribu/Repos/software/RIOT/master/sys/isrpipe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/libc
"make" -C /home/maribu/Repos/software/RIOT/master/sys/malloc_thread_safe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/pm_layered
"make" -C /home/maribu/Repos/software/RIOT/master/sys/preprocessor
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio_uart
"make" -C /home/maribu/Repos/software/RIOT/master/sys/test_utils/interactive_sync
"make" -C /home/maribu/Repos/software/RIOT/master/sys/test_utils/print_stack_usage
"make" -C /home/maribu/Repos/software/RIOT/master/sys/tiny_strerror
"make" -C /home/maribu/Repos/software/RIOT/master/sys/tsrb
"make" -C /home/maribu/Repos/software/RIOT/master/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  12020	    208	   1719	  13947	   367b	/home/maribu/Repos/software/RIOT/master/tests/bench/msg_pingpong/bin/arduino-mega2560/tests_msg_pingpong.elf
avrdude -c stk500v2 -p m2560 -P /dev/ttyACM0 -D -U flash:w:/home/maribu/Repos/software/RIOT/master/tests/bench/msg_pingpong/bin/arduino-mega2560/tests_msg_pingpong.hex
Reading 12228 bytes for flash from input file tests_msg_pingpong.hex
Writing 12228 bytes to flash
Writing | ################################################## | 100% 1.99 s 
Reading | ################################################## | 100% 1.51 s 
12228 bytes of flash verified

Avrdude done.  Thank you.
r
/home/maribu/Repos/software/RIOT/master/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "9600" -ln "/tmp/pyterm-maribu" -rn "2025-11-16_20.56.20-tests_msg_pingpong-arduino-mega2560" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0


Welcome to pyterm!
Type '/exit' to exit.
Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2026.01-devel-128-g2dfdf-core/lib/atomics)
main starting
{ "result" : 12302, "ticks" : 1300 }

make: Leaving directory '/home/maribu/Repos/software/RIOT/master/tests/bench/msg_pingpong'
```

</details>


### Issues/PRs references

None