### PR TITLE
nanocoap: Default the blocksize2 to the configured value

### DIFF
--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -1426,6 +1426,8 @@ void coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer)
         if (CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX - 4 < szx) {
             szx = CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX - 4;
         }
+    } else {
+        szx = CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX - 4;
     }
 
     coap_block_slicer_init(slicer, blknum, coap_szx2size(szx));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hii :penguin: 

The CoAP Blocksize [RFC7959](https://datatracker.ietf.org/doc/html/rfc7959#section-2.2) says: 
```
   There is no default value for the Block1 and Block2 Options.  Absence
   of one of these options is equivalent to an option value of 0 with
   respect to the value of NUM and M that could be given in the option,
   i.e., it indicates that the current block is the first and only block
   of the transfer (block number 0, M bit not set).  However, in
   contrast to the explicit value 0, which would indicate an SZX of 0
   and thus a size value of 16 bytes, there is no specific explicit size
   implied by the absence of the option -- the size is left unspecified.
   (As for any uint, the explicit value 0 is efficiently indicated by a
   zero-length option; this, therefore, is different in semantics from
   the absence of the option.)
```

RIOTs current behaviour is indeed to treat a missing Block2 option as `SZX == 0` and consequently sends `16 bytes` of response. 
I think this "feels" like a bug. Why would I want only 16 bytes if I (as the request sender) didn't bother to restrict the block size? It is very likely that I can handle more than 16 byte responses. In addition, any resource that is bigger than 16 bytes will be truncated to 16 bytes.

We already have a configuration for our maximum blocksize, I propose to default to that. 



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
