### PR TITLE
core/compiler_hints.h: improve assume()

### DIFF
--- a/core/lib/include/compiler_hints.h
+++ b/core/lib/include/compiler_hints.h
@@ -181,15 +181,13 @@ extern "C" {
  *          This allows the compiler to optimize the code accordingly even when
  *          `NDEBUG` is set / with `DEVELHELP=0`.
  *
- *          @p cond being false will result in undefined behavior.
+ * @warning When `NDEBUG` is set, @p cond being false will result in undefined
+ *          behavior. (With `NDEBUG` not being set, a failed assertion panic
+ *          will occur on @p cond being false instead.)
  *
  * @param[in] cond  Condition that is guaranteed to be true
  */
-#ifdef NDEBUG
-#  define assume(cond) ((cond) ? (void)0 : UNREACHABLE())
-#else
-#  define assume(cond) assert(cond)
-#endif
+#define assume(cond) ((cond) ? (void)0 : (assert(0), UNREACHABLE()))
 
 /**
  * @brief   Wrapper function to silence "comparison is always false due to limited


### PR DESCRIPTION
- Make the wording of the API doc a bit more explicit
- Make sure that the static analyzer of GCC does pick up invariants encoded with an `assume()` even with `NDEBUG` unset.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

With `master` and `NDEBUG` not being set, the static analyzer would emit traces like:

```
    |/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/core/lib/include/assert.h:139:49:
    |  139 | #  define assert(cond) (_likely(cond) ? (void)0 : _assert_panic())
    |      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
    |      |                                                 |
    |      |                                                 (12) following 'false' branch...
[...]
```

But there are no more steps to follow after an `_assert_panic()`, as that call will never return.

Interestingly, `_assert_panic()` does have the `__attribute__((noreturn))`, but at least on GCC 13.2.1 (as packaged by Ubuntu LTS 24.04) this is not picked up by the static analyzer. The `__builtin_unreachable()` however is, as evident by the static analyzer no longer showing any "following 'false' branch into `_assert_panic()`".

### Issues/PRs references

None