### PR TITLE
cpu/sam0_common/periph_i2c: reliably unstuck bus

### DIFF
--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -20,19 +20,14 @@
  */
 
 #include <assert.h>
-#include <stdint.h>
 #include <errno.h>
+#include <stdint.h>
 
 #include "busy_wait.h"
-#include "cpu.h"
-#include "board.h"
 #include "mutex.h"
 #include "periph_conf.h"
 #include "periph/gpio.h"
 #include "periph/i2c.h"
-
-#include "sched.h"
-#include "thread.h"
 
 #define ENABLE_DEBUG        0
 #include "debug.h"
@@ -112,7 +107,10 @@ static bool _check_and_unblock_bus(i2c_t dev_id, bool initialized)
 {
     const i2c_conf_t *dev_conf = &i2c_config[dev_id];
 
-    /* reconfigure pins to gpio for testing */
+    /* do a full reset of the SERCOM */
+    if (initialized) {
+        bus(dev_id)->CTRLA.reg = SERCOM_I2CM_CTRLA_SWRST;
+    }
     gpio_disable_mux(dev_conf->sda_pin);
     gpio_disable_mux(dev_conf->scl_pin);
     gpio_init(dev_conf->sda_pin, GPIO_IN);
@@ -153,13 +151,7 @@ static bool _check_and_unblock_bus(i2c_t dev_id, bool initialized)
     }
 
     if (initialized) {
-        /* reconfigure pins for i2c */
-        gpio_init_mux(dev_conf->scl_pin, dev_conf->mux);
-        gpio_init_mux(dev_conf->sda_pin, dev_conf->mux);
-
-        /* reset bus state */
-        dev_conf->dev->STATUS.reg = BUSSTATE_IDLE;
-        _syncbusy(dev_conf->dev);
+        i2c_init(dev_id);
     }
 
     return success;
@@ -168,7 +160,7 @@ static bool _check_and_unblock_bus(i2c_t dev_id, bool initialized)
 void i2c_init(i2c_t dev)
 {
     uint32_t timeout_counter = 0;
-    int32_t tmp_baud;
+    uint32_t tmp_baud;
 
     assert(dev < I2C_NUMOF);
 


### PR DESCRIPTION
### Contribution description

On a setup I have on my desk I can reliably get the I2C bus stuck. But the current unstuck logic will not get unstuck it. Adding a power cycle of the I2C bus to the unstuck logic does fix the issue, so let's do that.

### Testing procedure

I2C should still work. E.g. as seen here on the `same54-xpro`:

```
> i2c_scan 1
2025-11-17 22:29:58,475 # i2c_scan 1
2025-11-17 22:29:58,477 # Scanning I2C device 1...
2025-11-17 22:29:58,483 # addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
2025-11-17 22:29:58,487 #      0 1 2 3 4 5 6 7 8 9 a b c d e f
2025-11-17 22:29:58,491 # 0x00 R R R R R R R R - - - - - - - -
2025-11-17 22:29:58,495 # 0x10 - - - - - - - - - - - - - - - -
2025-11-17 22:29:58,500 # 0x20 - - - - - - - - X - - - - - - -
2025-11-17 22:29:58,505 # 0x30 - - - - - - X - - - - - - - - -
2025-11-17 22:29:58,510 # 0x40 - - - - - - - - - - - - - - - -
2025-11-17 22:29:58,515 # 0x50 - - - - - - X - - - - - - - X -
2025-11-17 22:29:58,520 # 0x60 X - - - - - - - - - - - - - - -
2025-11-17 22:29:58,524 # 0x70 - - - - - - - - R R R R R R R R
```

In addition, when the bus gets stuck, the current I2C transaction does indeed still fail. But subsequent transactions will work again.

In `master` using my cursed setup, the bus would stay stuck once it is stuck and never recover.

### Issues/PRs references

None