### PR TITLE
gnrc/ipv6/nib: add `gnrc_ipv6_nib_dyn_lladdr_get()`

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -120,6 +120,7 @@ PSEUDOMODULES += gnrc_ipv6_nib_6lbr
 PSEUDOMODULES += gnrc_ipv6_nib_6ln
 PSEUDOMODULES += gnrc_ipv6_nib_6lr
 PSEUDOMODULES += gnrc_ipv6_nib_dns
+PSEUDOMODULES += gnrc_ipv6_nib_dyn_lladdr
 PSEUDOMODULES += gnrc_ipv6_nib_rio
 PSEUDOMODULES += gnrc_ipv6_nib_router
 PSEUDOMODULES += gnrc_ipv6_nib_rtr_adv_pio_cb

--- a/sys/include/net/gnrc/ipv6/nib.h
+++ b/sys/include/net/gnrc/ipv6/nib.h
@@ -429,6 +429,19 @@ void gnrc_ipv6_nib_change_rtr_adv_iface(gnrc_netif_t *netif, bool enable);
     (void)netif; (void)enable
 #endif
 
+/**
+ * This function is implemented by the application, it assigns a link-local
+ * address to a specific network interface.
+ *
+ * To use this feature, enable the `gnrc_ipv6_nib_dyn_lladdr` module.
+ *
+ * @param[in] netif     Interface that the address would be added to
+ * @param[out] lladdr   Address to add to the interface (if function returns true)
+ *
+ * @returns true if a @p lladdr should be added to @p netif
+ */
+bool gnrc_ipv6_nib_dyn_lladdr_get(gnrc_netif_t *netif, ipv6_addr_t *lladdr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -173,6 +173,22 @@ static void _add_static_lladdr(gnrc_netif_t *netif)
 #endif
 }
 
+static void _add_dynamic_lladdr(gnrc_netif_t *netif)
+{
+    if (!IS_USED(MODULE_GNRC_IPV6_NIB_DYN_LLADDR)) {
+        return;
+    }
+
+    ipv6_addr_t lladdr;
+    if (!gnrc_ipv6_nib_dyn_lladdr_get(netif, &lladdr)) {
+        return;
+    }
+
+    assert(ipv6_addr_is_link_local(&lladdr));
+    gnrc_netif_ipv6_addr_add_internal(netif, &lladdr, 64U,
+                                      GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID);
+}
+
 void gnrc_ipv6_nib_iface_up(gnrc_netif_t *netif)
 {
     assert(netif != NULL);
@@ -190,6 +206,7 @@ void gnrc_ipv6_nib_iface_up(gnrc_netif_t *netif)
         DEBUG("nib: Can't join link-local all-nodes on interface %u\n", netif->pid);
     }
     _add_static_lladdr(netif);
+    _add_dynamic_lladdr(netif);
     _auto_configure_addr(netif, &ipv6_addr_link_local_prefix, 64U);
     if (_should_search_rtr(netif)) {
         uint32_t next_rs_time = random_uint32_range(0, NDP_MAX_RS_MS_DELAY);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This is similar to `CONFIG_GNRC_IPV6_STATIC_LLADDR`, but instead of hard-coding the address, this adds a callback function with which user code can decide which link-local address to add.

The motivation is that we have multiple boards running the same firmware that we want to tell apart by a well-known link-local address.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
