### PR TITLE
cdc/ecm: add TX timeout

### DIFF
--- a/sys/usb/usbus/Makefile.dep
+++ b/sys/usb/usbus/Makefile.dep
@@ -19,6 +19,8 @@ ifneq (,$(filter usbus_cdc_ecm,$(USEMODULE)))
   USEMODULE += netdev_new_api
   USEMODULE += netdev_eth
   USEMODULE += luid
+  USEMODULE += ztimer
+  USEMODULE += ztimer_usec
 endif
 
 ifneq (,$(filter usbus_hid,$(USEMODULE)))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

On a sam0 board I observed that during the USB host boot, sending packets towards the host will block the interface thread for up to 10 seconds. This blocking can propagate to less obvious parts of the system and render the system irresponsive, trigger watchdogs etc. I don't know if this is a sam0-specific problem, but I figured that dropping a packet when the link layer is irresponsive is probably not a bad idea.

It seems that when the host powers up, the interface is reported UP in RIOT before it is actually able to send packets:
```
2026-01-16 15:25:58,478 # CDC ECM: Reset
2026-01-16 15:25:58,686 # CDC ECM: Reset
2026-01-16 15:25:58,814 # CDC ECM: Reset
2026-01-16 15:25:58,909 # CDC ECM: Request: 0xb
2026-01-16 15:25:58,925 # CDC ECM: Changing active interface to alt 1
2026-01-16 15:25:58,925 # CDC ECM: sending link up indication   <<<=== interface goes up here
2026-01-16 15:25:58,926 # CDC ECM: Request: 0x43
2026-01-16 15:25:58,926 # CDC ECM: Not modifying filter to 0xc
2026-01-16 15:25:59,758 # CDC_ECM_netdev: sending 86 bytes
2026-01-16 15:25:59,759 # CDC_ECM_netdev: cur iol: 14
2026-01-16 15:25:59,759 # CDC_ECM: cur iol: 40
2026-01-16 15:25:59,759 # CDC_ECM: cur iol: 24
2026-01-16 15:25:59,759 # CDC_ECM_NETDEV: triggering xmit with len 64
2026-01-16 15:25:59,773 # CDC_ECM: Handling TX xmit from netdev
2026-01-16 15:25:59,821 # out_lock timeout!
2026-01-16 15:25:59,822 # CDC_ECM_netdev: sending 86 bytes
2026-01-16 15:25:59,822 # CDC_ECM_netdev: cur iol: 14
2026-01-16 15:25:59,885 # out_lock timeout!
2026-01-16 15:25:59,886 # CDC_ECM_netdev: sending 86 bytes
2026-01-16 15:25:59,886 # CDC_ECM_netdev: cur iol: 14
.
.
.
2026-01-16 15:26:18,285 # CDC_ECM_netdev: sending 86 bytes
2026-01-16 15:26:18,300 # CDC_ECM_netdev: cur iol: 14
2026-01-16 15:26:18,349 # out_lock timeout!
2026-01-16 15:26:18,349 # CDC_ECM_netdev: sending 86 bytes  
2026-01-16 15:26:18,350 # CDC_ECM_netdev: cur iol: 14
2026-01-16 15:26:18,397 # out_lock timeout!
2026-01-16 15:26:18,397 # CDC_ECM_netdev: sending 86 bytes
2026-01-16 15:26:18,413 # CDC_ECM_netdev: cur iol: 14
2026-01-16 15:26:18,461 # out_lock timeout!
2026-01-16 15:26:18,461 # CDC_ECM_netdev: sending 86 bytes <<<=== interface is able to send here, ~9 seconds later
2026-01-16 15:26:18,462 # CDC_ECM_netdev: cur iol: 14
2026-01-16 15:26:18,476 # CDC ECM: Request: 0x43
2026-01-16 15:26:18,477 # CDC ECM: Not modifying filter to 0xe
2026-01-16 15:26:18,477 # CDC_ECM: cur iol: 40
2026-01-16 15:26:18,478 # CDC_ECM: cur iol: 24
2026-01-16 15:26:18,478 # CDC_ECM_NETDEV: triggering xmit with len 64
2026-01-16 15:26:18,478 # CDC_ECM: Handling TX xmit from netdev
2026-01-16 15:26:18,492 # CDC ECM: sending link speed indication
2026-01-16 15:26:18,493 # CDC_ECM: cur iol: 8
2026-01-16 15:26:18,494 # CDC_ECM_NETDEV: triggering xmit with len 22
2026-01-16 15:26:18,494 # CDC_ECM: Handling TX xmit from netdev
2026-01-16 15:26:18,494 # CDC_ECM_netdev: sending 86 bytes
2026-01-16 15:26:18,508 # CDC_ECM_netdev: cur iol: 14
2026-01-16 15:26:18,509 # CDC_ECM: cur iol: 40
2026-01-16 15:26:18,510 # CDC_ECM: cur iol: 24
2026-01-16 15:26:18,510 # CDC_ECM_NETDEV: triggering xmit with len 64
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I tested this on a same54 board connected to a Linux USB host.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
