### PR TITLE
dist/tools: deprecate `git-cache` script, embrace `git-cache-rs`

### DIFF
--- a/doc/guides/build-system/advanced_build_system_tricks.md
+++ b/doc/guides/build-system/advanced_build_system_tricks.md
@@ -101,6 +101,36 @@ sys     0m0.327s
 [kaspar@booze default (master)]$
 ```
 
+## Speed-up Builds with git-cache-rs
+
+Some architectures and examples use code from external sources, such as vendor
+header files or SDKs. These repositories often have a download size which can
+slow down the initial build of a RIOT application, depending on your
+internet connection.
+
+To avoid downloading the full archive for each fresh build, a caching script
+was used called `git-cache`. This script has been deprecated in Release 2026.04
+and will be removed in favor of
+[`git-cache-rs`](https://github.com/kaspar030/git-cache-rs), which is
+implemented in Rust, offers more feature and is still under active development
+and maintenance.
+
+Please note that many popular Linux distributions provide very old Rust
+versions in their repositories. Therefore, it is
+recommended and easiest to use [**rustup**, installed as described
+on its project website].
+
+You can then proceed to install `git-cache-rs` by executing
+```sh
+cargo install git-cache
+```
+
+If you used RIOT's built-in `git-cache` previously, you can free some hard
+drive space by clearing the `~/.gitcache` folder or remove it entirely.
+`git-cache-rs` will create a new one.
+
+[**rustup**, installed as described on its project website]: https://rustup.rs/
+
 ## Analyze Dependency Resolution
 
 When refactoring dependency handling or modifying variables used for dependency resolution, one may want to evaluate the impact on the existing applications. This describe some debug targets to dump variables used during dependency resolution.

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -7,6 +7,11 @@
 # Packages should include this file just after defining the PKG_* variables
 # This will ensure the variables are defined in the Makefile.
 
+RIOTMAKE ?= $(RIOTBASE)/makefiles
+
+include $(RIOTMAKE)/utils/ansi.mk
+include $(RIOTMAKE)/color.inc.mk
+
 ifneq (,$(.DEFAULT_GOAL))
   $(error $(lastword $(MAKEFILE_LIST)) must be included at the beginning of the file after defining the PKG_* variables)
 endif
@@ -52,6 +57,13 @@ GITCACHE ?= $(RIOTTOOLS)/git/git-cache
 GIT_CACHE_DIR ?= $(HOME)/.gitcache
 include $(RIOTBASE)/makefiles/utils/variables.mk
 $(call target-export-variables,$(PKG_BUILDDIR)/.git,GIT_CACHE_DIR)
+
+# Check if git-cache-rs is installed in the local default directory and if so,
+# set the `GIT_CACHE_RS` variable to use it.
+DEFAULT_GIT_CACHE_RS ?= $(HOME)/.cargo/bin/git-cache
+ifeq ($(DEFAULT_GIT_CACHE_RS),$(wildcard $(DEFAULT_GIT_CACHE_RS)))
+  GIT_CACHE_RS ?= $(DEFAULT_GIT_CACHE_RS)
+endif
 
 # allow overriding package source with local folder (useful during development)
 ifneq (,$(PKG_SOURCE_LOCAL))
@@ -159,7 +171,11 @@ $(PKG_SOURCE_DIR)/.git: $(PKG_SPARSE_TAG) | $(PKG_CUSTOM_PREPARED)
 	$(Q)$(GIT_CACHE_RS) clone --commit $(PKG_VERSION) $(addprefix --sparse-add ,$(PKG_SPARSE_PATHS)) -- $(PKG_URL) $(PKG_SOURCE_DIR)
 else ifeq ($(GIT_CACHE_DIR),$(wildcard $(GIT_CACHE_DIR)))
 $(PKG_SOURCE_DIR)/.git: | $(PKG_CUSTOM_PREPARED)
-	$(if $(QUIETER),,$(info [INFO] cloning $(PKG_NAME) with git-cache))
+	$(if $(QUIETER),,$(info [INFO] cloning $(PKG_NAME) with git-cache with git-cache))
+	@echo "$(COLOR_YELLOW)Warning: git-cache is deprecated and will be" \
+	  "removed after the 2026.04 release! See" \
+	  "https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs" \
+	  "for more information.$(COLOR_RESET)"
 	$(Q)rm -Rf $(PKG_SOURCE_DIR)
 	$(Q)mkdir -p $(PKG_SOURCE_DIR)
 	$(Q)$(GITCACHE) clone $(PKG_URL) $(PKG_VERSION) $(PKG_SOURCE_DIR)
@@ -167,6 +183,10 @@ else
 # redirect stderr so git sees a pipe and not a terminal see https://github.com/git/git/blob/master/progress.c#L138
 $(PKG_SOURCE_DIR)/.git: | $(PKG_CUSTOM_PREPARED)
 	$(if $(QUIETER),,$(info [INFO] cloning $(PKG_NAME) without cache))
+	@echo "$(COLOR_YELLOW)[INFO] Consider using git-cache-rs to speed up your build" \
+	  "and reduce network traffic! See:" \
+	  "https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs" \
+	  "$(COLOR_RESET)"
 	$(Q)rm -Rf $(PKG_SOURCE_DIR)
 	$(Q)mkdir -p $(PKG_SOURCE_DIR)
 	$(Q)git init $(GIT_QUIET) $(PKG_SOURCE_DIR)


### PR DESCRIPTION
### Contribution description

The `git-cache` script was added by @kaspar030 in 2016 to speed up the build process. It has since been replaced by `git-cache-rs` by @kaspar030, which is still under active development and offers features such as sparse checkout that the original script does not.

Staying compatible with `git-cache` was quite a pain in #21800 and #22039.

I brought the topic up in the weekly a couple of weeks ago and AFAIR there were no voices against the deprecation of `git-cache`.

### Testing procedure

To avoid using any caches, we have to temporarily disable `git-cache-rs` and `git-cache`:
```
cbuec@W11nMate:~$ mv .cargo/bin/git-cache .cargo/bin/git-cache-old
cbuec@W11nMate:~$ mv .gitcache/ .gitcache_disabled

cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ rm -rf build && time QUIETER= BOARD=nrf52dk make -C tests/sys/shell -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell'
Building application "tests_shell" for "nrf52dk" with CPU "nrf52".

[INFO] cloning without cache nrf5x_nrfx_mdk
[INFO] Consider using git-cache-rs to speed up your build and reduce network traffic! See: https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs
[INFO] updating nrf5x_nrfx_mdk /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/nrf5x_nrfx_mdk/.pkg-state.git-downloaded
[INFO] patch nrf5x_nrfx_mdk
[INFO] cloning without cache cmsis
[INFO] Consider using git-cache-rs to speed up your build and reduce network traffic! See: https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs
[INFO] updating cmsis /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/cmsis/.pkg-state.git-downloaded
[INFO] patch cmsis
[INFO] cloning without cache mpaland-printf
[INFO] Consider using git-cache-rs to speed up your build and reduce network traffic! See: https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs
[INFO] updating mpaland-printf /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/mpaland-printf/.pkg-state.git-downloaded
[INFO] patch mpaland-printf
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/pkg/cmsis/
...
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/sys/ztimer
   text    data     bss     dec     hex filename
  15080     128    2564   17772    456c /home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell/bin/nrf52dk/tests_shell.elf
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell'

real    0m40.870s
user    0m20.226s
sys     0m7.308s
```

To use the now deprecated `git-cache` script, we have to enable the cache directory again:
```
cbuec@W11nMate:~$ mv .gitcache_disabled/ .gitcache

cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ rm -rf build && time QUIETER= BOARD=nrf52dk make -C tests/sys/shell -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell'
Building application "tests_shell" for "nrf52dk" with CPU "nrf52".

[INFO] cloning nrf5x_nrfx_mdk with git-cache
Warning: git-cache is deprecated and will be removed after the 2026.04 release! See https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs for more information.
git-cache: cloning from cache. tag=commit11f57e578c7feea13f21c79ea0efab2630ac68c7-106746
[INFO] updating nrf5x_nrfx_mdk /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/nrf5x_nrfx_mdk/.pkg-state.git-downloaded
[INFO] patch nrf5x_nrfx_mdk
[INFO] cloning cmsis with git-cache
Warning: git-cache is deprecated and will be removed after the 2026.04 release! See https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs for more information.
git-cache: cloning from cache. tag=commit2b7495b8535bdcb306dac29b9ded4cfb679d7e5c-106822
[INFO] updating cmsis /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/cmsis/.pkg-state.git-downloaded
[INFO] patch cmsis
[INFO] cloning mpaland-printf with git-cache
Warning: git-cache is deprecated and will be removed after the 2026.04 release! See https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs for more information.
git-cache: cloning from cache. tag=commit0dd4b64bc778bf55229428cefccba4c0a81f384b-106924
[INFO] updating mpaland-printf /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/mpaland-printf/.pkg-state.git-downloaded
[INFO] patch mpaland-printf
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/pkg/cmsis/
...
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/sys/ztimer
   text    data     bss     dec     hex filename
  15080     128    2564   17772    456c /home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell/bin/nrf52dk/tests_shell.elf
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell'

real    0m6.216s
user    0m15.888s
sys     0m5.134s
```

To use `git-cache-rs`, we have to enable it again:
```
cbuec@W11nMate:~$ mv .cargo/bin/git-cache-old .cargo/bin/git-cache

cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ rm -rf build && time QUIETER= BOARD=nrf52dk make -C tests/sys/shell -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell'
Building application "tests_shell" for "nrf52dk" with CPU "nrf52".

[INFO] cloning nrf5x_nrfx_mdk
Cloning into '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/nrf5x_nrfx_mdk'...
done.
HEAD is now at 11f57e5 nrfx 3.14.0 release
[INFO] updating nrf5x_nrfx_mdk /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/nrf5x_nrfx_mdk/.pkg-state.git-downloaded
[INFO] patch nrf5x_nrfx_mdk
[INFO] cloning cmsis
Cloning into '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/cmsis'...
done.
HEAD is now at 2b7495b85 Merge branch 'develop'
[INFO] updating cmsis /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/cmsis/.pkg-state.git-downloaded
[INFO] patch cmsis
[INFO] cloning mpaland-printf
Cloning into '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/mpaland-printf'...
done.
HEAD is now at 0dd4b64 test(test_suite): added support for PRINTF_DISABLE_SUPPORT_EXPONENTIAL
[INFO] updating mpaland-printf /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/mpaland-printf/.pkg-state.git-downloaded
[INFO] patch mpaland-printf
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/pkg/cmsis/
...
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/sys/ztimer
   text    data     bss     dec     hex filename
  15080     128    2564   17772    456c /home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell/bin/nrf52dk/tests_shell.elf
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell'

real    0m3.546s
user    0m13.220s
sys     0m3.132s
```

Due to the sparse checkout supported by `git-cache-rs`, we have a 50% performance increase compared to `git-cache`.
Since I only have DSL 16.000, the speedup for any caching is significant anyways :D

### Issues/PRs references
None.