### PR TITLE
cpu/sam0_common: allow to set callback in rtc_tamper_enable()

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -1375,8 +1375,12 @@ void rtc_tamper_pin_disable(gpio_t pin);
 
 /**
  * @brief   Enable Tamper Detection IRQs
+ *
+ * @param   cb      Callback function (only executed when not in
+ *                  Hibernation/Backup Sleep
+ * @param   arg     Callback argument
  */
-void rtc_tamper_enable(void);
+void rtc_tamper_enable(void(*cb)(void *), void *arg);
 
 /**
  * @brief   Get and clear the RTC tamper event that has woken the CPU

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -432,7 +432,7 @@ void gpio_pm_cb_enter(int deep)
     else if (IS_ACTIVE(MODULE_PERIPH_GPIO_TAMPER_WAKE)
           && mode > PM_SLEEPCFG_SLEEPMODE_STANDBY
           && _rtc_irq_enabled()) {
-        rtc_tamper_enable();
+        rtc_tamper_enable(NULL, NULL);
     }
 #else
     if (deep) {

--- a/cpu/sam0_common/periph/rtc_rtt.c
+++ b/cpu/sam0_common/periph/rtc_rtt.c
@@ -528,7 +528,7 @@ void rtc_tamper_pin_disable(gpio_t pin)
     atomic_clear_bit_u32(atomic_bit_u32(&tampctr, 2 * in));
 }
 
-void rtc_tamper_enable(void)
+void rtc_tamper_enable(rtc_alarm_cb_t cb, void *arg)
 {
     DEBUG("enable tamper\n");
 
@@ -537,6 +537,9 @@ void rtc_tamper_enable(void)
 
     /* write TAMPCTRL register */
     _set_tampctrl(tampctr);
+
+    tamper_cb.cb = cb;
+    tamper_cb.arg = arg;
 
     /* work around errata 2.17.4:
      * ignore the first tamper event on the rising edge */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

We have to use the RTC tamper pins even when not in hibernation to avoid a conflict with two pins mapping to the same EXTI number.
Both pins are distinct tamper pins, so we can tell them apart by enabling the RTC tamper event instead.

For that, allow to define a callback function to the tamper event.
This makes no sense when waking from deep sleep, but when we are not in deep sleep and enable the tamper pins, we would get this event. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
