### PR TITLE
sys/usbus: cdc_ecm: handle link up / link down events

### DIFF
--- a/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
@@ -156,9 +156,6 @@ static int _init(netdev_t *netdev)
 
     netdev_eui48_get(netdev, (eui48_t*)&cdcecm->mac_netdev);
 
-    /* signal link UP */
-    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
-
     return 0;
 }
 

--- a/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
@@ -170,6 +170,11 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
             assert(max_len >= ETHERNET_ADDR_LEN);
             memcpy(value, cdcecm->mac_netdev, ETHERNET_ADDR_LEN);
             return ETHERNET_ADDR_LEN;
+        case NETOPT_LINK:
+            assert(max_len >= sizeof(netopt_enable_t));
+            *(netopt_enable_t *)value = cdcecm->active_iface ? NETOPT_ENABLE
+                                                             : NETOPT_DISABLE;
+            return sizeof(netopt_enable_t);
         default:
             return netdev_eth_get(netdev, opt, value, max_len);
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `usbus_cdc_ecm` would always set the link state to UP, no matter if the USB device was actually connected or not.

But we can tell if the host has configured us as an interface, so make use of that information - otherwise trying to send data to an unconnected device will result in a hang of the netdev thread (waits for a mutex to get unlocked that never unlocks - see #21996)


### Testing procedure

When you disconnect the USB device, the link should now go DOWN and RIOT should no longer send frames over it.

When you connect it again, the link should be UP again and traffic proceeds as before. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
