### PR TITLE
sys/net/gnrc/pktbuf_malloc: fix undefined behavior

### DIFF
--- a/sys/net/gnrc/pktbuf/Makefile
+++ b/sys/net/gnrc/pktbuf/Makefile
@@ -1,3 +1,6 @@
 MODULE = gnrc_pktbuf
 
+# this module is expected to pass static analysis
+MODULE_SUPPORTS_STATIC_ANALYSIS := 1
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/pktbuf_malloc/Makefile
+++ b/sys/net/gnrc/pktbuf_malloc/Makefile
@@ -1,3 +1,6 @@
 MODULE = gnrc_pktbuf_malloc
 
+# this module is expected to pass static analysis
+MODULE_SUPPORTS_STATIC_ANALYSIS := 1
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c
+++ b/sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c
@@ -277,7 +277,10 @@ static gnrc_pktsnip_t *_create_snip(gnrc_pktsnip_t *next, const void *data, size
         }
     }
     _set_pktsnip(pkt, next, _data, size, type);
-    if (data != NULL) {
+    /* If size == 0, _data is NULL. The call `memcpy(NULL, non-NULL, 0)` looks
+     * harmless (as copying no data to NULL should be fine), but is in fact
+     * undefined behavior. We test here explicitly to ensure correctness. */
+    if ((data != NULL) && (_data != NULL)) {
         memcpy(_data, data, size);
     }
     return pkt;

--- a/sys/net/gnrc/pktbuf_static/Makefile
+++ b/sys/net/gnrc/pktbuf_static/Makefile
@@ -1,3 +1,6 @@
 MODULE = gnrc_pktbuf_static
 
+# this module is expected to pass static analysis
+MODULE_SUPPORTS_STATIC_ANALYSIS := 1
+
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
### Contribution description

- fix undefined behavior in `sys/net/gnrc/pkgbuf_malloc`
- enable static analysis for `sys/net/grnc/pktbuf*`

### Testing procedure

Without the fix from the first commit, compiling with

```diff
diff --git a/tests/unittests/tests-pktbuf/Makefile.include b/tests/unittests/tests-pktbuf/Makefile.include
index dfacccf361..c35629090d 100644
--- a/tests/unittests/tests-pktbuf/Makefile.include
+++ b/tests/unittests/tests-pktbuf/Makefile.include
@@ -1 +1 @@
-USEMODULE += gnrc_pktbuf_static
+USEMODULE += gnrc_pktbuf_malloc
```

results in:

```
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c:281:9: error: use of NULL ‘_data’ where non-null expected [CWE-476] [-Werror=analyzer-null-argument]
  281 |         memcpy(_data, data, size);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~
  ‘_create_snip’: events 1-5
    |
    |  261 | static gnrc_pktsnip_t *_create_snip(gnrc_pktsnip_t *next, const void *data, size_t size,
    |      |                        ^~~~~~~~~~~~
    |      |                        |
    |      |                        (1) entry to ‘_create_snip’
    |......
    |  267 |     if (pkt == NULL) {
    |      |        ~                
    |      |        |
    |      |        (2) following ‘false’ branch...
    |......
    |  271 |     if (size > 0) {
    |      |        ~                
    |      |        |
    |      |        (3) ...to here
    |      |        (4) following ‘false’ branch (when ‘size == 0’)...
    |......
    |  279 |     _set_pktsnip(pkt, next, _data, size, type);
    |      |     ~                   
    |      |     |
    |      |     (5) inlined call to ‘_set_pktsnip’ from ‘_create_snip’
    |
    +--> ‘_set_pktsnip’: events 6-7
           |
           |   82 |     pkt->next = next;
           |      |     ~~~~~~~~~~^~~~~~
           |      |               |
           |      |               (6) ...to here
           |   83 |     pkt->data = data;
           |      |     ~~~~~~~~~~~~~~~~
           |      |               |
           |      |               (7) ‘_data’ is NULL
           |
    <------+
    |
  ‘_create_snip’: events 8-10
    |
    |  280 |     if (data != NULL) {
    |      |        ^
    |      |        |
    |      |        (8) following ‘true’ branch (when ‘data’ is non-NULL)...
    |  281 |         memcpy(_data, data, size);
    |      |         ~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |         |
    |      |         (9) ...to here
    |      |         (10) argument 1 (‘_data’) NULL where non-null expected
    |
In file included from /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c:22:
/usr/include/string.h:43:14: note: argument 1 of ‘memcpy’ must be non-null
   43 | extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
      |              ^~~~~~
```

With the fix from the first commit, the static analysis passes. The unit tests for using `pktbuf_malloc` fail with

```
gnrc_pktbuf_tests.test_pktbuf_realloc_data__shrink (tests/unittests/tests-pktbuf/tests-pktbuf.c 540) exp_data == pkt->data

run 1251 failures 1
```

But that is the same failure as in `master`, so not a regression from this PR.

### Issues/PRs references

None