### PR TITLE
Draft: External cpu dir

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -11,7 +11,7 @@ endif
 -include $(BOARDDIR)/Makefile.dep
 
 # include cpu dependencies
--include $(RIOTCPU)/$(CPU)/Makefile.dep
+-include $(CPUDIR)/Makefile.dep
 
 # include external modules dependencies
 # processed before RIOT ones to be evaluated before the 'default' rules.

--- a/Makefile.features
+++ b/Makefile.features
@@ -38,7 +38,7 @@ endif
 include $(CPUDIR)/Makefile.features
 
 # Provide CPU as a feature to allow listing all boards with a CPU
-#FEATURES_PROVIDED += cpu_external#$(CPU)
+FEATURES_PROVIDED += cpu_$(CPU)
 
 # Features that are conflicting for all architectures
 FEATURES_CONFLICT += picolibc:newlib

--- a/Makefile.features
+++ b/Makefile.features
@@ -19,10 +19,26 @@ ifeq (,$(CPU))
   $(error $(BOARD): CPU must be defined by board / board_common Makefile.features)
 endif
 
-include $(RIOTCPU)/$(CPU)/Makefile.features
+CPUSDIRS := $(EXTERNAL_CPU_DIRS) $(RIOTCPU)
+
+# Take the first folder in $(CPUSDIRS) that contains a folder named $(CPU)
+CPUDIR := $(word 1,$(foreach dir,$(CPUSDIRS),$(wildcard $(dir)/$(CPU)/.)))
+# Sanitize folder
+CPUDIR := $(abspath $(CPUDIR))
+
+# Also provide CPUSDIR for compatibility and for accessing common folders
+# (e.g. include $(CPUSDIR)/common/external_common/Makefile.dep)
+CPUSDIR := $(dir $(CPUDIR))
+
+ifeq (,$(CPUDIR))
+  $(info Folders searched for the cpu: $(CPUSDIRS))
+  $(error The specified cpu $(CPU) does not exist.)
+endif
+
+include $(CPUDIR)/Makefile.features
 
 # Provide CPU as a feature to allow listing all boards with a CPU
-FEATURES_PROVIDED += cpu_$(CPU)
+#FEATURES_PROVIDED += cpu_external#$(CPU)
 
 # Features that are conflicting for all architectures
 FEATURES_CONFLICT += picolibc:newlib

--- a/Makefile.include
+++ b/Makefile.include
@@ -43,6 +43,7 @@ include $(RIOT_MAKEFILES_GLOBAL_PRE)
 # set undefined variables
 RIOTBASE                        ?= $(_riotbase)
 RIOTCPU                         ?= $(RIOTBASE)/cpu
+EXTERNAL_CPU_DIRS               ?=
 # Deprecated to set RIOTBOARD, use EXTERNAL_BOARD_DIRS
 RIOTBOARD                       ?= $(RIOTBASE)/boards
 EXTERNAL_BOARD_DIRS             ?=
@@ -106,6 +107,9 @@ ifeq ($(INSIDE_DOCKER),0)
   ifeq ($(origin EXTERNAL_PKG_DIRS),command line)
     $(error EXTERNAL_PKG_DIRS must be passed as environment variable, and not as command line argument)
   endif
+  ifeq ($(origin EXTERNAL_CPU_DIRS),command line)
+    $(error EXTERNAL_CPU_DIRS must be passed as environment variable, and not as command line argument)
+  endif
 endif
 
 # Deprecation of configuring 'RIOTBOARD'
@@ -151,6 +155,9 @@ EXTERNAL_MODULE_DIRS            := $(foreach dir,\
                                              $(abspath $(dir)))
 EXTERNAL_PKG_DIRS               := $(foreach dir,\
                                              $(EXTERNAL_PKG_DIRS),\
+                                             $(abspath $(dir)))
+EXTERNAL_CPU_DIRS               := $(foreach dir,\
+                                             $(EXTERNAL_CPU_DIRS),\
                                              $(abspath $(dir)))
 
 # Ensure that all directories are set and don't contain spaces.
@@ -425,8 +432,8 @@ include $(RIOTMAKE)/boot/riotboot_dfu-util.mk
 # Include Board and CPU configuration
 INCLUDES += $(addprefix -I,$(wildcard $(BOARDDIR)/include))
 include $(BOARDDIR)/Makefile.include
-INCLUDES += -I$(RIOTCPU)/$(CPU)/include
-include $(RIOTCPU)/$(CPU)/Makefile.include
+INCLUDES += -I$(CPUDIR)/include
+include $(CPUDIR)/Makefile.include
 
 # include global Makefile.include for `boards` modules
 include $(RIOTBASE)/boards/Makefile.include

--- a/makefiles/application.inc.mk
+++ b/makefiles/application.inc.mk
@@ -1,6 +1,6 @@
 MODULE = $(APPLICATION_MODULE)
 
-DIRS += $(RIOTCPU)/$(CPU) $(BOARDDIR)
+DIRS += $(CPUDIR) $(BOARDDIR)
 DIRS += $(RIOTBASE)/boards
 DIRS += $(RIOTBASE)/core $(RIOTBASE)/core/lib $(RIOTBASE)/drivers $(RIOTBASE)/sys
 

--- a/makefiles/defaultmodules_regular.inc.mk
+++ b/makefiles/defaultmodules_regular.inc.mk
@@ -12,4 +12,4 @@ DEFAULT_MODULE += board board_common_init \
 -include $(BOARDDIR)/Makefile.default
 
 # Include potentially added default modules by the CPU
--include $(RIOTCPU)/$(CPU)/Makefile.default
+-include $(CPUDIR)/Makefile.default

--- a/makefiles/dependency_resolution.inc.mk
+++ b/makefiles/dependency_resolution.inc.mk
@@ -74,6 +74,7 @@ else
 
   # Detect provided / used / optional features that do not exist
   include $(RIOTMAKE)/features_existing.inc.mk
+  -include $(EXTERNAL_CPU_DIRS)/features_existing.inc.mk
   FEATURES_NONEXISTING := $(sort $(filter-out $(FEATURES_EXISTING),$(FEATURES_PROVIDED)))
   ifneq (,$(FEATURES_NONEXISTING))
     $(error "The following non-existing features are provided by the board $(BOARD): $(FEATURES_NONEXISTING)")

--- a/makefiles/features_existing.inc.mk
+++ b/makefiles/features_existing.inc.mk
@@ -112,7 +112,6 @@ FEATURES_EXISTING := \
     cpu_stm32u5 \
     cpu_stm32wb \
     cpu_stm32wl \
-    cpu_external \
     dbgpin \
     efm32_coretemp \
     emulator_renode \

--- a/makefiles/features_existing.inc.mk
+++ b/makefiles/features_existing.inc.mk
@@ -112,6 +112,7 @@ FEATURES_EXISTING := \
     cpu_stm32u5 \
     cpu_stm32wb \
     cpu_stm32wl \
+    cpu_external \
     dbgpin \
     efm32_coretemp \
     emulator_renode \

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -43,6 +43,7 @@ info-build:
 	@echo 'RIOTBASE:    $(RIOTBASE)'
 	@echo 'BOARDDIR:    $(BOARDDIR)'
 	@echo 'EXTERNAL_BOARD_DIRS:$(EXTERNAL_BOARD_DIRS)'
+	@echo 'EXTERNAL_CPU_DIRS:$(EXTERNAL_CPU_DIRS)'
 	@echo 'RIOTCPU:     $(RIOTCPU)'
 	@echo 'RIOTPKG:     $(RIOTPKG)'
 	@echo ''

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -39,6 +39,9 @@ export RIOTBOARD             # This folder is the base of the riot boards.
 export BOARDSDIR             # This is the folder containing the board dir
 export EXTERNAL_BOARD_DIRS   # List of folders containing external board dirs
 export BOARDDIR              # This folder contains the board
+export CPUSDIR               # This is the folder containing the CPU dir
+export EXTERNAL_CPU_DIRS     # list of folders containing external CPU dirs
+export CPUDIR                # This folder contains the CPU
 export RIOTPKG               # For overriding RIOT's pkg directory
 export RIOTTOOLS             # Location of host machine tools
 export RIOTPROJECT           # Top level git root of the project being built, or PWD if not a git repository


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is a continuation of #20447. 

The first commit is basically a rebase of that PR onto the current master (missing a lot var-name changes that are not relevant to the second commit). 
The second commit is a first idea on how to solve the problem that cpus are features and therefore have to be in the `features_existing.inc.mk`. The solution taken here is to have a second `features_existing.inc.mk` in the external CPU dir.

Note that this PR does not necessarily replace the original one. I just need a place to test and discuss the options for this specific issue. 

### Testing procedure

TBD


### Issues/PRs references

#20447
