### PR TITLE
sys/walltime: add automatic test, more backends

### DIFF
--- a/drivers/ds3231/ds3231.c
+++ b/drivers/ds3231/ds3231.c
@@ -441,3 +441,33 @@ int ds3231_disable_bat(const ds3231_t *dev)
 {
     return _clrset(dev, REG_CTRL, 0, CTRL_EOSC, 1, 1);
 }
+
+#ifdef MODULE_WALLTIME_IMPL_DS3231
+#include "ds3231_params.h"
+
+static ds3231_t walltime_dev;
+static bool _init_done;
+
+void walltime_impl_init(void)
+{
+    _init_done = !ds3231_init(&walltime_dev, &ds3231_params[0]);
+}
+
+int walltime_impl_get(struct tm *time, uint16_t *ms)
+{
+    if (!_init_done) {
+        return -ENODEV;
+    }
+
+    *ms = 0;
+    return ds3231_get_time(&walltime_dev, time);
+}
+
+int walltime_impl_set(struct tm *time)
+{
+    if (!_init_done) {
+        return -ENODEV;
+    }
+    return ds3231_set_time(&walltime_dev, time);
+}
+#endif

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -547,6 +547,7 @@ PSEUDOMODULES += vfs_auto_mount
 ## backends.
 PSEUDOMODULES += vfs_default
 
+PSEUDOMODULES += walltime_default
 PSEUDOMODULES += walltime_impl_ds1307
 PSEUDOMODULES += walltime_impl_ds3231
 PSEUDOMODULES += walltime_impl_rtc

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -548,6 +548,7 @@ PSEUDOMODULES += vfs_auto_mount
 PSEUDOMODULES += vfs_default
 
 PSEUDOMODULES += walltime_impl_ds1307
+PSEUDOMODULES += walltime_impl_ds3231
 PSEUDOMODULES += walltime_impl_rtc
 PSEUDOMODULES += wakaama_objects_%
 PSEUDOMODULES += wifi_scan_list

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -547,6 +547,7 @@ PSEUDOMODULES += vfs_auto_mount
 ## backends.
 PSEUDOMODULES += vfs_default
 
+PSEUDOMODULES += walltime_impl_ds1307
 PSEUDOMODULES += walltime_impl_rtc
 PSEUDOMODULES += wakaama_objects_%
 PSEUDOMODULES += wifi_scan_list

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -713,6 +713,10 @@ ifneq (,$(filter auto_init%,$(USEMODULE)))
   USEMODULE += preprocessor_successor
 endif
 
+ifneq (,$(filter walltime_default,$(USEMODULE)))
+  USEMODULE += walltime
+endif
+
 ifneq (,$(filter wifi_scan_list,$(USEMODULE)))
   USEMODULE += l2scan_list
 endif

--- a/sys/walltime/Makefile.dep
+++ b/sys/walltime/Makefile.dep
@@ -4,3 +4,8 @@ USEMODULE += fmt
 ifneq (,$(filter walltime_impl_ds1307,$(USEMODULE)))
   USEMODULE += ds1307
 endif
+
+ifneq (,$(filter walltime_impl_rtc,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_rtc
+  FEATURES_OPTIONAL += periph_rtc_ms
+endif

--- a/sys/walltime/Makefile.dep
+++ b/sys/walltime/Makefile.dep
@@ -1,2 +1,6 @@
 USEMODULE += rtc_utils
 USEMODULE += fmt
+
+ifneq (,$(filter walltime_impl_ds1307,$(USEMODULE)))
+  USEMODULE += ds1307
+endif

--- a/sys/walltime/Makefile.dep
+++ b/sys/walltime/Makefile.dep
@@ -5,6 +5,10 @@ ifneq (,$(filter walltime_impl_ds1307,$(USEMODULE)))
   USEMODULE += ds1307
 endif
 
+ifneq (,$(filter walltime_impl_ds3231,$(USEMODULE)))
+  USEMODULE += ds3231
+endif
+
 ifneq (,$(filter walltime_impl_rtc,$(USEMODULE)))
   FEATURES_REQUIRED += periph_rtc
   FEATURES_OPTIONAL += periph_rtc_ms

--- a/sys/walltime/rtc.c
+++ b/sys/walltime/rtc.c
@@ -28,6 +28,7 @@ int walltime_impl_get(struct tm *time, uint16_t *ms)
     if (IS_USED(MODULE_PERIPH_RTC_MS)) {
         rtc_get_time_ms(time, ms);
     } else {
+        *ms = 0;
         rtc_get_time(time);
     }
     return 0;

--- a/tests/sys/walltime/Makefile
+++ b/tests/sys/walltime/Makefile
@@ -2,7 +2,8 @@ include ../Makefile.sys_common
 
 USEMODULE += shell
 USEMODULE += shell_cmds_default
-USEMODULE += walltime
+USEMODULE += walltime_default
+USEMODULE += rtc_utils
 USEMODULE += ztimer_msec
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/sys/walltime/tests/01-run.py
+++ b/tests/sys/walltime/tests/01-run.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.sendline("test")
+    child.expect("TEST PASSED")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This hooks up the `ds1307` and `ds3231` drivers as possible backends for the `walltime` module.
It also enhances the `tests/sys/walltime` with an automatic test.

When adding the modules I discovered a bug that when the backend has a time set before `RIOT_EPOCH`, we get an underflow when trying to set a new time.

To fix this, always initialize a backend with `RIOT_EPOCH` should it be set to a date further in the past.

There is now also a pseudo-module `walltime_default` with which a board can declare it's default clock source

```
ifneq (,$(filter walltime_default,$(USEMODULE)))
  USEMODULE += walltime_impl_ds1307
endif
```

### Testing procedure

Run the automatic test in `tests/sys/walltime` with `make test`:

```
RIOT native interrupts/signals initialized.
TZ not set, setting UTC
RIOT native64 board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2026.04-devel-54-g4eca8-sys/walltime-test)
> test
time changed by 45294 sec, 0 ms
time changed by 820540800 sec, 0 ms
TEST PASSED
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
