### PR TITLE
core/clist: add insert function to keep lists sorted without resorting them

### DIFF
--- a/core/lib/include/clist.h
+++ b/core/lib/include/clist.h
@@ -444,6 +444,55 @@ static inline void clist_sort(clist_node_t *list, clist_cmp_func_t cmp)
 }
 
 /**
+ * @brief Insert a node into a sorted clist
+ *
+ * This function will insert a @p node into an already @p cmp sorted @p list.
+ * New nodes are added to the right of equal elements.
+ * -> stable insertion sort can be done with @ref clist_lpop
+ *
+ * Complexity
+ *   - Best case O(1): insert before head or after tail.
+ *   - Worst case O(n): insert within the interior of the ring.
+ *
+ * @param[in,out]   list    sorted List to to insert in
+ * @param[in,out]   node    Node which gets inserted.
+ *                          Must not be NULL.
+ * @param[in]       cmp     Comparison function (see @ref clist_sort)
+ */
+static inline void clist_insert_sorted(clist_node_t *list, clist_node_t *node,
+                                       clist_cmp_func_t cmp)
+{
+    if (!list->next) {
+        node->next = node;
+        list->next = node;
+        return;
+    }
+
+    /* smaller than first */
+    if (cmp(list->next->next, node) > 0) {
+        node->next = list->next->next;
+        list->next->next = node;
+        return;
+    }
+
+    /* bigger than last */
+    if (cmp(list->next, node) <= 0) {
+        node->next = list->next->next;
+        list->next->next = node;
+        list->next = node; /* adjust list to new last element */
+        return;
+    }
+
+    clist_node_t *pos = list->next;
+    /* node must be smaller than last due to previous check */
+    while (cmp(pos->next, node) <= 0) {
+            pos = pos->next;
+    }
+    node->next = pos->next;
+    pos->next = node;
+}
+
+/**
  * @brief   Count the number of items in the given list
  *
  * @param[in]   list    ptr to the clist

--- a/sys/net/gnrc/network_layer/ipv6/ext/frag/gnrc_ipv6_ext_frag.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/frag/gnrc_ipv6_ext_frag.c
@@ -676,8 +676,7 @@ static _limits_res_t _overlaps(gnrc_ipv6_ext_frag_rbuf_t *rbuf,
         if (res != NULL) {
             res->start = limits.start;
             res->end = limits.end;
-            clist_rpush(&rbuf->limits, (clist_node_t *)res);
-            clist_sort(&rbuf->limits, _limits_cmp);
+            clist_insert_sorted(&rbuf->limits, (clist_node_t *)res, _limits_cmp);
             return FRAG_LIMITS_NEW;
         }
         else {

--- a/tests/unittests/tests-core/tests-core-clist.c
+++ b/tests/unittests/tests-core/tests-core-clist.c
@@ -363,7 +363,7 @@ static void _prepare_unsorted_clist(size_t len)
  * and adds the buffer elements in ascending memory order to the list. The
  * elements are filled with demo test data that contains duplicates.
  *
- * Afert sorting, it is verified that
+ * After sorting, it is verified that
  * - the resulting list is sorted
  * - the resulting list still has the correct size (no elements lost in sort)
  * - duplicate elements of the input data are still in the original order
@@ -378,6 +378,37 @@ static void test_clist_sort(void)
         clist_sort(list, _cmp);
         TEST_ASSERT(_is_clist_stable_sorted(list));
         TEST_ASSERT_EQUAL_INT(cur_len, clist_count(list));
+    }
+}
+
+/*
+ * This does as test_clist_sort, but sorts the list lpoping node by node
+ * and inserting each into a sorted_list using the insert function.
+ *
+ * This is a insertion sort to test the insert function.
+ *
+ * After sorting, it is verified that
+ * - the resulting list is sorted
+ * - the resulting list still has the correct size (no elements lost in sort)
+ * - duplicate elements of the input data are still in the original order
+ *   (the sort is stable)
+ */
+static void test_clist_insert_sorted(void)
+{
+    clist_node_t *list = &test_clist;
+    clist_node_t *sorted_list = &((clist_node_t){});
+
+    for (size_t cur_len = 0; cur_len < TEST_CLIST_LEN; cur_len++) {
+        /* empty sorted list */
+        sorted_list->next = NULL;
+        _prepare_unsorted_clist(cur_len);
+        clist_node_t * node;
+        /* a simple insertion sort based on insert lpop is stable */
+        while ((node = clist_lpop(list))) {
+            clist_insert_sorted(sorted_list, node, _cmp);
+        }
+        TEST_ASSERT(_is_clist_stable_sorted(sorted_list));
+        TEST_ASSERT_EQUAL_INT(cur_len, clist_count(sorted_list));
     }
 }
 
@@ -470,6 +501,7 @@ Test *tests_core_clist_tests(void)
         new_TestFixture(test_clist_lpoprpush),
         new_TestFixture(test_clist_foreach),
         new_TestFixture(test_clist_sort),
+        new_TestFixture(test_clist_insert_sorted),
         new_TestFixture(test_clist_count),
         new_TestFixture(test_clist_is_empty),
         new_TestFixture(test_clist_special_cardinality),


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

adds clist_insert function to insert a node into a list with its position determined by a comparison function linke its used for sort this way a list can be kept sorted without resorting it. 
Dropping the complexity of from append O(1) + merge_sort O(NlogN) = O(NlogN) to insert O(N).

adds a test mimicking the sort test doing primitive insertion sort on top.

applies that function to to the user (tests aside) of clist_sort (since it is a sorted insert that was previously done by push/append and resort).

Even though this able to implement an insertion sort it is less efficient than a dedicated insertion sort like #21398
since it can not use runs as efficient. 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### LLM usage
While developing I overlooked one of the special cases an LLM was used.
