### PR TITLE
build: allow external module dirs with the same name when not building in Docker

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -344,8 +344,10 @@ DOCKER_OVERRIDE_CMDLINE += $(call docker_cmdline_mapping,EXTERNAL_BOARD_DIRS,$(D
 # would lead to both being mapped to '$(DOCKER_BUILD_ROOT)/external/name'
 _mounted_dirs = $(foreach d,$(EXTERNAL_MODULE_DIRS),$(if $(call dir_is_outside_riotbase,$(d)),$(d)))
 ifneq ($(words $(sort $(notdir $(_mounted_dirs)))),$(words $(sort $(_mounted_dirs))))
-  $(warning Mounted EXTERNAL_MODULE_DIRS: $(_mounted_dirs))
-  $(error Mapping EXTERNAL_MODULE_DIRS in docker is not supported for directories with the same name)
+  ifeq (1, $(BUILD_IN_DOCKER))
+    $(warning Mounted EXTERNAL_MODULE_DIRS: $(_mounted_dirs))
+    $(error Mapping EXTERNAL_MODULE_DIRS in docker is not supported for directories with the same name)
+  endif
 endif
 
 # Handle worktree by mounting the git common dir in the same location


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

There's no reason not to allow multiple external module directories with the same name when not building in Docker. Having module directories named `modules` is the most straight forward thing to do but it's currently not possible.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Add multiple directories with the same name to `EXTERNAL_MODULE_DIRS`. When **not** building in Docker, compilation should succeed.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
