### PR TITLE
sys/net/nanocoap: make bounds tests more robust

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -681,7 +681,7 @@ static inline uint8_t coap_hdr_tkl_ext_len(const coap_udp_hdr_t *hdr)
         return 0;
     }
 
-    switch (hdr->ver_t_tkl & 0xf) {
+    switch (hdr->ver_t_tkl & 0x0f) {
     case 13:
         return 1;
     case 14:
@@ -708,6 +708,28 @@ static inline uint8_t coap_pkt_tkl_ext_len(const coap_pkt_t *pkt)
 {
     return coap_hdr_tkl_ext_len(coap_get_udp_hdr_const(pkt));
 }
+
+/**
+ * @brief   Validate that the header of @p pkt is no longer than
+ *          @p len bytes.
+ *
+ * This function will read at most @p len bytes of `pkt->buf`. It is intended
+ * to do basic validation of untrusted data. It only checks that the variable
+ * length CoAP header fields (such as the CoAP token and the extended TKL
+ * field) are within bounds, but it does not validate the header contents.
+ * Specifically, CoAP Options may still have Option Headers that refer to
+ * memory past @p len bytes.
+ *
+ * @param[in]   pkt     The CoAP packet to validate. (`pkt->buf` must be valid)
+ * @param[in]   len     Length of `pkt->buf` in bytes
+ *
+ * @retval      true    All header fields up to the CoAP token are within bounds
+ * @retval      false   The packet is not valid
+ *
+ * @warning     This function does not look at CoAP Options. They may still
+ *              be out of bounds.
+ */
+bool coap_is_hdr_in_bounds(const coap_pkt_t *pkt, size_t len);
 
 /**
  * @brief   Get the start of data after the header
@@ -825,7 +847,7 @@ static inline size_t coap_hdr_get_token_len(const coap_udp_hdr_t *hdr)
      */
     switch (coap_hdr_tkl_ext_len(hdr)) {
     case 0:
-        return hdr->ver_t_tkl & 0xf;
+        return hdr->ver_t_tkl & 0x0f;
     case 1:
         return buf[sizeof(coap_udp_hdr_t)] + 13;
     case 2:

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -2138,7 +2138,8 @@ size_t coap_put_block1_ok(uint8_t *pkt_pos, coap_block1_t *block1, uint16_t last
  *
  * @returns     amount of bytes written to @p buf
  */
-size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, const void *odata, size_t olen);
+size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum,
+                       const void *odata, size_t olen);
 
 /**
  * @brief   Insert block1 option into buffer

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -1026,7 +1026,8 @@ static unsigned _put_delta_optlen(uint8_t *buf, unsigned offset, unsigned shift,
     return offset;
 }
 
-size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, const void *odata, size_t olen)
+size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum,
+                       const void *odata, size_t olen)
 {
     assert(lastonum <= onum);
 

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -64,6 +64,51 @@ static int _decode_value(unsigned val, uint8_t **pkt_pos_ptr, uint8_t *pkt_end);
 static uint32_t _decode_uint(uint8_t *pkt_pos, unsigned nbytes);
 static size_t _encode_uint(uint32_t *val);
 
+bool coap_is_hdr_in_bounds(const coap_pkt_t *pkt, size_t len)
+{
+    assert(pkt->buf);
+    size_t min_len = sizeof(coap_udp_hdr_t);
+
+    if (len < min_len) {
+        return false;
+    }
+
+    if (IS_USED(MODULE_NANOCOAP_TOKEN_EXT)) {
+        /* coap_pkt_tkl_ext_len() blows an assertion on invalid TKL value, so
+         * we have to rule that out here already. The magic number 15 is the
+         * only invalid value here, as per
+         * https://datatracker.ietf.org/doc/html/rfc8974#section-2.1.
+         * The magic number has no name in the RFC, so adding a named constant
+         * here would rather obfuscate then help when checking the code against
+         * the spec. */
+        if ((coap_get_udp_hdr_const(pkt)->ver_t_tkl & 0x0f) == 15) {
+            return false;
+        }
+
+        min_len += coap_pkt_tkl_ext_len(pkt);
+
+        if (len < min_len) {
+            return false;
+        }
+
+        min_len += coap_get_token_len(pkt);
+    }
+    else {
+        uint8_t tkl = coap_get_token_len(pkt);
+
+        /* we have to either allow extendend token lengths fully
+         * (MODULE_NANOCOAP_TOKEN_EXT is used), or not at all */
+        if (tkl > COAP_TOKEN_LENGTH_MAX) {
+            DEBUG("nanocoap: token length invalid\n");
+            return false;
+        }
+
+        min_len += tkl;
+    }
+
+    return (len >= min_len);
+}
+
 /* http://tools.ietf.org/html/rfc7252#section-3
  *  0                   1                   2                   3
  *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -90,25 +135,16 @@ ssize_t coap_parse_udp(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     memset(pkt->opt_crit, 0, sizeof(pkt->opt_crit));
     pkt->snips = NULL;
 
-    if (len < sizeof(coap_udp_hdr_t)) {
+    if (!coap_is_hdr_in_bounds(pkt, len)) {
         DEBUG("msg too short\n");
         return -EBADMSG;
     }
-    else if ((coap_get_code_raw(pkt) == 0) && (len > sizeof(coap_udp_hdr_t))) {
+
+    if ((coap_get_code_raw(pkt) == 0) && (len > sizeof(coap_udp_hdr_t))) {
         DEBUG("empty msg too long\n");
         return -EBADMSG;
     }
 
-    if (IS_USED(MODULE_NANOCOAP_TOKEN_EXT)) {
-        if ((coap_get_udp_hdr(pkt)->ver_t_tkl & 0xf) == 15) {
-            DEBUG("nanocoap: token length is reserved value 15,"
-                  "invalid for extended token length field.\n");
-            return -EBADMSG;
-        }
-    } else if (coap_get_token_len(pkt) > COAP_TOKEN_LENGTH_MAX) {
-        DEBUG("nanocoap: token length invalid\n");
-        return -EBADMSG;
-    }
     /* pkt_pos range is validated after options parsing loop below */
     pkt_pos += coap_get_token_len(pkt);
 

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -106,6 +106,37 @@ static void test_nanocoap__hdr_2(void)
 }
 
 /*
+ * Unit tests for the CoAP header bounds check
+ */
+static void test_nanocoap__hdr_bounds_check(void)
+{
+    uint8_t valid_hdr[] = {
+        (COAP_V1 << 6) | (COAP_TYPE_CON << 4) | 3, /* version = 1, type = CON, TKL = 3 */
+        COAP_METHOD_GET,
+        0x13, 0x37, /* Message ID = 0x1337 */
+        0xca, 0xfe, 0x42, /* Token = 0xcafe42 */
+    };
+
+    coap_pkt_t pkt = { .buf = valid_hdr };
+    TEST_ASSERT(coap_is_hdr_in_bounds(&pkt, sizeof(valid_hdr)));
+    TEST_ASSERT_EQUAL_INT(sizeof(valid_hdr), coap_parse_udp(&pkt, valid_hdr, sizeof(valid_hdr)));
+    /* without the last byte, the header becomes invalid */
+    TEST_ASSERT(!coap_is_hdr_in_bounds(&pkt, sizeof(valid_hdr) - 1));
+    TEST_ASSERT_EQUAL_INT(-EBADMSG, coap_parse_udp(&pkt, valid_hdr, sizeof(valid_hdr) - 1));
+
+    uint8_t invalid_hdr[] = {
+        (COAP_V1 << 6) | (COAP_TYPE_CON << 4) | 13, /* version = 1, type = CON, TKL = 13 */
+        COAP_METHOD_GET,
+        0xac, 0xdc, /* Message ID = 0xacdc */
+     };
+
+     pkt.buf = invalid_hdr;
+    TEST_ASSERT(!coap_is_hdr_in_bounds(&pkt, sizeof(invalid_hdr)));
+
+    TEST_ASSERT_EQUAL_INT(-EBADMSG, coap_parse_udp(&pkt, invalid_hdr, sizeof(invalid_hdr)));
+}
+
+/*
  * Client GET request with simple path. Test request generation.
  * Request /time resource from libcoap example
  */
@@ -1286,6 +1317,7 @@ Test *tests_nanocoap_tests(void)
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_nanocoap__hdr),
         new_TestFixture(test_nanocoap__hdr_2),
+        new_TestFixture(test_nanocoap__hdr_bounds_check),
         new_TestFixture(test_nanocoap__get_req),
         new_TestFixture(test_nanocoap__put_req),
         new_TestFixture(test_nanocoap__get_multi_path),


### PR DESCRIPTION
### Contribution description

With extendend CoAP token length and an invalid received CoAP packet (e.g. a four byte packet with TKL 13 or 14) would have read past the received packet (one byte for TKL 13 and two bytes for TKL 14).

In theory it might have been possible that someone would have allocated a receive buffer of 4 bytes that would have been allocated right in front of memory that cannot be read (e.g. right at the end of SRAM). In that case, a specifically crafted message could trigger e.g. a bus fault and crashing the device.

The odds for that to happen are pretty low, because all of the following would be needed to happen:

1. One would need to enable the `nanocoap_token_ext` module. There are some valid use cases for it, but the majority of people won't use that
2. A receive buffer of four bytes (or five bytes) would need to used. That is pretty insane to do and completely unexpected to every happen.
3. That four byte receive buffer needs to be allocated directly at the end of SRAM. The chance of that occurring naturally are rather slim.

So while there is effectively no practical impact of the bug, it is still a valid memory handling bug and, therefore, is fixed here.

### Testing procedure

The unit tests have been extended accordingly and pass in this PR.

We cannot run the unit test directly on master, because the new tests checks both calls to `coap_parse_udp()` and to the newly introduced `coap_is_hdr_in_bounds()`. But we can just comment out the later tests.

<details><summary>Patch to <code>master</code> to port back the unit tests from this PR</summary>

```diff
diff --git a/tests/unittests/tests-nanocoap/tests-nanocoap.c b/tests/unittests/tests-nanocoap/tests-nanocoap.c
index 8cb1a0efc1..813a2e8c40 100644
--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -105,6 +105,35 @@ static void test_nanocoap__hdr_2(void)
     TEST_ASSERT_EQUAL_INT(0, res);
 }
 
+/*
+ * Unit tests for the CoAP header bounds check
+ */
+static void test_nanocoap__hdr_bounds_check(void)
+{
+    uint8_t valid_hdr[] = {
+        (COAP_V1 << 6) | (COAP_TYPE_CON << 4) | 3, /* version = 1, type = CON, TKL = 3 */
+        COAP_METHOD_GET,
+        0x13, 0x37, /* Message ID = 0x1337 */
+        0xca, 0xfe, 0x42, /* Token = 0xcafe42 */
+    };
+
+    coap_pkt_t pkt = { .buf = valid_hdr };
+    TEST_ASSERT_EQUAL_INT(sizeof(valid_hdr), coap_parse_udp(&pkt, valid_hdr, sizeof(valid_hdr)));
+    /* without the last byte, the header becomes invalid */
+    //TEST_ASSERT(!coap_is_hdr_in_bounds(&pkt, sizeof(valid_hdr) - 1));
+    TEST_ASSERT_EQUAL_INT(-EBADMSG, coap_parse_udp(&pkt, valid_hdr, sizeof(valid_hdr) - 1));
+
+    uint8_t invalid_hdr[] = {
+        (COAP_V1 << 6) | (COAP_TYPE_CON << 4) | 13, /* version = 1, type = CON, TKL = 13 */
+        COAP_METHOD_GET,
+        0xac, 0xdc, /* Message ID = 0xacdc */
+     };
+
+     pkt.buf = invalid_hdr;
+    //TEST_ASSERT(!coap_is_hdr_in_bounds(&pkt, sizeof(invalid_hdr)));
+    TEST_ASSERT_EQUAL_INT(-EBADMSG, coap_parse_udp(&pkt, invalid_hdr, sizeof(invalid_hdr)));
+}
+
 /*
  * Client GET request with simple path. Test request generation.
  * Request /time resource from libcoap example
@@ -1286,6 +1315,7 @@ Test *tests_nanocoap_tests(void)
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_nanocoap__hdr),
         new_TestFixture(test_nanocoap__hdr_2),
+        new_TestFixture(test_nanocoap__hdr_bounds_check),
         new_TestFixture(test_nanocoap__get_req),
         new_TestFixture(test_nanocoap__put_req),
         new_TestFixture(test_nanocoap__get_multi_path),
```

</details>

<details><summary>With that backported test, ASAN detects the read past the buffer.</summary>

```
==66310==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7beccf1abdb4 at pc 0x000000441b95 bp 0x00000064b530 sp 0x00000064b520
READ of size 1 at 0x7beccf1abdb4 thread T0
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests/bin/native64/tests_unittests.elf: getpid(): not implemented
    #0 0x441b94  (/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests/bin/native64/tests_unittests.elf+0x441b94) (BuildId: 70b57a3cff89b9d68c9ceae59fe88173d03bd6e9)
    #1 0x44304f  (/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests/bin/native64/tests_unittests.elf+0x44304f) (BuildId: 70b57a3cff89b9d68c9ceae59fe88173d03bd6e9)
    #2 0x4de264  (/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests/bin/native64/tests_unittests.elf+0x4de264) (BuildId: 70b57a3cff89b9d68c9ceae59fe88173d03bd6e9)
    #3 0x41a173  (/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests/bin/native64/tests_unittests.elf+0x41a173) (BuildId: 70b57a3cff89b9d68c9ceae59fe88173d03bd6e9)
    #4 0x419fcd  (/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests/bin/native64/tests_unittests.elf+0x419fcd) (BuildId: 70b57a3cff89b9d68c9ceae59fe88173d03bd6e9)
    #5 0x41a727  (/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests/bin/native64/tests_unittests.elf+0x41a727) (BuildId: 70b57a3cff89b9d68c9ceae59fe88173d03bd6e9)
    #6 0x4e7b27  (/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests/bin/native64/tests_unittests.elf+0x4e7b27) (BuildId: 70b57a3cff89b9d68c9ceae59fe88173d03bd6e9)
    #7 0x402d16  (/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests/bin/native64/tests_unittests.elf+0x402d16) (BuildId: 70b57a3cff89b9d68c9ceae59fe88173d03bd6e9)
    #8 0x408eb9  (/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests/bin/native64/tests_unittests.elf+0x408eb9) (BuildId: 70b57a3cff89b9d68c9ceae59fe88173d03bd6e9)
    #9 0x7becd105ef7f  (/lib/x86_64-linux-gnu/libc.so.6+0x5ef7f) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)

Address 0x7beccf1abdb4 is located in stack of thread T0 at offset 180 in frame
    #0 0x4ddfb0  (/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests/bin/native64/tests_unittests.elf+0x4ddfb0) (BuildId: 70b57a3cff89b9d68c9ceae59fe88173d03bd6e9)

  This frame has 3 object(s):
    [32, 136) 'pkt' (line 120)
    [176, 180) 'invalid_hdr' (line 126) <== Memory access at offset 180 overflows this variable
    [192, 199) 'valid_hdr' (line 113)
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow (/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests/bin/native64/tests_unittests.elf+0x441b94) (BuildId: 70b57a3cff89b9d68c9ceae59fe88173d03bd6e9) 
Shadow bytes around the buggy address:
  0x7beccf1abb00: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7beccf1abb80: f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00 00 00 00 00
  0x7beccf1abc00: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7beccf1abc80: f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00 00 00 00 00
  0x7beccf1abd00: f1 f1 f1 f1 00 00 00 00 00 00 00 00 00 00 00 00
=>0x7beccf1abd80: 00 f2 f2 f2 f2 f2[04]f2 07 f3 f3 f3 00 00 00 00
  0x7beccf1abe00: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7beccf1abe80: f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00 00 00 00 00
  0x7beccf1abf00: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7beccf1abf80: f5 f5 f5 f5 f5 f5 f5 f5 00 00 00 00 00 00 00 00
  0x7beccf1ac000: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==66310==ABORTING
```

</details>

### Issues/PRs references

Thanks to @pamusuo for reporting this bug.

Fixes https://github.com/RIOT-OS/RIOT/security/advisories/GHSA-p9hp-2jxm-6rqp#event-534987