### PR TITLE
examples/net/gnrc/border_router: extend ESP32x variants

### DIFF
--- a/examples/networking/gnrc/border_router/Makefile.board.dep
+++ b/examples/networking/gnrc/border_router/Makefile.board.dep
@@ -5,7 +5,7 @@ ifeq (,$(filter native native32 native64,$(BOARD)))
   else ifeq (ethos,$(UPLINK))
     USEMODULE += stdio_ethos
   else ifeq (wifi,$(UPLINK))
-    ifneq (,$(filter esp32 esp8266,$(CPU)))
+    ifneq (,$(filter esp32 esp32s* esp32c* esp8266,$(CPU)))
       USEMODULE += esp_wifi
       ifneq (ble, $(DOWNLINK))
         USEMODULE += esp_now

--- a/examples/networking/gnrc/border_router/README.md
+++ b/examples/networking/gnrc/border_router/README.md
@@ -41,8 +41,10 @@ The network must provide a DHCPv6 server that supports prefix delegation (IA_PD)
 Use `WIFI_SSID="SSID" WIFI_PASS="password"` in your `make` command to set your WiFi's
 credentials. You can alternatively edit the `Makefile`.
 
-Currently, `wifi` requires an esp8266 or esp32 for the border router and will default
-to using `esp_now` for the downstream interface.
+Currently, `wifi` requires an esp8266, esp32, esp32s2, esp32s3, esp32c3 or esp32c6
+for the border router and will default to using `esp_now` for the downlink interface.
+Note: The channel used for the `esp_now` downlink must be the same as the channel
+used for the `wifi` uplink. Use `ESP_NOW_CHANNEL` in `CFLAGS` to define it.
 
 ### Connection sharing with host
 


### PR DESCRIPTION
### Contribution description

This PR extends the list of ESP SoCs for all supported ESP32x SoC variants with WiFi interface that can be used as border routers, in detail:
- esp32s2
- esp32s3
- esp32c3
- esp32c6

### Testing procedure

Compile `examples/networking/gnrc/border_router` for ESP32x variants, for example:
```
UPLINK=wifi BOARD=esp32s3-devkit make -j8 -C examples/networking/gnrc/border_router
```

### Issues/PRs references