### PR TITLE
boards/slstk3701a: fix pin configuration issues

### DIFF
--- a/boards/slstk3701a/Makefile.features
+++ b/boards/slstk3701a/Makefile.features
@@ -10,7 +10,7 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_uart periph_uart_modecfg
+FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 include $(RIOTBOARD)/common/silabs/Makefile.features

--- a/boards/slstk3701a/board.c
+++ b/boards/slstk3701a/board.c
@@ -18,11 +18,18 @@
 
 #include "board.h"
 #include "board_common.h"
+#include "periph/gpio.h"
 
 void board_init(void)
 {
 #ifndef RIOTBOOT
     /* perform common board initialization */
     board_common_init();
+
+#ifdef MODULE_SI7021
+    /* initialize the Si7021 sensor */
+    gpio_init(SI7021_EN_PIN, GPIO_OUT);
+    gpio_set(SI7021_EN_PIN);
+#endif
 #endif
 }

--- a/boards/slstk3701a/doc.md
+++ b/boards/slstk3701a/doc.md
@@ -78,6 +78,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | RTT         | -       | RTCC       |                  | 1 Hz interval, either RTT or RTC    |
 | RTC         | -       | RTCC       |                  | 1 Hz interval, either RTT or RTC    |
 | SPI         | 0       | USART0     | MOSI:PE10, MISO:PE11, CLK:PE12 |                       |
+| SPI         | 1       | USART1     | MOSI:PA14, MISO:PC2, CLK:PC15  | Memory LCD            |
 | Timer       | 0       | WTIMER0 + WTIMER1 |           | WTIMER0 is used as prescaler        |
 | Timer       | 1       | TIMER0 + TIMER1   |           | TIMER0 is used as prescaler         |
 | Timer       | 2       | LETIMER0   |                  |                                     |
@@ -101,24 +102,26 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ## Implementation Status
 
-| Device                        | ID         | Supported | Comments                                           |
-|-------------------------------|------------|-----------|----------------------------------------------------|
-| MCU                           | EFM32GG11B | yes       | Power modes supported                              |
-| Low-level driver              | ADC        | yes       |                                                    |
-|                               | DAC        | yes       | VDAC, IDAC is not supported                        |
-|                               | Ethernet   | no        |                                                    |
-|                               | Flash      | yes       |                                                    |
-|                               | GPIO       | yes       | Interrupts are shared across pins (see ref manual) |
-|                               | HW Crypto  | yes       |                                                    |
-|                               | I2C        | yes       |                                                    |
-|                               | PWM        | yes       |                                                    |
-|                               | RTCC       | yes       | As RTT or RTC                                      |
-|                               | SPI        | yes       | Only master mode                                   |
-|                               | Timer      | yes       |                                                    |
-|                               | TRNG       | yes       | True Random Number Generator                       |
-|                               | UART       | yes       | USART is shared with SPI. LEUART baud rate limited |
-|                               | USB        | yes       | Device mode                                        |
-| Temperature + humidity sensor | Si7021     | yes       | Silicon Labs Temperature + Humidity sensor         |
+| Device                        | ID          | Supported | Comments                                              |
+|-------------------------------|-------------|-----------|-------------------------------------------------------|
+| MCU                           | EFM32GG11B  | yes       | Power modes supported                                 |
+| Low-level driver              | ADC         | yes       |                                                       |
+|                               | DAC         | yes       | VDAC, IDAC is not supported                           |
+|                               | Ethernet    | no        |                                                       |
+|                               | Flash       | yes       |                                                       |
+|                               | GPIO        | yes       | Interrupts are shared across pins (see ref manual)    |
+|                               | HW Crypto   | yes       |                                                       |
+|                               | I2C         | yes       |                                                       |
+|                               | PWM         | yes       |                                                       |
+|                               | RTCC        | yes       | As RTT or RTC                                         |
+|                               | SPI         | yes       | Only master mode                                      |
+|                               | Timer       | yes       |                                                       |
+|                               | TRNG        | yes       | True Random Number Generator                          |
+|                               | UART        | yes       | USART is shared with SPI. LEUART baud rate limited    |
+|                               | USB         | yes       | Device mode                                           |
+| LCD driver                    | LS013B7DH06 | no        | Sharp Low Power Memory color LCD (Rev. A0 - A5 board) |
+| LCD driver                    | LPM013M126A | no        | JDI Low Power Memory color LCD (Rev. B0+ boards)      |
+| Temperature + humidity sensor | Si7021      | yes       | Silicon Labs Temperature + Humidity sensor            |
 
 ## Board configuration
 

--- a/boards/slstk3701a/doc.md
+++ b/boards/slstk3701a/doc.md
@@ -90,14 +90,14 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |------------|-----------|-----------|------------|
 | Button     | PB0_PIN   | PC8       |            |
 |            | PB1_PIN   | PC9       |            |
-| LED        | LED0R_PIN | PH10      |            |
-|            | LED0G_PIN | PH11      |            |
-|            | LED0B_PIN | PH12      |            |
-|            | LED1R_PIN | PH13      |            |
-|            | LED1G_PIN | PH14      |            |
-|            | LED1B_PIN | PH15      |            |
-|            | LED0_PIN  | LED0R_PIN |            |
-|            | LED1_PIN  | LED1R_PIN |            |
+| LED        | LED0R_PIN | PH10      | Active low |
+|            | LED0G_PIN | PH11      | Active low |
+|            | LED0B_PIN | PH12      | Active low |
+|            | LED1R_PIN | PH13      | Active low |
+|            | LED1G_PIN | PH14      | Active low |
+|            | LED1B_PIN | PH15      | Active low |
+|            | LED0_PIN  | LED0R_PIN | Active low |
+|            | LED1_PIN  | LED1R_PIN | Active low |
 
 ## Implementation Status
 

--- a/boards/slstk3701a/doc.md
+++ b/boards/slstk3701a/doc.md
@@ -71,7 +71,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | ADC         | 1       | ADC0:CH1   |                  | AVDD                                |
 | DAC         | 0       | DAC0:OUT0  | PB11             | AVVD as reference voltage           |
 | I2C         | 0       | I2C0       | SDA:PC0, SCL:PC1 | Normal speed                        |
-| I2C         | 1       | I2C1       | SDA:PC7, SCL:PC5 | Normal speed                        |
+| I2C         | 1       | I2C1       | SDA:PC4, SCL:PC5 | Normal speed                        |
 | I2C         | 2       | I2C2       | SDA:PI4, SCL:PI5 | Normal speed, Sensor I2C bus        |
 | HWCRYPTO    | -       | -          |                  | AES128/AES256, SHA1, SHA224/SHA256  |
 | HWRNG       | -       | TNRG0      |                  | True Random Number Generator (TRNG) |

--- a/boards/slstk3701a/doc.md
+++ b/boards/slstk3701a/doc.md
@@ -101,23 +101,24 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ## Implementation Status
 
-| Device           | ID         | Supported | Comments                                           |
-|------------------|------------|-----------|----------------------------------------------------|
-| MCU              | EFM32GG11B | yes       | Power modes supported                              |
-| Low-level driver | ADC        | yes       |                                                    |
-|                  | DAC        | yes       | VDAC, IDAC is not supported                        |
-|                  | Ethernet   | no        |                                                    |
-|                  | Flash      | yes       |                                                    |
-|                  | GPIO       | yes       | Interrupts are shared across pins (see ref manual) |
-|                  | HW Crypto  | yes       |                                                    |
-|                  | I2C        | yes       |                                                    |
-|                  | PWM        | yes       |                                                    |
-|                  | RTCC       | yes       | As RTT or RTC                                      |
-|                  | SPI        | yes       | Only master mode                                   |
-|                  | Timer      | yes       |                                                    |
-|                  | TRNG       | yes       | True Random Number Generator                       |
-|                  | UART       | yes       | USART is shared with SPI. LEUART baud rate limited |
-|                  | USB        | yes       | Device mode                                        |
+| Device                        | ID         | Supported | Comments                                           |
+|-------------------------------|------------|-----------|----------------------------------------------------|
+| MCU                           | EFM32GG11B | yes       | Power modes supported                              |
+| Low-level driver              | ADC        | yes       |                                                    |
+|                               | DAC        | yes       | VDAC, IDAC is not supported                        |
+|                               | Ethernet   | no        |                                                    |
+|                               | Flash      | yes       |                                                    |
+|                               | GPIO       | yes       | Interrupts are shared across pins (see ref manual) |
+|                               | HW Crypto  | yes       |                                                    |
+|                               | I2C        | yes       |                                                    |
+|                               | PWM        | yes       |                                                    |
+|                               | RTCC       | yes       | As RTT or RTC                                      |
+|                               | SPI        | yes       | Only master mode                                   |
+|                               | Timer      | yes       |                                                    |
+|                               | TRNG       | yes       | True Random Number Generator                       |
+|                               | UART       | yes       | USART is shared with SPI. LEUART baud rate limited |
+|                               | USB        | yes       | Device mode                                        |
+| Temperature + humidity sensor | Si7021     | yes       | Silicon Labs Temperature + Humidity sensor         |
 
 ## Board configuration
 

--- a/boards/slstk3701a/include/board.h
+++ b/boards/slstk3701a/include/board.h
@@ -80,11 +80,11 @@ extern "C" {
  * @name    Macros for controlling the on-board LEDs
  * @{
  */
-#define LED0_ON             gpio_set(LED0_PIN)
-#define LED0_OFF            gpio_clear(LED0_PIN)
+#define LED0_ON             gpio_clear(LED0_PIN)
+#define LED0_OFF            gpio_set(LED0_PIN)
 #define LED0_TOGGLE         gpio_toggle(LED0_PIN)
-#define LED1_ON             gpio_set(LED1_PIN)
-#define LED1_OFF            gpio_clear(LED1_PIN)
+#define LED1_ON             gpio_clear(LED1_PIN)
+#define LED1_OFF            gpio_set(LED1_PIN)
 #define LED1_TOGGLE         gpio_toggle(LED1_PIN)
 /** @} */
 

--- a/boards/slstk3701a/include/board.h
+++ b/boards/slstk3701a/include/board.h
@@ -91,10 +91,11 @@ extern "C" {
 /**
  * @name    Display configuration
  *
- * Connection to the on-board Sharp Memory LCD (LS013B7DH03).
+ * Connection to the on-board LCD. Rev A0 - A5 boards have a Sharp LS013B7DH06,
+ * display, while Rev B0 boards and newer have a JDI LPM013M126A display.
  * @{
  */
-#define DISP_SPI            SPI_DEV(0)
+#define DISP_SPI            SPI_DEV(1)
 #define DISP_COM_PIN        GPIO_PIN(PA, 11)
 #define DISP_CS_PIN         GPIO_PIN(PC, 14)
 #define DISP_EN_PIN         GPIO_PIN(PA, 9)

--- a/boards/slstk3701a/include/gpio_params.h
+++ b/boards/slstk3701a/include/gpio_params.h
@@ -30,12 +30,14 @@ static const  saul_gpio_params_t saul_gpio_params[] =
     {
         .name = "LED 0",
         .pin = LED0_PIN,
-        .mode = GPIO_OUT
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR
     },
     {
         .name = "LED 1",
         .pin = LED1_PIN,
-        .mode = GPIO_OUT
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR
     },
     {
         .name = "Button 1",

--- a/boards/slstk3701a/include/periph_conf.h
+++ b/boards/slstk3701a/include/periph_conf.h
@@ -166,6 +166,17 @@ static const spi_dev_t spi_config[] = {
                USART_ROUTELOC0_CLKLOC_LOC0,
         .cmu = cmuClock_USART0,
         .irq = USART0_RX_IRQn
+    },
+    {
+        .dev = USART1,
+        .mosi_pin = GPIO_PIN(PA, 14),
+        .miso_pin = GPIO_PIN(PC, 2),
+        .clk_pin = GPIO_PIN(PC, 15),
+        .loc = USART_ROUTELOC0_TXLOC_LOC6 |
+               USART_ROUTELOC0_RXLOC_LOC4 |
+               USART_ROUTELOC0_CLKLOC_LOC3,
+        .cmu = cmuClock_USART1,
+        .irq = USART1_RX_IRQn
     }
 };
 

--- a/boards/slstk3701a/include/periph_conf.h
+++ b/boards/slstk3701a/include/periph_conf.h
@@ -116,7 +116,7 @@ static const i2c_conf_t i2c_config[] = {
     },
     {
         .dev = I2C1,
-        .sda_pin = GPIO_PIN(PC, 7),
+        .sda_pin = GPIO_PIN(PC, 4),
         .scl_pin = GPIO_PIN(PC, 5),
         .loc = I2C_ROUTELOC0_SDALOC_LOC0 |
                I2C_ROUTELOC0_SCLLOC_LOC0,


### PR DESCRIPTION
### Contribution description

The peripheral and board configuration for the SLSTK3701a was not correct, which resulted in the board not working `examples/basic/default` (that initializes the on-board Si7021 driver).

<details>
<summary>Datasheet screenshots</summary>

For validation, here are the relevant screenshots from the board's [user manual](https://www.silabs.com/documents/public/user-guides/ug287-efm32gg11-stk3701-user-guide.pdf).

<img width="620" height="343" alt="Scherm­afbeelding 2026-02-09 om 21 43 17" src="https://github.com/user-attachments/assets/4c22d948-dbd6-4fcc-bc56-c31256c119d6" />

<img width="855" height="471" alt="Scherm­afbeelding 2026-02-09 om 21 43 44" src="https://github.com/user-attachments/assets/cfa30fb8-6c1e-4934-8af1-0988086b66cb" />

<img width="560" height="274" alt="Scherm­afbeelding 2026-02-09 om 21 44 06" src="https://github.com/user-attachments/assets/ddf9f5cf-d86e-496c-98f8-b6bd6d92aefa" />
</details>

### Testing procedure

Flash the board with `examples/basic/default` and use the shell to interact with the LEDs and Si7021 sensor. 

Before this PR, board initialization would stall because the Si7021 sensor was not enabled (and because of #22065).

### Issues/PRs references

#22065, #22052