### PR TITLE
cpu/esp32: fix compilation for GCC 15.2 on ESP32x RISC-V SoCs

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -312,6 +312,7 @@ CFLAGS += -D_CONST=const
 # TODO no relaxation yet
 ifneq (,$(filter riscv%,$(TARGET_ARCH)))
   CFLAGS += -DCONFIG_IDF_TARGET_ARCH_RISCV
+  CFLAGS += -DQCBOR_DISABLE_FLOAT_HW_USE
   CFLAGS += -mno-relax -mabi=ilp32 -DRISCV_NO_RELAX
   CFLAGS += -fno-jump-tables
   LDGENFLAGS += -DCONFIG_IDF_TARGET_ARCH_RISCV


### PR DESCRIPTION
### Contribution description

This PR fixes the compilation of the QCBOR package for RISC-V variants of ESP32x SoCs with GCC 15.2.

RISC-V variants of ESP32x do not have a floating point unit. The use of floating point hardware must be explicitly disabled in GCC 15.2 to avoid compilation errors.

The change also works with the current toolchain, which uses GCC 14.2. However, it is necessary in order to be able to switch the GCC version in riotdocker and Murdock first before the ESP-IDF can be ugraded which requires GCC 15.2.

### Testing procedure

Compile and flash `tests/pkg/qcbor` for any ESP32x RISC-V board, for example:
```
BOARD=esp32c3-wemos-mini make -j8 -C tests/pkg/qcbor flash term
```
Without the PR, the compilation fails. With the PR, the compilation and the test work:
```
main(): This is RIOT! (Version: 2018.04-devel-32480-gd24fb-cpu/e..
OK (2 tests)
{ "threads": [{ "name": "idle", "stack_size": 2048, "stack_used": 256 }]}
{ "threads": [{ "name": "main", "stack_size": 3584, "stack_used": 852 }]}
```

### Issues/PRs references
