### PR TITLE
sys/net/gnrc_sixlowpan: fix a possible NULL ptr dereference

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -71,8 +71,7 @@ void gnrc_sixlowpan_dispatch_recv(gnrc_pktsnip_t *pkt, void *context,
     (void)page;
 #ifndef MODULE_GNRC_IPV6
     type = GNRC_NETTYPE_UNDEF;
-    for (gnrc_pktsnip_t *ptr = pkt; (ptr || (type == GNRC_NETTYPE_UNDEF));
-         ptr = ptr->next) {
+    for (gnrc_pktsnip_t *ptr = pkt; ptr != NULL; ptr = ptr->next) {
         if ((ptr->next) && (ptr->next->type == GNRC_NETTYPE_NETIF)) {
             type = ptr->type;
             break;


### PR DESCRIPTION
### Contribution description

Due to a typo in a logical operation, a specifically crafted packet could cause a NULL ptr dereference. However, the affected code is only active when 6LoWPAN without IPv6 support is used, which is not expected to ever happen in any real world deployment.

### Testing procedure

- this makes static analysis happy
- when not using IPv6 and receiving a packet with only header counting as `type == GNRC_NETTYPE_UNDEF` after the 6LoWPAN header, no NULL pointer dereference should occur

### Issues/PRs references

None
