### PR TITLE
doc/starlight: add unit tests to tutorials

### DIFF
--- a/doc/starlight/Makefile
+++ b/doc/starlight/Makefile
@@ -27,7 +27,7 @@ clean:
 	-@rm -rf node_modules .astro dist
 
 .PHONY: integrate_outside_files
-integrate_outside_files: code_of_conduct governance lostandfound coding_conventions coding_conventions_cpp security
+integrate_outside_files: code_of_conduct governance lostandfound coding_conventions coding_conventions_cpp security unittests
 
 .PHONY: code_of_conduct
 code_of_conduct: ../../CODE_OF_CONDUCT.md
@@ -60,3 +60,9 @@ security: ../../SECURITY.md
 	-@mkdir -p ../guides/generated
 	-@echo "Generating Security Guidelines..."
 	-@sed '1,2d' $< | cat ./templates/SECURITY.template.md - > ../guides/generated/SECURITY.md
+
+.PHONY: unittests
+unittests: ../../tests/unittests/README.md
+	-@echo "Generating Unittests documentation..."
+	-@mkdir -p ../guides/generated/tests/unittests
+	-@sed '1,2d' $< | cat ./templates/UNITTESTS.template.md - > ../guides/generated/tests/unittests/README.md

--- a/doc/starlight/astro.config.ts
+++ b/doc/starlight/astro.config.ts
@@ -139,6 +139,7 @@ export default defineConfig({
               items: [
                 "advanced_tutorials/creating_application",
                 "advanced_tutorials/creating_modules",
+                "advanced_tutorials/unittests",
                 "advanced_tutorials/device_drivers",
                 "advanced_tutorials/porting_boards",
                 "advanced_tutorials/event_queue",

--- a/doc/starlight/templates/UNITTESTS.template.md
+++ b/doc/starlight/templates/UNITTESTS.template.md
@@ -1,0 +1,5 @@
+---
+title: Unittests
+description: This document provides an overview of unit testing in RIOT-OS.
+slug: advanced_tutorials/unittests
+---

--- a/tests/unittests/README.md
+++ b/tests/unittests/README.md
@@ -1,6 +1,6 @@
 # Unittests
 
-## Building and running tests
+## Building and Running Tests
 Tests can be built by calling:
 
 ```bash
@@ -31,7 +31,7 @@ make debug
 ```
 and using GDB as usual.
 
-### Other output formats
+### Other Output Formats
 Other output formats using [*embUnit*](http://embunit.sourceforge.net/)'s ``textui`` library are available by setting the environment variable ``OUTPUT``:
 
 * Compiler: ``OUTPUT="COMPILER"``
@@ -40,7 +40,7 @@ Other output formats using [*embUnit*](http://embunit.sourceforge.net/)'s ``text
 * Color: ``OUTPUT="COLOR"`` (like default, but with red/green output)
 * Colored-Text: ``OUTPUT="COLORTEXT"`` (like ``TEXT``, but with red/green output)
 
-#### Compile example
+#### Compile Example
 ```bash
 OUTPUT="COMPILER" make tests-core
 make term
@@ -48,7 +48,7 @@ make term
 
 (only outputs in case of test failures)
 
-#### Text example
+#### Text Example
 ```bash
 OUTPUT="TEXT" make tests-core
 make term
@@ -66,13 +66,13 @@ make term
 OK (... tests)
 ```
 
-#### XML example
+#### XML Example
 ```bash
 OUTPUT="XML" make tests-core
 make term
 ```
 
-```XML
+```xml
 <?xml version="1.0" encoding='shift_jis' standalone='yes' ?>
 <TestRun>
 <core_bitarithm_tests>
@@ -96,18 +96,18 @@ make term
 </TestRun>
 ```
 
-## Writing unit tests
+## Writing Unittests
 
-### File structure
+### File Structure
 RIOT uses [*embUnit*](http://embunit.sourceforge.net/) for unit testing.
-All unit tests are organized in ``tests/unittests`` and can be built module-wise, if needed.
+All unittests are organized in ``tests/unittests`` and can be built module-wise, if needed.
 For each module there exists a ``tests-<modulename>/tests-<modulename>.h`` file, at least one C file in ``tests-<modulename>/`` and a ``tests-<modulename>/Makefile``.
 It is recommended to add a C file named ``tests-<modulename>/tests-<modulename>-<headername>.c`` for every header file that defines functions (or macros) implemented in the module.
 If there is only one such header file ``tests-<modulename>/tests-<modulename>.c`` should suffice.
 
 Each ``*.c`` file should implement a function defined in ``tests-<modulename>/tests-<modulename>.h``, named like
 
-```C
+```c
 Test *tests_<modulename>_<headername>_tests(void);
 
 /* or respectively */
@@ -115,7 +115,7 @@ Test *tests_<modulename>_<headername>_tests(void);
 Test *tests_<modulename>_tests(void);
 ```
 
-### Testing a module
+### Testing a Module
 To write new tests for a module you need to do three things:
 
 1. **[Create a Makefile](#create-a-makefile)**: add a file ``tests-<modulename>/Makefile``
@@ -125,14 +125,14 @@ To write new tests for a module you need to do three things:
 #### Create a Makefile
 The Makefile should have the following content:
 
-```Makefile
+```makefile
 include $(RIOTBASE)/Makefile.base
 ```
 
-#### Define a test header.
+#### Define a Test Header.
 The test header ``tests-<modulename>/tests-<module>.h`` of a module you add to ``tests/unittests/`` should have the following structure
 
-```C
+```c
 /*
  * SPDX-FileCopyrightText: <year> <author>
  * SPDX-License-Identifier: LGPL-2.1-only
@@ -179,10 +179,10 @@ Test *tests_<module>_<header2>_tests(void);
 /** @} */
 ```
 
-#### Implement tests
+#### Implement Tests
 Every ``tests-<modulename>/tests-<module>*.c`` file you add to ``tests/unittests/`` should have the following structure:
 
-```C
+```c
 /*
  * SPDX-FileCopyrightText: <year> <author>
  * SPDX-License-Identifier: LGPL-2.1-only
@@ -324,13 +324,13 @@ The following assertion macros are available via *embUnit*
   </tbody>
 </table>
 
-## Out of Tree Unit Tests
+## Out of Tree Unittests
 
 Export the environment variable `EXTERNAL_UNITTEST_DIRS` that contains a space
-separated list of out-of-tree unit tests to also include in the test. The tests
+separated list of out-of-tree unittests to also include in the test. The tests
 will be treated the exact same way as tests in this folder and must follow the
 same naming convention (each folder in `EXTERNAL_UNITTEST_DIRS` should have
-`tests-<name>` folders containing the unit tests).
+`tests-<name>` folders containing the unittests).
 
 This feature works best with `EXTERNAL_MODULE_DIRS` that contain the code the
-external unit tests should cover.
+external unittests should cover.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/865fdf04-c262-4be8-b15a-01849b31e26c" />

This is a follow-up to #22035 as requested. It simply adds the unit tests readme to the guide site.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`make doc-starlight`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
