### PR TITLE
pkg/mpaland-printf: Add missing wrapper for fputs [backport 2025.10]

### DIFF
--- a/pkg/mpaland-printf/Makefile.include
+++ b/pkg/mpaland-printf/Makefile.include
@@ -14,6 +14,7 @@ LINKFLAGS += -Wl,-wrap=putchar
 LINKFLAGS += -Wl,-wrap=putc
 LINKFLAGS += -Wl,-wrap=fputc
 LINKFLAGS += -Wl,-wrap=puts
+LINKFLAGS += -Wl,-wrap=fputs
 
 # By wrapping the newlib only `_printf_common` symbol to the undefined
 # `__wrap__printf_common` symbol, linking will fail if any reference to

--- a/pkg/mpaland-printf/patches/0004-Wrapper-targets-Add-endpoints-for-Wl-wrap.patch
+++ b/pkg/mpaland-printf/patches/0004-Wrapper-targets-Add-endpoints-for-Wl-wrap.patch
@@ -1,15 +1,15 @@
-From a01af4cb4991f6d5f0320f03d1f1d918df07caec Mon Sep 17 00:00:00 2001
+From b1ee169d8cfd6e37817ad267736aa1f92f1a2076 Mon Sep 17 00:00:00 2001
 From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
 Date: Sat, 11 May 2024 17:51:38 +0200
-Subject: [PATCH] Wrapper targets: Add endpoints for -Wl,wrap=...
+Subject: [PATCH 4/6] Wrapper targets: Add endpoints for -Wl,wrap=...
 
 This adds aliases needed to wrap printf() and friends.
 ---
- printf.c | 99 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 99 insertions(+)
+ printf.c | 108 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 108 insertions(+)
 
 diff --git a/printf.c b/printf.c
-index edf41d1..e00c3e5 100644
+index edf41d1..ed7f72b 100644
 --- a/printf.c
 +++ b/printf.c
 @@ -32,6 +32,9 @@
@@ -22,7 +22,7 @@ index edf41d1..e00c3e5 100644
  
  #include "printf.h"
  #include "stdio_base.h"
-@@ -920,3 +923,99 @@ static void _putchar(char character)
+@@ -920,3 +923,108 @@ static void _putchar(char character)
  {
    stdio_write(&character, sizeof(character));
  }
@@ -74,6 +74,15 @@ index edf41d1..e00c3e5 100644
 +  stdio_write(s, len);
 +  stdio_write("\n", 1);
 +  return len + 1;
++}
++
++
++int __wrap_fputs(const char *s, FILE *stream)
++{
++  (void)stream;
++  size_t len = strlen(s);
++  write_all(s, len);
++  return len;
 +}
 +
 +


### PR DESCRIPTION
# Backport of #21889

### Contribution description

Another endpoint that was forgotten to overwrite. This fixes the output of the `i2c_scan` shell command that is e.g. included in the test app in `tests/periph/i2c`.

### Testing procedure

#### In `master`

```
$ make BOARD=same54-xpro -C tests/periph/i2c flash term
make: Entering directory '/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/periph/i2c'
Building application "tests_i2c" for "same54-xpro" with CPU "samd5x".
   text	  data	   bss	   dec	   hex	filename
  24500	   172	  2844	 27516	  6b7c	/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/periph/i2c/bin/same54-xpro/tests_i2c.elf
[...]
> i2c_scan 0
2025-11-17 20:36:56,633 # i2c_scan 0
2025-11-17 20:36:56,636 # Scanning I2C device 0...
2025-11-17 20:36:56,642 # addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
2025-11-17 20:36:56,645 #      0 1 2 3 4 5 6 7 8 9 a b c d e f
2025-11-17 20:36:56,646 # 
2025-11-17 20:36:56,648 # 
2025-11-17 20:36:56,650 # 
2025-11-17 20:36:56,652 # 
2025-11-17 20:36:56,654 # 
2025-11-17 20:36:56,656 # 
2025-11-17 20:36:56,657 # 
2025-11-17 20:36:56,658 # 
> i2c_scan 0
2025-11-17 20:37:00,096 # 0x00 R R R R R R R R - - - - - - - -0x10 - - - - - - - - - - - - - - - -0x20 - - - - - - - - - - - - - - - -0x30 - - - - - - - - - - - - - - - -0x40 - - - - - - - - - - - - - - - -0x50 - - - - - - - - - - - - - - - -0x60 - - - - - - - - - - - - - - - -0x70 - - - - - - - - R R R R R R R Ri2c_scan 0
2025-11-17 20:37:00,098 # Scanning I2C device 0...
2025-11-17 20:37:00,104 # addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
2025-11-17 20:37:00,107 #      0 1 2 3 4 5 6 7 8 9 a b c d e f
2025-11-17 20:37:00,108 # 
2025-11-17 20:37:00,110 # 
2025-11-17 20:37:00,112 # 
2025-11-17 20:37:00,114 # 
2025-11-17 20:37:00,116 # 
2025-11-17 20:37:00,118 # 
2025-11-17 20:37:00,120 # 
2025-11-17 20:37:00,121 # 
```

#### This PR

```
$ make BOARD=same54-xpro -C tests/periph/i2c flash term
make: Entering directory '/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/periph/i2c'
Building application "tests_i2c" for "same54-xpro" with CPU "samd5x".
[...]
   text	  data	   bss	   dec	   hex	filename
  24132	   172	  2844	 27148	  6a0c	/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/periph/i2c/bin/same54-xpro/tests_i2c.elf
[...]
> i2c_scan 0
2025-11-17 20:35:12,668 # i2c_scan 0
2025-11-17 20:35:12,670 # Scanning I2C device 0...
2025-11-17 20:35:12,677 # addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
2025-11-17 20:35:12,680 #      0 1 2 3 4 5 6 7 8 9 a b c d e f
2025-11-17 20:35:12,684 # 0x00 R R R R R R R R - - - - - - - -
2025-11-17 20:35:12,689 # 0x10 - - - - - - - - - - - - - - - -
2025-11-17 20:35:12,694 # 0x20 - - - - - - - - - - - - - - - -
2025-11-17 20:35:12,698 # 0x30 - - - - - - - - - - - - - - - -
2025-11-17 20:35:12,703 # 0x40 - - - - - - - - - - - - - - - -
2025-11-17 20:35:12,708 # 0x50 - - - - - - - - - - - - - - - -
2025-11-17 20:35:12,713 # 0x60 - - - - - - - - - - - - - - - -
2025-11-17 20:35:12,717 # 0x70 - - - - - - - - R R R R R R R R
```

### Issues/PRs references

None
