### PR TITLE
sys/evtimer: fix 0 offset events

### DIFF
--- a/tests/sys/evtimer_msg/main.c
+++ b/tests/sys/evtimer_msg/main.c
@@ -111,4 +111,26 @@ int main(void)
     ztimer_sleep(ZTIMER_MSEC, (offsets[3] + 10));
     puts("By now all msgs should have been received");
     puts("If yes, the tests were successful");
+
+    /**************************
+     * test: zero-offset events
+     **************************/
+    printf("\nTesting zero-offset event handling\n");
+
+    evtimer_msg_event_t zero_event;
+
+    zero_event.event.offset = 0;
+    zero_event.msg.content.ptr = "zero offset event";
+
+    /* Add zero-offset event and verify it is handled immediately */
+    evtimer_add_msg(&evtimer, &zero_event, pid);
+
+    /* If the fix works, this message should be delivered immediately */
+    /* Wait a tiny bit to let the worker print */
+    ztimer_sleep(ZTIMER_MSEC, 10);
+
+    /* Verify list is empty afterwards */
+    printf("Zero offset event should have been received\n");
+
+    return 0;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Something is weird in the `evtimer`. When a 0 offset event is added it seems like the timer IRQ does not fire.
I got the fix from AI actually 😅.
But I noticed in development that sometimes an event with 0 offset is stuck in the `_nib_evtimer` which prevents any further events.

This is not the case on `native`, but on `same54-xpro`.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Added a test in `tests/sys/evtimer` Without the fix the 0 offset event does not trigger.
Try to run it with the fix and it triggers.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
