### PR TITLE
pkg/pkg.mk: enable sparse checkout for non-cache

### DIFF
--- a/cpu/nrf5x_common/Makefile.nrfx
+++ b/cpu/nrf5x_common/Makefile.nrfx
@@ -46,15 +46,23 @@ else ifneq (nrf53%, $(CPU_FAM))
 
 endif
 
-# The rust implementation of git-cache is the only one doing
-# a sparse checkout. The others do a full clone, which we need to
-# consider here.
-ifneq (,$(GIT_CACHE_RS))
-  PKG_SOURCE_DIR = $(BUILD_DIR)/nrf5x_nrfx_mdk/$(CPU_FAM)
-  VENDOR_FOLDER = $(PKG_SOURCE_DIR)/vendor
-else
-  PKG_SOURCE_DIR = $(BUILD_DIR)/nrf5x_nrfx_mdk
-  VENDOR_FOLDER = $(PKG_SOURCE_DIR)/$(CPU_FAM)/vendor
+# proactively set the GIT_CACHE_DIR, otherwise we have no choice of knowing
+# whether or not git-cache might be used or not
+GIT_CACHE_DIR ?= $(HOME)/.gitcache
+
+# The current implementation of git-cache always does a full clone
+# and does not care for the sparse paths. To avoid issues changing
+# between different CPU families, the sparse checkouts have to
+# be done in different subfolders to avoid missing file errors.
+
+PKG_SOURCE_DIR = $(BUILD_DIR)/nrf5x_nrfx_mdk/$(CPU_FAM)
+VENDOR_FOLDER = $(PKG_SOURCE_DIR)/vendor
+
+ifeq ($(GIT_CACHE_DIR),$(wildcard $(GIT_CACHE_DIR)))
+  ifeq (,$(GIT_CACHE_RS))
+    PKG_SOURCE_DIR = $(BUILD_DIR)/nrf5x_nrfx_mdk
+    VENDOR_FOLDER = $(PKG_SOURCE_DIR)/$(CPU_FAM)/vendor
+  endif
 endif
 
 PKG_PATCH_DIR = $(RIOTCPU)/nrf5x_common/include/vendor/patches


### PR DESCRIPTION
### Contribution description

During the development of #21800 I noticed that our current `pkg/pkg.mk` script always fetches the whole repository, which can be quite a lot. Especially CMSIS and NRFX are big.

The easy solution is to use `git-cache-rs`, but it would be nice to utilize the built-in sparse checkout that git supports since version 2.25.0 from January 2020.
IMO it's safe to assume that users have a more recent version than that, Ubuntu 22.04 LTS ships with 2.34.1 from late 2021.

### Testing procedure

If you have `git-cache` set up, make sure to (temporarily) rename your `~/.gitcache` folder:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ mv ~/.gitcache/ ~/.gitcache_disabled
```

For testing I enabled the debug messages and delete the `build` subdirectory before each run. The multiple git calls are only present the first time the build is run. If the `build` directory already has the relevant files, it's not called again.
```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ rm -rf build/ && QUIETER= BOARD=nrf52dk make -C tests/sys/shell -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell'
Building application "tests_shell" for "nrf52dk" with CPU "nrf52".

[INFO] cloning nrf5x_nrfx_mdk without cache
[INFO] using sparse checkout
[INFO] updating nrf5x_nrfx_mdk /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/nrf5x_nrfx_mdk/.pkg-state.git-downloaded
[INFO] patch nrf5x_nrfx_mdk
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (1/1), 12.80 KiB | 1.28 MiB/s, done.
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (1/1), 16.32 KiB | 2.04 MiB/s, done.
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (1/1), 19.59 KiB | 2.18 MiB/s, done.
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (1/1), 36.99 KiB | 2.64 MiB/s, done.
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (1/1), 18.96 KiB | 1.35 MiB/s, done.
[INFO] cloning cmsis without cache
[INFO] using sparse checkout
[INFO] updating cmsis /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/cmsis/.pkg-state.git-downloaded
[INFO] patch cmsis
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (1/1), 2.97 KiB | 2.97 MiB/s, done.
[INFO] cloning mpaland-printf without cache
[INFO] updating mpaland-printf /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/mpaland-printf/.pkg-state.git-downloaded
[INFO] patch mpaland-printf
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/pkg/cmsis/
...
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/sys/ztimer
   text    data     bss     dec     hex filename
  15064     128    2564   17756    455c /home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell/bin/nrf52dk/tests_shell.elf
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell'
```

As you can see, the build folder is quite small.
```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ du -sh build/*
4.0K    build/CACHEDIR.TAG
13M     build/nrf5x_nrfx_mdk
6.9M    build/pkg
```

With the current master we get this:

```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ rm -rf build/ && QUIETER= BOARD=nrf52dk make -C tests/sys/shell -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell'
Building application "tests_shell" for "nrf52dk" with CPU "nrf52".

[INFO] cloning without cache nrf5x_nrfx_mdk
[INFO] updating nrf5x_nrfx_mdk /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/nrf5x_nrfx_mdk/.pkg-state.git-downloaded
[INFO] patch nrf5x_nrfx_mdk
[INFO] cloning without cache cmsis
[INFO] updating cmsis /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/cmsis/.pkg-state.git-downloaded
[INFO] patch cmsis
[INFO] cloning without cache mpaland-printf
[INFO] updating mpaland-printf /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/mpaland-printf/.pkg-state.git-downloaded
[INFO] patch mpaland-printf
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/pkg/cmsis/
...
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/sys/ztimer
   text    data     bss     dec     hex filename
  15032     128    2564   17724    453c /home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell/bin/nrf52dk/tests_shell.elf
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell'
```

As you can see, not quite so small.
```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ du -sh build/*
4.0K    build/CACHEDIR.TAG
221M    build/nrf5x_nrfx_mdk
176M    build/pkg
```


### Issues/PRs references

Noticed in #21800.