### PR TITLE
drivers/ws281x: support rgbw

### DIFF
--- a/cpu/sam0_common/Makefile.features
+++ b/cpu/sam0_common/Makefile.features
@@ -34,6 +34,7 @@ FEATURES_PROVIDED += periph_spi_reconfigure
 FEATURES_PROVIDED += periph_spi_gpio_mode
 FEATURES_PROVIDED += periph_spi_reconfigure
 FEATURES_PROVIDED += periph_timer_periodic # implements timer_set_periodic()
+FEATURES_PROVIDED += periph_timer_poll
 FEATURES_PROVIDED += periph_timer_query_freqs
 FEATURES_PROVIDED += periph_uart_modecfg
 FEATURES_PROVIDED += periph_uart_nonblocking

--- a/cpu/sam0_common/include/timer_arch.h
+++ b/cpu/sam0_common/include/timer_arch.h
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2026 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     cpu_sam0_common
+ * @ingroup     drivers_periph_timer
+ * @{
+ *
+ * @file
+ * @brief       CPU specific part of the timer API
+ *
+ * @author      Fabian Hüßler <fabian.huessler@ml-pa.com>
+ */
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef DOXYGEN /* hide implementation specific details from Doxygen */
+
+static inline bool timer_poll_channel(tim_t tim, int channel)
+{
+    /**
+     * ~~~~~~~~~~~~~~~{.c}
+     * typedef union {
+     *   TcCount8                  COUNT8;
+     *   TcCount16                 COUNT16;
+     *   TcCount32                 COUNT32;
+     * } Tc;
+     * ~~~~~~~~~~~~~~~
+     * INTFLAG has for all timerwidth the same offset, so it does not matter which union member is used.
+     */
+    switch (channel) {
+    case 0:
+        return timer_config[tim].dev->COUNT32.INTFLAG.reg & TC_INTFLAG_MC0;
+    case 1:
+        return timer_config[tim].dev->COUNT32.INTFLAG.reg & TC_INTFLAG_MC1;
+    default:
+        return false;
+    }
+}
+
+#endif /* DOXYGEN */
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/drivers/include/ws281x.h
+++ b/drivers/include/ws281x.h
@@ -97,10 +97,21 @@
 extern "C" {
 #endif
 
+#ifndef WS281X_BYTES_PER_DEVICE
 /**
  * @brief   The number of bytes to allocate in the data buffer per LED
  */
-#define WS281X_BYTES_PER_DEVICE       (3U)
+#  define WS281X_BYTES_PER_DEVICE       (3U)
+#endif
+
+/**
+ * @brief   Pixel type representing a single LED
+ */
+#if WS281X_BYTES_PER_DEVICE == 4
+typedef color_rgbw_t ws281x_pixel_t;
+#else
+typedef color_rgb_t ws281x_pixel_t;
+#endif
 
 /**
  * @brief   Struct to hold initialization parameters for a WS281x RGB LED
@@ -214,7 +225,7 @@ static inline void ws281x_end_transmission(ws281x_t *dev)
  * @warning This change will not become active until @ref ws281x_write is
  *          called
  */
-void ws281x_set_buffer(void *dest, uint16_t index, color_rgb_t color);
+void ws281x_set_buffer(void *dest, uint16_t index, ws281x_pixel_t color);
 
 /**
  * @brief   Sets the color of an LED in the chain in the internal buffer
@@ -226,7 +237,7 @@ void ws281x_set_buffer(void *dest, uint16_t index, color_rgb_t color);
  * @warning This change will not become active until @ref ws281x_write is
  *          called
  */
-static inline void ws281x_set(ws281x_t *dev, uint16_t index, color_rgb_t color)
+static inline void ws281x_set(ws281x_t *dev, uint16_t index, ws281x_pixel_t color)
 {
     ws281x_set_buffer(dev->params.buf, index, color);
 }

--- a/drivers/ws281x/include/ws281x_constants.h
+++ b/drivers/ws281x/include/ws281x_constants.h
@@ -68,6 +68,10 @@ extern "C" {
  * @brief   Offset for the blue color component
  */
 #define WS281X_OFFSET_B                 (2U)
+/**
+ * @brief   Offset for the white color component (only for 4-byte variants)
+ */
+#define WS281X_OFFSET_W                 (3U)
 /**@}*/
 
 #ifdef __cplusplus

--- a/drivers/ws281x/include/ws281x_params.h
+++ b/drivers/ws281x/include/ws281x_params.h
@@ -18,6 +18,8 @@
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
 
+#include <limits.h>
+
 #include "board.h"
 #include "saul_reg.h"
 
@@ -90,11 +92,10 @@ static const ws281x_params_t ws281x_params[] =
 
 /** @brief Maximum value of the timer used for WS281x (by the timer_gpio_ll implementation)
  *
- * This macro needs to be defined to the `TIMER_x_MAX_VALUE` corresponding to
- * the `TIMER_DEV(x)` in @ref WS281X_TIMER_DEV.
+ * This macro needs to be defined to the maximum value of @ref WS281X_TIMER_DEV.
  * */
 #ifndef WS281X_TIMER_MAX_VALUE
-#define WS281X_TIMER_MAX_VALUE TIMER_2_MAX_VALUE
+#define WS281X_TIMER_MAX_VALUE UINT_MAX
 #endif
 
 /** @brief Frequency for the timer used for WS281x (by the timer_gpio_ll implementation)

--- a/drivers/ws281x/timer_gpio_ll.c
+++ b/drivers/ws281x/timer_gpio_ll.c
@@ -146,8 +146,8 @@ int ws281x_init(ws281x_t *dev, const ws281x_params_t *params)
     uint8_t pin = gpio_get_pin_num(dev->params.pin);
 
     err = gpio_ll_init(port, pin, gpio_ll_out);
-    DEBUG("Initializing port %x pin %d (originally %lx): %d\n",
-            port, pin, params->pin, err);
+    DEBUG("Initializing port %x pin %d (originally %x): %d\n",
+            port, pin, (unsigned)params->pin, err);
     if (err != 0) {
         return -EIO;
     }

--- a/drivers/ws281x/timer_gpio_ll.c
+++ b/drivers/ws281x/timer_gpio_ll.c
@@ -120,6 +120,8 @@ void ws281x_write_buffer(ws281x_t *dev, const void *buf, size_t size)
             while (!timer_poll_channel(WS281X_TIMER_DEV, 1)) {}
             gpio_ll_clear(port, mask);
             timer_stop(WS281X_TIMER_DEV);
+            timer_clear(WS281X_TIMER_DEV, 0);
+            timer_clear(WS281X_TIMER_DEV, 1);
 
             last_bit = bit;
         }
@@ -144,7 +146,7 @@ int ws281x_init(ws281x_t *dev, const ws281x_params_t *params)
     uint8_t pin = gpio_get_pin_num(dev->params.pin);
 
     err = gpio_ll_init(port, pin, gpio_ll_out);
-    DEBUG("Initializing port %x pin %d (originally %x): %d\n",
+    DEBUG("Initializing port %x pin %d (originally %lx): %d\n",
             port, pin, params->pin, err);
     if (err != 0) {
         return -EIO;
@@ -156,6 +158,8 @@ int ws281x_init(ws281x_t *dev, const ws281x_params_t *params)
         return -EIO;
     }
     timer_stop(WS281X_TIMER_DEV);
+    timer_clear(WS281X_TIMER_DEV, 0);
+    timer_clear(WS281X_TIMER_DEV, 1);
 
     /* We're not trying to make an assessment on whether that means we can
      * manage or not, for that also depends on the number of instructions in

--- a/drivers/ws281x/ws281x.c
+++ b/drivers/ws281x/ws281x.c
@@ -31,10 +31,13 @@
 /* Default buffer used in ws281x_params.h. Will be optimized out if unused */
 uint8_t ws281x_buf[WS281X_PARAM_NUMOF * WS281X_BYTES_PER_DEVICE];
 
-void ws281x_set_buffer(void *_dest, uint16_t n, color_rgb_t c)
+void ws281x_set_buffer(void *_dest, uint16_t n, ws281x_pixel_t c)
 {
     uint8_t *dest = _dest;
     dest[WS281X_BYTES_PER_DEVICE * n + WS281X_OFFSET_R] = c.r;
     dest[WS281X_BYTES_PER_DEVICE * n + WS281X_OFFSET_G] = c.g;
     dest[WS281X_BYTES_PER_DEVICE * n + WS281X_OFFSET_B] = c.b;
+#if WS281X_BYTES_PER_DEVICE == 4
+    dest[WS281X_BYTES_PER_DEVICE * n + WS281X_OFFSET_W] = c.w;
+#endif
 }

--- a/drivers/ws281x/ws281x_saul.c
+++ b/drivers/ws281x/ws281x_saul.c
@@ -27,7 +27,7 @@
 static int set_rgb_led(const void *dev, const phydat_t *res)
 {
     ws281x_t *ws281x = (ws281x_t *)dev;
-    color_rgb_t color = {
+    ws281x_pixel_t color = {
         .r = res->val[0],
         .g = res->val[1],
         .b = res->val[2]

--- a/sys/include/color.h
+++ b/sys/include/color.h
@@ -29,13 +29,24 @@ extern "C" {
 #endif
 
 /**
- * @brief Data-structure describing a RGB color
+ * @brief Data-structure describing an RGB color
  */
 typedef struct {
     uint8_t r;          /**< red value      [0 - 255] */
     uint8_t g;          /**< green value    [0 - 255] */
     uint8_t b;          /**< blue value     [0 - 255] */
 } color_rgb_t;
+
+/**
+ * @brief Data-structure describing an RGBW color
+ */
+typedef struct {
+    uint8_t r;          /**< red value      [0 - 255] */
+    uint8_t g;          /**< green value    [0 - 255] */
+    uint8_t b;          /**< blue value     [0 - 255] */
+    uint8_t w;          /**< white value    [0 - 255] */
+} color_rgbw_t;
+
 
 /**
  * @brief RGBA color value

--- a/tests/drivers/ws281x/main.c
+++ b/tests/drivers/ws281x/main.c
@@ -21,7 +21,7 @@
 #include "ws281x_params.h"
 #include "xtimer.h"
 
-static const color_rgb_t rainbow[] = {
+static const ws281x_pixel_t rainbow[] = {
     {.r = 0x94, .g = 0x00, .b = 0xd3},
     {.r = 0x4b, .g = 0x00, .b = 0x82},
     {.r = 0x00, .g = 0x00, .b = 0xff},
@@ -71,8 +71,8 @@ int main(void)
         last_wakeup = xtimer_now();
         for (unsigned i = 0; i < RAINBOW_LEN; i++) {
             for (unsigned j = 0; j < 255; j++) {
-                color_rgb_t col;
-                color_rgb_set_brightness(&rainbow[i], &col, j);
+                ws281x_pixel_t col = {0};
+                color_rgb_set_brightness((const color_rgb_t *)&rainbow[i], (color_rgb_t *)&col, j);
                 for (uint16_t k = 0; k < dev.params.numof; k++) {
                     ws281x_set(&dev, k, col);
                 }
@@ -80,8 +80,8 @@ int main(void)
                 xtimer_periodic_wakeup(&last_wakeup, 10 * US_PER_MS);
             }
             for (unsigned j = 255; j > 0; j--) {
-                color_rgb_t col;
-                color_rgb_set_brightness(&rainbow[i], &col, j);
+                ws281x_pixel_t col = {0};
+                color_rgb_set_brightness((const color_rgb_t *)&rainbow[i], (color_rgb_t *)&col, j);
                 for (uint16_t k = 0; k < dev.params.numof; k++) {
                     ws281x_set(&dev, k, col);
                 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

I have an `ws281x` ~~RGBA~~ RGBW light strip.

- add RGBW option to `ws281x` driver
- add `timer_poll_channel` for sam0.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Run `tests/drivers/ws281x` on same54-xpro with ws281x light strip. The test emulates brightness by color scaling, but still my LED chain consumes 4 bytes.
 
```mk
BOARD := same54-xpro

USEMODULE += ws281x
USEMODULE += ws281x_timer_gpio_ll
CFLAGS += -DWS281X_BYTES_PER_DEVICE=4
CFLAGS += -DWS281X_TIMER_FREQ=8000000
CFLAGS += -DWS281X_TIMER_DEV="TIMER_DEV(2)"
CFLAGS += -DWS281X_TIMER_MAX_VALUE=UINT32_MAX
CFLAGS += -DWS281X_PARAM_PIN="GPIO_PIN(PB, 5)"
CFLAGS += -DWS281X_PARAM_NUMOF=144

include Makefile
```

```diff

diff --git a/boards/same54-xpro/include/periph_conf.h b/boards/same54-xpro/include/periph_conf.h
index e658b24b6e..4ceccc9d0d 100644
--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -88,6 +88,16 @@ static const tc32_conf_t timer_config[] = {
         .gclk_id        = TC2_GCLK_ID,
         .gclk_src       = SAM0_GCLK_TIMER,
         .flags          = TC_CTRLA_MODE_COUNT32,
+    },
+    {   /* Timer 2 */
+        .dev            = TC4,
+        .irq            = TC4_IRQn,
+        .mclk           = &MCLK->APBCMASK.reg,
+        .mclk_mask      = MCLK_APBCMASK_TC4 | MCLK_APBCMASK_TC5,
+        .gclk_id        = TC4_GCLK_ID,
+        .gclk_src       = SAM0_GCLK_TIMER,
+        .flags          = TC_CTRLA_MODE_COUNT32,
+
     }
 };
 
@@ -99,6 +109,10 @@ static const tc32_conf_t timer_config[] = {
 #define TIMER_1_CHANNELS    2
 #define TIMER_1_ISR         isr_tc2
 
+/* Timer 2 configuration */
+#define TIMER_2_CHANNELS    2
+#define TIMER_2_ISR         isr_tc4
+
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
```
### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
