### PR TITLE
pkg/lwip/sock_udp: correctly report IP family in dual-stack scenario

### DIFF
--- a/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
+++ b/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
@@ -144,7 +144,7 @@ ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **ctx,
         size_t addr_len = sizeof(ipv4_addr_t);
         int family = AF_INET;
 
-        if (NETCONNTYPE_ISIPV6(sock->base.conn->type)) {
+        if (IP_IS_V6(&buf->addr)) {
             addr_len = sizeof(ipv6_addr_t);
             family = AF_INET6;
         }


### PR DESCRIPTION
### Contribution description

The source address reported by the `sock_udp` implementation of lwip currently always shows IPv6 even when receiving a datagram over IPv4 in a dual-stack scenario.

This PR fixes this.


### Testing procedure

```
$ LWIP_IPV4=1 LWIP_IPV6=1 make -C tests/pkg/lwip flash term -j
...
> ifconfig add ET0 10.0.0.2/24
> udp server start 1234
```

on Linux:

```
$ sudo ip a a 10.0.0.1/24 dev tap0
$ echo -n "hello" | socat - udp-sendto:10.0.0.2:1234 
```

on current `master`:

```
2026-02-10 17:16:25,835 # Received UDP data from [a00:1::]:32931
2026-02-10 17:16:25,835 # 00000000  68  65  6C  6C  6F
```

with this PR:

```
2026-02-10 17:09:51,343 # Received UDP data from [10.0.0.1]:38782
2026-02-10 17:09:51,343 # 00000000  68  65  6C  6C  6F
```

Also confirmed to still work in both single-stack scenarios.