### PR TITLE
sys/shell/cmd: fix iw scan command output

### DIFF
--- a/sys/shell/cmds/iw.c
+++ b/sys/shell/cmds/iw.c
@@ -81,8 +81,8 @@ static const char *_ssec(wifi_security_mode_t mode)
 
 static void _list_ap(void)
 {
-    puts(" SSID                            | BSSID             | SEC             | RSSI  | CHANNEL");
-    puts("---------------------------------+-------------------+-----------------+-------+--------");
+    puts(" SSID                             | BSSID             | SEC             | RSSI  | CHANNEL");
+    puts("----------------------------------+-------------------+-----------------+-------+--------");
     for (unsigned i = 0; i < _aps.numof; i++) {
         printf(" %-32s | %02x:%02x:%02x:%02x:%02x:%02x | %-15s | %-5"PRId16" | %-6d \n",
                _aps.ap[i].ssid,


### PR DESCRIPTION
### Contribution description

The PR fixes the output of the `iw scan` command.

PR #22051 fixed the number of possible characters in the SSID in the output of the `iw scan` command from 31 to 32. However, it was forgotten to add a space in the SSID column in the table header, resulting in a misalignment in the output. :see_no_evil: 

### Testing procedure

Without the PR, the table looks like:
```
> iw 9 scan
 SSID                            | BSSID             | SEC             | RSSI  | CHANNEL
---------------------------------+-------------------+-----------------+-------+--------
 BSHS1                            | b0:f2:08:f5:52:4a | WPA2            | -64   | 1      
```
With the PR, the alignment of the SSID column should be correct:
```
> iw 9 scan
 SSID                             | BSSID             | SEC             | RSSI  | CHANNEL
----------------------------------+-------------------+-----------------+-------+--------
 BSHS1                            | b0:f2:08:f5:52:4a | WPA2            | -64   | 1      
```

### Issues/PRs references

Fixes a problem introduced with PR #22051 