### PR TITLE
kw2xrf/Radio HAL: fixed endianness setting of short addressing

### DIFF
--- a/drivers/kw2xrf/kw2xrf_getset.c
+++ b/drivers/kw2xrf/kw2xrf_getset.c
@@ -263,26 +263,25 @@ void kw2xrf_set_pan(kw2xrf_t *dev, uint16_t pan)
 
 void kw2xrf_set_addr_short(kw2xrf_t *dev, uint16_t addr)
 {
-    uint8_t val_ar[2];
-    val_ar[0] = (addr >> 8);
-    val_ar[1] = (uint8_t)addr;
+    uint16_t tmp;
+    uint8_t *ap = (uint8_t *)&tmp;
+
+    byteorder_htolebufs(ap, addr);
 #ifdef MODULE_SIXLOWPAN
     /* https://tools.ietf.org/html/rfc4944#section-12 requires the first bit to
      * 0 for unicast addresses */
-    val_ar[0] &= 0x7F;
+    ap[0] &= 0x7F;
 #endif
-    kw2xrf_write_iregs(dev, MKW2XDMI_MACSHORTADDRS0_LSB, val_ar,
+    kw2xrf_write_iregs(dev, MKW2XDMI_MACSHORTADDRS0_LSB, ap,
                        IEEE802154_SHORT_ADDRESS_LEN);
 }
 
 void kw2xrf_set_addr_long(kw2xrf_t *dev, uint64_t addr)
 {
     uint64_t tmp;
-    uint8_t *ap = (uint8_t *)(&tmp);
+    uint8_t *ap = (uint8_t *)&tmp;
 
-    for (unsigned i = 0; i < IEEE802154_LONG_ADDRESS_LEN; i++) {
-        ap[i] = (addr >> ((IEEE802154_LONG_ADDRESS_LEN - 1 - i) * 8));
-    }
+    byteorder_htolebufll(ap, addr);
 
     kw2xrf_write_iregs(dev, MKW2XDMI_MACLONGADDRS0_0, ap,
                        IEEE802154_LONG_ADDRESS_LEN);

--- a/drivers/kw2xrf/kw2xrf_radio_hal.c
+++ b/drivers/kw2xrf/kw2xrf_radio_hal.c
@@ -575,7 +575,7 @@ static int _config_addr_filter(ieee802154_dev_t *dev, ieee802154_af_cmd_t cmd, c
             kw2xrf_set_addr_short(kw_dev, byteorder_ntohs(*short_addr));
             break;
         case IEEE802154_AF_EXT_ADDR:
-            kw2xrf_set_addr_long(kw_dev, ext_addr->uint64.u64);
+            kw2xrf_set_addr_long(kw_dev, byteorder_ntohll(ext_addr->uint64));
             break;
         case IEEE802154_AF_PANID:
             kw2xrf_set_pan(kw_dev, *pan_id);


### PR DESCRIPTION
### Contribution description

Setting the short address wasn't possible therefor the sending also not.
It was a wrong endianess on the register. 
I changed the setting of the long address (it was correct) accordingly for consistency.


### Testing procedure

Test before fixing: 
- examples/basic/default: 
    - short sending not possible

Test after fixing: 
 - examples/basic/default
     - short sending possible
     - long sending still possible