### PR TITLE
cpu/native: implement fputs and fwrite

### DIFF
--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -230,6 +230,12 @@ int putchar(int c)
     return _native_write(STDOUT_FILENO, &tmp, sizeof(tmp));
 }
 
+int fputc(int c, FILE *fp)
+{
+    char tmp = c;
+    return _native_write(fileno(fp), &tmp, sizeof(tmp));
+}
+
 int puts(const char *s)
 {
     int r;


### PR DESCRIPTION
### Contribution description

Implement `fputs` and `fwrite` explicitly for `cpu/native`, so it will be passed through `_native_write` instead of calling into the (linked-in) C library, which would somehow end up in a different `stdout`.


### Testing procedure

```diff
diff --git a/examples/basic/hello-world/Makefile b/examples/basic/hello-world/Makefile
index ad1fa6fdcb..14dbbb2fdd 100644
--- a/examples/basic/hello-world/Makefile
+++ b/examples/basic/hello-world/Makefile
@@ -12,6 +12,8 @@ RIOTBASE ?= $(CURDIR)/../../..
 # development process:
 DEVELHELP ?= 1
 
+USEMODULE += ztimer_msec
+
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
diff --git a/examples/basic/hello-world/main.c b/examples/basic/hello-world/main.c
index c1fe9bae12..811ce82352 100644
--- a/examples/basic/hello-world/main.c
+++ b/examples/basic/hello-world/main.c
@@ -18,6 +18,8 @@
 
 #include <stdio.h>
 
+#include "ztimer.h"
+
 int main(void)
 {
     puts("Hello World!");
@@ -25,5 +27,13 @@ int main(void)
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s CPU.\n", RIOT_CPU);
 
+    while (1) {
+        fprintf(stdout, "fprintf - ");
+        printf("printf - ");
+        fputs("fputs - ", stdout);
+        puts("puts");
+        ztimer_sleep(ZTIMER_MSEC, 1000);
+    }
+
     return 0;
 }
```

on `master`

```
$ make -C examples/basic/hello-world flash cleanterm
/home/mikolai/TUD/Code/RIOT/examples/basic/hello-world/bin/native64/hello-world.elf  tap0 
...
printf - puts
printf - puts
printf - puts
^C
native: exiting
fprintf - fputs - fprintf - fputs - fprintf - fputs - 
```

with this PR

```
$ make -C examples/basic/hello-world flash term
...
fprintf - printf - fputs - puts
fprintf - printf - fputs - puts
fprintf - printf - fputs - puts
```


### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/21910
