### PR TITLE
.gitattributes: mark package-lock.json as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@ Cargo.lock binary
 *.md conflict-marker-size=100
 *.txt conflict-marker-size=100
 *.svg binary
+package-lock.json binary


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Starlight uses Node.js and NPM (Node Package Manager) similar to Cargo in Rust it creates a package-lock.json, which is generated when updating versions of packages.
I think it is reasonable to treat this as binary similar to how we also treat Cargo.lock as binary.

EDIT: Blocks #21944 