### PR TITLE
drivers/sx126x: fix compilation for sx126x_dio3

### DIFF
--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -394,9 +394,8 @@ int sx126x_init(sx126x_t *dev)
 #endif
 #if IS_USED(MODULE_SX126X_DIO3)
      if (dev->params->dio3_mode == SX126X_DIO3_TCXO) {
-        sx126x_set_dio3_as_tcxo_ctrl(dev, dev->params->u_dio3_arg.tcxo_volt,
-                                     dev->params->u_dio3_arg.tcx0_timeout);
-
+        sx126x_set_dio3_as_tcxo_ctrl(dev, dev->params->dio3_arg.tcxo_volt,
+                                     dev->params->dio3_arg.tcxo_timeout);
         /* Once the command SetDIO3AsTCXOCtrl(...) is sent to the device,
            the register controlling the internal cap on XTA will be automatically
            changed to 0x2F (33.4 pF) to filter any spurious injection which could occur


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Fix compilation with `sx126x_dio3`.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Compilation works now: `USEMODULE+=sx126x_dio3 make -C tests/drivers/sx126x`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
