### PR TITLE
cpu/esp32: fix 6LoWPAN over BLE issue for ESP32-C3

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -371,6 +371,7 @@ else ifeq (esp32c3,$(CPU_FAM))
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.bt_funcs.ld
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib.ld
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.eco3.ld
+  LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.eco3_bt_funcs.ld
 else ifeq (esp32c6,$(CPU_FAM))
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.coexist.ld
   LINKFLAGS += -T$(ESP32_SDK_DIR)/components/esp_rom/$(CPU_FAM)/ld/$(CPU_FAM).rom.newlib.ld


### PR DESCRIPTION
### Contribution description

This PR fixes the issue 6LoWPAN over BLE issue for ESP32-C3 described in issue #19319.

A number of symbols of the BLE PHY that have to be used from ROM to ensure that they can be called when the SPI Flash cache is disabled were placed in IROM by mistake. Adding an additional ld script solves this issue.

### Testing procedure

Compile and flash the boarder router example with BLE downlink on any ESP32-C3 board, for example:
```python
WIFI_SSID="ssid" WIFI_PASS="pass" UPLINK=wifi DOWNLINK=ble \
BOARD=esp32c3-devkit make -C examples/networking/gnrc/border_router flash term
```

Without the PR the example will crash shortly after connecting to the WiFi AP. With the PR, the example should work as expected.

### Issues/PRs references

Fixes #19319 