### PR TITLE
doc/starlight: fix edit link for generated documents

### DIFF
--- a/doc/starlight/astro.config.ts
+++ b/doc/starlight/astro.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       markdown: {
         processedDirs: ["../guides"],
       },
+      routeMiddleware: "./src/routeData.ts",
       head: [
         {
           tag: "link",

--- a/doc/starlight/src/routeData.ts
+++ b/doc/starlight/src/routeData.ts
@@ -1,0 +1,22 @@
+import { defineRouteMiddleware } from "@astrojs/starlight/route-data";
+
+const generatedPath = "/doc/guides/generated/";
+
+/**
+ * Since some of our guides are generated during build time, we need to
+ * adjust the "Edit this page" links to point to the correct source files.
+ * This middleware checks if the edit URL contains the generated path segment
+ * and removes it to point to the actual source file.
+ */
+export const onRequest = defineRouteMiddleware((context) => {
+  const { starlightRoute } = context.locals;
+
+  if (starlightRoute.editUrl) {
+    let editUrl = starlightRoute.editUrl.toString();
+    if (editUrl.includes(generatedPath)) {
+      const filename = editUrl.split(generatedPath)[1];
+      editUrl = editUrl.split(generatedPath)[0] + "/" + filename;
+    }
+    starlightRoute.editUrl = new URL(editUrl);
+  }
+});


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

@miri64 noticed that the edit link was broken when the site was generated using one of the root markdown files, this should fix that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`make doc-starlight` and then click on the edit page link on e.g. Security

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
