### PR TITLE
drivers/atwinc15x0: fix a potential buffer overflow on stack [backport 2026.01]

### DIFF
--- a/drivers/atwinc15x0/include/atwinc15x0_internal.h
+++ b/drivers/atwinc15x0/include/atwinc15x0_internal.h
@@ -19,7 +19,7 @@
  */
 
 #include <stdbool.h>
-#include <string.h>
+#include <string_utils.h>
 
 #include "driver/include/m2m_types.h"
 #include "atwinc15x0.h"
@@ -274,7 +274,7 @@ static inline bool _atwinc15x0_is_sleeping(const atwinc15x0_t *dev) {
 static inline void _atwinc15x0_sta_set_current_ssid(atwinc15x0_t *dev, const char *ssid) {
     (void)dev; (void)ssid;
 #if IS_USED(MODULE_ATWINC15X0_DYNAMIC_CONNECT)
-    strcpy(atwinc15x0->ssid, ssid);
+    strscpy(atwinc15x0->ssid, ssid, ARRAY_SIZE(atwinc15x0->ssid));
 #endif
 }
 


### PR DESCRIPTION
# Backport of #22041

### Contribution description

The PR fixes a potential buffer overflow on stack described in [GHSA-gwgv-6976-hxrg](https://github.com/RIOT-OS/RIOT/security/advisories/GHSA-gwgv-6976-hxrg).

To prevent a buffer overflow if a BSSID with an invalid size is used, the `strncpy` function is used instead of `strcpy` for bounds checking in `_atwinc15x0_sta_set_current_ssid`.

### Testing procedure

t.b.d.

### Issues/PRs references

[GHSA-gwgv-6976-hxrg](https://github.com/RIOT-OS/RIOT/security/advisories/GHSA-gwgv-6976-hxrg)