### PR TITLE
boards: use boards.h to indicated UF2 bootloader usage

### DIFF
--- a/boards/adafruit-grand-central-m4-express/Makefile.include
+++ b/boards/adafruit-grand-central-m4-express/Makefile.include
@@ -1,5 +1,3 @@
-CFLAGS += -DBOOTLOADER_UF2
-
 PROG_TTY_BOARD_FILTER := --vendor 'Adafruit Industries' --model 'Grand Central M4 Express'
 
 # Include all definitions for flashing with bossa other USB

--- a/boards/adafruit-grand-central-m4-express/include/board.h
+++ b/boards/adafruit-grand-central-m4-express/include/board.h
@@ -85,6 +85,8 @@ extern "C" {
 #endif
 /** @} */
 
+#define BOOTLOADER_UF2    1     /**< This board uses the UF2 bootloader */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/adafruit-itsybitsy-m4/Makefile.include
+++ b/boards/adafruit-itsybitsy-m4/Makefile.include
@@ -1,5 +1,3 @@
-CFLAGS += -DBOOTLOADER_UF2
-
 # Include all definitions for flashing with bossa other USB
 include $(RIOTBOARD)/common/samdx1-arduino-bootloader/Makefile.include
 # Include handling of serial and non-bossa programmers (if selected by user)

--- a/boards/adafruit-itsybitsy-m4/include/board.h
+++ b/boards/adafruit-itsybitsy-m4/include/board.h
@@ -60,6 +60,8 @@ extern "C" {
 #define XTIMER_HZ                   (1000000ul)
 /** @} */
 
+#define BOOTLOADER_UF2    1     /**< This board uses the UF2 bootloader */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/adafruit-metro-m4-express/Makefile.include
+++ b/boards/adafruit-metro-m4-express/Makefile.include
@@ -1,5 +1,3 @@
-CFLAGS += -DBOOTLOADER_UF2
-
 PROG_TTY_BOARD_FILTER := --vendor 'Adafruit Industries' --model 'Metro M4 Express'
 
 # Include all definitions for flashing with bossa other USB

--- a/boards/adafruit-metro-m4-express/include/board.h
+++ b/boards/adafruit-metro-m4-express/include/board.h
@@ -66,6 +66,8 @@ extern "C" {
 #define MTD_0 mtd_dev_get(0)    /**< MTD device for the 8 MiB QSPI Flash */
 /** @} */
 
+#define BOOTLOADER_UF2    1     /**< This board uses the UF2 bootloader */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/adafruit-pybadge/Makefile.include
+++ b/boards/adafruit-pybadge/Makefile.include
@@ -1,5 +1,3 @@
-CFLAGS += -DBOOTLOADER_UF2
-
 # stdio over usb takes several seconds to be up after flashing
 TERM_DELAY ?= 4
 

--- a/boards/adafruit-pybadge/include/board.h
+++ b/boards/adafruit-pybadge/include/board.h
@@ -107,6 +107,8 @@ extern "C" {
 #define XTIMER_HZ                   (1000000ul)                 /**< Default timer runs at 1MHz */
 /** @} */
 
+#define BOOTLOADER_UF2    1     /**< This board uses the UF2 bootloader */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/common/samdx1-arduino-bootloader/reset.c
+++ b/boards/common/samdx1-arduino-bootloader/reset.c
@@ -20,21 +20,22 @@
 
 #define USB_H_USER_IS_RIOT_INTERNAL
 
+#include "board.h"
 #include "cpu.h"
 #include "usb_board_reset.h"
 
 #ifdef HMCRAMC0_ADDR
-#define DBL_TAP_PTR ((volatile uint32_t *)(HMCRAMC0_ADDR + HMCRAMC0_SIZE - 4))
+#  define DBL_TAP_PTR ((volatile uint32_t *)(HMCRAMC0_ADDR + HMCRAMC0_SIZE - 4))
 #else
-#define DBL_TAP_PTR ((volatile uint32_t *)(HSRAM_ADDR + HSRAM_SIZE - 4))
+#  define DBL_TAP_PTR ((volatile uint32_t *)(HSRAM_ADDR + HSRAM_SIZE - 4))
 #endif
 
-#ifdef BOOTLOADER_UF2
-#define SAMD21_DOUBLE_TAP_ADDR              DBL_TAP_PTR
-#define SAMD21_DOUBLE_TAP_MAGIC_NUMBER      (0xF01669EFUL)
+#if BOOTLOADER_UF2
+#  define SAMD21_DOUBLE_TAP_ADDR            DBL_TAP_PTR
+#  define SAMD21_DOUBLE_TAP_MAGIC_NUMBER    (0xF01669EFUL)
 #else
-#define SAMD21_DOUBLE_TAP_ADDR              (0x20007FFCUL)
-#define SAMD21_DOUBLE_TAP_MAGIC_NUMBER      (0x07738135UL)
+#  define SAMD21_DOUBLE_TAP_ADDR            (0x20007FFCUL)
+#  define SAMD21_DOUBLE_TAP_MAGIC_NUMBER    (0x07738135UL)
 #endif
 
 void usb_board_reset_in_bootloader(void)

--- a/boards/feather-m0/Makefile.include
+++ b/boards/feather-m0/Makefile.include
@@ -1,8 +1,3 @@
-# Boards after around 2018 use the more modern UF2 bootloader.
-# Comment out for the old BOSSA bootloader or upgrade to
-# the UF2 bootloader.
-CFLAGS += -DBOOTLOADER_UF2
-
 # setup the flash tool used
 ifeq ($(PROGRAMMER),jlink)
   # in case J-Link is attached to SWD pins, use a plain CPU memory model

--- a/boards/feather-m0/include/board.h
+++ b/boards/feather-m0/include/board.h
@@ -67,6 +67,15 @@ extern "C" {
 #define SX127X_PARAM_PASELECT           (SX127X_PA_BOOST)
 /** @} */
 
+/**
+ * @brief   This board uses the UF2 bootloader
+ *
+ * @details Boards after around 2018 use the more modern UF2 bootloader.
+ *          Comment out for the old BOSSA bootloader or upgrade to
+ *          the UF2 bootloader.
+ */
+#define BOOTLOADER_UF2    1
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/seeeduino_xiao/Makefile.include
+++ b/boards/seeeduino_xiao/Makefile.include
@@ -1,5 +1,3 @@
-CFLAGS += -DBOOTLOADER_UF2
-
 # Include all definitions for flashing with bossa other USB
 include $(RIOTBOARD)/common/samdx1-arduino-bootloader/Makefile.include
 # Include handling of serial and non-bossa programmers (if selected by user)

--- a/boards/seeeduino_xiao/include/board.h
+++ b/boards/seeeduino_xiao/include/board.h
@@ -65,6 +65,8 @@ extern "C" {
 #define INTERNAL_PERIPHERAL_PID         (0x0057)
 /** @} */
 
+#define BOOTLOADER_UF2    1     /**< This board uses the UF2 bootloader */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/serpente/Makefile.include
+++ b/boards/serpente/Makefile.include
@@ -1,5 +1,3 @@
-CFLAGS += -DBOOTLOADER_UF2
-
 # Include all definitions for flashing with bossa other USB
 include $(RIOTBOARD)/common/samdx1-arduino-bootloader/Makefile.include
 # Include handling of serial and non-bossa programmers (if selected by user)

--- a/boards/serpente/include/board.h
+++ b/boards/serpente/include/board.h
@@ -85,6 +85,8 @@ extern "C" {
 #define INTERNAL_PERIPHERAL_PID         (0x0057)
 /** @} */
 
+#define BOOTLOADER_UF2    1     /**< This board uses the UF2 bootloader */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description

Using `CFLAGS += -DBOOTLOADER_UF2` poisens the ccache. Using the `board.h` only adds entropy to the files actually including that header.

The single user of that flag has been updated accordingly.

### Testing procedure

The generated binaries should not change with this PR.

### Issues/PRs references

None