### PR TITLE
sys/usb/cdc_acm: don't generate flush event when disconnected

### DIFF
--- a/sys/usb/usbus/cdc/acm/cdc_acm.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm.c
@@ -173,9 +173,13 @@ void usbus_cdc_acm_set_coding_cb(usbus_cdcacm_device_t *cdcacm,
 /* flush event */
 void usbus_cdc_acm_flush(usbus_cdcacm_device_t *cdcacm)
 {
-    if (cdcacm->usbus) {
-        usbus_event_post(cdcacm->usbus, &cdcacm->flush);
+    if (!cdcacm->usbus) {
+        return;
     }
+    if (cdcacm->state == USBUS_CDC_ACM_LINE_STATE_DISCONNECTED) {
+        return;
+    }
+    usbus_event_post(cdcacm->usbus, &cdcacm->flush);
 }
 
 void usbus_cdc_acm_init(usbus_t *usbus, usbus_cdcacm_device_t *cdcacm,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The event handler will check the connected state too, but when we are not connected we don't have to generate the event in the first place.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

follow-up to #21890
