### PR TITLE
dist/tools/esptools: remove non-existing 'esptool' tool target

### DIFF
--- a/dist/tools/esptools/install.sh
+++ b/dist/tools/esptools/install.sh
@@ -235,7 +235,7 @@ if [ -z "$1" ]; then
     echo "Usage: install.sh <tool>"
     echo "       install.sh gdb <platform>"
     echo "       install.sh qemu <platform>"
-    echo "<tool> = all | esptool | gdb | openocd | qemu |"
+    echo "<tool> = all | gdb | openocd | qemu |"
     echo "         esp8266 | esp32 | esp32c3 | esp32c6 | esp32h2 | esp32s2 | esp32s3"
     echo "<platform> = xtensa | riscv"
     exit 1


### PR DESCRIPTION
### Contribution description

Commit be9172f from PR #21522 errorneously introduced the `esptool` as an installation target, which does not exist.

This PR removes that regression.

Discovered by `tomnatosoup` in the Matrix chat.

### Testing procedure

Run `dist/tools/esptools/install.sh` and observe that `esptool` is not displayed as an option anymore:

Before:
```
buechse@skyleaf:~/RIOTstuff/riot-vanillaice/RIOT$ dist/tools/esptools/install.sh
Usage: install.sh <tool>
       install.sh gdb <platform>
       install.sh qemu <platform>
<tool> = all | esptool | gdb | openocd | qemu |
         esp8266 | esp32 | esp32c3 | esp32c6 | esp32h2 | esp32s2 | esp32s3
<platform> = xtensa | riscv
```

After:
```
buechse@skyleaf:~/RIOTstuff/riot-vanillaice/RIOT$ dist/tools/esptools/install.sh
Usage: install.sh <tool>
       install.sh gdb <platform>
       install.sh qemu <platform>
<tool> = all | gdb | openocd | qemu |
         esp8266 | esp32 | esp32c3 | esp32c6 | esp32h2 | esp32s2 | esp32s3
<platform> = xtensa | riscv
```

### Issues/PRs references

Introduced in #21522.