### PR TITLE
sys/net/nanocoap: add missing dependency to sock_udp

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -576,6 +576,15 @@ ifneq (,$(filter nanocoap_%,$(USEMODULE)))
   USEMODULE += nanocoap
 endif
 
+# bare nanocoap is supposed to be concerned only with parsing and building of
+# CoAP message and should not care about any networking, but it sadly contains
+# code such as coap_handle_request() that very much is intermixed with
+# networking. Until that get's cleaned up, we have to model the dependency
+# that is there in the code.
+ifneq (,$(filter nanocoap,$(USEMODULE)))
+  USEMODULE += sock_udp
+endif
+
 # include unicoap dependencies
 ifneq (,$(filter unicoap%,$(USEMODULE)))
   include $(RIOTBASE)/sys/net/application_layer/unicoap/Makefile.dep


### PR DESCRIPTION
### Contribution description

As the title says

### Testing procedure

#### In `master`:

```
$ make BOARD=native64 tests-nanocoap flash test -j 32 -C tests/unittests
[...]
In file included from /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/net/application_layer/nanocoap/nanocoap.c:31:
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/include/net/nanocoap_sock.h:211:16error: field ‘udp’ has incomplete type
  211 |     sock_udp_t udp;                         /**< UDP socket     */
      |                ^~~
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/include/net/nanocoap_sock.h:501:1:error: unknown type name ‘kernel_pid_t’
  501 | kernel_pid_t nanocoap_server_start(const sock_udp_ep_t *local);
      | ^~~~~~~~~~~~
```
 
 #### This PR
 
 ```
 $ make BOARD=native64 tests-nanocoap flash test -j 32 -C tests/unittests
make: Entering directory '/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests'
Building application "tests_unittests" for "native64" with CPU "native".
[...]
   text	  data	   bss	   dec	   hex	filename
 149538	 36040	 78120	263698	 40612	/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests/bin/native64/tests_unittests.elf
[...]
main(): This is RIOT! (Version: 2026.01-devel-436-g816f586-sys/net/nanocoap/missing-dep)
.....................................
OK (37 tests)
 ```

### Issues/PRs references

None