### PR TITLE
pkg/lvgl: Fix configuration header and compilation issue

### DIFF
--- a/pkg/lvgl/Makefile
+++ b/pkg/lvgl/Makefile
@@ -7,6 +7,7 @@ PKG_LICENSE=MIT
 include $(RIOTBASE)/pkg/pkg.mk
 
 CFLAGS += -Wno-empty-body
+CFLAGS += -fno-jump-tables
 
 LVGL_DEFAULT_MODULES =  \
     lvgl_core           \

--- a/pkg/lvgl/include/lv_conf.h
+++ b/pkg/lvgl/include/lv_conf.h
@@ -24,6 +24,9 @@ extern "C" {
 #include "kernel_defines.h"
 #include "lvgl_riot_conf.h"
 
+/* LVGL package requires this definition to confirm that the configuration has been included. */
+#define LV_CONF_H   1
+
 /*====================
    COLOR SETTINGS
  *====================*/


### PR DESCRIPTION
### Contribution description
This fixes two issues with the lvgl package that showed during testing for 2026.01.

First, #21701 modified the guards of `lv_conf.h` to use `#pragma`. The issue is that the LVGL package checks for the macro to ensure that the configuration has been loaded. The check is here: https://github.com/lvgl/lvgl/blob/9ec3b8706b098f60940cee6ac211d3cb3141aedf/src/lv_conf_internal.h#L30-L48

Without the define, we get several warnings:

```
In file included from [01m[K/data/riotbuild/riotbase/build/pkg/lvgl/src/core/../hal/../draw/lv_draw.h:16[m[K,
                 from [01m[K/data/riotbuild/riotbase/build/pkg/lvgl/src/core/../hal/lv_hal_disp.h:21[m[K,
                 from [01m[K/data/riotbuild/riotbase/build/pkg/lvgl/src/core/../hal/lv_hal.h:16[m[K,
                 from [01m[K/data/riotbuild/riotbase/build/pkg/lvgl/src/core/lv_disp.h:16[m[K,
                 from [01m[K/data/riotbuild/riotbase/build/pkg/lvgl/src/core/lv_disp.c:9[m[K:
[01m[K/data/riotbuild/riotbase/build/pkg/lvgl/src/core/../hal/../draw/../lv_conf_internal.h:46:17:[m[K [01;36m[Knote: [m[K'[01m[K#pragma message: Possible failure to include lv_conf.h, please read the comment in this file if you get errors[m[K'
   46 |         #pragma [01;36m[Kmessage[m[K("Possible failure to include lv_conf.h, please read the comment in this file if you get errors")
      |                 [01;36m[K^~~~~~~[m[K
In file included from [01m[K/data/riotbuild/riotbase/build/pkg/lvgl/src/core/lv_obj.h:16[m[K,
                 from [01m[K/data/riotbuild/riotbase/build/pkg/lvgl/src/core/lv_event.c:9[m[K:
[01m[K/data/riotbuild/riotbase/build/pkg/lvgl/src/core/../lv_conf_internal.h:46:17:[m[K [01;36m[Knote: [m[K'[01m[K#pragma message: Possible failure to include lv_conf.h, please read the comment in this file if you get errors[m[K'
   46 |         #pragma [01;36m[Kmessage[m[K("Possible failure to include lv_conf.h, please read the comment in this file if you get errors")
      |                 [01;36m[K^~~~~~~[m[K
```

This is fixed by re-introducing the macro.

Second, a compilation issue is hitting some platforms. It seems like a change in the gcc optimization is raising a compilation issue on the package:

```
# on tests/pkg/lvgl

> env BUILD_IN_DOCKER=1 BOARD=samr21-xpro make
Launching build container using image "docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736".
docker run --rm --tty --user $(id -u) --platform linux/amd64 -v '/usr/share/zoneinfo/Europe/Berlin:/etc/localtime:ro' -v '/home/lanzieri/Work/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/lanzieri/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/lanzieri/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=samr21-xpro' -e 'DISABLE_MODULE=test_utils_interactive_sync' -e 'DEFAULT_MODULE=' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=lvgl_contrib lvgl_extra_layout_flex lvgl_extra_theme_default lvgl_extra_theme_default_dark lvgl_extra_widget_chart lvgl_extra_widget_win' -e 'USEPKG=lvgl'  -w '/data/riotbuild/riotbase/tests/pkg/lvgl/' 'docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736' make     
Building application "tests_lvgl" for "samr21-xpro" with CPU "samd21".

"make" -C /data/riotbuild/riotbase/pkg/cmsis/ 
"make" -C /data/riotbuild/riotbase/pkg/lvgl/ 
"make" -C /data/riotbuild/riotbase/build/pkg/lvgl/src/core -f /data/riotbuild/riotbase/pkg/lvgl/Makefile.lvgl_module MODULE=lvgl_core
/tmp/ccn3NoUX.s: Assembler messages:
/tmp/ccn3NoUX.s: Error: unaligned opcodes detected in executable segment
make[2]: *** [/data/riotbuild/riotbase/Makefile.base:157: /data/riotbuild/riotbase/tests/pkg/lvgl/bin/samr21-xpro/lvgl_core/lv_event.o] Error 1
make[1]: *** [Makefile:76: lvgl_core] Error 2
make: *** [/data/riotbuild/riotbase/Makefile.include:807: pkg-build] Error 2
make: *** [/home/lanzieri/Work/RIOT/makefiles/docker.inc.mk:395: ..in-docker-container] Error 2

```

This issue was discussed previously here: https://github.com/earlephilhower/arduino-pico/issues/792. By setting `CFLAGS += -fno-jump-tables` in the package Makefile the error is fixed.


### Testing procedure
Compile the LVGL package test with the docker toolchain (possibly for samr21-xpro). It should succeed.

### Issues/PRs references

#21701
https://github.com/RIOT-OS/Release-Specs/issues/330