### PR TITLE
sys/event/periodic_callback: add _start_now

### DIFF
--- a/sys/include/event/periodic_callback.h
+++ b/sys/include/event/periodic_callback.h
@@ -83,8 +83,8 @@ static inline void event_periodic_callback_init(event_periodic_callback_t *event
  * This will make the event as configured in @p event be triggered
  * at every interval ticks (based on event->periodic.clock).
  *
- * @note: the used event_periodic struct must stay valid until after the timeout
- *        event has been processed!
+ * @note: @p event must stay valid until after all periodic timeout
+ *        events have been processed!
  *
  * @note: this function does not touch the current count value.
  *
@@ -99,10 +99,39 @@ static inline void event_periodic_callback_start(event_periodic_callback_t *even
 }
 
 /**
+ * @brief   Starts a periodic callback event without delay for the first occurrence
+ *
+ * If the event is already started, it's interval will be updated and it
+ * will be scheduled immediately.
+ *
+ * This will make the event as configured in @p event be triggered
+ * at every interval ticks (based on event->periodic.clock).
+ *
+ * @note: @p event must stay valid until after all periodic timeout
+ *        events have been processed!
+ *
+ * @note: this function does not touch the current count value.
+ *
+ * @note: the periodic event will start without initial delay.
+ *
+ * @param[in]   event           event_periodic_callback context object to use
+ * @param[in]   interval        period length for the event
+ */
+static inline void event_periodic_callback_start_now(event_periodic_callback_t *event,
+                                                     uint32_t interval)
+{
+    assert(event->event.callback);
+    event_periodic_start_now(&event->periodic, interval);
+}
+
+/**
  * @brief   Initialize and start a periodic callback event
  *
  * This is a convenience function that combines @ref event_periodic_callback_init
  * and @ref event_periodic_callback_start
+ *
+ * @note: The periodic callback event is configured to run forever, and the first
+ *        occurrence happens after the delay given by @p timeout .
  *
  * @param[out]  event           event_periodic_callback object to initialize
  * @param[in]   clock           the clock to configure this timer on

--- a/tests/sys/event_periodic_callback/main.c
+++ b/tests/sys/event_periodic_callback/main.c
@@ -41,11 +41,11 @@ int main(void)
 
     event_periodic_callback_set_count(&a, 6);
     event_periodic_callback_set_count(&b, 3);
-    event_periodic_callback_set_count(&c, 2);
+    event_periodic_callback_set_count(&c, 3);
 
     event_periodic_callback_start(&a,  502);
     event_periodic_callback_start(&b, 1001);
-    event_periodic_callback_start(&c, 1500);
+    event_periodic_callback_start_now(&c, 1500);
 
     ztimer_sleep(ZTIMER_MSEC, 3020);
 

--- a/tests/sys/event_periodic_callback/tests/01-run.py
+++ b/tests/sys/event_periodic_callback/tests/01-run.py
@@ -6,6 +6,7 @@ from testrunner import run
 
 def testfunc(child):
     child.expect_exact("event 0")
+    child.expect_exact("event C")
     child.expect_exact("event A")
     child.expect_exact("event D")
     child.expect_exact("event B")


### PR DESCRIPTION
### Contribution description

https://github.com/RIOT-OS/RIOT/pull/20911 introduced `event_periodic_start_now` to start triggering a periodic event without initial delay.

This PR adds the corresponding functionality to `event_periodic_callback`.


### Testing procedure

```
make -C tests/sys/event_periodic_callback all test -j
```