### PR TITLE
cpu/esp32: include `esptool` settings if PROGRAMMER is not set to `esptool`

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -459,6 +459,12 @@ ifneq (,$(filter esp_jtag,$(USEMODULE)))
   OPENOCD_DBG_EXTRA_CMD += -c 'reset halt'
 endif
 
+ifneq (esptool,$(PROGRAMMER))
+  # we must explicitly include the esptool settings if this is not done via
+  # the PROGRAMMER variable
+  include $(RIOTMAKE)/tools/esptool.inc.mk
+endif
+
 LD_SCRIPTS += $(BINDIR)/memory.ld $(BINDIR)/sections.ld
 LDGENFLAGS += -DLD_FILE_GEN
 LDGENFLAGS += -DRESERVE_RTC_MEM=0x18


### PR DESCRIPTION
### Contribution description

This PR fixes a compilation problem if the `PROGRAMMER` variable is set explicitly at command line.

If the `PROGRAMMER` variable isn't set explicitly, it is set to `esptool` by default and the settings for the `epstool` are included automatically via the `$(RIOTBASE)/makefiles/tools/esptool.inc.mk` file. However, if the `PROGRAMMER` variable is set to something else, e.g. `openocd`, the settings for the `esptools` must be explicitly included, otherwise building the binary file will fail.

With this PR using OpenOCD as `PROGRAMMER` works as documented [here](https://doc.riot-os.org/group__cpu__esp32.html#esp32_jtag_debugging).

### Testing procedure

Compile and check any application, for example:
```console
PROGRAMMER=openocd USEMODULE=esp_jtag \
make BOARD=esp32-wrover-kit -C examples/basic/hello-world clean all
```
Without the PR, the compilation will fail:
```console
make: Verzeichnis „examples/basic/hello-world“ wird betreten
rm -rf examples/basic/hello-world/bin/esp32-wrover-kit/pkg-build/esp32_sdk
Building application "hello-world" for "esp32-wrover-kit" with CPU "esp32".

"make" -C pkg/esp32_sdk/ 
...
"make" -C sys/stdio_uart
make: chip: Datei oder Verzeichnis nicht gefunden
make: [cpu/esp_common/Makefile.include:143: examples/basic/hello-world/bin/esp32-wrover-kit/hello-world.elf.bin] Fehler 127 (ignoriert)
# append size of examples/basic/hello-world/bin/esp32-wrover-kit/hello-world.elf.bin
/bin/sh: 1: cannot open examples/basic/hello-world/bin/esp32-wrover-kit/hello-world.elf.bin: No such file
make: *** [cpu/esp_common/Makefile.include:173: examples/basic/hello-world/bin/esp32-wrover-kit/partitions.csv] Fehler 2
make: Verzeichnis „examples/basic/hello-world“ wird verlassen
```
With the PR, the compilation should succeed:
```console
make: Verzeichnis „examples/basic/hello-world“ wird betreten
rm -rf examples/basic/hello-world/bin/esp32-wrover-kit/pkg-build/esp32_sdk
Building application "hello-world" for "esp32-wrover-kit" with CPU "esp32".

"make" -C pkg/esp32_sdk/ 
...
"make" -C sys/stdio_uart
esptool v5.0.0
Creating ESP32 image...
Merged 2 ELF sections.
Successfully created ESP32 image.
# append size of examples/basic/hello-world/bin/esp32-wrover-kit/hello-world.elf.bin
Parsing CSV input...
   text	   data	    bss	    dec	    hex	filename
  63543	  12640	  63661	 139844	  22244	examples/basic/hello-world/bin/esp32-wrover-kit/hello-world.elf
make: Verzeichnis „examples/basic/hello-world“ wird verlassen
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
