### PR TITLE
cpu/stm32h7, boards/nucleo-h753zi: add support for more peripherals

### DIFF
--- a/boards/common/stm32/include/cfg_i2c1_pb8_pb9.h
+++ b/boards/common/stm32/include/cfg_i2c1_pb8_pb9.h
@@ -62,6 +62,10 @@ static const i2c_conf_t i2c_config[] = {
         .rcc_mask       = RCC_APB1ENR_I2C1EN,
         .rcc_sw_mask    = RCC_DCKCFGR2_I2C1SEL_1,       /* HSI (16 MHz) */
         .irqn           = I2C1_ER_IRQn,
+#elif CPU_FAM_STM32H7
+        .rcc_mask       = RCC_APB1LENR_I2C1EN,
+        .rcc_sw_mask    = RCC_D2CCIP2R_I2C123SEL_1,  /* HSI (64MHz) */
+        .irqn           = I2C1_ER_IRQn,
 #elif CPU_FAM_STM32F0 || CPU_FAM_STM32L0
         .rcc_mask       = RCC_APB1ENR_I2C1EN,
 #if CPU_FAM_STM32F0
@@ -74,7 +78,8 @@ static const i2c_conf_t i2c_config[] = {
 
 #if CPU_FAM_STM32F4 || CPU_FAM_STM32F2
 #define I2C_0_ISR           isr_i2c1_ev
-#elif CPU_FAM_STM32L4 || CPU_FAM_STM32F7 || CPU_FAM_STM32WB || CPU_FAM_STM32L5
+#elif CPU_FAM_STM32L4 || CPU_FAM_STM32F7 || CPU_FAM_STM32WB || CPU_FAM_STM32L5 || \
+      CPU_FAM_STM32H7
 #define I2C_0_ISR           isr_i2c1_er
 #elif CPU_FAM_STM32F0 || CPU_FAM_STM32L0 || CPU_FAM_STM32G0 || CPU_FAM_STM32C0
 #define I2C_0_ISR           isr_i2c1

--- a/boards/nucleo-h753zi/Makefile.features
+++ b/boards/nucleo-h753zi/Makefile.features
@@ -2,6 +2,12 @@ CPU = stm32
 CPU_MODEL = stm32h753zi
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dma
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_wdt

--- a/boards/nucleo-h753zi/include/periph_conf.h
+++ b/boards/nucleo-h753zi/include/periph_conf.h
@@ -25,11 +25,30 @@
 
 #include "periph_cpu.h"
 #include "clk_conf.h"
+#include "cfg_i2c1_pb8_pb9.h"
 #include "cfg_timer_tim5_and_tim2.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @name    DMA configuration
+ * @note    STM32H7 peripherals (D2 domain) use DMA1/DMA2.
+ * @{
+ */
+static const dma_conf_t dma_config[] = {
+    { .stream = 4 },   /* DMA1 Stream 4 - USART3_TX */
+    { .stream = 14 },  /* DMA2 Stream 6 - USART6_TX */
+    { .stream = 6 },   /* DMA1 Stream 6 - USART2_TX */
+};
+
+#define DMA_0_ISR  isr_dma1_stream4
+#define DMA_1_ISR  isr_dma2_stream6
+#define DMA_2_ISR  isr_dma1_stream6
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+/** @} */
 
 /**
  * @name    UART configuration
@@ -45,7 +64,11 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF7,
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
-        .irqn       = USART3_IRQn
+        .irqn       = USART3_IRQn,
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 0,
+        .dma_chan   = 46 /* DMAMUX_REQ_USART3_TX */
+#endif
     },
     {
         .dev        = USART6,
@@ -55,7 +78,11 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF7,
         .tx_af      = GPIO_AF7,
         .bus        = APB2,
-        .irqn       = USART6_IRQn
+        .irqn       = USART6_IRQn,
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 1,
+        .dma_chan   = 72 /* DMAMUX_REQ_USART6_TX */
+#endif
     },
     {
         .dev        = USART2,
@@ -65,7 +92,11 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF7,
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
-        .irqn       = USART2_IRQn
+        .irqn       = USART2_IRQn,
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 2,
+        .dma_chan   = 44 /* DMAMUX_REQ_USART2_TX */
+#endif
     }
 };
 
@@ -73,6 +104,92 @@ static const uart_conf_t uart_config[] = {
 #define UART_1_ISR          (isr_usart6)
 #define UART_2_ISR          (isr_usart2)
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name   SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_B, 5),
+        .miso_pin = GPIO_PIN(PORT_A, 6),
+        .sclk_pin = GPIO_PIN(PORT_A, 5),
+        .cs_pin   = GPIO_PIN(PORT_A, 4), /* For HW NSS */
+        .mosi_af  = GPIO_AF5,
+        .miso_af  = GPIO_AF5,
+        .sclk_af  = GPIO_AF5,
+        .cs_af    = GPIO_AF5,
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+        .apbbus   = APB2
+    },
+    {
+        .dev      = SPI4,
+        .mosi_pin = GPIO_PIN(PORT_E, 6),
+        .miso_pin = GPIO_PIN(PORT_E, 5),
+        .sclk_pin = GPIO_PIN(PORT_E, 2),
+        .cs_pin   = GPIO_PIN(PORT_E, 4), /* For HW NSS */
+        .mosi_af  = GPIO_AF5,
+        .miso_af  = GPIO_AF5,
+        .sclk_af  = GPIO_AF5,
+        .cs_af    = GPIO_AF5,
+        .rccmask  = RCC_APB2ENR_SPI4EN,
+        .apbbus   = APB2
+    }
+};
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name   ADC configuration
+ * @note   STM32H7 ADC is 16-bit, and uses independent clocks
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 3), 0, 15},
+    {GPIO_PIN(PORT_C, 0), 1, 10},
+    {GPIO_PIN(PORT_C, 3), 0, 13},
+    {GPIO_PIN(PORT_B, 1), 1, 5},
+    {GPIO_PIN(PORT_C, 2), 0, 12},
+    {GPIO_PIN(PORT_F, 10), 2, 6},
+    {GPIO_UNDEF, 2, 17}, /* VBAT */
+};
+
+/**
+ * @brief   ADC line for internal VBAT channel
+ */
+#define VBAT_ADC            ADC_LINE(6)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+/** @} */
+
+/**
+ * @name    PWM configuration
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev      = TIM1,
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_E, 9),  .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_E, 11), .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_E, 13), .cc_chan = 2},
+                      { .pin = GPIO_PIN(PORT_E, 14), .cc_chan = 3} },
+        .af       = GPIO_AF1,
+        .bus      = APB2
+    },
+    {
+        .dev      = TIM4,
+        .rcc_mask = RCC_APB1LENR_TIM4EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_D, 12), .cc_chan = 0},
+                      { .pin = GPIO_PIN(PORT_D, 13), .cc_chan = 1},
+                      { .pin = GPIO_PIN(PORT_D, 14), .cc_chan = 2},
+                      { .pin = GPIO_PIN(PORT_D, 15), .cc_chan = 3} },
+        .af       = GPIO_AF2,
+        .bus      = APB1
+    },
+};
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -88,7 +88,7 @@ endif
 
 # Not all F4 and L0 parts implement a RNG.
 CPU_MODELS_WITHOUT_HWRNG = stm32f401% stm32f411% stm32f446% stm32l031% stm32l011%
-ifneq (,$(filter $(CPU_FAM),f2 f4 f7 g4 l0 l4 l5 u5 wb))
+ifneq (,$(filter $(CPU_FAM),f2 f4 f7 g4 h7 l0 l4 l5 u5 wb))
   ifeq (,$(filter $(CPU_MODELS_WITHOUT_HWRNG),$(CPU_MODEL)))
     FEATURES_PROVIDED += periph_hwrng
   endif

--- a/cpu/stm32/periph/Makefile
+++ b/cpu/stm32/periph/Makefile
@@ -2,7 +2,7 @@ MODULE = periph
 
 # Select the specific implementation for `periph_i2c`
 ifneq (,$(filter periph_i2c,$(USEMODULE)))
-  ifneq (,$(filter $(CPU_FAM),f0 f3 f7 g0 g4 l0 l4 l5 u5 wb wl c0))
+  ifneq (,$(filter $(CPU_FAM),f0 f3 f7 g0 g4 h7 l0 l4 l5 u5 wb wl c0))
     SRC += i2c_1.c
   else ifneq (,$(filter $(CPU_FAM),f1 f2 f4 l1))
     SRC += i2c_2.c
@@ -13,7 +13,9 @@ endif
 
 # Select the specific implementation for `periph_adc`
 ifneq (,$(filter periph_adc,$(USEMODULE)))
-  ifneq (,$(filter $(CPU_FAM),f4 f7))
+  ifneq (,$(filter $(CPU_FAM),f3 h7))
+    SRC += adc_f3_h7.c
+  else ifneq (,$(filter $(CPU_FAM),f4 f7))
     SRC += adc_f4_f7.c
   else ifneq (,$(filter $(CPU_FAM),f0 g0 c0))
     SRC += adc_f0_g0_c0.c

--- a/cpu/stm32/periph/hwrng.c
+++ b/cpu/stm32/periph/hwrng.c
@@ -35,6 +35,11 @@ void hwrng_read(void *buf, unsigned int num)
     unsigned int count = 0;
     uint8_t *b = (uint8_t *)buf;
 
+/* Select PLL1Q as RNG clock source for STM32H7 */
+#if defined(CPU_FAM_STM32H7)
+    RCC->D2CCIP2R |= RCC_D2CCIP2R_RNGSEL_0;
+#endif
+
     /* power on and enable the device */
 #if defined(CPU_LINE_STM32F410Rx)
     periph_clk_en(AHB1, RCC_AHB1ENR_RNGEN);

--- a/cpu/stm32/periph/i2c_1.c
+++ b/cpu/stm32/periph/i2c_1.c
@@ -63,6 +63,8 @@
 #define I2C_CLOCK_SRC_REG       (RCC->CCIPR1)
 #elif defined(RCC_DCKCFGR2_I2C1SEL)
 #define I2C_CLOCK_SRC_REG       (RCC->DCKCFGR2)
+#elif defined(RCC_D2CCIP2R_I2C123SEL)
+#  define I2C_CLOCK_SRC_REG     (RCC->D2CCIP2R)
 #endif
 
 static uint32_t hsi_state;
@@ -97,7 +99,8 @@ void i2c_init(i2c_t dev)
 
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3) || \
     defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L4) || \
-    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32WB)
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32WB) || \
+    defined(CPU_FAM_STM32H7)
     /* select I2C clock source */
     I2C_CLOCK_SRC_REG |= i2c_config[dev].rcc_sw_mask;
 #endif

--- a/cpu/stm32/periph/rtc_all.c
+++ b/cpu/stm32/periph/rtc_all.c
@@ -41,7 +41,7 @@
 
 /* map some EXTI register names */
 #if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
-    defined(CPU_FAM_STM32G4)
+    defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32H7)
 #  define EXTI_REG_RTSR     (EXTI->RTSR1)
 #  define EXTI_REG_FTSR     (EXTI->FTSR1)
 #  define EXTI_REG_PR       (EXTI->PR1)
@@ -123,6 +123,11 @@
 #  define EXTI_FTSR_BIT     (EXTI_FTSR1_FT11)
 #  define EXTI_RTSR_BIT     (EXTI_RTSR1_RT11)
 #  define EXTI_PR_BIT       (EXTI_RPR1_RPIF11)
+#elif defined(CPU_FAM_STM32H7)
+#  define EXTI_IMR_BIT        (EXTI_IMR1_IM17)
+#  define EXTI_RTSR_BIT       (EXTI_RTSR1_TR17)
+#  define EXTI_FTSR_BIT       (EXTI_FTSR1_TR17)
+#  define EXTI_PR_BIT         (EXTI_PR1_PR17)
 #else
 #  if defined(CPU_FAM_STM32L0)
 #    define EXTI_IMR_BIT    (EXTI_IMR_IM17)
@@ -288,6 +293,8 @@ void rtc_init(void)
     periph_clk_en(APB1, RCC_APBENR1_RTCAPBEN);
 #elif defined(CPU_FAM_STM32U5)
     periph_clk_en(APB3, RCC_APB3ENR_RTCAPBEN);
+#elif defined(CPU_FAM_STM32H7)
+    periph_clk_en(APB4, RCC_APB4ENR_RTCAPBEN);
 #endif
 
 #if IS_ACTIVE(CONFIG_BOARD_HAS_LSE)

--- a/cpu/stm32/periph/uart.c
+++ b/cpu/stm32/periph/uart.c
@@ -424,7 +424,6 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
             dev(uart)->CR3 |= USART_CR3_DMAT;
             dma_transfer(uart_config[uart].dma, uart_config[uart].dma_chan, data,
                          (void *)&dev(uart)->TDR_REG, len, DMA_MEM_TO_PERIPH, DMA_INC_SRC_ADDR);
-
             /* make sure the function is synchronous by waiting for the transfer to
              * finish */
             wait_for_tx_complete(uart);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR adds further peripheral support for the nucleo-h753zi board.
The following drivers and low-level implementations are introduced:

- PWM
- HWRNG
- RTC
- SPI
- I2C
- ADC
- DMA

**Note on ADC, PWM and DMA:**
The ADC, PWM, and DMA implementations are based directly on prior work by @Enoch247. The code was kept largely unchanged, with only minor modifications required for ADC and DMA.