### PR TITLE
drivers/at86rf215: always enable RX start IRQ after reset

### DIFF
--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -95,9 +95,6 @@ void at86rf215_reset_and_cfg(at86rf215_t *dev)
             IS_ACTIVE(CONFIG_IEEE802154_DEFAULT_ACK_REQ) ? NETOPT_ENABLE : NETOPT_DISABLE;
     netdev_ieee802154_set(&dev->netdev, NETOPT_ACK_REQ,
                           &ack_req, sizeof(ack_req));
-
-    /* enable RX start IRQs */
-    at86rf215_reg_or(dev, dev->BBC->RG_IRQM, BB_IRQ_RXAM);
 }
 
 void at86rf215_reset(at86rf215_t *dev)
@@ -133,8 +130,8 @@ if (!IS_ACTIVE(CONFIG_AT86RF215_USE_CLOCK_OUTPUT)){
     at86rf215_set_trim(dev, CONFIG_AT86RF215_TRIM_VAL);
 #endif
 
-    /* enable TXFE & RXFE IRQ */
-    at86rf215_reg_write(dev, dev->BBC->RG_IRQM, BB_IRQ_TXFE | BB_IRQ_RXFE);
+    /* enable TXFE, RXFE & RX Start IRQ */
+    at86rf215_reg_write(dev, dev->BBC->RG_IRQM, BB_IRQ_TXFE | BB_IRQ_RXFE | BB_IRQ_RXAM);
 
     /* enable EDC IRQ */
     at86rf215_reg_write(dev, dev->RF->RG_IRQM, RF_IRQ_EDC | RF_IRQ_TRXRDY);


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

I discovered an old bug report that RX start IRQs are not enabled again when waking from sleep - but this is easy to fix.


### Testing procedure

still untested


### Issues/PRs references

fixes #20505
