### PR TITLE
dist/tools/usb-cdc-ecm: script fixes

### DIFF
--- a/dist/tools/usb-cdc-ecm/start_network.sh
+++ b/dist/tools/usb-cdc-ecm/start_network.sh
@@ -19,7 +19,11 @@ find_interface() {
 }
 
 echo "Waiting for network interface."
-find_interface
+if [ -z "${INTERFACE}" ]; then
+    find_interface
+else
+    INTERFACE_CHECK=1
+fi
 
 if [ "${INTERFACE_CHECK}" -eq 0 ]; then
     echo "Unable to find network interface"

--- a/dist/tools/usb-cdc-ecm/start_network.sh
+++ b/dist/tools/usb-cdc-ecm/start_network.sh
@@ -58,17 +58,27 @@ stop_radvd() {
     fi
 }
 
-cleanup() {
-    echo "Cleaning up..."
-    stop_radvd
-    cleanup_interface
-    if [ -n "${UHCPD_PID}" ]; then
-        kill "${UHCPD_PID}"
-    fi
+stop_dhcpdv6() {
     if [ -n "${DHCPD_PIDFILE}" ]; then
         kill "$(cat "${DHCPD_PIDFILE}")"
         rm "${DHCPD_PIDFILE}"
+        ip route del "${PREFIX}" via "${IPV6_ROUTE_NEXT_HOP}" dev "${INTERFACE}"
     fi
+}
+
+stop_uhcpd() {
+    if [ -n "${UHCPD_PID}" ]; then
+        kill "${UHCPD_PID}"
+        ip route del "${PREFIX}" via "${IPV6_ROUTE_NEXT_HOP}" dev "${INTERFACE}"
+    fi
+}
+
+cleanup() {
+    echo "Cleaning up..."
+    stop_radvd
+    stop_dhcpdv6
+    stop_uhcpd
+    cleanup_interface
     trap "" INT QUIT TERM EXIT
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

- Fixing `start_network.sh` for CDC_ECM when there are multiple interfaces.
- stop radvd
- keep addresses

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`sudo ./dist/tools/usb-cdc-ecm/start_network.sh -d fd00:a:a::/48`

`sudo ./dist/tools/usb-cdc-ecm/start_network.sh -r fd00:a:b:1::/64`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
