### PR TITLE
cpu/native: Fix `make all-valgrind`

### DIFF
--- a/core/thread.c
+++ b/core/thread.c
@@ -32,10 +32,14 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-#if defined(HAVE_VALGRIND_H)
-#  include <valgrind.h>
-#elif defined(HAVE_VALGRIND_VALGRIND_H)
-#  include <valgrind/valgrind.h>
+#if defined(HAVE_VALGRIND)
+/* __has_include() will only be reached on native and only when valgrind is
+ * enabled, so we do not limit compatibility with embedded toolchains here */
+#  if __has_include(<valgrind/valgrind.h>)
+#    include <valgrind/valgrind.h>
+#  else
+#    include <valgrind.h>
+#  endif
 #else
 #  define   VALGRIND_DISABLE_ERROR_REPORTING    (void)0
 #  define   VALGRIND_ENABLE_ERROR_REPORTING     (void)0

--- a/cpu/native/include/util/valgrind.h
+++ b/cpu/native/include/util/valgrind.h
@@ -5,12 +5,16 @@
 
 #pragma once
 
-#ifdef HAVE_VALGRIND_H
+#ifdef HAVE_VALGRIND
+/* __has_include() will only be reached on native and only when valgrind is
+ * enabled, so we do not limit compatibility with embedded toolchains here */
+#  if __has_include(<valgrind/valgrind.h>)
+#    include <valgrind/valgrind.h>
+#  else
+#    include <valgrind.h>
+#  endif
 #  include <valgrind.h>
-#define VALGRIND_DEBUG DEBUG
-#  elif defined(HAVE_VALGRIND_VALGRIND_H)
-#  include <valgrind/valgrind.h>
-#define VALGRIND_DEBUG DEBUG
+#  define VALGRIND_DEBUG DEBUG
 #else
 #  define VALGRIND_STACK_REGISTER(...) (0)
 #  define VALGRIND_DEBUG(...)

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -90,7 +90,7 @@ void _native_syscall_leave(void)
 /* make use of TLSF if it is included, except when building with valgrind
  * support, where one probably wants to make use of valgrind's memory leak
  * detection abilities*/
-#if (!(defined MODULE_TLSF) && !(defined NATIVE_MEMORY)) || (defined(HAVE_VALGRIND_H))
+#if (!(defined MODULE_TLSF) && !(defined NATIVE_MEMORY)) || (defined(HAVE_VALGRIND))
 int _native_in_malloc = 0;
 void *malloc(size_t size)
 {
@@ -157,7 +157,7 @@ void *realloc(void *ptr, size_t size)
     _native_syscall_leave();
     return r;
 }
-#endif /* !(defined MODULE_TLSF) || (defined(HAVE_VALGRIND_H)) */
+#endif /* !(defined MODULE_TLSF) || (defined(HAVE_VALGRIND)) */
 
 ssize_t _native_read(int fd, void *buf, size_t count)
 {

--- a/makefiles/arch/native.inc.mk
+++ b/makefiles/arch/native.inc.mk
@@ -113,7 +113,7 @@ debug-valgrind-server: export VALGRIND_FLAGS ?= --vgdb=yes --vgdb-error=0 -v \
 	--read-var-info=yes
 term-cachegrind: export CACHEGRIND_FLAGS += --tool=cachegrind
 term-gprof: TERMPROG = GMON_OUT_PREFIX=gmon.out $(ELFFILE)
-all-valgrind: CFLAGS += -DHAVE_VALGRIND_H
+all-valgrind: CFLAGS += -DHAVE_VALGRIND
 all-valgrind: NATIVEINCLUDES += $(shell pkg-config valgrind --cflags)
 all-gprof: CFLAGS += -pg
 all-gprof: LINKFLAGS += -pg


### PR DESCRIPTION
### Contribution description

On Ubuntu 24.04 `#include <valgrind.h>` fails and we have to use `#include <valgrind/valgrind.h>`. There has been some custom preprocessor magic in place already (`HAVE_VALGRIND_H` vs `HAVE_VALGRIND_VALGRIND_H`), but there is (no longer?) any code that provides the correct define depending on the system compiled on.

This simplifies the code to select the right include name by using the `__has_include()` extension. The use of valgrind is still guarded behind an `#ifdef HAVE_VALGRIND`, so that the `__has_include()` extension is only used on `native64` / `native32` and with valgrind enabled. Hence, we don't need that extension to be present on embedded toolchains.

### Testing procedure

Running `make BOARD=native64 all-valgrind` should work now e.g. on Ubuntu 24.04.

### Issues/PRs references

None