### PR TITLE
pkg/ficl: new package

### DIFF
--- a/dist/tools/codespell/ignored_words.txt
+++ b/dist/tools/codespell/ignored_words.txt
@@ -192,3 +192,6 @@ emac
 
 # For some reason it looked at some binary dump and found this to be a word...
 joo
+
+# ANS (American National Standard) ==> AND
+ans

--- a/examples/lang_support/community/forth_REPL/Makefile
+++ b/examples/lang_support/community/forth_REPL/Makefile
@@ -1,0 +1,32 @@
+# name of your application
+APPLICATION = ficl_repl
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../../../..
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+# select ficl package
+USEPKG += ficl
+
+# Modules to include:
+USEMODULE += shell
+USEMODULE += ztimer_msec
+
+# For now `examples/%/tests" still rely on the test applicaton being reset after
+# a terminal is opened to synchronize.
+TESTRUNNER_RESET_AFTER_TERM ?= 1
+
+# avoid running Kconfig by default
+SHOULD_RUN_KCONFIG ?=
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/lang_support/community/forth_REPL/Makefile.ci
+++ b/examples/lang_support/community/forth_REPL/Makefile.ci
@@ -1,0 +1,14 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-c031c6 \
+    nucleo-f031k6 \
+    nucleo-f042k6 \
+    nucleo-l011k4 \
+    nucleo-l031k6 \
+    samd10-xmini \
+    stk3200 \
+    stm32c0116-dk \
+    stm32c0316-dk \
+    stm32f030f4-demo \
+    stm32g0316-disco \
+    weact-g030f6 \
+    #

--- a/examples/lang_support/community/forth_REPL/README.md
+++ b/examples/lang_support/community/forth_REPL/README.md
@@ -1,0 +1,19 @@
+## Forth/Ficl interactive interpreter
+
+### About
+
+This example shows how to run a [Ficl](https://ficl.sourceforge.net/index.html) Read-Eval-Print loop.
+
+### How to run
+
+Type `make all flash` to program your board. The ficl interpreter communicates
+via UART (like the shell).
+
+It is not recommended to use `make term` because the default RIOT terminal messes
+up the input. Instead, use a real terminal like gtkterm or picocom.
+
+### Using the interpreter
+
+See the [forth tutorial](https://learnxinyminutes.com/forth/) for the syntax of the language.
+
+The word `led0` controls the internal LED0 on the board.

--- a/examples/lang_support/community/forth_REPL/ficl_custom.c
+++ b/examples/lang_support/community/forth_REPL/ficl_custom.c
@@ -1,0 +1,1 @@
+../forth_blinky/ficl_custom.c

--- a/examples/lang_support/community/forth_REPL/main.c
+++ b/examples/lang_support/community/forth_REPL/main.c
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Francois Perrad
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#include "ficl.h"
+#include "shell.h"
+
+int main(void)
+{
+    char in[80] = { 0 };
+    FICL_SYSTEM *pSys = ficlInitSystem(4096);
+    FICL_VM *pVM = ficlNewVM(pSys);
+    int ret = ficlEvaluate(pVM, ".ver 2 spaces .( " __DATE__ " ) cr");
+
+    while (ret != VM_USEREXIT && shell_readline(in, sizeof(in)) >= 0) {
+        ret = ficlExec(pVM, in);
+    }
+
+    ficlTermSystem(pSys);
+    return 0;
+}

--- a/examples/lang_support/community/forth_blinky/Makefile
+++ b/examples/lang_support/community/forth_blinky/Makefile
@@ -1,0 +1,34 @@
+# name of your application
+APPLICATION = ficl_blinky
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../../../..
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+# select ficl package
+USEPKG += ficl
+
+# Modules to include:
+USEMODULE += ztimer_msec
+
+# For now `examples/%/tests" still rely on the test applicaton being reset after
+# a terminal is opened to synchronize.
+TESTRUNNER_RESET_AFTER_TERM ?= 1
+
+# avoid running Kconfig by default
+SHOULD_RUN_KCONFIG ?=
+
+# generate .f.h header files of .f files
+BLOBS += $(wildcard *.f)
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/lang_support/community/forth_blinky/Makefile.ci
+++ b/examples/lang_support/community/forth_blinky/Makefile.ci
@@ -1,0 +1,14 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    nucleo-c031c6 \
+    nucleo-f031k6 \
+    nucleo-f042k6 \
+    nucleo-l011k4 \
+    nucleo-l031k6 \
+    samd10-xmini \
+    stk3200 \
+    stm32c0116-dk \
+    stm32c0316-dk \
+    stm32f030f4-demo \
+    stm32g0316-disco \
+    weact-g030f6 \
+    #

--- a/examples/lang_support/community/forth_blinky/README.md
+++ b/examples/lang_support/community/forth_blinky/README.md
@@ -1,0 +1,20 @@
+### About
+
+This example shows how to write IoT applications using Forth.
+
+### How to extend
+
+In the function `ficlCompilePlatform` registers all C defined words
+with `dictAppendWord`.
+
+### How to use
+
+Put your Forth code into "main.f" (check the example). The file will
+be included in your application as an ASCII byte array (see BLOBS in the
+Makefile).
+
+The script will then be run immediately after RIOT has started up.
+
+### How to run
+
+Type `make flash term`

--- a/examples/lang_support/community/forth_blinky/ficl_custom.c
+++ b/examples/lang_support/community/forth_blinky/ficl_custom.c
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Francois Perrad
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#include "ficl.h"
+#include "led.h"
+#include "ztimer.h"
+
+static void led0(FICL_VM *pVM)
+{
+#if FICL_ROBUST > 1
+    vmCheckStack(pVM, 1, 0);
+#endif
+    if (POPINT() > 0) {
+        LED0_ON;
+    }
+    else {
+        LED0_OFF;
+    }
+    return;
+}
+
+static void ms(FICL_VM *pVM)
+{
+#if FICL_ROBUST > 1
+    vmCheckStack(pVM, 1, 0);
+#endif
+    ztimer_sleep(ZTIMER_MSEC, POPUNS());
+    return;
+}
+
+void ficlCompilePlatform(FICL_SYSTEM *pSys)
+{
+    FICL_DICT *dp = pSys->dp;
+
+    assert(dp);
+
+    dictAppendWord(dp, "led0",      led0,           FW_DEFAULT);
+    dictAppendWord(dp, "ms",        ms,             FW_DEFAULT);
+    return;
+}

--- a/examples/lang_support/community/forth_blinky/main.c
+++ b/examples/lang_support/community/forth_blinky/main.c
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Francois Perrad
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#include "ficl.h"
+
+#include "blob/main.f.h"
+
+int main(void)
+{
+    FICL_SYSTEM *pSys = ficlInitSystem(4096);
+    FICL_VM *pVM = ficlNewVM(pSys);
+    ficlEvaluate(pVM, (char *)main_f);
+    return 0;
+}

--- a/examples/lang_support/community/forth_blinky/main.f
+++ b/examples/lang_support/community/forth_blinky/main.f
@@ -1,0 +1,9 @@
+: blink
+	1 led0
+	500 ms
+	0 led0
+	500 ms
+	;
+: run begin blink again ;
+
+run

--- a/pkg/ficl/Makefile
+++ b/pkg/ficl/Makefile
@@ -1,0 +1,57 @@
+PKG_NAME = ficl
+PKG_URL = https://github.com/jwsadler58/ficl.git
+PKG_VERSION = 59a03fae46c342edd173fcb9bacdebdf3c34ded2 # ficl306-166-g59a03fa
+
+PKG_LICENSE=BSD-3-Clause
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+CFLAGS += -Wno-array-bounds
+CFLAGS += -Wno-char-subscripts
+CFLAGS += -Wno-cast-align
+CFLAGS += -Wno-format-nonliteral
+CFLAGS += -Wno-strict-aliasing
+CFLAGS += -Wno-unused-but-set-variable
+
+#
+#   Configuration
+#
+CFLAGS += -DFICL_WANT_SOFTWORDS=1
+CFLAGS += -DFICL_WANT_FILE=0
+CFLAGS += -DFICL_WANT_FLOAT=0
+CFLAGS += -DFICL_WANT_INTERRUPT=1
+CFLAGS += -DFICL_WANT_USER=0
+CFLAGS += -DFICL_WANT_LOCALS=0
+CFLAGS += -DFICL_WANT_OOP=0
+CFLAGS += -DFICL_ROBUST=2
+CFLAGS += -DFICL_EXTENDED_PREFIX=0
+
+# includes custom part with ficlCompilePlatform()
+CFLAGS += -DFICL_PLATFORM_EXTEND=1
+
+#
+# Port (ficlTextOut, ficlMalloc, ficlFree, ficlRealloc), see sysdep.c
+#
+CFLAGS += -Dlinux
+
+export SRC := \
+  dict.c \
+  ficl.c \
+  fileaccess.c \
+  float.c \
+  dpmath.c \
+  prefix.c \
+  search.c \
+  softcore.c \
+  stack.c \
+  sysdep.c \
+  tools.c \
+  vm.c \
+  words.c
+
+all: softcore_c
+	$(MAKE) -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base
+
+softcore_c:
+	$(MAKE) -C $(PKG_SOURCE_DIR)/softwords softcore.c
+	cp $(PKG_SOURCE_DIR)/softwords/softcore.c $(PKG_SOURCE_DIR)/softcore.c

--- a/pkg/ficl/Makefile.dep
+++ b/pkg/ficl/Makefile.dep
@@ -1,0 +1,5 @@
+# Ficl Target: 32 & 64 bit processors
+FEATURES_REQUIRED_ANY += arch_32bit|arch_64bit
+
+# Ficl uses sprintf() with format non literal
+FEATURES_BLACKLIST += arch_avr8

--- a/pkg/ficl/Makefile.include
+++ b/pkg/ficl/Makefile.include
@@ -1,0 +1,1 @@
+INCLUDES += -I$(PKGDIRBASE)/ficl

--- a/pkg/ficl/doc.md
+++ b/pkg/ficl/doc.md
@@ -1,0 +1,38 @@
+<!--
+SPDX-FileCopyrightText: 2026 Francois Perrad
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+
+@defgroup pkg_ficl ficl
+@ingroup  pkg
+@brief    a lightweight, embeddable scripting language designed to be embedded.
+@see      https://github.com/jwsadler58/ficl
+@see      https://ficl.sourceforge.net/
+
+# Forth programming language support
+
+## Introduction
+
+Ficl (Forth-inspired command language) is an ANS Forth
+interpreter written in C. Unlike traditional Forths, this
+interpreter is designed to be embedded into other systems
+as a command/macro/development prototype language.
+
+@note     Many of the RIOT features are not directly available to forth code,
+but first need to be exposed to ficl by writing some glue code.
+See examples in examples/lang_support/community/forth_*.
+
+## Typical use
+
+```c
+    char in[80] = { 0 };
+    FICL_SYSTEM *pSys = ficlInitSystem(4096);
+    FICL_VM *pVM = ficlNewVM(pSys);
+    int ret = ficlEvaluate(pVM, ".ver 2 spaces .( " __DATE__ " ) cr");
+
+    while (ret != VM_USEREXIT && shell_readline(in, sizeof(in)) >= 0) {
+        ret = ficlExec(pVM, in);
+    }
+
+    ficlTermSystem(pSys);
+```


### PR DESCRIPTION
### Contribution description

- add new package ficl (a Forth language variant), from https://github.com/jwsadler58/ficl
- add 2 new examples: forth_blinky & forth_REPL

### Testing procedure

Currently tested on `native` & `rpi-pico`

### Issues/PRs references

none