### PR TITLE
cpu/esp32: fix esp_wifi stability problem by placing wdt_hal_* functions in IRAM

### DIFF
--- a/cpu/esp32/vendor/ld/esp32c6/sections.ld.in
+++ b/cpu/esp32/vendor/ld/esp32c6/sections.ld.in
@@ -292,6 +292,7 @@ SECTIONS
     *components/hal/spi_hal_iram.*(.literal .literal.* .text .text.*)
     *components/hal/spi_slave_hal_iram.*(.literal .literal.* .text .text.*)
     *components/hal/timer_hal.*(.literal.timer_hal_capture_and_get_counter_value .text.timer_hal_capture_and_get_counter_value)
+    *components/hal/wdt_hal_iram.*(.literal .literal.* .text .text.*)
     *components/heap/multi_heap.*(.literal._multi_heap_lock .text._multi_heap_lock)
     *components/heap/multi_heap.*(.literal._multi_heap_unlock .text._multi_heap_unlock)
     *components/heap/multi_heap.*(.literal.multi_heap_aligned_alloc_offs .text.multi_heap_aligned_alloc_offs)
@@ -467,6 +468,7 @@ SECTIONS
     *components/hal/spi_flash_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *components/hal/spi_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *components/hal/spi_slave_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/hal/wdt_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *components/log/*/log_lock.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
 
     *components/newlib/abort.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)

--- a/cpu/esp32/vendor/ld/esp32h2/sections.ld.in
+++ b/cpu/esp32/vendor/ld/esp32h2/sections.ld.in
@@ -280,6 +280,7 @@ SECTIONS
     *components/hal/spi_hal_iram.*(.literal .literal.* .text .text.*)
     *components/hal/spi_slave_hal_iram.*(.literal .literal.* .text .text.*)
     *components/hal/timer_hal.*(.literal.timer_hal_capture_and_get_counter_value .text.timer_hal_capture_and_get_counter_value)
+    *components/hal/wdt_hal_iram.*(.literal .literal.* .text .text.*)
     *components/heap/multi_heap.*(.literal._multi_heap_lock .text._multi_heap_lock)
     *components/heap/multi_heap.*(.literal._multi_heap_unlock .text._multi_heap_unlock)
     *components/heap/multi_heap.*(.literal.multi_heap_aligned_alloc_offs .text.multi_heap_aligned_alloc_offs)
@@ -441,6 +442,7 @@ SECTIONS
     *components/hal/spi_flash_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *components/hal/spi_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *components/hal/spi_slave_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/hal/wdt_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *components/log/*/log_lock.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
 
     *components/newlib/abort.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)

--- a/cpu/esp32/vendor/ld/esp32s3/sections.ld.in
+++ b/cpu/esp32/vendor/ld/esp32s3/sections.ld.in
@@ -313,6 +313,7 @@ SECTIONS
     *components/hal/spi_slave_hal_iram.*(.literal .literal.* .text .text.*)
     *components/hal/systimer_hal.*(.literal .literal.* .text .text.*)
     *components/hal/timer_hal.*(.literal.timer_hal_capture_and_get_counter_value .text.timer_hal_capture_and_get_counter_value)
+    *components/hal/wdt_hal_iram.*(.literal .literal.* .text .text.*)
     *components/heap/multi_heap.*(.literal.assert_valid_block .text.assert_valid_block)
     *components/heap/multi_heap.*(.literal.multi_heap_aligned_alloc_impl .text.multi_heap_aligned_alloc_impl)
     *components/heap/multi_heap.*(.literal.multi_heap_aligned_alloc_impl_offs .text.multi_heap_aligned_alloc_impl_offs)
@@ -454,6 +455,7 @@ SECTIONS
     *components/hal/spi_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *components/hal/spi_slave_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *components/hal/systimer_hal.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
+    *components/hal/wdt_hal_iram.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
     *components/log/log_lock.*(.rodata .rodata.* .sdata2 .sdata2.* .srodata .srodata.*)
 
     _nimble_data_start = ABSOLUTE(.);


### PR DESCRIPTION
### Contribution description

The PR fixes an issue caused by missing entries for `wdt_hal_*` functions in `sections.ld` files for ESP32-S3, ESP32-C6 and ESP32-H2.

`wdt_hal_*` functions of the IDF have to be placed in IRAM to avoid crashes when `wdt_hal_*` functions are used while SPI Flash Cache is disabled. For ESP32-S3, ESP32-C6 and ESP32-H2, these functions were placed in IROM due to missing entries in  `sections.ld` files. Especially on ESP32-S3, this led to crashes while connecting to a WiFi AP.

The issue was found while investigating issue #21923.

### Testing procedure

Use any ESP32-S3 board and flash the GNRC networking example with enabled `esp_wifi` module, for example
```python
CFLAGS='-DWIFI_SSID=\"ssid\" -DWIFI_PASS=\"pass\"' USEMODULE='esp_wifi' \
BOARD=esp32s3-devkit make -j8 -C examples/networking/gnrc/networking flash term
```
Without this PR, the ESP32-S3 board mostly hangs after reset while connecting to the WiFi AP. With the PR connecting to the WiFi AP should work stable.

### Issues/PRs references