### PR TITLE
shell: Clarify ifconfig error on IPv6 assignment

### DIFF
--- a/sys/shell/cmds/gnrc_netif.c
+++ b/sys/shell/cmds/gnrc_netif.c
@@ -1765,7 +1765,7 @@ static int _netif_add(char *cmd_name, netif_t *iface, int argc, char **argv)
     (void)iface;
     (void)argc;
     (void)argv;
-    printf("error: unable to add IPv6 address.\n");
+    printf("error: GNRC_IPV6 module not enabled.\n");
 
     return 1;
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hey hey :flamingo: 

this just clarifies an error message to the user.

### Testing procedure

Not needed as long as it builds.

