### PR TITLE
build-system: fix RIOTBOOT_SKIP_COMPILE

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -18,7 +18,7 @@ $(BINDIR_RIOTBOOT): $(CLEAN)
 export SLOT0_OFFSET SLOT0_LEN SLOT1_OFFSET SLOT1_LEN
 
 # Mandatory APP_VER, set to epoch by default
-EPOCH = $(call memoized,EPOCH,$(shell date +%s))
+EPOCH := $(call memoized,EPOCH,$(shell date +%s))
 APP_VER ?= $(EPOCH)
 
 # Final target for slot 0 with riot_hdr
@@ -96,7 +96,7 @@ endif
 # allocated space. This is used afterwards to create a combined
 # binary with both bootloader and RIOT firmware with header
 BOOTLOADER_BIN = $(RIOTBOOT_DIR)/bin/$(BOARD)
-$(BOOTLOADER_BIN)/riotboot.extended.bin: $(BOOTLOADER_BIN)/riotboot.bin
+$(BINDIR_RIOTBOOT)/riotboot.extended.bin: $(BOOTLOADER_BIN)/riotboot.bin
 	$(Q)cp $^ $@.tmp
 	$(Q)truncate -s $$(($(RIOTBOOT_LEN))) $@.tmp
 	$(Q)mv $@.tmp $@
@@ -112,7 +112,7 @@ endif
 # Create combined binary booloader + RIOT firmware with header
 RIOTBOOT_COMBINED_BIN = $(BINDIR_RIOTBOOT)/slot0-combined.bin
 riotboot/combined-slot0: $(RIOTBOOT_COMBINED_BIN)
-$(RIOTBOOT_COMBINED_BIN): $(BOOTLOADER_BIN)/riotboot.extended.bin $(SLOT0_RIOT_BIN)
+$(RIOTBOOT_COMBINED_BIN): $(BINDIR_RIOTBOOT)/riotboot.extended.bin $(SLOT0_RIOT_BIN)
 	$(Q)cat $^ > $@
 
 RIOTBOOT_EXTENDED_BIN = $(BINDIR_RIOTBOOT)/slot0-extended.bin


### PR DESCRIPTION
### Contribution description

The RIOTBOOT_SKIP_COMPILE flag is already present in our code base, but it did not really result in compilation of `riotboot` as a dependency of another app to be skipped.

This fixes the issue and allows users to explicitly build riotboot for a given set of boards upfront, and then build any number of apps depending on `riotboot` to be build with `RIOTBOOT_SKIP_COMPILE=1` and cutting the compilation time in half.

This is particularly valuable as various parameters such as `RIOT_CI_BULLD` or `CCACHE` do not get passed down to the implicit `riotboot` build. In a CI that makes use of `CCACHE`, this results in the CI time quickly being dominated by implicit builds of `riotboot` when many apps use SUIT.

### Testing procedure

Running

```
make RIOT_CI_BUILD=1 BOARD=same54-xpro RIOTBOOT_SKIP_COMPILE=1 -C examples/advanced/suit_update -j
```

in `master` results in `riotboot` to be build (which can easily be noticed by that build ignoring `RIOT_CI_BUILD=1` and being more verbose). With this PR the implicit build of `riotboot` indeed does not occur (which easily can be seen by the faster compilation time and the less verbose output).

### Issues/PRs references

None