### PR TITLE
cpu/stm32: simplify handling of generated IRQ header

### DIFF
--- a/cpu/stm32/Makefile.include
+++ b/cpu/stm32/Makefile.include
@@ -113,8 +113,9 @@ ifeq (,$(filter STM32MP157Cxx STM32F030x4,$(CPU_LINE)))
   # package so they are hardcoded in RIOTs codebase.
   # For other lines, the IRQs are automatically generated once from the whole
   # list of CMSIS headers available in a given family
-  STM32IRQS_INCLUDE_FILE = $(RIOTCPU)/stm32/include/irqs/$(CPU_FAM)/irqs.h
+  STM32IRQS_INCLUDE_FILE = $(RIOTCPU)/stm32/include/irqs/$(CPU_FAM)/stm32_irqs.h
   BUILDDEPS += $(STM32IRQS_INCLUDE_FILE)
+  INCLUDES += -I$(RIOTCPU)/stm32/include/irqs/$(CPU_FAM)
 endif
 
 # The IRQ header for a given family requires the family headers to be fetched

--- a/cpu/stm32/dist/irqs/gen_irqs.py
+++ b/cpu/stm32/dist/irqs/gen_irqs.py
@@ -18,7 +18,7 @@ RIOTBASE = os.getenv(
     "RIOTBASE", os.path.abspath(os.path.join(CURRENT_DIR, "../../../..")))
 STM32_INCLUDE_DIR = os.path.join(RIOTBASE, "cpu/stm32/include")
 STM32_IRQS_DIR = os.path.join(
-    RIOTBASE, STM32_INCLUDE_DIR, "irqs/{}/irqs.h")
+    RIOTBASE, STM32_INCLUDE_DIR, "irqs/{}/stm32_irqs.h")
 
 IRQS_FORMAT = """
 /*
@@ -30,6 +30,8 @@ IRQS_FORMAT = """
 
 #ifndef IRQS_{cpu_fam}_H
 #define IRQS_{cpu_fam}_H
+
+#include "{cpu_fam_include}"
 
 #ifdef __cplusplus
 extern "C" {{
@@ -122,6 +124,7 @@ def generate_irqs(context):
     irqs_content = IRQS_FORMAT.format(
         cpu_fam=context["cpu_fam"].upper(),
         irq_lines="\n".join(irq_lines),
+        cpu_fam_include="stm32{}xx.h".format(context["cpu_fam"])
         )
     dest_file = os.path.join(STM32_IRQS_DIR.format(context["cpu_fam"]))
 

--- a/cpu/stm32/include/cpu_conf.h
+++ b/cpu/stm32/include/cpu_conf.h
@@ -24,57 +24,8 @@
 #include "vendor/stm32f030x4.h"
 #elif defined(CPU_LINE_STM32MP157Cxx)
 #include "vendor/stm32mp157cxx_cm4.h"
-#elif CPU_FAM_STM32F0
-#include "stm32f0xx.h"
-#include "irqs/f0/irqs.h"
-#elif CPU_FAM_STM32F1
-#include "stm32f1xx.h"
-#include "irqs/f1/irqs.h"
-#elif CPU_FAM_STM32F2
-#include "stm32f2xx.h"
-#include "irqs/f2/irqs.h"
-#elif CPU_FAM_STM32F3
-#include "stm32f3xx.h"
-#include "irqs/f3/irqs.h"
-#elif CPU_FAM_STM32F4
-#include "stm32f4xx.h"
-#include "irqs/f4/irqs.h"
-#elif CPU_FAM_STM32F7
-#include "stm32f7xx.h"
-#include "irqs/f7/irqs.h"
-#elif CPU_FAM_STM32G0
-#include "stm32g0xx.h"
-#include "irqs/g0/irqs.h"
-#elif CPU_FAM_STM32C0
-#include "stm32c0xx.h"
-#include "irqs/c0/irqs.h"
-#elif CPU_FAM_STM32G4
-#include "stm32g4xx.h"
-#include "irqs/g4/irqs.h"
-#elif CPU_FAM_STM32L0
-#include "stm32l0xx.h"
-#include "irqs/l0/irqs.h"
-#elif CPU_FAM_STM32L1
-#include "stm32l1xx.h"
-#include "irqs/l1/irqs.h"
-#elif CPU_FAM_STM32L4
-#include "stm32l4xx.h"
-#include "irqs/l4/irqs.h"
-#elif CPU_FAM_STM32L5
-#include "stm32l5xx.h"
-#include "irqs/l5/irqs.h"
-#elif CPU_FAM_STM32U5
-#include "stm32u5xx.h"
-#include "irqs/u5/irqs.h"
-#define NUM_HEAPS   3
-#elif CPU_FAM_STM32WB
-#include "stm32wbxx.h"
-#include "irqs/wb/irqs.h"
-#elif CPU_FAM_STM32WL
-#include "stm32wlxx.h"
-#include "irqs/wl/irqs.h"
 #else
-#error Not supported CPU family
+#include "stm32_irqs.h"
 #endif
 
 /* add unused backup RAM as extra heap */
@@ -101,7 +52,7 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
-/* STM32MP1 family has no flah */
+/* STM32MP1 family has no flash */
 #if !defined(CPU_FAM_STM32MP1)
 #define CPU_FLASH_BASE                  FLASH_BASE
 #endif


### PR DESCRIPTION
### Contribution description

- rename `irqs/<CPU_FAM>/irqs.h` to `irqs/<CPU_FAM>/stm32_irqs.h` to reduce chance of a name conflict (`irqs.h` might not be unique)
- add `irqs/<CPU_FAM>` to the include paths
- add the `#include "stm32{f0,f1,f2,f3,f4,f7,l0,...}xx.h"` to the generated `stm32_irqs.h`

==> Now we can just go for `#include "stm32_irqs.h` and drop a lot of preprocessor conditionals

### Testing procedure

The generated binaries should not change

### Issues/PRs references

None