### PR TITLE
cpu/native: fix lockup on libucontext

### DIFF
--- a/cpu/native/include/native_internal.h
+++ b/cpu/native/include/native_internal.h
@@ -87,6 +87,12 @@ void native_cpu_init(void);
 extern volatile bool _native_interrupts_enabled;
 
 /**
+ * @brief Signal set during "IRQs enabled"
+ * @internal
+ */
+extern sigset_t _native_sig_set;
+
+/**
  * @brief Pipe yielding signals
  * @private
  *

--- a/cpu/native/irq.c
+++ b/cpu/native/irq.c
@@ -40,7 +40,7 @@ ucontext_t *_native_current_context = NULL;
 
 volatile uintptr_t _native_user_fptr;
 
-static sigset_t _native_sig_set;
+sigset_t _native_sig_set;
 static sigset_t _native_sig_set_dint;
 volatile int _native_pending_signals;
 int _signal_pipe_fd[2];


### PR DESCRIPTION
### Contribution description

The `setcontext()` implementation of glibc does restore the signal mask to the target thread during the switch, libucontext [does not][1]

[1]: https://man.archlinux.org/man/libucontext.3.en#CAVEATS

Instead, we just manually enable signals again just before the call to `setcontext()`.

With this, tests like `tests/core/mutex_canel` or `tests/core/irq` now pass on `native64` when using libucontext.

### Testing procedure

Run

```
make BOARD=native64 -C tests/core/irq
make BOARD=native64 -C tests/core/mutex_cancel 
```

#### On `master` e.g. using Alpine Linux


```
git:(master) ~/Repos/software/RIOT/master ➜ make BOARD=native64 flash test -j -C tests/core/irq         
make: Entering directory '/home/maribu/Repos/software/RIOT/master/tests/core/irq'
Building application "tests_irq" for "native64" with CPU "native".
[...]
RIOT native interrupts/signals initialized.
TZ not set, setting UTC
RIOT native64 board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2026.01-devel-164-gb8c553)
START
busy_thread created
xtimer_wait()
busy_thread starting
Timeout in expect script at "child.expect('SUCCESS')" (tests/core/irq/tests/01-run.py:9)

make: *** [/home/maribu/Repos/software/RIOT/master/makefiles/tests/tests.inc.mk:32: test] Error 1
make: Leaving directory '/home/maribu/Repos/software/RIOT/master/tests/core/irq'
```

```
git:(master) ~/Repos/software/RIOT/master ➜ make BOARD=native64 flash test -j -C tests/core/mutex_cancel
make: Entering directory '/home/maribu/Repos/software/RIOT/master/tests/core/mutex_cancel'
Building application "tests_mutex_cancel" for "native64" with CPU "native".
[...]
RIOT native interrupts/signals initialized.
TZ not set, setting UTC
RIOT native64 board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2026.01-devel-164-gb8c553)
Test Application for mutex_cancel / mutex_lock_cancelable
=========================================================

Test without cancellation: OK
Test early cancellation: OK
Verify no side effects on subsequent calls: Timeout in expect script at "child.expect("TEST PASSED")" (tests/core/mutex_cancel/tests/01-run.py:16)

make: *** [/home/maribu/Repos/software/RIOT/master/makefiles/tests/tests.inc.mk:32: test] Error 1
make: Leaving directory '/home/maribu/Repos/software/RIOT/master/tests/core/mutex_cancel'
```

#### This PR

```
git:(cpu/native/libucontext/fix-lockup) ~/Repos/software/RIOT/master ➜ make BOARD=native64 flash test -j -C tests/core/irq
make: Entering directory '/home/maribu/Repos/software/RIOT/master/tests/core/irq'
Building application "tests_irq" for "native64" with CPU "native".
[...]
RIOT native interrupts/signals initialized.
TZ not set, setting UTC
RIOT native64 board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2026.01-devel-165-g8c44f-cpu/native/libucontext/fix-lockup)
START
busy_thread created
xtimer_wait()
busy_thread starting
main: return
{ "threads": [{ "name": "idle", "stack_size": 16384, "stack_used": 1048 }]}
{ "threads": [{ "name": "main", "stack_size": 20480, "stack_used": 2600 }]}
i: 119908691
j: 119908691
k: 119908691
SUCCESS
{ "threads": [{ "name": "busy_thread", "stack_size": 20480, "stack_used": 2552 }]}

Process already stopped
make: Leaving directory '/home/maribu/Repos/software/RIOT/master/tests/core/irq'
```

```
git:(cpu/native/libucontext/fix-lockup) ~/Repos/software/RIOT/master ➜ make BOARD=native64 flash test -j -C tests/core/mutex_cancel 
make: Entering directory '/home/maribu/Repos/software/RIOT/master/tests/core/mutex_cancel'
Building application "tests_mutex_cancel" for "native64" with CPU "native".
[...]
RIOT native interrupts/signals initialized.
TZ not set, setting UTC
RIOT native64 board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2026.01-devel-165-g8c44f-cpu/native/libucontext/fix-lockup)
Test Application for mutex_cancel / mutex_lock_cancelable
=========================================================

Test without cancellation: OK
Test early cancellation: OK
Verify no side effects on subsequent calls: OK
Test late cancellation: OK
TEST PASSED
{ "threads": [{ "name": "idle", "stack_size": 16384, "stack_used": 1296 }]}
{ "threads": [{ "name": "main", "stack_size": 20480, "stack_used": 2728 }]}

Process already stopped
make: Leaving directory '/home/maribu/Repos/software/RIOT/master/tests/core/mutex_cancel'
```

### Issues/PRs references
None
