### PR TITLE
cpu/efm32: add configurable i2c pull-up

### DIFF
--- a/boards/common/slwstk6000b/include/periph_conf.h
+++ b/boards/common/slwstk6000b/include/periph_conf.h
@@ -88,9 +88,10 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin = MODULE_PIN_P12,
         .loc = I2C_ROUTELOC0_SDALOC_LOC16 |
                I2C_ROUTELOC0_SCLLOC_LOC14,
+        .speed = I2C_SPEED_NORMAL,
         .cmu = cmuClock_I2C0,
         .irq = I2C0_IRQn,
-        .speed = I2C_SPEED_NORMAL
+        .use_internal_pull_ups = true
     }
 };
 

--- a/boards/slstk3400a/include/periph_conf.h
+++ b/boards/slstk3400a/include/periph_conf.h
@@ -83,9 +83,10 @@ static const i2c_conf_t i2c_config[] = {
         .sda_pin = GPIO_PIN(PD, 6),
         .scl_pin = GPIO_PIN(PD, 7),
         .loc = I2C_ROUTE_LOCATION_LOC1,
+        .speed = I2C_SPEED_NORMAL,
         .cmu = cmuClock_I2C0,
         .irq = I2C0_IRQn,
-        .speed = I2C_SPEED_NORMAL
+        .use_internal_pull_ups = true
     }
 };
 

--- a/boards/slstk3401a/include/periph_conf.h
+++ b/boards/slstk3401a/include/periph_conf.h
@@ -95,9 +95,10 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin = GPIO_PIN(PC, 11),
         .loc = I2C_ROUTELOC0_SDALOC_LOC15 |
                I2C_ROUTELOC0_SCLLOC_LOC15,
+        .speed = I2C_SPEED_NORMAL,
         .cmu = cmuClock_I2C0,
         .irq = I2C0_IRQn,
-        .speed = I2C_SPEED_NORMAL
+        .use_internal_pull_ups = true
     }
 };
 

--- a/boards/slstk3402a/include/periph_conf.h
+++ b/boards/slstk3402a/include/periph_conf.h
@@ -86,9 +86,10 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin = GPIO_PIN(PC, 11),
         .loc = I2C_ROUTELOC0_SDALOC_LOC15 |
                I2C_ROUTELOC0_SCLLOC_LOC15,
+        .speed = I2C_SPEED_NORMAL,
         .cmu = cmuClock_I2C0,
         .irq = I2C0_IRQn,
-        .speed = I2C_SPEED_NORMAL
+        .use_internal_pull_ups = true
     }
 };
 

--- a/boards/slstk3701a/include/periph_conf.h
+++ b/boards/slstk3701a/include/periph_conf.h
@@ -110,9 +110,10 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin = GPIO_PIN(PC, 1),
         .loc = I2C_ROUTELOC0_SDALOC_LOC4 |
                I2C_ROUTELOC0_SCLLOC_LOC4,
+        .speed = I2C_SPEED_NORMAL,
         .cmu = cmuClock_I2C0,
         .irq = I2C0_IRQn,
-        .speed = I2C_SPEED_NORMAL
+        .use_internal_pull_ups = true
     },
     {
         .dev = I2C1,
@@ -120,9 +121,10 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin = GPIO_PIN(PC, 5),
         .loc = I2C_ROUTELOC0_SDALOC_LOC0 |
                I2C_ROUTELOC0_SCLLOC_LOC0,
+        .speed = I2C_SPEED_NORMAL,
         .cmu = cmuClock_I2C1,
         .irq = I2C1_IRQn,
-        .speed = I2C_SPEED_NORMAL
+        .use_internal_pull_ups = true
     },
     {
         .dev = I2C2,
@@ -130,9 +132,10 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin = GPIO_PIN(PI, 5),
         .loc = I2C_ROUTELOC0_SDALOC_LOC7 |
                I2C_ROUTELOC0_SCLLOC_LOC7,
+        .speed = I2C_SPEED_NORMAL,
         .cmu = cmuClock_I2C2,
         .irq = I2C2_IRQn,
-        .speed = I2C_SPEED_NORMAL
+        .use_internal_pull_ups = true
     }
 };
 

--- a/boards/sltb001a/include/periph_conf.h
+++ b/boards/sltb001a/include/periph_conf.h
@@ -95,9 +95,10 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin = GPIO_PIN(PC, 11),
         .loc = I2C_ROUTELOC0_SDALOC_LOC15 |
                I2C_ROUTELOC0_SCLLOC_LOC15,
+        .speed = I2C_SPEED_NORMAL,
         .cmu = cmuClock_I2C0,
         .irq = I2C0_IRQn,
-        .speed = I2C_SPEED_NORMAL
+        .use_internal_pull_ups = true
     }
 };
 

--- a/boards/sltb009a/include/periph_conf.h
+++ b/boards/sltb009a/include/periph_conf.h
@@ -110,9 +110,10 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin = GPIO_PIN(PE, 5),
         .loc = I2C_ROUTELOC0_SDALOC_LOC7 |
                I2C_ROUTELOC0_SCLLOC_LOC7,
+        .speed = I2C_SPEED_NORMAL,
         .cmu = cmuClock_I2C0,
         .irq = I2C0_IRQn,
-        .speed = I2C_SPEED_NORMAL
+        .use_internal_pull_ups = true
     }
 };
 

--- a/boards/slwstk6220a/include/periph_conf.h
+++ b/boards/slwstk6220a/include/periph_conf.h
@@ -105,9 +105,10 @@ static const i2c_conf_t i2c_config[] = {
         .sda_pin = GPIO_PIN(PE, 0),
         .scl_pin = GPIO_PIN(PE, 1),
         .loc = I2C_ROUTE_LOCATION_LOC2,
+        .speed = I2C_SPEED_NORMAL,
         .cmu = cmuClock_I2C1,
         .irq = I2C1_IRQn,
-        .speed = I2C_SPEED_NORMAL
+        .use_internal_pull_ups = true
     }
 };
 

--- a/boards/stk3200/include/periph_conf.h
+++ b/boards/stk3200/include/periph_conf.h
@@ -82,9 +82,10 @@ static const i2c_conf_t i2c_config[] = {
         .sda_pin = GPIO_PIN(PE, 12),
         .scl_pin = GPIO_PIN(PE, 13),
         .loc = I2C_ROUTE_LOCATION_LOC6,
+        .speed = I2C_SPEED_NORMAL,
         .cmu = cmuClock_I2C0,
         .irq = I2C0_IRQn,
-        .speed = I2C_SPEED_NORMAL
+        .use_internal_pull_ups = true
     }
 };
 

--- a/boards/stk3600/include/periph_conf.h
+++ b/boards/stk3600/include/periph_conf.h
@@ -106,18 +106,20 @@ static const i2c_conf_t i2c_config[] = {
         .sda_pin = GPIO_PIN(PD, 6),
         .scl_pin = GPIO_PIN(PD, 7),
         .loc = I2C_ROUTE_LOCATION_LOC1,
+        .speed = I2C_SPEED_NORMAL,
         .cmu = cmuClock_I2C0,
         .irq = I2C0_IRQn,
-        .speed = I2C_SPEED_NORMAL
+        .use_internal_pull_ups = true
     },
     {
         .dev = I2C1,
         .sda_pin = GPIO_PIN(PC, 4),
         .scl_pin = GPIO_PIN(PC, 5),
         .loc = I2C_ROUTE_LOCATION_LOC0,
+        .speed = I2C_SPEED_NORMAL,
         .cmu = cmuClock_I2C1,
         .irq = I2C1_IRQn,
-        .speed = I2C_SPEED_NORMAL
+        .use_internal_pull_ups = true
     }
 };
 

--- a/boards/stk3700/include/periph_conf.h
+++ b/boards/stk3700/include/periph_conf.h
@@ -106,18 +106,20 @@ static const i2c_conf_t i2c_config[] = {
         .sda_pin = GPIO_PIN(PD, 6),
         .scl_pin = GPIO_PIN(PD, 7),
         .loc = I2C_ROUTE_LOCATION_LOC1,
+        .speed = I2C_SPEED_NORMAL,
         .cmu = cmuClock_I2C0,
         .irq = I2C0_IRQn,
-        .speed = I2C_SPEED_NORMAL
+        .use_internal_pull_ups = true
     },
     {
         .dev = I2C1,
         .sda_pin = GPIO_PIN(PC, 4),
         .scl_pin = GPIO_PIN(PC, 5),
         .loc = I2C_ROUTE_LOCATION_LOC0,
+        .speed = I2C_SPEED_NORMAL,
         .cmu = cmuClock_I2C1,
         .irq = I2C1_IRQn,
-        .speed = I2C_SPEED_NORMAL
+        .use_internal_pull_ups = true
     }
 };
 

--- a/boards/xg23-pk6068a/include/periph_conf.h
+++ b/boards/xg23-pk6068a/include/periph_conf.h
@@ -92,9 +92,10 @@ static const i2c_conf_t i2c_config[] = {
         .dev = I2C0,
         .sda_pin = GPIO_PIN(PC, 7),
         .scl_pin = GPIO_PIN(PC, 5),
+        .speed = I2C_SPEED_NORMAL,
         .cmu = cmuClock_I2C0,
         .irq = I2C0_IRQn,
-        .speed = I2C_SPEED_NORMAL
+        .use_internal_pull_ups = true
     }
 };
 

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -425,15 +425,16 @@ typedef enum {
  * @brief   I2C device configuration.
  */
 typedef struct {
-    I2C_TypeDef *dev;       /**< USART device used */
-    gpio_t sda_pin;         /**< pin used for SDA */
-    gpio_t scl_pin;         /**< pin used for SCL */
+    I2C_TypeDef *dev;           /**< I2C device used */
+    gpio_t sda_pin;             /**< pin used for SDA */
+    gpio_t scl_pin;             /**< pin used for SCL */
 #if defined(_SILICON_LABS_32B_SERIES_0) || defined(_SILICON_LABS_32B_SERIES_1)
-    uint32_t loc;           /**< location of I2C pins */
+    uint32_t loc;               /**< location of I2C pins */
 #endif
-    CMU_Clock_TypeDef cmu;  /**< the device CMU channel */
-    IRQn_Type irq;          /**< the devices base IRQ channel */
-    uint32_t speed;         /**< the bus speed */
+    uint32_t speed;             /**< the bus speed */
+    CMU_Clock_TypeDef cmu;      /**< the device CMU channel */
+    IRQn_Type irq;              /**< the devices base IRQ channel */
+    bool use_internal_pull_ups; /**< enable internal pull-ups on SDA and SCL pins */
 } i2c_conf_t;
 
 /**


### PR DESCRIPTION
### Contribution description

The EFM32 I2C driver has a few problems. One of these problems, is that when no devices are connected to the I2C bus, the driver can hang forever. That is because during an I2C transfer, the pins could be low due to the lack of pull-ups, so the driver (in its current state) waits for an event indefinitely.

This PR ensures that the driver adds support for the (very weak) internal pull-up resistors, so that the pins are in a high state. That at least reduces the likelihood for the driver to hang forever.

I already proposed this solution as part of #15764, based on the [Silicon Labs SDK Driver](https://github.com/SiliconLabs/gecko_sdk/blob/gsdk_4.5/hardware/kit/common/drivers/i2cspm.c#L104), but it was debatable if this should be enabled by default or not. Pull-ups increase power consumption and well-defined hardware should not have this problem. However, I believe this makes sense for development boards, more-dynamic hardware configurations or simply more resiliency. Also, the ESP32 has a similar feature.

~~That said, I only enabled the pull-up for boards that have no sensors connected, such as the STK3600. Most other EFM32-based development boards have an on-board Si7021 temperature sensor, so there are external pull-ups already.~~

I revised this, because the development boards only enable the pull-ups when the sensors are enabled. That happens only when the sensors are included as modules.

### Testing procedure

Take a boards without I2C devices connected (and no external pull-ups), such as the STK3600.

Compile `examples/basic/default` with `USEMODULE=shell_cmds_i2c_scan`, e.g.

```
USEMODULE=shell_cmd_i2c_scan BOARD=stk3600 make -j14 flash
``` 

Without PR (it stalls):

```
> main(): This is RIOT! (Version: 2026.04-devel-85-g8d5752-feature/efm32_i2c_pull_up)
Welcome to RIOT!

> i2c_scan 0

Scanning I2C device 0...
addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
     0 1 2 3 4 5 6 7 8 9 a b c d e f
0x00 R R R R R R R R
```

With PR: (it finishes).

```
> main(): This is RIOT! (Version: 2026.04-devel-85-g8d5752-feature/efm32_i2c_pull_up)
Welcome to RIOT!

> i2c_scan 0

Scanning I2C device 0...
addr not ack'ed = "-", addr ack'ed = "X", addr reserved = "R", error = "E"
     0 1 2 3 4 5 6 7 8 9 a b c d e f
0x00 R R R R R R R R - - - - - - - -
0x10 - - - - - - - - - - - - - - - -
0x20 - - - - - - - - - - - - - - - -
0x30 - - - - - - - - - - - - - - - -
0x40 - - - - - - - - - - - - - - - -
0x50 - - - - - - - - - - - - - - - -
0x60 - - - - - - - - - - - - - - - -
0x70 - - - - - - - - R R R R R R R R
```

### Issues/PRs references

Revisited from #15764.