### PR TITLE
Fixed _hex_chars length for latest gcc version

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -35,7 +35,7 @@
 extern ssize_t stdio_write(const void* buffer, size_t len);
 
 NONSTRING
-static const char _hex_chars[16] = "0123456789ABCDEF";
+static const char _hex_chars[] = "0123456789ABCDEF";
 
 static const uint32_t _tenmap[] = {
     0,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Added fix for _hex_chars array.


### Testing procedure
Just build any binary which depends on the fmt.c file.

### Issues/PRs references

Fixed _hex_chars string length issue in sys/fmt/fmt.c