### PR TITLE
drivers/mrf24j40: replace && with || in TX power validation

### DIFF
--- a/drivers/mrf24j40/mrf24j40_radio_hal.c
+++ b/drivers/mrf24j40/mrf24j40_radio_hal.c
@@ -254,7 +254,7 @@ static int _config_phy(ieee802154_dev_t *hal, const ieee802154_phy_conf_t *conf)
     mrf24j40_t *dev = hal->priv;
     int8_t pow = conf->pow;
     uint8_t channel = conf->channel;
-    if (pow < MRF24J40_MIN_TXPOWER && pow > MRF24J40_MAX_TXPOWER) {
+    if (pow < MRF24J40_MIN_TXPOWER || pow > MRF24J40_MAX_TXPOWER) {
         return -EINVAL;
     }
     mrf24j40_set_txpower(dev, pow);


### PR DESCRIPTION
Fix TX power range check in MRF24J40 driver

I encountered incorrect checking logic in config_phy function.
The current logic using && is impossible to satisfy - a value cannot be both less than
the minimum AND greater than the maximum.