### PR TITLE
tests/core/msg_queue_print: fully initialize msg for sending

### DIFF
--- a/tests/core/msg_queue_print/main.c
+++ b/tests/core/msg_queue_print/main.c
@@ -39,8 +39,10 @@ int main(void)
 
     /* fill message queue */
     for (uintptr_t i = 0; i < QUEUE_SIZE; i++) {
-        msg.type = i;
-        msg.content.ptr = (void *) i;
+        msg = (msg_t) {
+            .type = i,
+            .content.ptr = (void *)i,
+        };
         msg_send_to_self(&msg);
     }
 
@@ -55,8 +57,10 @@ int main(void)
 
     /* fill up message queue again */
     for (uintptr_t i = QUEUE_SIZE; i < QUEUE_SIZE + QUEUE_SIZE/2; i++) {
-        msg.type = i;
-        msg.content.ptr = (void *) i;
+        msg = (msg_t) {
+            .type = i,
+            .content.ptr = (void *)i,
+        };
         msg_send_to_self(&msg);
     }
 


### PR DESCRIPTION
### Contribution description

On 8-bit and 16-bit platforms `uint32_t` is wider than `void *`, as pointers are (typically) only 16 bit in size. This causes output like:

    Message queue of thread 2
        size: 8 (avail: 8)
        * 0: sender: 2, type: 0x0000, content: 2701197312 (0)
        * 1: sender: 2, type: 0x0001, content: 2701197313 (0x1)

As seen here, the leading two bytes of `msg.content.value` contain "random" bits, as those bytes are not explicitly initialized.

This fixes the issue by explicitly initializing the whole `msg_t` via an initializer list.

### Testing procedure

#### On `master`

<details><summary><code>    * 0: sender: 2, type: 0x0000, content: 2701197312 (0)
</code></summary>

```
make BOARD=arduino-mega2560 -C tests/core/msg_queue_print flash test -j
make: Entering directory '/home/maribu/Repos/software/RIOT/master/tests/core/msg_queue_print'
Building application "tests_msg_queue_print" for "arduino-mega2560" with CPU "atmega2560".

"make" -C /home/maribu/Repos/software/RIOT/master/boards
"make" -C /home/maribu/Repos/software/RIOT/master/boards/arduino-mega2560
"make" -C /home/maribu/Repos/software/RIOT/master/core
"make" -C /home/maribu/Repos/software/RIOT/master/core/lib
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/atmega2560
"make" -C /home/maribu/Repos/software/RIOT/master/drivers
"make" -C /home/maribu/Repos/software/RIOT/master/sys
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/arduino-atmega
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/atmega_common
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/periph_common
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/atmega
"make" -C /home/maribu/Repos/software/RIOT/master/sys/auto_init
"make" -C /home/maribu/Repos/software/RIOT/master/sys/isrpipe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/libc
"make" -C /home/maribu/Repos/software/RIOT/master/sys/malloc_thread_safe
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/atmega_common/periph
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/avr8_common
"make" -C /home/maribu/Repos/software/RIOT/master/sys/pm_layered
"make" -C /home/maribu/Repos/software/RIOT/master/sys/preprocessor
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio_uart
"make" -C /home/maribu/Repos/software/RIOT/master/sys/test_utils/interactive_sync
"make" -C /home/maribu/Repos/software/RIOT/master/sys/test_utils/print_stack_usage
"make" -C /home/maribu/Repos/software/RIOT/master/sys/tiny_strerror
"make" -C /home/maribu/Repos/software/RIOT/master/sys/tsrb
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/avr8_common/avr_libc_extra
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/avr8_common/periph
   text	   data	    bss	    dec	    hex	filename
   8184	    172	   1080	   9436	   24dc	/home/maribu/Repos/software/RIOT/master/tests/core/msg_queue_print/bin/arduino-mega2560/tests_msg_queue_print.elf
avrdude -c stk500v2 -p m2560 -P /dev/ttyACM0 -D -U flash:w:/home/maribu/Repos/software/RIOT/master/tests/core/msg_queue_print/bin/arduino-mega2560/tests_msg_queue_print.hex
Reading 8356 bytes for flash from input file tests_msg_queue_print.hex
Writing 8356 bytes to flash
Writing | ################################################## | 100% 1.39 s 
Reading | ################################################## | 100% 0.99 s 
8356 bytes of flash verified

Avrdude done.  Thank you.
r
/home/maribu/Repos/software/RIOT/master/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "9600" -ln "/tmp/pyterm-maribu" -rn "2025-11-16_23.05.27-tests_msg_queue_print-arduino-mega2560" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
p: Press s to start test, r to print it is ready


Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2026.01-devel-127-g31ea0-tests/bench/runtime_coreapis)
No messages or no message queue
No messages or no message queue
Message queue of thread 2
    size: 8 (avail: 8)
    * 0: sender: 2, type: 0x0000, content: 2701197312 (0)
    * 1: sender: 2, type: 0x0001, content: 2701197313 (0x1)

Traceback (most recent call last):
  File "/home/maribu/Repos/software/RIOT/master/tests/core/msg_queue_print/tests/01-run.py", line 62, in <module>
    sys.exit(run(testfunc))
             ^^^^^^^^^^^^^
  File "/home/maribu/Repos/software/RIOT/master/dist/pythonlibs/testrunner/__init__.py", line 30, in run
    testfunc(child)
  File "/home/maribu/Repos/software/RIOT/master/tests/core/msg_queue_print/tests/01-run.py", line 55, in testfunc
    expect_some(child, 8, 8, 0)
  File "/home/maribu/Repos/software/RIOT/master/tests/core/msg_queue_print/tests/01-run.py", line 36, in expect_some
    expect_content(child, counter)
  File "/home/maribu/Repos/software/RIOT/master/tests/core/msg_queue_print/tests/01-run.py", line 48, in expect_content
    assert int(child.match.group(2)) == counter, f"Expected {counter} as content, got child.match.group(2)"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Expected 1 as content, got child.match.group(2)
make: *** [/home/maribu/Repos/software/RIOT/master/makefiles/tests/tests.inc.mk:32: test] Error 1
make: Leaving directory '/home/maribu/Repos/software/RIOT/master/tests/core/msg_queue_print'
```

</details>

#### This PR

<details><summary><code>    * 0: sender: 2, type: 0x0000, content: 0 (0)</code></summary>

```
make BOARD=arduino-mega2560 -C tests/core/msg_queue_print flash test -j
make: Entering directory '/home/maribu/Repos/software/RIOT/master/tests/core/msg_queue_print'
Building application "tests_msg_queue_print" for "arduino-mega2560" with CPU "atmega2560".

"make" -C /home/maribu/Repos/software/RIOT/master/boards
"make" -C /home/maribu/Repos/software/RIOT/master/boards/arduino-mega2560
"make" -C /home/maribu/Repos/software/RIOT/master/core
"make" -C /home/maribu/Repos/software/RIOT/master/core/lib
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/atmega2560
"make" -C /home/maribu/Repos/software/RIOT/master/drivers
"make" -C /home/maribu/Repos/software/RIOT/master/sys
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/arduino-atmega
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/init
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/atmega_common
"make" -C /home/maribu/Repos/software/RIOT/master/drivers/periph_common
"make" -C /home/maribu/Repos/software/RIOT/master/sys/auto_init
"make" -C /home/maribu/Repos/software/RIOT/master/boards/common/atmega
"make" -C /home/maribu/Repos/software/RIOT/master/sys/isrpipe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/libc
"make" -C /home/maribu/Repos/software/RIOT/master/sys/malloc_thread_safe
"make" -C /home/maribu/Repos/software/RIOT/master/sys/pm_layered
"make" -C /home/maribu/Repos/software/RIOT/master/sys/preprocessor
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio
"make" -C /home/maribu/Repos/software/RIOT/master/sys/stdio_uart
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/atmega_common/periph
"make" -C /home/maribu/Repos/software/RIOT/master/sys/test_utils/interactive_sync
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/avr8_common
"make" -C /home/maribu/Repos/software/RIOT/master/sys/test_utils/print_stack_usage
"make" -C /home/maribu/Repos/software/RIOT/master/sys/tiny_strerror
"make" -C /home/maribu/Repos/software/RIOT/master/sys/tsrb
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/avr8_common/avr_libc_extra
"make" -C /home/maribu/Repos/software/RIOT/master/cpu/avr8_common/periph
   text	   data	    bss	    dec	    hex	filename
   8194	    172	   1080	   9446	   24e6	/home/maribu/Repos/software/RIOT/master/tests/core/msg_queue_print/bin/arduino-mega2560/tests_msg_queue_print.elf
avrdude -c stk500v2 -p m2560 -P /dev/ttyACM0 -D -U flash:w:/home/maribu/Repos/software/RIOT/master/tests/core/msg_queue_print/bin/arduino-mega2560/tests_msg_queue_print.hex
Reading 8366 bytes for flash from input file tests_msg_queue_print.hex
Writing 8366 bytes to flash
Writing | ################################################## | 100% 1.38 s 
Reading | ################################################## | 100% 0.99 s 
8366 bytes of flash verified

Avrdude done.  Thank you.
r
/home/maribu/Repos/software/RIOT/master/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "9600" -ln "/tmp/pyterm-maribu" -rn "2025-11-16_23.06.24-tests_msg_queue_print-arduino-mega2560" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.


Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2026.01-devel-127-g31ea0-tests/bench/runtime_coreapis)
No messages or no message queue
No messages or no message queue
Message queue of thread 2
    size: 8 (avail: 8)
    * 0: sender: 2, type: 0x0000, content: 0 (0)
    * 1: sender: 2, type: 0x0001, content: 1 (0x1)
    * 2: sender: 2, type: 0x0002, content: 2 (0x2)
    * 3: sender: 2, type: 0x0003, content: 3 (0x3)
    * 4: sender: 2, type: 0x0004, content: 4 (0x4)
    * 5: sender: 2, type: 0x0005, content: 5 (0x5)
    ... (print more by changing CONFIG_MSG_QUEUE_PRINT_MAX)
Message queue of thread 2
    size: 8 (avail: 4)
    * 0: sender: 2, type: 0x0004, content: 4 (0x4)
    * 1: sender: 2, type: 0x0005, content: 5 (0x5)
    * 2: sender: 2, type: 0x0006, content: 6 (0x6)
    * 3: sender: 2, type: 0x0007, content: 7 (0x7)
Message queue of thread 2
    size: 8 (avail: 8)
    * 0: sender: 2, type: 0x0004, content: 4 (0x4)
    * 1: sender: 2, type: 0x0005, content: 5 (0x5)
    * 2: sender: 2, type: 0x0006, content: 6 (0x6)
    * 3: sender: 2, type: 0x0007, content: 7 (0x7)
    * 4: sender: 2, type: 0x0008, content: 8 (0x8)
    * 5: sender: 2, type: 0x0009, content: 9 (0x9)
    ... (print more by changing CONFIG_MSG_QUEUE_PRINT_MAX)
DONE

make: Leaving directory '/home/maribu/Repos/software/RIOT/master/tests/core/msg_queue_print'
```

</details>

### Issues/PRs references

None