### PR TITLE
sys/ztimer64/xtimer_compat: also provide fallback options when ztimer64 is used

### DIFF
--- a/sys/include/ztimer/xtimer_compat.h
+++ b/sys/include/ztimer/xtimer_compat.h
@@ -140,6 +140,20 @@ static inline uint32_t xtimer_now_usec(void)
     return xtimer_now();
 }
 
+static inline uint32_t xtimer_now_msec(void)
+{
+    if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        return ztimer_now(ZTIMER_MSEC);
+    }
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        return ztimer_now(ZTIMER_USEC) / US_PER_MS;
+    }
+    else {
+        _XTIMER_BACKEND_NOT_IMPLEMENTED;
+        return 0;
+    }
+}
+
 static inline void _ztimer_sleep_scale(ztimer_clock_t *clock, uint32_t time,
                                        uint32_t scale)
 {

--- a/sys/include/ztimer64/xtimer_compat.h
+++ b/sys/include/ztimer64/xtimer_compat.h
@@ -27,6 +27,7 @@
 /* make sure to overwrite potentially conflicting XTIMER_WIDTH definition from
  * board.h by eagerly including it */
 #include "board.h"
+#include "busy_wait.h"
 #include "div.h"
 #include "timex.h"
 #ifdef MODULE_CORE_MSG
@@ -65,10 +66,28 @@ extern "C" {
 #define XTIMER_BACKOFF  1
 #endif
 
+/**
+ * @brief   Generate a link-time failure if a function is used that can not be
+ *          implemented with the selected backends.
+ */
+#define _XTIMER_BACKEND_NOT_IMPLEMENTED \
+    extern void xtimer_function_called_but_no_backend_available(void); \
+    xtimer_function_called_but_no_backend_available()
+
 typedef ztimer64_t xtimer_t;
 typedef uint32_t xtimer_ticks32_t;
 typedef uint64_t xtimer_ticks64_t;
 typedef void (*xtimer_callback_t)(void *);
+
+static inline uint32_t _div_round_up_u32(uint32_t a, uint32_t b)
+{
+    return (a + b - 1) / b;
+}
+
+static inline uint32_t _div_round_up_u64(uint64_t a, uint32_t b)
+{
+    return (a + b - 1) / b;
+}
 
 static inline void xtimer_init(void)
 {
@@ -80,9 +99,62 @@ static inline xtimer_ticks32_t xtimer_ticks(uint32_t ticks)
     return ticks;
 }
 
+static inline uint64_t xtimer_usec_from_ticks64(xtimer_ticks64_t ticks)
+{
+    return ticks;
+}
+
+static inline uint32_t xtimer_usec_from_ticks(xtimer_ticks32_t ticks)
+{
+    return ticks;
+}
+
+static inline uint32_t xtimer_msec_from_ticks(xtimer_ticks32_t ticks)
+{
+    return _div_round_up_u32(ticks, US_PER_MS);
+}
+
+static inline xtimer_ticks32_t xtimer_ticks_from_usec(uint32_t usec)
+{
+    return usec;
+}
+
+static inline xtimer_ticks64_t xtimer_ticks_from_usec64(uint64_t usec)
+{
+    return usec;
+}
+
 static inline xtimer_ticks32_t xtimer_now(void)
 {
-    return ztimer64_now(ZTIMER64_USEC);
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        return ztimer_now(ZTIMER_USEC);
+    }
+    else if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        return ztimer_now(ZTIMER_MSEC) * US_PER_MS;
+    }
+    else {
+        _XTIMER_BACKEND_NOT_IMPLEMENTED;
+        return 0;
+    }
+}
+
+static inline uint32_t xtimer_now_usec(void)
+{
+    return xtimer_now();
+}
+
+static inline uint64_t xtimer_now_usec64(void)
+{
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        return ztimer64_now(ZTIMER64_USEC);
+    }
+    else if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        return ztimer64_now(ZTIMER64_MSEC) * US_PER_MS;
+    }
+    else {
+        _XTIMER_BACKEND_NOT_IMPLEMENTED;
+        return 0;
+    }
 }
 
 static inline uint32_t _xtimer_now(void)
@@ -92,22 +164,20 @@ static inline uint32_t _xtimer_now(void)
 
 static inline xtimer_ticks64_t xtimer_now64(void)
 {
-    return ztimer64_now(ZTIMER64_USEC);
+    return xtimer_now_usec64();
+}
+
+static inline void xtimer_now_timex(timex_t *out)
+{
+    uint64_t now = xtimer_now_usec64();
+
+    out->seconds = div_u64_by_1000000(now);
+    out->microseconds = now - (out->seconds * US_PER_SEC);
 }
 
 static inline void xtimer_usleep64(uint64_t microseconds)
 {
     ztimer64_sleep(ZTIMER64_USEC, microseconds);
-}
-
-static inline uint32_t xtimer_now_usec(void)
-{
-    return ztimer64_now(ZTIMER64_USEC);
-}
-
-static inline uint64_t xtimer_now_usec64(void)
-{
-    return ztimer64_now(ZTIMER64_USEC);
 }
 
 static inline void xtimer_sleep(uint32_t seconds)
@@ -126,24 +196,51 @@ static inline void xtimer_msleep(uint32_t milliseconds)
     if (IS_ACTIVE(MODULE_ZTIMER_MSEC)) {
         ztimer_sleep(ZTIMER_MSEC, milliseconds);
     }
-    else {
+    else if (IS_USED(MODULE_ZTIMER_USEC)) {
         ztimer64_sleep(ZTIMER64_USEC, ((uint64_t)milliseconds) * 1000LLU);
+    }
+    else {
+        busy_wait_us(US_PER_MS * milliseconds);
     }
 }
 
 static inline void xtimer_usleep(uint32_t microseconds)
 {
-    ztimer_sleep(ZTIMER_USEC, microseconds);
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        ztimer_sleep(ZTIMER_USEC, microseconds);
+    }
+    else if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        ztimer_sleep(ZTIMER_MSEC, _div_round_up_u32(microseconds, US_PER_MS));
+    }
+    else {
+        busy_wait_us(microseconds);
+    }
 }
 
 static inline void xtimer_set(xtimer_t *timer, uint32_t offset)
 {
-    ztimer64_set(ZTIMER64_USEC, timer, offset);
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        ztimer64_set(ZTIMER64_USEC, timer, offset);
+    }
+    else if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        ztimer64_set(ZTIMER64_MSEC, timer, _div_round_up_u32(offset, US_PER_MS));
+    }
+    else {
+        _XTIMER_BACKEND_NOT_IMPLEMENTED;
+    }
 }
 
 static inline void xtimer_remove(xtimer_t *timer)
 {
-    ztimer64_remove(ZTIMER64_USEC, timer);
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        ztimer64_remove(ZTIMER64_USEC, timer);
+    }
+    else if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        ztimer64_remove(ZTIMER64_MSEC, timer);
+    }
+    else {
+        _XTIMER_BACKEND_NOT_IMPLEMENTED;
+    }
 }
 
 static inline bool xtimer_is_set(const xtimer_t *timer)
@@ -154,79 +251,136 @@ static inline bool xtimer_is_set(const xtimer_t *timer)
 static inline void xtimer_set_msg(xtimer_t *timer, uint32_t offset, msg_t *msg,
                                   kernel_pid_t target_pid)
 {
-    ztimer64_set_msg(ZTIMER64_USEC, timer, offset, msg, target_pid);
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        ztimer64_set_msg(ZTIMER64_USEC, timer, offset, msg, target_pid);
+    }
+    else if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        ztimer64_set_msg(ZTIMER64_MSEC, timer, _div_round_up_u32(offset, US_PER_MS),
+                         msg, target_pid);
+    }
+    else {
+        _XTIMER_BACKEND_NOT_IMPLEMENTED;
+    }
 }
 
 static inline void xtimer_periodic_wakeup(xtimer_ticks32_t *last_wakeup,
                                           uint32_t period)
 {
-    ztimer_periodic_wakeup(ZTIMER_USEC, last_wakeup, period);
-}
-
-static inline uint32_t xtimer_usec_from_ticks(xtimer_ticks32_t ticks)
-{
-    return ticks;
-}
-
-static inline xtimer_ticks32_t xtimer_ticks_from_usec(uint32_t usec)
-{
-    return usec;
-}
-
-static inline void xtimer_now_timex(timex_t *out)
-{
-    uint64_t now = xtimer_now_usec64();
-
-    out->seconds = div_u64_by_1000000(now);
-    out->microseconds = now - (out->seconds * US_PER_SEC);
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        ztimer_periodic_wakeup(ZTIMER_USEC, last_wakeup, period);
+    }
+    else if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        ztimer_periodic_wakeup(ZTIMER_MSEC, last_wakeup, _div_round_up_u32(period, US_PER_MS));
+    }
+    else {
+        _XTIMER_BACKEND_NOT_IMPLEMENTED;
+    }
 }
 
 static inline int xtimer_msg_receive_timeout(msg_t *msg, uint32_t timeout)
 {
-    return ztimer_msg_receive_timeout(ZTIMER_USEC, msg, timeout);
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        return ztimer_msg_receive_timeout(ZTIMER_USEC, msg, timeout);
+    }
+    else if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        return ztimer_msg_receive_timeout(ZTIMER_MSEC, msg, _div_round_up_u32(timeout, US_PER_MS));
+    }
+    else {
+        _XTIMER_BACKEND_NOT_IMPLEMENTED;
+        return 0;
+    }
 }
 
 static inline void xtimer_set_wakeup(xtimer_t *timer, uint32_t offset,
                                      kernel_pid_t pid)
 {
-    ztimer64_set_wakeup(ZTIMER64_USEC, timer, offset, pid);
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        ztimer64_set_wakeup(ZTIMER64_USEC, timer, offset, pid);
+    }
+    else if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        ztimer64_set_wakeup(ZTIMER64_MSEC, timer, _div_round_up_u32(offset, US_PER_MS), pid);
+    }
+    else {
+        _XTIMER_BACKEND_NOT_IMPLEMENTED;
+    }
 }
 
 static inline int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us)
 {
-    if (ztimer64_mutex_lock_timeout(ZTIMER64_USEC, mutex, us)) {
-        /* Impedance matching required: Convert -ECANCELED error code to -1: */
-        return -1;
+    int res;
+
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        res = ztimer64_mutex_lock_timeout(ZTIMER64_USEC, mutex, us);
     }
-    return 0;
+    else if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        us = _div_round_up_u64(us, US_PER_MS);
+        res = ztimer64_mutex_lock_timeout(ZTIMER64_MSEC, mutex, us);
+    }
+    else {
+        _XTIMER_BACKEND_NOT_IMPLEMENTED;
+        res = -1;
+    }
+
+    /* Impedance matching required: Convert -ECANCELED error code to -1: */
+    return res ? -1 : 0;
 }
 
-static inline int xtimer_rmutex_lock_timeout(rmutex_t *rmutex, uint64_t timeout)
+static inline int xtimer_rmutex_lock_timeout(rmutex_t *rmutex, uint64_t us)
 {
-    if (ztimer64_rmutex_lock_timeout(ZTIMER64_USEC, rmutex, timeout)) {
-        /* Impedance matching required: Convert -ECANCELED error code to -1: */
-        return -1;
-    }
-    return 0;
-}
+    int res;
 
-static inline void xtimer_set_timeout_flag64(xtimer_t *t, uint64_t timeout)
-{
-    ztimer64_set_timeout_flag(ZTIMER64_USEC, t, timeout);
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        res = ztimer64_rmutex_lock_timeout(ZTIMER64_USEC, rmutex, us);
+    }
+    else if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        us = _div_round_up_u64(us, US_PER_MS);
+        res = ztimer64_rmutex_lock_timeout(ZTIMER64_MSEC, rmutex, us);
+    }
+    else {
+        _XTIMER_BACKEND_NOT_IMPLEMENTED;
+        res = -1;
+    }
+
+    /* Impedance matching required: Convert -ECANCELED error code to -1: */
+    return res ? -1 : 0;
 }
 
 static inline void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout)
 {
-    xtimer_set_timeout_flag64(t, timeout);
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        ztimer64_set_timeout_flag(ZTIMER64_USEC, t, timeout);
+    }
+    else if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        ztimer64_set_timeout_flag(ZTIMER64_MSEC, t, _div_round_up_u32(timeout, US_PER_MS));
+    }
+    else {
+        _XTIMER_BACKEND_NOT_IMPLEMENTED;
+    }
+}
+
+static inline void xtimer_set_timeout_flag64(xtimer_t *t, uint64_t timeout)
+{
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        ztimer64_set_timeout_flag(ZTIMER64_USEC, t, timeout);
+    }
+    else if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        ztimer64_set_timeout_flag(ZTIMER64_MSEC, t, _div_round_up_u64(timeout, US_PER_MS));
+    }
+    else {
+        _XTIMER_BACKEND_NOT_IMPLEMENTED;
+    }
 }
 
 static inline void xtimer_spin(xtimer_ticks32_t ticks)
 {
-    assert(ticks < US_PER_MS);
-    ztimer_now_t start = ztimer_now(ZTIMER_USEC);
-
-    while (ztimer_now(ZTIMER_USEC) - start < ticks) {
-        /* busy waiting */
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        ztimer_spin(ZTIMER_USEC, xtimer_usec_from_ticks(ticks));
+    }
+    else if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        ztimer_spin(ZTIMER_MSEC, xtimer_msec_from_ticks(ticks));
+    }
+    else {
+        busy_wait_us(xtimer_usec_from_ticks(ticks));
     }
 }
 
@@ -288,12 +442,31 @@ static inline void xtimer_set_wakeup64(xtimer_t *timer, uint64_t offset,
 static inline void xtimer_set_msg64(xtimer_t *timer, uint64_t offset,
                                     msg_t *msg, kernel_pid_t target_pid)
 {
-    ztimer64_set_msg(ZTIMER64_USEC, timer, offset, msg, target_pid);
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        ztimer64_set_msg(ZTIMER64_USEC, timer, offset, msg, target_pid);
+    }
+    else if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        ztimer64_set_msg(ZTIMER64_MSEC, timer,
+                         _div_round_up_u64(offset, US_PER_MS), msg, target_pid);
+    }
+    else {
+        _XTIMER_BACKEND_NOT_IMPLEMENTED;
+    }
 }
 
 static inline int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t timeout)
 {
-    return ztimer64_msg_receive_timeout(ZTIMER64_USEC, msg, timeout);
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        return ztimer64_msg_receive_timeout(ZTIMER64_USEC, msg, timeout);
+    }
+    else if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        return ztimer64_msg_receive_timeout(ZTIMER64_MSEC, msg,
+                                            _div_round_up_u64(timeout, US_PER_MS));
+    }
+    else {
+        _XTIMER_BACKEND_NOT_IMPLEMENTED;
+        return 0;
+    }
 }
 
 #endif

--- a/sys/include/ztimer64/xtimer_compat.h
+++ b/sys/include/ztimer64/xtimer_compat.h
@@ -27,7 +27,6 @@
 /* make sure to overwrite potentially conflicting XTIMER_WIDTH definition from
  * board.h by eagerly including it */
 #include "board.h"
-#include "busy_wait.h"
 #include "div.h"
 #include "timex.h"
 #ifdef MODULE_CORE_MSG
@@ -143,6 +142,20 @@ static inline uint32_t xtimer_now_usec(void)
     return xtimer_now();
 }
 
+static inline uint32_t xtimer_now_msec(void)
+{
+    if (IS_USED(MODULE_ZTIMER_MSEC)) {
+        return ztimer_now(ZTIMER_MSEC);
+    }
+    if (IS_USED(MODULE_ZTIMER_USEC)) {
+        return ztimer64_now(ZTIMER64_USEC) / US_PER_MS;
+    }
+    else {
+        _XTIMER_BACKEND_NOT_IMPLEMENTED;
+        return 0;
+    }
+}
+
 static inline uint64_t xtimer_now_usec64(void)
 {
     if (IS_USED(MODULE_ZTIMER_USEC)) {
@@ -200,7 +213,7 @@ static inline void xtimer_msleep(uint32_t milliseconds)
         ztimer64_sleep(ZTIMER64_USEC, ((uint64_t)milliseconds) * 1000LLU);
     }
     else {
-        busy_wait_us(US_PER_MS * milliseconds);
+        assume(0);
     }
 }
 
@@ -213,7 +226,7 @@ static inline void xtimer_usleep(uint32_t microseconds)
         ztimer_sleep(ZTIMER_MSEC, _div_round_up_u32(microseconds, US_PER_MS));
     }
     else {
-        busy_wait_us(microseconds);
+        assume(0);
     }
 }
 
@@ -380,7 +393,7 @@ static inline void xtimer_spin(xtimer_ticks32_t ticks)
         ztimer_spin(ZTIMER_MSEC, xtimer_msec_from_ticks(ticks));
     }
     else {
-        busy_wait_us(xtimer_usec_from_ticks(ticks));
+        assume(0);
     }
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Turns out we also have to provide those fallback implementations in `ztimer64/xtimer_compat.h` for when `ztimer64` is used.

Take the opportunity to re-order the `ztimer/xtimer_compat.h` so it better aligns with `ztimer64/xtimer_compat.h`.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

follow-up to #20494
