### PR TITLE
gh-actions: deploy guides to main riot-os.org server as well

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -36,3 +36,14 @@ jobs:
                 publish_branch: gh-pages
                 cname: guide.riot-os.org
                 commit_message: "Deploy documentation"
+
+          - name: Deploy to riot-os.org server
+            uses: burnett01/rsync-deployments@v8
+            with:
+              switches: -avzr --delete
+              path: doc/starlight/dist/
+              remote_path: /
+              remote_host: ${{ secrets.SSH_GUIDES_REMOTE_HOST }}
+              remote_port: ${{ secrets.SSH_GUIDES_REMOTE_PORT }}
+              remote_user: ${{ secrets.SSH_GUIDES_REMOTE_USER }}
+              remote_key: ${{ secrets.SSH_GUIDES_PRIVATE_KEY }}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This basically copies https://github.com/RIOT-OS/riot-os.org/blob/master/.github/workflows/deployment.yml#L48-L57. Currently that deployment is not hot, but it prepares moving guide.riot-os.org to our server (and should also ease moving doc.riot-os.org to guide.riot-os.org as discussed elsewhere).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I guess we can only merge and see... But except for the differing secrets (which are local to RIOT-OS/riot-os.org) it is just an update to the action already in use for riot-os.org.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
