### PR TITLE
cpu/sam0_common: implement periph_gpio_read_output

### DIFF
--- a/cpu/samd21/Makefile.features
+++ b/cpu/samd21/Makefile.features
@@ -1,6 +1,7 @@
 CPU_CORE = cortex-m0plus
 
 FEATURES_PROVIDED += periph_gpio_fast_read
+FEATURES_PROVIDED += periph_gpio_read_output
 
 ifeq (,$(filter samd20%,$(CPU_MODEL)))
   FEATURES_PROVIDED += periph_uart_collision

--- a/cpu/samd5x/Makefile.features
+++ b/cpu/samd5x/Makefile.features
@@ -3,6 +3,7 @@ CPU_CORE = cortex-m4f
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += backup_ram
 FEATURES_PROVIDED += cortexm_mpu
+FEATURES_PROVIDED += periph_gpio_read_output
 FEATURES_PROVIDED += periph_gpio_tamper_wake
 FEATURES_PROVIDED += periph_rtc_mem
 FEATURES_PROVIDED += periph_spi_on_qspi

--- a/cpu/saml1x/Makefile.features
+++ b/cpu/saml1x/Makefile.features
@@ -5,6 +5,7 @@ CPU_CORE = cortex-m23
 
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_gpio_fast_read
+FEATURES_PROVIDED += periph_gpio_read_output
 FEATURES_PROVIDED += periph_uart_collision
 
 include $(RIOTCPU)/sam0_common/Makefile.features

--- a/cpu/saml21/Makefile.features
+++ b/cpu/saml21/Makefile.features
@@ -4,6 +4,7 @@ CPU_CORE = cortex-m0plus
 CPU_MODELS_WITHOUT_HWRNG += samr30%
 
 FEATURES_PROVIDED += periph_gpio_fast_read
+FEATURES_PROVIDED += periph_gpio_read_output
 FEATURES_PROVIDED += periph_uart_collision
 
 # Low Power SRAM is *not* retained during Backup Sleep.

--- a/features.yaml
+++ b/features.yaml
@@ -512,6 +512,13 @@ groups:
             Enabling this feature reduces read latency for an increase in power
             consumption. It affects both the classic GPIO API driver and the
             GPIO LL driver.
+    - name: periph_gpio_read_output
+      help: This feature is currently implemented on Microchip SAM0 based MCUs only.
+            Enabling this feature makes `gpio_read()` read back the actual pin level
+            of an output GPIO (instead of just returning the configured level).
+            This can be used to detect hardware problems (e.g. if a pin is set HIGH but
+            reads low).
+            The feature comes at the cost of slightly higher power consumption.
 
     groups:
     - title: Pin Level Peripheral GPIO API

--- a/makefiles/features_existing.inc.mk
+++ b/makefiles/features_existing.inc.mk
@@ -185,6 +185,7 @@ FEATURES_EXISTING := \
     periph_gpio_ll_open_source \
     periph_gpio_ll_open_source_pull_down \
     periph_gpio_ll_switch_dir \
+    periph_gpio_read_output \
     periph_gpio_tamper_wake \
     periph_hash_md5 \
     periph_hash_sha3_256 \

--- a/tests/periph/gpio/Makefile
+++ b/tests/periph/gpio/Makefile
@@ -5,6 +5,7 @@ include ../Makefile.periph_common
 FEATURES_REQUIRED += periph_gpio
 FEATURES_OPTIONAL += periph_gpio_irq
 FEATURES_OPTIONAL += periph_gpio_fast_read
+FEATURES_OPTIONAL += periph_gpio_read_output
 FEATURES_OPTIONAL += periph_gpio_tamper_wake
 
 USEMODULE += shell_cmds_default


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The GPIO peripheral of the sam0 MCUs have a feature where they can read back the output level of a GPIO as if the GPIO was in input. (As opposed to the currently implemented mode where `gpio_read()` just returns the configured register value).

<img width="1120" height="459" alt="image" src="https://github.com/user-attachments/assets/18d07e91-b79e-4a7f-8a42-18f8d2c66b27" />

This can be useful to detect hardware defects.
The drawback is slightly higher power draw (according to the data sheet, didn't measure), so guard this behind the `periph_gpio_read_output`, just like `periph_gpio_fast_read`.

### Testing procedure

The GPIO test application `tests/periph/gpio` has been updated to make use of the feature when available.

```
2025-12-16 17:22:39,054 # > init_out 1 5
2025-12-16 17:22:41,031 # > read 1 5
2025-12-16 17:22:41,033 # GPIO_PIN(1.05) is LOW

2025-12-16 17:22:43,160 # > set 1 5
2025-12-16 17:22:44,309 # > read 1 5
2025-12-16 17:22:44,311 # GPIO_PIN(1.05) is HIGH

2025-12-16 17:22:48,471 # > clear 1 5
2025-12-16 17:22:49,971 # > read 1 5
2025-12-16 17:22:49,973 # GPIO_PIN(1.05) is LOW
```



### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
