### PR TITLE
tests: fix SPDX license tags

### DIFF
--- a/tests/core/bitarithm_timings/main.c
+++ b/tests/core/bitarithm_timings/main.c
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2014 René Kijewski <rene.kijewski@fu-berlin.de>
- * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 /**

--- a/tests/pkg/libfixmath/main.c
+++ b/tests/pkg/libfixmath/main.c
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2014 René Kijewski <rene.kijewski@fu-berlin.de>
- * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 /**

--- a/tests/pkg/libfixmath_unittests/main.c
+++ b/tests/pkg/libfixmath_unittests/main.c
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2014 René Kijewski <rene.kijewski@fu-berlin.de>
- * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 /**

--- a/tests/sys/pipe/main.c
+++ b/tests/sys/pipe/main.c
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2014 René Kijewski <rene.kijewski@fu-berlin.de>
- * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 /**

--- a/tests/sys/pthread_rwlock/main.c
+++ b/tests/sys/pthread_rwlock/main.c
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2014 René Kijewski <rene.kijewski@fu-berlin.de>
- * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 /**

--- a/tests/sys/struct_tm_utility/main.c
+++ b/tests/sys/struct_tm_utility/main.c
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2014 René Kijewski <rene.kijewski@fu-berlin.de>
- * SPDX-License-Identifier: LGPL-2.1-only
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 /**


### PR DESCRIPTION
### Contribution description

During the conversion to SPDX tags a few files that actually should have been tagged `LGPL-2.1-or-later` got tagged `LGPL-2.1-only`.

This fixes the labels to match the actual file license.

### Testing procedure

Check the diff log of the affected files and watch for the part "either version 2.1 of the License, or (at your option) any later version.". If it has been present prior to converting the Copyright to an SPDX tag, the correct SPDX tag is `LGPL-2.1-or-later`, not `LGPL-2.1-only`.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/issues/21515