### PR TITLE
ci/deploy_docs: stop deploying to gh_pages

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -27,17 +27,6 @@ jobs:
             uses: actions/setup-node@v4
           - name: Build documentation
             run: make build
-            # This step will probably need to be changed to use the actual service RIOT is using
-            # This makes it more convenient to deploy while still in development though
-          - name: Deploy documentation
-            uses: peaceiris/actions-gh-pages@v3
-            with:
-                github_token: ${{ secrets.GITHUB_TOKEN }}
-                publish_dir: doc/starlight/dist
-                publish_branch: gh-pages
-                cname: guide.riot-os.org
-                commit_message: "Deploy documentation"
-
           - name: Deploy to riot-os.org server
             uses: burnett01/rsync-deployments@v8
             with:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

RE: Weekly Meeting

Stop deploying to the gh_pages branch. After the PR the gh_pages branch still needs to be deleted 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
