### PR TITLE
sys/net: enable static analysis for `gnrc_netapi`, `gnrc_netreg`, `gnrc_pkt`, `gnrc_pktdump`, `gnrc_lorawan`, `gnrc_txsync`, `gnrc_pktshark`

### DIFF
--- a/sys/net/gnrc/link_layer/lorawan/Makefile
+++ b/sys/net/gnrc/link_layer/lorawan/Makefile
@@ -1,3 +1,6 @@
 MODULE = gnrc_lorawan
 
+# this module is expected to pass static analysis
+MODULE_SUPPORTS_STATIC_ANALYSIS := 1
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/netapi/Makefile
+++ b/sys/net/gnrc/netapi/Makefile
@@ -1,3 +1,6 @@
 MODULE = gnrc_netapi
 
+# this module is expected to pass static analysis
+MODULE_SUPPORTS_STATIC_ANALYSIS := 1
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/netapi/notify/Makefile
+++ b/sys/net/gnrc/netapi/notify/Makefile
@@ -1,3 +1,6 @@
 MODULE = gnrc_netapi_notify
 
+# this module is expected to pass static analysis
+MODULE_SUPPORTS_STATIC_ANALYSIS := 1
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/netreg/Makefile
+++ b/sys/net/gnrc/netreg/Makefile
@@ -1,3 +1,6 @@
 MODULE = gnrc_netreg
 
+# this module is expected to pass static analysis
+MODULE_SUPPORTS_STATIC_ANALYSIS := 1
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/pkt/Makefile
+++ b/sys/net/gnrc/pkt/Makefile
@@ -1,3 +1,6 @@
 MODULE := gnrc_pkt
 
+# this module is expected to pass static analysis
+MODULE_SUPPORTS_STATIC_ANALYSIS := 1
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/pktdump/Makefile
+++ b/sys/net/gnrc/pktdump/Makefile
@@ -1,3 +1,6 @@
 MODULE = gnrc_pktdump
 
+# this module is expected to pass static analysis
+MODULE_SUPPORTS_STATIC_ANALYSIS := 1
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/pktshark/Makefile
+++ b/sys/net/gnrc/pktshark/Makefile
@@ -1,3 +1,6 @@
 MODULE = gnrc_pktshark
 
+# this module is expected to pass static analysis
+MODULE_SUPPORTS_STATIC_ANALYSIS := 1
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/tx_sync/Makefile
+++ b/sys/net/gnrc/tx_sync/Makefile
@@ -1,3 +1,6 @@
 MODULE := gnrc_tx_sync
 
+# this module is expected to pass static analysis
+MODULE_SUPPORTS_STATIC_ANALYSIS := 1
+
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
### Contribution description

As the title says.

### Testing procedure

Green CI.

### Issues/PRs references

None