### PR TITLE
drivers/ws281x: fix unused dev

### DIFF
--- a/drivers/ws281x/spi.c
+++ b/drivers/ws281x/spi.c
@@ -186,6 +186,7 @@ static void _ws281x_write_buffer_aligned(const void *_buf, size_t size)
 
 void ws281x_write_buffer(ws281x_t *dev, const void *_buf, size_t size)
 {
+    (void)dev;
     assert(dev);
     assert(size % WS281X_BYTES_PER_DEVICE == 0);
     assert(size * WS281X_SPI_BITS_PER_WS_BIT <= sizeof(_spi_buf));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Fixes unused `dev` when `assert` is disabled

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
