### PR TITLE
sys/shell/cmds: improvment of iw scan command

### DIFF
--- a/sys/shell/cmds/iw.c
+++ b/sys/shell/cmds/iw.c
@@ -71,7 +71,7 @@ static const char *_ssec(wifi_security_mode_t mode)
         case WIFI_SECURITY_MODE_WEP_PSK:
             return "WEP";
         case WIFI_SECURITY_MODE_WPA2_PERSONAL:
-            return "WPA";
+            return "WPA2";
         case WIFI_SECURITY_MODE_WPA2_ENTERPRISE:
             return "WPA2 Enterprise";
         default:
@@ -81,11 +81,17 @@ static const char *_ssec(wifi_security_mode_t mode)
 
 static void _list_ap(void)
 {
-    puts(" SSID                            | SEC             | RSSI  | CHANNEL");
-    puts("---------------------------------+-----------------+-------+--------");
+    puts(" SSID                            | BSSID             | SEC             | RSSI  | CHANNEL");
+    puts("---------------------------------+-------------------+-----------------+-------+--------");
     for (unsigned i = 0; i < _aps.numof; i++) {
-        printf(" %-31s | %-15s | %-5"PRId16" | %-6d \n",
+        printf(" %-32s | %02x:%02x:%02x:%02x:%02x:%02x | %-15s | %-5"PRId16" | %-6d \n",
                _aps.ap[i].ssid,
+               _aps.ap[i].bssid[0],
+               _aps.ap[i].bssid[1],
+               _aps.ap[i].bssid[2],
+               _aps.ap[i].bssid[3],
+               _aps.ap[i].bssid[4],
+               _aps.ap[i].bssid[5],
                _ssec(_aps.ap[i].sec_mode),
                _aps.ap[i].base.strength,
                _aps.ap[i].base.channel);


### PR DESCRIPTION
### Contribution description

This PR improves the `iw scan` command as follows:

- BSSID is now displayed, as it is an important parameter, especially when the SSID is not set.
- The displayed security mode has been corrected. WPA2 is now displayed as WPA2 and not as WPA. WPA and WPA2 are different.

### Testing procedure

Without the PR, `iw scan` output is:
```
> iw 9 scan
 SSID                            | SEC             | RSSI  | CHANNEL
---------------------------------+-----------------+-------+--------
 BSHS1                           | WPA             | -63   | 1      
 BSHS1                           | WPA             | -76   | 1      
 Free_BASA                       | open            | -87   | 1      
                                 | WPA             | -87   | 1      
 UPC-AP-8031428                  | WPA             | -92   | 11     
iw: ok
```
With the PR, `iw scan` the output should be:
```
> iw 9 scan
 SSID                            | BSSID             | SEC             | RSSI  | CHANNEL
---------------------------------+-------------------+-----------------+-------+--------
 BSHS1                           | b0:f2:08:f5:52:4a | WPA2            | -63   | 1      
 BSHS1                           | 3c:37:12:c5:88:f3 | WPA2            | -76   | 1      
 Free_BASA                       | bc:e6:7c:80:dd:b0 | open            | -87   | 1      
                                 | bc:e6:7c:80:dd:b1 | WPA2            | -87   | 1      
 UPC-AP-8031428                  | d8:b6:b7:67:d4:90 | WPA2            | -92   | 11     
iw: ok
```

### Issues/PRs references

