### PR TITLE
cpu/esp8266: Fix crashes of the ESP866 when rebooting with or disconnecting from WiFi

### DIFF
--- a/cpu/esp8266/periph/pm.c
+++ b/cpu/esp8266/periph/pm.c
@@ -18,6 +18,7 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
+#include "esp_wifi.h"
 #include "sdk/sdk.h"
 #include "syscalls.h"
 
@@ -48,6 +49,11 @@ void pm_off(void)
 void pm_reboot(void)
 {
     DEBUG("%s\n", __func__);
+
+    if (IS_USED(MODULE_ESP_WIFI_ANY)) {
+        /* stop WiFi if necessary */
+        esp_wifi_stop();
+    }
 
 #ifdef MODULE_PERIPH_RTT
     /* save counters */


### PR DESCRIPTION
### Contribution description

This PR fixes the problem described in issue #21558.

With the ESP8266, `vTaskDelay` is only called by `ieee80211_sta_new_state`, with interrupts of all levels disabled, for example as a result of executing `esp_wifi_disconnect`. `vTaskDelay` uses `ztimer_sleep` and if `ztimer_sleep` is then called with interrupts disabled, it leads to memory corruption for some reason when interrupts are re-enabled afterwards. The only way to avoid this is to re-enable interrupts before calling `ztimer_sleep` in `vTaskDelay`.

Since debugging ESP8266 code is very limited and sometimes impossible due to there being only one hardware breakpoint and a lot of closed binary code involved when calling `esp_wifi_disconnect`, it was not possible to find the reason for the memory corruption. An exception occurs after executing `esp_wifi_disconnect` in `ztimer_handler` when
`_callback_unlock_mutex` is called with a mutex parameter that points to wrong address in IROM.

Therefore, enabling the interrupts in `vTaskDelay` before calling `ztimer_sleep` is currently the only way to avoid the exception, even though this is only a hack.

The PR includes a small improvement of the `pm_reboot` function. Even though `esp_wifi_stop` is implicitly called later in the restart process by `esp_restart`, it is cleaner to stop the WiFi interface here before saving the RTT counters.


### Testing procedure

Compile and flash the GNRC networking example for any ESP8266 with WiFi enabled:
```python
CFLAGS='-DWIFI_SSID=\"ssid\" -DWIFI_PASS=\"pass\"' USEMODULE='esp_wifi' \
BOARD=esp8266-esp-12x make -j8 -C examples/networking/gnrc/networking flash term
```
Without the PR, using `reboot` after connecting to the WiFi AP will lead to an exception. With the PR, it should work.

### Issues/PRs references

Fixes #21558 