### PR TITLE
boards/slstk3402a: expose SPI1 for on-board LCD

### DIFF
--- a/boards/slstk3402a/doc.md
+++ b/boards/slstk3402a/doc.md
@@ -66,7 +66,8 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | HWRNG      | &mdash; | TNRG0             |                                | Hardware-based true random number generator              |
 | RTT        | &mdash; | RTCC              |                                | 1 Hz interval. Either RTT or RTC (see below)             |
 | RTC        | &mdash; | RTCC              |                                | 1 Hz interval. Either RTC or RTT (see below)             |
-| SPI        | 0       | USART1            | MOSI: PC6, MISO: PC7, CLK: PC8 |                                                          |
+| SPI        | 0       | USART2            | MOSI: PA6, MISO: PA7, CLK: PA8 |                                                          |
+|            | 1       | USART1            | MOSI: PC6, MISO: PC7, CLK: PC8 | On-board LCD                                             |
 | Timer      | 0       | WTIMER0 + WTIMER1 |                                | WTIMER0 is used as prescaler (must be adjacent)          |
 | Timer      | 1       | TIMER0 + TIMER1   |                                | TIMER0 is used as prescaler (must be adjacent)           |
 |            | 2       | LETIMER0          |                                |                                                          |

--- a/boards/slstk3402a/include/board.h
+++ b/boards/slstk3402a/include/board.h
@@ -98,7 +98,7 @@ extern "C" {
  * Connection to the on-board Sharp Memory LCD (LS013B7DH03).
  * @{
  */
-#define DISP_SPI            SPI_DEV(0)
+#define DISP_SPI            SPI_DEV(1)
 #define DISP_COM_PIN        GPIO_PIN(PD, 13)
 #define DISP_CS_PIN         GPIO_PIN(PD, 14)
 #define DISP_EN_PIN         GPIO_PIN(PD, 15)

--- a/boards/slstk3402a/include/periph_conf.h
+++ b/boards/slstk3402a/include/periph_conf.h
@@ -120,6 +120,17 @@ static const spi_dev_t spi_config[] = {
                USART_ROUTELOC0_CLKLOC_LOC1,
         .cmu = cmuClock_USART2,
         .irq = USART2_RX_IRQn
+    },
+    {
+        .dev = USART1,
+        .mosi_pin = GPIO_PIN(PC, 6),
+        .miso_pin = GPIO_PIN(PC, 7),
+        .clk_pin = GPIO_PIN(PC, 8),
+        .loc = USART_ROUTELOC0_RXLOC_LOC11 |
+               USART_ROUTELOC0_TXLOC_LOC11 |
+               USART_ROUTELOC0_CLKLOC_LOC11,
+        .cmu = cmuClock_USART1,
+        .irq = USART1_RX_IRQn
     }
 };
 


### PR DESCRIPTION
### Contribution description

While testing an upcoming U8g2 package upgrade for the on-board display of the SLSTK3402a, I realised that it was not exposed correctly. The documentation correctly mentioned the pin-out for the on-board LCD, but `periph_conf.h` exposed the SPI pins for the expansion port only.

~~I decided to stick with the pins on the documentation, because that keeps the USARTs in order, ensures the on-board peripherals have lower peripheral index and pleases my OCD.~~

SPI1 is now added, and connects to the on-board LCD. The documentation has been updated.

<details>
<summary>LCD pin-out</summary>
<img width="957" height="552" alt="Scherm­afbeelding 2026-02-15 om 10 27 41" src="https://github.com/user-attachments/assets/88b07a8f-bac5-4a94-93e6-6503333f6a2d" />
</details>

<details>
<summary>Expansion port pinout (US2 == SPI1)</summary>
<img width="1305" height="263" alt="Scherm­afbeelding 2026-02-15 om 10 29 03" src="https://github.com/user-attachments/assets/364c123e-1144-4b4a-bb41-497711fb78a5" />
</details>

<details>
<summary>Pin location mapping</summary>
<img width="1028" height="1010" alt="Scherm­afbeelding 2026-02-15 om 10 32 35" src="https://github.com/user-attachments/assets/90975dfd-ae6e-49b0-917f-160bf3c14111" />

<img width="1074" height="946" alt="Scherm­afbeelding 2026-02-15 om 10 33 42" src="https://github.com/user-attachments/assets/021347f4-cea5-45da-a17a-c661ff031384" />
</details>

<details>
<summary>Test/Proof that LCD now works</summary>

![IMG_6386](https://github.com/user-attachments/assets/ef72b187-f6f0-40c1-8bba-fb4f3c719861)

</details>


### Testing procedure

The U8g2 test in `tests/pkg/u8g2` needs to enable the on-board display:

Somewhere in the `main` method,

```
gpio_init(DISP_EN_PIN, GPIO_OUT);
gpio_init(DISP_COM_PIN, GPIO_OUT);
gpio_set(DISP_EN_PIN);
```

Then compile with:

```
TEST_OUTPUT=3 TEST_PIN_CS="GPIO_PIN\(PD,14\)" TEST_DISPLAY="u8g2_Setup_ls013b7dh03_128x128_f"  BOARD="slstk3402a" make flash
```

### Issues/PRs references

None
