### PR TITLE
cpu/efm32: remove i2c clock 'reset'

### DIFF
--- a/cpu/efm32/periph/i2c.c
+++ b/cpu/efm32/periph/i2c.c
@@ -112,12 +112,6 @@ void i2c_init(i2c_t dev)
     gpio_init(i2c_config[dev].scl_pin, GPIO_OD);
     gpio_init(i2c_config[dev].sda_pin, GPIO_OD);
 
-    /* ensure slave is in a known state, which it may not be after a reset */
-    for (int i = 0; i < 9; i++) {
-        gpio_set(i2c_config[dev].scl_pin);
-        gpio_clear(i2c_config[dev].scl_pin);
-    }
-
     /* reset and initialize the peripheral */
     I2C_Init_TypeDef init = I2C_INIT_DEFAULT;
 


### PR DESCRIPTION
### Contribution description

This was copied from the [Gecko SDK I2C driver](https://github.com/SiliconLabs/gecko_sdk/blob/gsdk_4.5/hardware/kit/common/drivers/i2cspm.c#L110) back in the days, but it does not add any proven value:

- It does not take into account clock frequency (there should be delays in between)
- No other drivers have this
- It works without

Removing this saves about 24-52 bytes (depending on series).


### Testing procedure

Take any EFM32-based board, ant interact with I2C.


### Issues/PRs references

None.
