### PR TITLE
tests/unittests: fix failure with CONFIG_SOCK_URLPATH_MAXLEN=128

### DIFF
--- a/tests/unittests/tests-sock_util/tests-sock_util.c
+++ b/tests/unittests/tests-sock_util/tests-sock_util.c
@@ -47,9 +47,11 @@
 #define TEST_URL_LONG_HOSTPORT      "https://veryveryvery.long.hostname.that." \
                                     "doesnt.fit.inside.sixtyfour.characters." \
                                     "of.buffer.space/localpart"
-#define TEST_URL_LONG_URLPATH       "http://shorthostname/very/very/long/ " \
-                                    "path/that/doesnt/fit/inside/sixtyfour/" \
-                                    "chars/of/buffer/space"
+#define TEST_URL_LONG_URLPATH       "http://shorthostname/super/duper/"\
+                                    "mega/ultra/collssaly/massively/long/ " \
+                                    "path/that/doesnt/fit/inside/" \
+                                    "one-hundred-and-twentyfour/bytes/" \
+                                    "/of/preallocated/buffer/space"
 
 static char addr[CONFIG_SOCK_URLPATH_MAXLEN];
 static char urlpath[CONFIG_SOCK_URLPATH_MAXLEN];


### PR DESCRIPTION
### Contribution description

The test checking for a failure on a too long URL path will fail when allowing longer URL paths. E.g. in `makefiles/suit.inc.mk` we bump `CONFIG_SOCK_URLPATH_MAXLEN`  to 128 byte. This changes the test case to provide a path that is indeed longer than 128 byte to also fail in that case.

### Testing procedure

Add `CFLAGS += -DCONFIG_SOCK_URLPATH_MAXLEN=128` to the `Makefile` in `tests/unittests`. It should fail in `master`, but succeed with this PR.

### Issues/PRs references

None