### PR TITLE
sys/include/net/zep.h: add NONSTRING attribute

### DIFF
--- a/sys/include/net/zep.h
+++ b/sys/include/net/zep.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 
 #include "byteorder.h"
+#include "compiler_hints.h"
 #include "net/ntp_packet.h"
 
 #ifdef __cplusplus
@@ -51,6 +52,7 @@ extern "C" {
  * @brief   ZEP header definition
  */
 typedef struct __attribute__((packed)) {
+    NONSTRING
     char preamble[2];       /**< Preamble code (must be "EX") */
     uint8_t version;        /**< Protocol Version (must be 1 or 2) */
 } zep_hdr_t;


### PR DESCRIPTION
### Contribution description

This fixes the following compilation error when using modern GCC:

    RIOT/cpu/native/socket_zep/socket_zep.c: In function '_send_zep_hello':
    RIOT/cpu/native/socket_zep/socket_zep.c:244:29: error: initializer-string for array of 'char' truncates NUL terminator but destination lacks 'nonstring' attribute (3 chars into 2 available) [-Werror=unterminated-string-initialization]
      244 |             .hdr.preamble = "EX",
          |                             ^~~~
    cc1: all warnings being treated as errors

### Testing procedure

- no compilation regressions (e.g. happy CI)
- compilation with modern GCC succeeds

### Issues/PRs references

None
