### PR TITLE
tests/bench/runtime_coreapis: fix test on 8 bit system

### DIFF
--- a/tests/bench/runtime_coreapis/main.c
+++ b/tests/bench/runtime_coreapis/main.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "architecture.h"
 #include "benchmark.h"
 #include "mutex.h"
 #include "test_utils/expect.h"
@@ -38,8 +39,14 @@
 #  endif
 #endif
 
+/* Assuming < 32 bit architectures to be too slow to sort 256 nodes in time
+ * for this benchmark */
 #ifndef BENCH_CLIST_SORT_TEST_NODES
-#  define BENCH_CLIST_SORT_TEST_NODES 256
+#  if ARCHITECTURE_WORD_BITS < 32
+#    define BENCH_CLIST_SORT_TEST_NODES 64
+#  else
+#    define BENCH_CLIST_SORT_TEST_NODES 256
+#  endif
 #endif
 
 struct test_node {


### PR DESCRIPTION
### Contribution description

Reduce size of list nodes to sort to 64 on 8 bit and 16 bit systems to reduce the time the test takes. On 8 bit systems sorting 256 list items a thousand times takes more than 2 minutes, which is way above the 30 seconds timeout the test waits to receive the next expected output.

### Testing procedure

In `master` running `make BOARD=arduino-mega2560 -C tests/bench/runtime_coreapis flash test` fails due to a timeout, with this PR it passes.

### Issues/PRs references

None