### PR TITLE
cpu/esp8266: fix the crashes on startup in vendor code

### DIFF
--- a/cpu/esp8266/vendor/esp-idf/esp8266/source/startup.c
+++ b/cpu/esp8266/vendor/esp-idf/esp8266/source/startup.c
@@ -121,7 +121,10 @@ void call_user_start(size_t start_addr)
     esp_image_header_t *head = (esp_image_header_t *)(FLASH_MAP_ADDR + (start_addr & (FLASH_MAP_SIZE - 1)));
     esp_image_segment_header_t *segment = (esp_image_segment_header_t *)((uintptr_t)head + sizeof(esp_image_header_t));
 
-    for (i = 0; i < 3; i++) {
+    /* The data in flash cannot be accessed by byte in this stage, so just access by word and get the segment count. */
+    uint8_t segment_count = ((*(volatile uint32_t *)head) & 0xFF00) >> 8;
+
+    for (i = 0; i < segment_count - 1; i++) {
         segment = (esp_image_segment_header_t *)((uintptr_t)segment + sizeof(esp_image_segment_header_t) + segment->data_len);
 
         uint32_t *dest = (uint32_t *)segment->load_addr;


### PR DESCRIPTION
### Contribution description

This PR fixes arbitrary crashes or hangs when starting ESP8266 boards.

RIOT uses an older version of the vendor code from the ESP8266-RTOS-SDK, in which the `call_user_startup` function tried to copy a fixed number of 3 segments from flash memory to RAM. This led to arbitrary crashes or hangs during startup when there were only two segments in the flash memory that needed to be copied to RAM. With this fix, the number of segments specified in the image header is now used.


### Testing procedure

Compile and flash an ESP8266 board with command
```
USEMODULE='sock_dns gnrc_ipv6_nib_dns' BOARD=esp8266-esp-12x \
make -C examples/networking/gnrc/networking flash term
```
Without the PR, the example should get stuck or crash at startup. With the PR, the example should work.

### Issues/PRs references
