### PR TITLE
sys/suit: write  size in suit_worker_try_prepare()

### DIFF
--- a/sys/include/suit/transport/worker.h
+++ b/sys/include/suit/transport/worker.h
@@ -68,10 +68,10 @@ void suit_worker_trigger_prepared(const uint8_t *manifest, size_t size);
  * area into which the manifest is to be written. The lock must be released by
  * calling @ref suit_worker_trigger_prepared later.
  *
- * @param[out]    buffer   On success, buffer into which the image may be
+ * @param[out]    buffer   On success, buffer into which the manifest may be
  *                         written.
- * @param[in,out] size     Requested buffer size. On some errors, this will be
- *                         decreased to a size that would be acceptable.
+ * @param[in,out] size     Requested buffer size. When size is `0` or on some
+ *                         errors, this will be set to a size that would be acceptable.
  *
  * @return 0 on success
  * @return -EAGAIN if the worker is currently busy.

--- a/sys/suit/transport/worker.c
+++ b/sys/suit/transport/worker.c
@@ -265,5 +265,8 @@ int suit_worker_try_prepare(uint8_t **buffer, size_t *size)
     }
 
     *buffer = _manifest_buf;
+    if (!*size) {
+        *size = SUIT_MANIFEST_BUFSIZE;
+    }
     return 0;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`suit_worker_try_prepare()` is a bit awkward to use. 
The idea is that we can request the buffer into which the SUIT manifest shall be written. 
However it only tells us the size of the destination buffer if we call it with a size larger than the destination buffer.

Otherwise the caller has to either guess the size or call `suit_worker_try_prepare()` twice.

```C
uint8_t *mani_buf;
size_t mani_size_max = UINT32_MAX;

suit_worker_try_prepare(&mani_buf, &mani_size_max); // get size
suit_worker_try_prepare(&mani_buf, &mani_size_max); // get buffer
```

Just populate `size` at all times to avoid such nonsense. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
