### PR TITLE
drivers/ws281x: move configurables to params

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,4 +6,4 @@
 
 [patch.crates-io]
 riot-sys = { git = "https://github.com/RIOT-OS/rust-riot-sys" }
-riot-wrappers = { git = "https://github.com/RIOT-OS/rust-riot-wrappers" }
+riot-wrappers = { git = "https://github.com/RIOT-OS/rust-riot-wrappers", rev = "d9b05bb2523ebed899f9b55a0dadd4b26c8576c4" }

--- a/drivers/include/ws281x.h
+++ b/drivers/include/ws281x.h
@@ -91,7 +91,6 @@
 #include "periph/gpio.h"
 #include "ws281x_backend.h"
 #include "ws281x_constants.h"
-#include "xtimer.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -134,7 +133,6 @@ typedef struct {
     ws281x_params_t params;   /**< Parameters of the LED chain */
 } ws281x_t;
 
-#if defined(WS281X_HAVE_INIT) || defined(DOXYGEN)
 /**
  * @brief   Initialize an WS281x RGB LED chain
  *
@@ -146,12 +144,6 @@ typedef struct {
  * @retval  -EIO    Failed to initialize the data GPIO pin
  */
 int ws281x_init(ws281x_t *dev, const ws281x_params_t *params);
-#else
-static inline int ws281x_init(ws281x_t *dev, const ws281x_params_t *params) {
-    dev->params = *params;
-    return 0;
-}
-#endif
 
 /**
  * @brief   Writes the color data of the user supplied buffer
@@ -183,21 +175,13 @@ static inline int ws281x_init(ws281x_t *dev, const ws281x_params_t *params) {
  */
 void ws281x_write_buffer(ws281x_t *dev, const void *buf, size_t size);
 
-#if defined(WS281X_HAVE_PREPARE_TRANSMISSION) || defined(DOXYGEN)
 /**
  * @brief   Sets up everything needed to write data to the WS281X LED chain
  *
  * @param   dev     Device descriptor of the LED chain to write to
  */
 void ws281x_prepare_transmission(ws281x_t *dev);
-#else
-static inline void ws281x_prepare_transmission(ws281x_t *dev)
-{
-    (void)dev;
-}
-#endif
 
-#if defined(WS281X_HAVE_END_TRANSMISSION) || defined(DOXYGEN)
 /**
  * @brief   Ends the transmission to the WS2812/SK6812 LED chain
  *
@@ -207,13 +191,6 @@ static inline void ws281x_prepare_transmission(ws281x_t *dev)
  * it simply waits for 80µs to send the end of transmission signal.
  */
 void ws281x_end_transmission(ws281x_t *dev);
-#else
-static inline void ws281x_end_transmission(ws281x_t *dev)
-{
-    (void)dev;
-    xtimer_usleep(WS281X_T_END_US);
-}
-#endif
 
 /**
  * @brief   Sets the color of an LED in the given data buffer

--- a/drivers/ws281x/esp32.c
+++ b/drivers/ws281x/esp32.c
@@ -28,6 +28,7 @@
 #include "board.h"
 #include "log.h"
 #include "periph_cpu.h"
+#include "time_units.h"
 
 #include "ws281x.h"
 #include "ws281x_params.h"

--- a/drivers/ws281x/include/ws281x_constants.h
+++ b/drivers/ws281x/include/ws281x_constants.h
@@ -23,40 +23,6 @@ extern "C" {
 #endif
 
 /**
- * @name    Timing parameters for WS2812/SK6812 RGB LEDs
- * @{
- */
-
-/**
- * @brief   Data transmission time in nanoseconds
- *
- * For the SK6812, WS2812 and WS2812b this is 1.25 µs. This is the total time
- * required to transmit one bit.
- */
-#define WS281X_T_DATA_NS                (1250U)
-
-/**
- * @brief The high-times in nanoseconds.
- * @{
- */
-#ifndef WS281X_T_DATA_ONE_NS
-#  define WS281X_T_DATA_ONE_NS          (650U)
-#endif
-#ifndef WS281X_T_DATA_ZERO_NS
-#  define WS281X_T_DATA_ZERO_NS         (325U)
-#endif
-/**@}*/
-
-/**
- * @brief   Time in microseconds to pull the data line low to signal end of data
- *
- * For the WS2812 it is ≥ 50µs, for the SK6812 it is ≥ 80µs. We choose 80µs to
- * be compatible with both.
- */
-#define WS281X_T_END_US                 (80U)
-/**@}*/
-
-/**
  * @name    Data encoding parameters for WS2812/SK6812 RGB LEDs
  * @{
  */

--- a/drivers/ws281x/include/ws281x_params.h
+++ b/drivers/ws281x/include/ws281x_params.h
@@ -67,6 +67,46 @@ static const ws281x_params_t ws281x_params[] =
     WS281X_PARAMS
 };
 
+/**
+ * @name    Timing parameters for WS2812/SK6812 RGB LEDs
+ * @{
+ */
+
+/**
+ * @brief   Data transmission time in nanoseconds
+ *
+ * For the SK6812, WS2812 and WS2812b this is 1.25 µs. This is the total time
+ * required to transmit one bit.
+ */
+#ifndef WS281X_T_DATA_NS
+#  define WS281X_T_DATA_NS              (1250U)
+#endif
+
+/**
+ * @brief The high-time of a 1 in nanoseconds.
+ */
+#ifndef WS281X_T_DATA_ONE_NS
+#  define WS281X_T_DATA_ONE_NS          (650U)
+#endif
+
+/**
+ * @brief The high-time of a 0 in nanoseconds.
+ */
+#ifndef WS281X_T_DATA_ZERO_NS
+#  define WS281X_T_DATA_ZERO_NS         (325U)
+#endif
+
+/**
+ * @brief   Time in microseconds to pull the data line low to signal end of data
+ *
+ * For the WS2812 it is ≥ 50µs, for the SK6812 it is ≥ 80µs. We choose 80µs to
+ * be compatible with both.
+ */
+#ifndef WS281X_T_END_US
+#  define WS281X_T_END_US               (80U)
+#endif
+/**@}*/
+
 /** @brief Timer used for WS281x (by the timer_gpio_ll implementation)
  *
  * A single timer is configured for any number of WS281x strands, so this does

--- a/drivers/ws281x/spi.c
+++ b/drivers/ws281x/spi.c
@@ -120,9 +120,11 @@ void ws281x_end_transmission(ws281x_t *dev)
     const uint8_t *non_zero_spi_byte = memchk(_spi_buf, 0x00, sizeof(_spi_buf));
     if (non_zero_spi_byte) {
         size_t led_numof = (non_zero_spi_byte - _spi_buf) / sizeof(ws281x_spi_data_t);
-        led_numof -= (_SPI_RESET_BYTES / sizeof(ws281x_spi_data_t));
-        dev->params.numof = led_numof;
-        DEBUG("Detected %u LEDs in chain\n", (unsigned)dev->params.numof);
+        if (led_numof > (_SPI_RESET_BYTES / sizeof(ws281x_spi_data_t))) {
+            led_numof -= (_SPI_RESET_BYTES / sizeof(ws281x_spi_data_t));
+            dev->params.numof = led_numof;
+            DEBUG("Detected %u LEDs in chain\n", (unsigned)dev->params.numof);
+        }
     }
 #if ENABLE_DEBUG && MODULE_OD
     DEBUG("Received SPI data (%u bytes):\n", (unsigned)_spi_size);

--- a/drivers/ws281x/spi.c
+++ b/drivers/ws281x/spi.c
@@ -188,7 +188,8 @@ void ws281x_write_buffer(ws281x_t *dev, const void *_buf, size_t size)
 {
     assert(dev);
     assert(size % WS281X_BYTES_PER_DEVICE == 0);
-    assert(size * WS281X_SPI_BITS_PER_WS_BIT <= sizeof(_spi_buf));
+    /* number of already written bytes plus number of bytes to write fits in buffer */
+    assert(_spi_size + size * WS281X_SPI_BITS_PER_WS_BIT <= sizeof(_spi_buf));
 
     if (8 % WS281X_SPI_BITS_PER_WS_BIT) {
         _ws281x_write_buffer_unaligned(_buf, size);

--- a/drivers/ws281x/ws281x.c
+++ b/drivers/ws281x/ws281x.c
@@ -24,9 +24,11 @@
 #include <string.h>
 
 #include "ws281x.h"
+#include "ws281x_backend.h"
 #include "ws281x_constants.h"
 #include "ws281x_params.h"
 #include "periph/gpio.h"
+#include "xtimer.h"
 
 /* Default buffer used in ws281x_params.h. Will be optimized out if unused */
 uint8_t ws281x_buf[WS281X_PARAM_NUMOF * WS281X_BYTES_PER_DEVICE];
@@ -41,3 +43,28 @@ void ws281x_set_buffer(void *_dest, uint16_t n, ws281x_pixel_t c)
     dest[WS281X_BYTES_PER_DEVICE * n + WS281X_OFFSET_W] = c.w;
 #endif
 }
+
+/* Backend may implement these functions */
+
+#if !defined(WS281X_HAVE_INIT)
+int ws281x_init(ws281x_t *dev, const ws281x_params_t *params)
+{
+    dev->params = *params;
+    return 0;
+}
+#endif
+
+#if !defined(WS281X_HAVE_PREPARE_TRANSMISSION)
+void ws281x_prepare_transmission(ws281x_t *dev)
+{
+    (void)dev;
+}
+#endif
+
+#if !defined(WS281X_HAVE_END_TRANSMISSION)
+void ws281x_end_transmission(ws281x_t *dev)
+{
+    (void)dev;
+    xtimer_usleep(WS281X_T_END_US);
+}
+#endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

More `constants` must be configurable for `ws281x`. For example `ws2813` has a 250us reset delay.

I moved the default implementation of backend functions to the c file because else I would need to include `ws281x_params.h` in `ws281x.h`.  

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

CI should be fine.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
