### PR TITLE
sys/net/link_layer/ieee802154/submac: move ack transmission

### DIFF
--- a/cpu/native/Makefile.dep
+++ b/cpu/native/Makefile.dep
@@ -43,7 +43,7 @@ ifneq (,$(filter socket_zep,$(USEMODULE)))
   USEMODULE += ieee802154
   ifneq (,$(filter netdev,$(USEMODULE)))
     USEMODULE += netdev_ieee802154_submac
-    USEMODULE += netdev_ieee802154_submac_soft_ack
+    USEMODULE += ieee802154_submac_soft_ack
   endif
 endif
 

--- a/cpu/native/Makefile.dep
+++ b/cpu/native/Makefile.dep
@@ -43,6 +43,8 @@ ifneq (,$(filter socket_zep,$(USEMODULE)))
   USEMODULE += ieee802154
   ifneq (,$(filter netdev,$(USEMODULE)))
     USEMODULE += netdev_ieee802154_submac
+  endif
+  ifneq (,$(filter ieee802154_submac,$(USEMODULE)))
     USEMODULE += ieee802154_submac_soft_ack
   endif
 endif

--- a/cpu/nrf52/Makefile.dep
+++ b/cpu/nrf52/Makefile.dep
@@ -14,7 +14,7 @@ ifneq (,$(filter nrf802154,$(USEMODULE)))
   USEMODULE += luid
   ifneq (,$(filter netdev,$(USEMODULE)))
     USEMODULE += netdev_ieee802154_submac
-    USEMODULE += netdev_ieee802154_submac_soft_ack
+    USEMODULE += ieee802154_submac_soft_ack
   endif
 endif
 

--- a/cpu/nrf52/Makefile.dep
+++ b/cpu/nrf52/Makefile.dep
@@ -14,6 +14,8 @@ ifneq (,$(filter nrf802154,$(USEMODULE)))
   USEMODULE += luid
   ifneq (,$(filter netdev,$(USEMODULE)))
     USEMODULE += netdev_ieee802154_submac
+  endif
+  ifneq (,$(filter ieee802154_submac,$(USEMODULE)))
     USEMODULE += ieee802154_submac_soft_ack
   endif
 endif

--- a/drivers/netdev_ieee802154_submac/Makefile.dep
+++ b/drivers/netdev_ieee802154_submac/Makefile.dep
@@ -4,3 +4,8 @@ USEMODULE += ieee802154
 USEMODULE += ieee802154_submac
 USEMODULE += iolist
 USEMODULE += ztimer_usec
+
+ifneq (,$(filter netdev_ieee802154_submac_soft_ack,$(USEMODULE)))
+  USEMODULE += ieee802154_submac_soft_ack
+  $(warning SubMAC Soft ACK is renamed to ieee802154_submac_soft_ack.)
+endif

--- a/drivers/netdev_ieee802154_submac/Makefile.dep
+++ b/drivers/netdev_ieee802154_submac/Makefile.dep
@@ -7,5 +7,5 @@ USEMODULE += ztimer_usec
 
 ifneq (,$(filter netdev_ieee802154_submac_soft_ack,$(USEMODULE)))
   USEMODULE += ieee802154_submac_soft_ack
-  $(warning SubMAC Soft ACK is renamed to ieee802154_submac_soft_ack.)
+  $(warning SubMAC Soft ACK has been renamed to ieee802154_submac_soft_ack. Will be removed after release 2027.04)
 endif

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -227,7 +227,7 @@ static void _isr(netdev_t *netdev)
                                      | NETDEV_SUBMAC_FLAGS_TX_DONE);
 
         if (flags & NETDEV_SUBMAC_FLAGS_CRC_ERROR) {
-            DEBUG("IEEE802154 submac:c NETDEV_SUBMAC_FLAGS_CRC_ERROR\n");
+            DEBUG("IEEE802154 submac: _isr(): NETDEV_SUBMAC_FLAGS_CRC_ERROR\n");
             ieee802154_submac_crc_error_cb(submac);
             flags &= ~NETDEV_SUBMAC_FLAGS_CRC_ERROR;
         }
@@ -301,30 +301,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
         netdev_rx_info->lqi = rx_info.lqi;
     }
-#if IS_USED(MODULE_NETDEV_IEEE802154_SUBMAC_SOFT_ACK)
-    const uint8_t *mhr = buf;
-    if ((mhr[0] & IEEE802154_FCF_TYPE_MASK) == IEEE802154_FCF_TYPE_DATA &&
-        (mhr[0] & IEEE802154_FCF_ACK_REQ)) {
-        ieee802154_filter_mode_t mode;
-        if (!ieee802154_radio_has_capability(&submac->dev, IEEE802154_CAP_AUTO_ACK) &&
-            (ieee802154_radio_get_frame_filter_mode(&submac->dev, &mode) < 0
-                || mode == IEEE802154_FILTER_ACCEPT)) {
-            /* send ACK if not handled by the driver and not in promiscuous mode */
-            uint8_t ack[IEEE802154_ACK_FRAME_LEN - IEEE802154_FCS_LEN]
-                = { IEEE802154_FCF_TYPE_ACK, 0x00, ieee802154_get_seq(mhr) };
-            iolist_t io = {
-                .iol_base = ack,
-                .iol_len = sizeof(ack),
-                .iol_next = NULL
-            };
-            DEBUG("IEEE802154 submac: Sending ACK\n");
-            int snd = _send(netdev, &io);
-            if (snd < 0) {
-                DEBUG("IEEE802154 submac: failed to send ACK (%d)\n", snd);
-            }
-        }
-    }
-#endif
+
     return res;
 }
 

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -284,7 +284,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
                                                              netdev_ieee802154_submac_t,
                                                              dev);
     ieee802154_submac_t *submac = &netdev_submac->submac;
-    ieee802154_rx_info_t rx_info;
+    ieee802154_rx_info_t rx_info = { 0 };
 
     if (buf == NULL && len == 0) {
         return ieee802154_get_frame_length(submac);

--- a/makefiles/deprecated_modules.inc.mk
+++ b/makefiles/deprecated_modules.inc.mk
@@ -1,3 +1,4 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!111elven
+DEPRECATED_MODULES += netdev_ieee802154_submac_soft_ack
 DEPRECATED_MODULES += sema_deprecated

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -247,6 +247,7 @@ PSEUDOMODULES += gnrc_sock_check_reuse
 PSEUDOMODULES += gnrc_txtsnd
 PSEUDOMODULES += ieee802154_security
 PSEUDOMODULES += ieee802154_submac
+PSEUDOMODULES += ieee802154_submac_soft_ack
 PSEUDOMODULES += ipv4
 PSEUDOMODULES += ipv6
 PSEUDOMODULES += l2filter_blacklist

--- a/sys/include/net/ieee802154/submac.h
+++ b/sys/include/net/ieee802154/submac.h
@@ -427,6 +427,8 @@ static inline int ieee802154_set_tx_power(ieee802154_submac_t *submac,
 /**
  * @brief Get the received frame length
  *
+ * @pre this function MUST be called either inside @ref ieee802154_submac_cb_t::rx_done
+ *      or in SLEEP state.
  * @param[in] submac pointer to the SubMAC
  *
  * @return length of the PSDU (excluding FCS length)
@@ -442,7 +444,7 @@ static inline int ieee802154_get_frame_length(ieee802154_submac_t *submac)
  * This functions reads the received PSDU from the device (excluding FCS)
  *
  * @pre this function MUST be called either inside @ref ieee802154_submac_cb_t::rx_done
- * or in SLEEP state.
+ *      or in SLEEP state.
  *
  * @param[in] submac pointer to the SubMAC descriptor
  * @param[out] buf buffer to write into. If NULL, the packet is discarded

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -48,6 +48,9 @@ static char *str_states[IEEE802154_FSM_STATE_NUMOF] = {
     "PREPARE",
     "TX",
     "WAIT_FOR_ACK",
+#if IS_USED(MODULE_IEEE802154_SUBMAC_SOFT_ACK)
+    "TX_ACK",
+#endif /* MODULE_IEEE802154_SUBMAC_SOFT_ACK */
 };
 
 static char *str_ev[IEEE802154_FSM_EV_NUMOF] = {
@@ -65,6 +68,14 @@ static inline bool _does_handle_ack(ieee802154_dev_t *dev)
 {
     return ieee802154_radio_has_frame_retrans(dev) ||
            ieee802154_radio_has_irq_ack_timeout(dev);
+}
+
+static inline bool _does_send_ack(ieee802154_dev_t *dev)
+{
+    if (!IS_USED(MODULE_IEEE802154_SUBMAC_SOFT_ACK)) {
+        return true;
+    }
+    return ieee802154_radio_has_capability(dev, IEEE802154_CAP_AUTO_ACK);
 }
 
 static inline bool _does_handle_csma(ieee802154_dev_t *dev)
@@ -86,12 +97,22 @@ static ieee802154_fsm_state_t _tx_end(ieee802154_submac_t *submac, int status,
     /* This is required to prevent unused variable warnings */
     (void) res;
 
+    ieee802154_dev_t *dev = &submac->dev;
+
     submac->wait_for_ack = false;
 
-    res = ieee802154_radio_set_idle(&submac->dev, true);
+    res = ieee802154_radio_set_idle(dev, true);
 
     assert(res >= 0);
-    submac->cb->tx_done(submac, status, info);
+    /* notify upper layer after ACK transmission about reception */
+    if (!_does_send_ack(dev) && submac->fsm_state == IEEE802154_FSM_STATE_TX_ACK) {
+        DEBUG("IEEE802154 submac: ACK transmission done\n");
+        submac->cb->rx_done(submac);
+    }
+    else
+    {
+        submac->cb->tx_done(submac, status, info);
+    }
     return IEEE802154_FSM_STATE_IDLE;
 }
 
@@ -148,25 +169,41 @@ static ieee802154_fsm_state_t _fsm_state_prepare(ieee802154_submac_t *submac,
 static ieee802154_fsm_state_t _fsm_state_tx(ieee802154_submac_t *submac,
                                             ieee802154_fsm_ev_t ev);
 
-static int _handle_fsm_ev_tx_ack(ieee802154_submac_t *submac)
+static int _handle_fsm_ev_tx_ack(ieee802154_submac_t *submac, uint8_t seq_num)
 {
     ieee802154_dev_t *dev = &submac->dev;
 
-    /* Set state to TX_ON */
-    int res;
-    if ((res = ieee802154_radio_set_idle(dev, false)) < 0) {
+    /* radio sends ack automatically */
+    if (_does_send_ack(dev)) {
+        return 0;
+    }
+    uint8_t ack[]
+         = { IEEE802154_FCF_TYPE_ACK, 0x00,  seq_num };
+    iolist_t iolist = {
+        .iol_base = ack,
+        .iol_len = sizeof(ack),
+        .iol_next = NULL
+    };
+    submac->wait_for_ack = 0;
+    submac->psdu = &iolist;
+    submac->retrans = 0;
+    submac->csma_retries_nb = 0;
+    submac->backoff_mask = (1 << submac->be.min) - 1;
+
+    DEBUG("IEEE802154 submac: Sending ACK\n");
+
+    int res = ieee802154_radio_set_idle(dev, false);
+
+    if (res < 0) {
         return res;
     }
-    if ((res = ieee802154_radio_write(dev, submac->psdu)) < 0) {
-        return res;
+    else {
+        /* write frame to radio */
+        ieee802154_radio_write(dev, submac->psdu);
+        /* do is synchronously so upper layer wouldn't notice */
+        _fsm_state_prepare(submac, IEEE802154_FSM_EV_BH, IEEE802154_FCF_TYPE_ACK);
+        return 0;
     }
-    /* skip async Tx request */
-    _fsm_state_prepare(submac, IEEE802154_FSM_EV_BH, IEEE802154_FCF_TYPE_ACK);
-    /* wait for Tx done */
-    while (_fsm_state_tx(submac, IEEE802154_FSM_EV_TX_DONE) == IEEE802154_FSM_STATE_INVALID) {
-        DEBUG("IEEE802154 submac: wait until ACK sent\n");
-    }
-    return 0;
 }
 
 static ieee802154_fsm_state_t _fsm_state_rx(ieee802154_submac_t *submac, ieee802154_fsm_ev_t ev)
@@ -184,27 +221,47 @@ static ieee802154_fsm_state_t _fsm_state_rx(ieee802154_submac_t *submac, ieee802
         }
         return IEEE802154_FSM_STATE_PREPARE;
     case IEEE802154_FSM_EV_RX_DONE:
+        while (ieee802154_radio_set_idle(dev, false) < 0) {}
+        submac->rx_len = ieee802154_radio_len(dev);
+        assert(submac->rx_len <= IEEE802154_FRAME_LEN_MAX);
+        res = ieee802154_radio_read(dev, submac->rx_buf, submac->rx_len, &submac->rx_info);
+        assert(res == (int)submac->rx_len);
         /* Make sure it's not an ACK frame */
-        while (ieee802154_radio_set_idle(&submac->dev, false) < 0) {}
-        if (ieee802154_radio_len(&submac->dev) > (int)IEEE802154_MIN_FRAME_LEN) {
+        if (ieee802154_radio_len(dev) > (int)IEEE802154_MIN_FRAME_LEN) {
+            /* sending ACK if radio does not support auto-ACK */
+            if (!_does_send_ack(dev)) {
+                ieee802154_filter_mode_t mode;
+                if ((submac->rx_buf[0] & IEEE802154_FCF_TYPE_MASK) == IEEE802154_FCF_TYPE_DATA &&
+                    (submac->rx_buf[0] & IEEE802154_FCF_ACK_REQ) &&
+                    (ieee802154_radio_get_frame_filter_mode(dev, &mode) < 0 ||
+                    mode == IEEE802154_FILTER_ACCEPT)) {
+                    if ((res = _handle_fsm_ev_tx_ack(submac, ieee802154_get_seq(submac->rx_buf))) < 0) {
+                        DEBUG("IEEE802154 submac: Sending ACK failed with status: %d\n", res);
+                    }
+                    else {
+                       /* Do not call rx_done yet. ACK must be sent first */
+                       return IEEE802154_FSM_STATE_TX_ACK;
+                    }
+                }
+            }
             submac->cb->rx_done(submac);
             return IEEE802154_FSM_STATE_IDLE;
         }
         else {
-            ieee802154_radio_read(&submac->dev, NULL, 0, NULL);
+            ieee802154_radio_read(dev, NULL, 0, NULL);
 
             /* If the radio doesn't support RX Continuous, go to RX */
-            res = ieee802154_radio_set_rx(&submac->dev);
+            res = ieee802154_radio_set_rx(dev);
             assert(res >= 0);
 
             /* Keep on current state */
             return IEEE802154_FSM_STATE_RX;
         }
     case IEEE802154_FSM_EV_CRC_ERROR:
-        while (ieee802154_radio_set_idle(&submac->dev, false) < 0) {}
-        ieee802154_radio_read(&submac->dev, NULL, 0, NULL);
+        while (ieee802154_radio_set_idle(dev, false) < 0) {}
+        ieee802154_radio_read(dev, NULL, 0, NULL);
         /* If the radio doesn't support RX Continuous, go to RX */
-        res = ieee802154_radio_set_rx(&submac->dev);
+        res = ieee802154_radio_set_rx(dev);
         assert(res >= 0);
         /* Keep on current state */
         return IEEE802154_FSM_STATE_RX;
@@ -231,16 +288,7 @@ static ieee802154_fsm_state_t _fsm_state_idle(ieee802154_submac_t *submac, ieee8
 
     switch (ev) {
     case IEEE802154_FSM_EV_REQUEST_TX:
-        /* An ACK is sent synchronous to prevent that the upper layer (IPv6)
-           can initiate the next transmission which would fail because the transceiver
-           is still busy. */
-        if (submac->psdu->iol_len == IEEE802154_ACK_FRAME_LEN - IEEE802154_FCS_LEN &&
-            (((uint8_t *)submac->psdu->iol_base)[0] & IEEE802154_FCF_TYPE_ACK) &&
-            submac->psdu->iol_next == NULL) {
-            _handle_fsm_ev_tx_ack(submac);
-            return IEEE802154_FSM_STATE_IDLE;
-        }
-        else if (_handle_fsm_ev_request_tx(submac) < 0) {
+        if (_handle_fsm_ev_request_tx(submac) < 0) {
             return IEEE802154_FSM_STATE_IDLE;
         }
         return IEEE802154_FSM_STATE_PREPARE;
@@ -257,7 +305,7 @@ static ieee802154_fsm_state_t _fsm_state_idle(ieee802154_submac_t *submac, ieee8
          * and TX_DONE. We simply discard the frame and keep the state as
          * it is
          */
-        ieee802154_radio_read(&submac->dev, NULL, 0, NULL);
+        ieee802154_radio_read(dev, NULL, 0, NULL);
         return IEEE802154_FSM_STATE_IDLE;
     default:
         break;
@@ -271,8 +319,11 @@ static ieee802154_fsm_state_t _fsm_state_prepare(ieee802154_submac_t *submac,
 {
     ieee802154_dev_t *dev = &submac->dev;
 
+    ieee802154_fsm_state_t tx_state = IEEE802154_FSM_STATE_INVALID;
+
     switch (ev) {
     case IEEE802154_FSM_EV_BH:
+        tx_state = IEEE802154_FSM_STATE_TX;
         if (ftype == IEEE802154_FCF_TYPE_DATA
             && !_does_handle_csma(dev)) {
             /* delay for an adequate random backoff period */
@@ -286,20 +337,20 @@ static ieee802154_fsm_state_t _fsm_state_prepare(ieee802154_submac_t *submac,
                 submac->backoff_mask = (submac->backoff_mask << 1) | 1;
             }
         }
-        else if (ftype == IEEE802154_FCF_TYPE_ACK) {
+        else if (!_does_send_ack(dev) && ftype == IEEE802154_FCF_TYPE_ACK) {
             /* no backoff for ACK frames but wait for SIFSPeriod */
             ztimer_sleep(ZTIMER_USEC, SIFS_PERIOD_US);
+            tx_state = IEEE802154_FSM_STATE_TX_ACK;
         }
-
         while (ieee802154_radio_request_transmit(dev) == -EBUSY) {}
-        return IEEE802154_FSM_STATE_TX;
+        return tx_state;
     case IEEE802154_FSM_EV_RX_DONE:
     case IEEE802154_FSM_EV_CRC_ERROR:
         /* This might happen in case there's a race condition between ACK_TIMEOUT
          * and TX_DONE. We simply discard the frame and keep the state as
          * it is
          */
-        ieee802154_radio_read(&submac->dev, NULL, 0, NULL);
+        ieee802154_radio_read(dev, NULL, 0, NULL);
         return IEEE802154_FSM_STATE_PREPARE;
     default:
         break;
@@ -319,13 +370,13 @@ static ieee802154_fsm_state_t _fsm_state_tx_process_tx_done(ieee802154_submac_t 
 
     switch (info->status) {
     case TX_STATUS_FRAME_PENDING:
-        assert(_does_handle_ack(&submac->dev));
+        assert(_does_handle_ack(dev));
     /* FALL-THRU */
     case TX_STATUS_SUCCESS:
         submac->csma_retries_nb = 0;
         /* If the radio handles ACK, the TX_DONE event marks completion of
         * the transmission procedure. Report TX done to the upper layer */
-        if (_does_handle_ack(&submac->dev) || !submac->wait_for_ack) {
+        if (_does_handle_ack(dev) || !submac->wait_for_ack) {
             return _tx_end(submac, info->status, info);
         }
         /* If the radio doesn't handle ACK, set the transceiver state to RX_ON
@@ -341,7 +392,7 @@ static ieee802154_fsm_state_t _fsm_state_tx_process_tx_done(ieee802154_submac_t 
         }
         break;
     case TX_STATUS_NO_ACK:
-        assert(_does_handle_ack(&submac->dev));
+        assert(_does_handle_ack(dev));
         submac->csma_retries_nb = 0;
         return _handle_tx_no_ack(submac);
     case TX_STATUS_MEDIUM_BUSY:
@@ -349,7 +400,7 @@ static ieee802154_fsm_state_t _fsm_state_tx_process_tx_done(ieee802154_submac_t 
          * procedure failed. We finish the SubMAC operation and report
          * medium busy
          */
-        if (_does_handle_csma(&submac->dev)
+        if (_does_handle_csma(dev)
             || submac->csma_retries_nb++ >= submac->csma_retries) {
             return _tx_end(submac, info->status, info);
         }
@@ -425,6 +476,30 @@ static ieee802154_fsm_state_t _fsm_state_wait_for_ack(ieee802154_submac_t *subma
     return IEEE802154_FSM_STATE_INVALID;
 }
 
+#if IS_USED(MODULE_IEEE802154_SUBMAC_SOFT_ACK)
+static ieee802154_fsm_state_t _fsm_state_tx_ack(ieee802154_submac_t *submac,
+                                                ieee802154_fsm_ev_t ev)
+{
+    ieee802154_tx_info_t info;
+    int res;
+
+    /* This is required to prevent unused variable warnings */
+    (void) res;
+
+    switch (ev) {
+    case IEEE802154_FSM_EV_TX_DONE:
+        if ((res = ieee802154_radio_confirm_transmit(&submac->dev, &info)) >= 0) {
+            return _fsm_state_tx_process_tx_done(submac, &info);
+        }
+        break;
+    default:
+        break;
+    }
+
+    return IEEE802154_FSM_STATE_INVALID;
+}
+#endif /* MODULE_IEEE802154_SUBMAC_SOFT_ACK */
+
 ieee802154_fsm_state_t ieee802154_submac_process_ev(ieee802154_submac_t *submac,
                                                     ieee802154_fsm_ev_t ev)
 {
@@ -451,6 +526,12 @@ ieee802154_fsm_state_t ieee802154_submac_process_ev(ieee802154_submac_t *submac,
         DEBUG("IEEE802154 submac: ieee802154_submac_process_ev(): IEEE802154_FSM_STATE_WAIT_FOR_ACK + %s\n", str_ev[ev]);
         new_state = _fsm_state_wait_for_ack(submac, ev);
         break;
+#if IS_USED(MODULE_IEEE802154_SUBMAC_SOFT_ACK)
+    case IEEE802154_FSM_STATE_TX_ACK:
+        DEBUG("IEEE802154 submac: ieee802154_submac_process_ev(): IEEE802154_FSM_STATE_TX_ACK + %s\n", str_ev[ev]);
+        new_state = _fsm_state_tx_ack(submac, ev);
+        break;
+#endif /* MODULE_IEEE802154_SUBMAC_SOFT_ACK */
     default:
         DEBUG("IEEE802154 submac: ieee802154_submac_process_ev(): INVALID STATE\n");
         new_state = IEEE802154_FSM_STATE_INVALID;
@@ -479,8 +560,6 @@ int ieee802154_send(ieee802154_submac_t *submac, const iolist_t *iolist)
 
     uint8_t *buf = iolist->iol_base;
     bool cnf = buf[0] & IEEE802154_FCF_ACK_REQ;
-    bool is_ack = iolist->iol_len == IEEE802154_ACK_FRAME_LEN - IEEE802154_FCS_LEN &&
-                  (buf[0] & IEEE802154_FCF_TYPE_MASK) == IEEE802154_FCF_TYPE_ACK;
 
     submac->wait_for_ack = cnf;
     submac->psdu = iolist;
@@ -488,14 +567,9 @@ int ieee802154_send(ieee802154_submac_t *submac, const iolist_t *iolist)
     submac->csma_retries_nb = 0;
     submac->backoff_mask = (1 << submac->be.min) - 1;
 
-    if (!is_ack && ieee802154_submac_process_ev(submac, IEEE802154_FSM_EV_REQUEST_TX)
+    if (ieee802154_submac_process_ev(submac, IEEE802154_FSM_EV_REQUEST_TX)
         != IEEE802154_FSM_STATE_PREPARE) {
         DEBUG("IEEE802154 submac: ieee802154_send(): Tx frame failed %s\n", str_states[current_state]);
-        return -EBUSY;
-    }
-    if (is_ack && ieee802154_submac_process_ev(submac, IEEE802154_FSM_EV_REQUEST_TX)
-             != IEEE802154_FSM_STATE_IDLE) {
-        DEBUG("IEEE802154 submac: ieee802154_send(): Tx ACK failed %s\n", str_states[current_state]);
         return -EBUSY;
     }
     return 0;
@@ -710,6 +784,11 @@ int ieee802154_submac_init(ieee802154_submac_t *submac, const network_uint16_t *
     ieee802154_dev_t *dev = &submac->dev;
 
     submac->fsm_state = IEEE802154_FSM_STATE_RX;
+
+    submac->rx_len = 0;
+    submac->rx_info.rssi = 0;
+    submac->rx_info.lqi = 0;
+    memset(submac->rx_buf, 0, sizeof(submac->rx_buf));
 
     int res;
 

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -90,7 +90,7 @@ static inline bool _does_handle_ack(ieee802154_dev_t *dev)
 static inline bool _does_send_ack(ieee802154_dev_t *dev)
 {
     if (IS_USED(MODULE_IEEE802154_SUBMAC_SOFT_ACK) &&
-    !ieee802154_radio_has_capability(dev, IEEE802154_CAP_AUTO_ACK)) {
+        !ieee802154_radio_has_capability(dev, IEEE802154_CAP_AUTO_ACK)) {
         return false;
     }
     return true;
@@ -127,8 +127,7 @@ static ieee802154_fsm_state_t _tx_end(ieee802154_submac_t *submac, int status,
         DEBUG("IEEE802154 submac: ACK transmission done\n");
         submac->cb->rx_done(submac);
     }
-    else
-    {
+    else {
         submac->cb->tx_done(submac, status, info);
     }
     return IEEE802154_FSM_STATE_IDLE;
@@ -195,8 +194,7 @@ static int _handle_fsm_ev_tx_ack(ieee802154_submac_t *submac, uint8_t seq_num)
     if (_does_send_ack(dev)) {
         return 0;
     }
-    uint8_t ack[]
-         = { IEEE802154_FCF_TYPE_ACK, 0x00,  seq_num };
+    uint8_t ack[] = { IEEE802154_FCF_TYPE_ACK, 0x00,  seq_num };
     iolist_t iolist = {
         .iol_base = ack,
         .iol_len = sizeof(ack),
@@ -249,16 +247,15 @@ static ieee802154_fsm_state_t _fsm_state_rx(ieee802154_submac_t *submac, ieee802
             /* sending ACK if radio does not support auto-ACK */
             if (!_does_send_ack(dev)) {
                 ieee802154_filter_mode_t mode;
-                if ((submac->rx_buf[0] & IEEE802154_FCF_TYPE_MASK) == IEEE802154_FCF_TYPE_DATA &&
-                    (submac->rx_buf[0] & IEEE802154_FCF_ACK_REQ) &&
+                if ((submac->rx_buf[0] & IEEE802154_FCF_ACK_REQ) &&
                     (ieee802154_radio_get_frame_filter_mode(dev, &mode) < 0 ||
                     mode == IEEE802154_FILTER_ACCEPT)) {
                     if ((res = _handle_fsm_ev_tx_ack(submac, ieee802154_get_seq(submac->rx_buf))) < 0) {
                         DEBUG("IEEE802154 submac: Sending ACK failed with status: %d\n", res);
                     }
                     else {
-                       /* Do not call rx_done yet. ACK must be sent first */
-                       return IEEE802154_FSM_STATE_TX_ACK;
+                        /* Do not call rx_done yet. ACK must be sent first */
+                        return IEEE802154_FSM_STATE_TX_ACK;
                     }
                 }
             }

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -250,7 +250,8 @@ static ieee802154_fsm_state_t _fsm_state_rx(ieee802154_submac_t *submac, ieee802
                 if ((submac->rx_buf[0] & IEEE802154_FCF_ACK_REQ) &&
                     (ieee802154_radio_get_frame_filter_mode(dev, &mode) < 0 ||
                     mode == IEEE802154_FILTER_ACCEPT)) {
-                    if ((res = _handle_fsm_ev_tx_ack(submac, ieee802154_get_seq(submac->rx_buf))) < 0) {
+                    if ((res = _handle_fsm_ev_tx_ack(submac, 
+                                                                          ieee802154_get_seq(submac->rx_buf))) < 0) {
                         DEBUG("IEEE802154 submac: Sending ACK failed with status: %d\n", res);
                     }
                     else {

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -227,7 +227,7 @@ static ieee802154_fsm_state_t _fsm_state_rx(ieee802154_submac_t *submac, ieee802
         res = ieee802154_radio_read(dev, submac->rx_buf, submac->rx_len, &submac->rx_info);
         assert(res == (int)submac->rx_len);
         /* Make sure it's not an ACK frame */
-        if (ieee802154_radio_len(dev) > (int)IEEE802154_MIN_FRAME_LEN) {
+        if (submac->rx_len > (int)IEEE802154_MIN_FRAME_LEN) {
             /* sending ACK if radio does not support auto-ACK */
             if (!_does_send_ack(dev)) {
                 ieee802154_filter_mode_t mode;

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -194,6 +194,7 @@ static int _handle_fsm_ev_tx_ack(ieee802154_submac_t *submac, uint8_t seq_num)
     if (_does_send_ack(dev)) {
         return 0;
     }
+    /* TODO: set pending bit accordingly, currently always 0 */
     uint8_t ack[] = { IEEE802154_FCF_TYPE_ACK, 0x00,  seq_num };
     iolist_t iolist = {
         .iol_base = ack,
@@ -250,8 +251,8 @@ static ieee802154_fsm_state_t _fsm_state_rx(ieee802154_submac_t *submac, ieee802
                 if ((submac->rx_buf[0] & IEEE802154_FCF_ACK_REQ) &&
                     (ieee802154_radio_get_frame_filter_mode(dev, &mode) < 0 ||
                     mode == IEEE802154_FILTER_ACCEPT)) {
-                    if ((res = _handle_fsm_ev_tx_ack(submac, 
-                                                                          ieee802154_get_seq(submac->rx_buf))) < 0) {
+                    if ((res = _handle_fsm_ev_tx_ack(submac,
+                        ieee802154_get_seq(submac->rx_buf))) < 0) {
                         DEBUG("IEEE802154 submac: Sending ACK failed with status: %d\n", res);
                     }
                     else {

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -72,10 +72,13 @@ static inline bool _does_handle_ack(ieee802154_dev_t *dev)
 
 static inline bool _does_send_ack(ieee802154_dev_t *dev)
 {
-    if (!IS_USED(MODULE_IEEE802154_SUBMAC_SOFT_ACK)) {
-        return true;
+    /* if return false we have to send ack, can only send ack if SOFTACK is used */
+    if (IS_USED(MODULE_IEEE802154_SUBMAC_SOFT_ACK) &&
+    !ieee802154_radio_has_capability(dev, IEEE802154_CAP_AUTO_ACK)) {
+        return false;
     }
-    return ieee802154_radio_has_capability(dev, IEEE802154_CAP_AUTO_ACK);
+    /* someone else will send the ACK for us */
+    return true;
 }
 
 static inline bool _does_handle_csma(ieee802154_dev_t *dev)
@@ -481,14 +484,10 @@ static ieee802154_fsm_state_t _fsm_state_tx_ack(ieee802154_submac_t *submac,
                                                 ieee802154_fsm_ev_t ev)
 {
     ieee802154_tx_info_t info;
-    int res;
-
-    /* This is required to prevent unused variable warnings */
-    (void) res;
 
     switch (ev) {
     case IEEE802154_FSM_EV_TX_DONE:
-        if ((res = ieee802154_radio_confirm_transmit(&submac->dev, &info)) >= 0) {
+        if (ieee802154_radio_confirm_transmit(&submac->dev, &info) >= 0) {
             return _fsm_state_tx_process_tx_done(submac, &info);
         }
         break;

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -64,20 +64,35 @@ static char *str_ev[IEEE802154_FSM_EV_NUMOF] = {
     "REQUEST_SET_IDLE",
 };
 
+/**
+ * @brief   Returns true if we do not need to do retransmissions
+ *          aka radio will watchout for ack from the receiver.
+ *
+ * @param   dev IEEE802.15.4 device descriptor
+ *
+ * @return  true if radio will take care of ack handling
+ */
 static inline bool _does_handle_ack(ieee802154_dev_t *dev)
 {
     return ieee802154_radio_has_frame_retrans(dev) ||
            ieee802154_radio_has_irq_ack_timeout(dev);
 }
 
+/**
+ * @brief   If softack module is used, we will check if submac should really send ack
+ *          aka radio does not send it.
+ *          If the module is not used, we pretend the radio will always send ack.
+ *
+ * @param   dev IEEE802.15.4 device descriptor
+ *
+ * @return  false if we should send ack
+ */
 static inline bool _does_send_ack(ieee802154_dev_t *dev)
 {
-    /* if return false we have to send ack, can only send ack if SOFTACK is used */
     if (IS_USED(MODULE_IEEE802154_SUBMAC_SOFT_ACK) &&
     !ieee802154_radio_has_capability(dev, IEEE802154_CAP_AUTO_ACK)) {
         return false;
     }
-    /* someone else will send the ACK for us */
     return true;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The transmission of IEEE802.15.4 Acknowledgements should be handled by the SubMAC-Layer itself, rather than the SubMAC-netdev. This will allow applications using SubMAC directly, to reduce redundant code.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Flash `tests/net/ieee802154_submac` onto two devices which do not contain the `IEEE802154_CAP_AUTO_ACK` capability.
Send a message using `txtsnd` from one device to the other. Notice, that  `No ACK` will appear in the terminal, because SubMAC does not send Acks.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
[#13376](https://github.com/RIOT-OS/RIOT/issues/13376)
#14950
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
