### PR TITLE
cpu/stm32h7,boards/nucleo-h753zi: Add support for `periph_vbat`, fix ADC bug

### DIFF
--- a/boards/nucleo-h753zi/Makefile.features
+++ b/boards/nucleo-h753zi/Makefile.features
@@ -10,6 +10,7 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_vbat
 FEATURES_PROVIDED += periph_wdt
 
 # load the common Makefile.features for Nucleo boards

--- a/cpu/stm32/periph/adc_f3_h7.c
+++ b/cpu/stm32/periph/adc_f3_h7.c
@@ -42,16 +42,16 @@
 #define ADC_SMPR2_FIRST_CHAN (10)
 
 #ifdef ADC1_COMMON
-#define ADC_INSTANCE    ADC1_COMMON
+#  define ADC_INSTANCE  ADC1_COMMON
 #else
-#define ADC_INSTANCE    ADC12_COMMON
+#  define ADC_INSTANCE  ADC12_COMMON
 #endif
 
 /**
  * @brief   Default VBAT undefined value
  */
 #ifndef VBAT_ADC
-#define VBAT_ADC    ADC_UNDEF
+#  define VBAT_ADC  ADC_UNDEF
 #endif
 
 /**
@@ -91,8 +91,8 @@ static inline ADC_TypeDef *dev(adc_t line)
 static inline void prep(adc_t line)
 {
     mutex_lock(&locks[adc_config[line].dev]);
-/* Enable the clock here only if it will be disabled by done, else just
- * enable it once in adc_init() */
+    /* Enable the clock here only if it will be disabled by done, else just
+     * enable it once in adc_init() */
 #if defined(RCC_AHBENR_ADC1EN)
     periph_clk_en(AHB, RCC_AHBENR_ADC1EN);
 #endif
@@ -100,8 +100,8 @@ static inline void prep(adc_t line)
 
 static inline void done(adc_t line)
 {
-/* On some STM32F3 ADC are grouped by paire (ADC12EN or ADC34EN) so
- * don't disable the clock as the other device may still use it. */
+    /* On some STM32F3 ADC are grouped by paire (ADC12EN or ADC34EN) so
+     * don't disable the clock as the other device may still use it. */
 #if defined(RCC_AHBENR_ADC1EN)
     periph_clk_dis(AHB, RCC_AHBENR_ADC1EN);
 #endif

--- a/cpu/stm32/periph/adc_f3_h7.c
+++ b/cpu/stm32/periph/adc_f3_h7.c
@@ -236,13 +236,15 @@ int adc_init(adc_t line)
 
     /* Configure sampling time for the given channel */
     if (adc_config[line].chan < 10) {
-        dev(line)->SMPR1 = (smp_time << (adc_config[line].chan
-                                        * ADC_SMP_BIT_WIDTH));
+        uint8_t shift = adc_config[line].chan * ADC_SMP_BIT_WIDTH;
+        uint32_t mask = ~(ADC_SMPR1_SMP0 << shift);
+        dev(line)->SMPR1 = (dev(line)->SMPR1 & mask) | (smp_time << shift);
     }
     else {
-        dev(line)->SMPR2 = (smp_time << ((adc_config[line].chan
-                                        - ADC_SMPR2_FIRST_CHAN)
-                                        * ADC_SMP_BIT_WIDTH));
+        uint8_t shift = (adc_config[line].chan - ADC_SMPR2_FIRST_CHAN)
+                                               * ADC_SMP_BIT_WIDTH;
+        uint32_t mask = ~(ADC_SMPR2_SMP10 << shift);
+        dev(line)->SMPR2 = (dev(line)->SMPR2 & mask) | (smp_time << shift);
     }
 
     /* Power off and unlock device again */

--- a/cpu/stm32/periph/vbat.c
+++ b/cpu/stm32/periph/vbat.c
@@ -99,6 +99,10 @@
       defined(CPU_LINE_STM32GBK1CB)
 #  define VBAT_ADC_SCALE      3
 #  define VBAT_ADC_MIN_MV     1550
+/* h7 */
+#elif defined(CPU_LINE_STM32H723xx) || defined(CPU_LINE_STM32H753xx)
+#  define VBAT_ADC_SCALE      4
+#  define VBAT_ADC_MIN_MV     1360
 /* l4 */
 #elif defined(CPU_LINE_STM32L412xx) || defined(CPU_LINE_STM32L422xx)    || \
       defined(CPU_LINE_STM32L431xx) || defined(CPU_LINE_STM32L432xx)    || \
@@ -146,6 +150,8 @@
  */
 #if defined(CPU_LINE_STM32F373xC) || defined(CPU_LINE_STM32F378xx)
 #  define ADC_CCR_REG (SYSCFG->CFGR1) /* ADCx_COMMON is also defined */
+#elif defined(CPU_FAM_STM32H7)
+#  define ADC_CCR_REG (ADC3_COMMON->CCR) /* STM32H7 uses ADC3 for VBAT */
 #elif defined(ADC_COMMON)
 #  define ADC_CCR_REG (ADC_COMMON->CCR)
 #elif defined(ADC1_COMMON)

--- a/cpu/stm32/periph/vbat.c
+++ b/cpu/stm32/periph/vbat.c
@@ -36,13 +36,13 @@
       defined(CPU_LINE_STM32F071xB) || defined(CPU_LINE_STM32F072xB)    || \
       defined(CPU_LINE_STM32F078xx) || defined(CPU_LINE_STM32F091xC)    || \
       defined(CPU_LINE_STM32F098xx)
-#define VBAT_ADC_SCALE        2
-#define VBAT_ADC_MIN_MV       1650
+#  define VBAT_ADC_SCALE      2
+#  define VBAT_ADC_MIN_MV     1650
 /* f2 */
 #elif defined(CPU_LINE_STM32F205xx) || defined(CPU_LINE_STM32F207xx)    || \
       defined(CPU_LINE_STM32F215xx) || defined(CPU_LINE_STM32F217xx)
-#define VBAT_ADC_SCALE        2
-#define VBAT_ADC_MIN_MV       1800
+#  define VBAT_ADC_SCALE      2
+#  define VBAT_ADC_MIN_MV     1800
 /* f3 */
 #elif defined(CPU_LINE_STM32F301x8) || defined(CPU_LINE_STM32F302x8)    || \
       defined(CPU_LINE_STM32F302xC) || defined(CPU_LINE_STM32F302xE)    || \
@@ -52,8 +52,8 @@
       defined(CPU_LINE_STM32F334x8) || defined(CPU_LINE_STM32F358xx)    || \
       defined(CPU_LINE_STM32F373xC) || defined(CPU_LINE_STM32F378xx)    || \
       defined(CPU_LINE_STM32F398xx)
-#define VBAT_ADC_SCALE        2
-#define VBAT_ADC_MIN_MV       1650
+#  define VBAT_ADC_SCALE      2
+#  define VBAT_ADC_MIN_MV     1650
 /* f4 */
 #elif defined(CPU_LINE_STM32F401xC) || defined(CPU_LINE_STM32F401xE)    || \
       defined(CPU_LINE_STM32F410Cx) || defined(CPU_LINE_STM32F410Rx)    || \
@@ -65,12 +65,12 @@
       defined(CPU_LINE_STM32F437xx) || defined(CPU_LINE_STM32F439xx)    || \
       defined(CPU_LINE_STM32F446xx) || defined(CPU_LINE_STM32F469xx)    || \
       defined(CPU_LINE_STM32F479xx)
-#define VBAT_ADC_SCALE        4
-#define VBAT_ADC_MIN_MV       1650
+#  define VBAT_ADC_SCALE      4
+#  define VBAT_ADC_MIN_MV     1650
 #elif defined(CPU_LINE_STM32F405xx) || defined(CPU_LINE_STM32F407xx)    || \
       defined(CPU_LINE_STM32F415xx) || defined(CPU_LINE_STM32F417xx)
-#define VBAT_ADC_SCALE        2
-#define VBAT_ADC_MIN_MV       1650
+#  define VBAT_ADC_SCALE      2
+#  define VBAT_ADC_MIN_MV     1650
 /* f7 */
 #elif defined(CPU_LINE_STM32F722xx) || defined(CPU_LINE_STM32F723xx)    || \
       defined(CPU_LINE_STM32F730xx) || defined(CPU_LINE_STM32F732xx)    || \
@@ -79,8 +79,8 @@
       defined(CPU_LINE_STM32F756xx) || defined(CPU_LINE_STM32F765xx)    || \
       defined(CPU_LINE_STM32F767xx) || defined(CPU_LINE_STM32F769xx)    || \
       defined(CPU_LINE_STM32F777xx) || defined(CPU_LINE_STM32F779xx)
-#define VBAT_ADC_SCALE        4
-#define VBAT_ADC_MIN_MV       1650
+#  define VBAT_ADC_SCALE      4
+#  define VBAT_ADC_MIN_MV     1650
 /* g0 */
 #elif defined(CPU_LINE_STM32G030xx) || defined(CPU_LINE_STM32G031xx)    || \
       defined(CPU_LINE_STM32G041xx) || defined(CPU_LINE_STM32G050xx)    || \
@@ -88,8 +88,8 @@
       defined(CPU_LINE_STM32G070xx) || defined(CPU_LINE_STM32G071xx)    || \
       defined(CPU_LINE_STM32G081xx) || defined(CPU_LINE_STM32G0B0xx)    || \
       defined(CPU_LINE_STM32G0B1xx) || defined(CPU_LINE_STM32G0C1xx)
-#define VBAT_ADC_SCALE        3
-#define VBAT_ADC_MIN_MV       1550
+#  define VBAT_ADC_SCALE      3
+#  define VBAT_ADC_MIN_MV     1550
 /* g4 */
 #elif defined(CPU_LINE_STM32G431xx) || defined(CPU_LINE_STM32G441xx)    || \
       defined(CPU_LINE_STM32G471xx) || defined(CPU_LINE_STM32G473xx)    || \
@@ -97,8 +97,8 @@
       defined(CPU_LINE_STM32G484xx) || defined(CPU_LINE_STM32G491xx)    || \
       defined(CPU_LINE_STM32G4A1xx) || defined(CPU_LINE_STM32G441xx)    || \
       defined(CPU_LINE_STM32GBK1CB)
-#define VBAT_ADC_SCALE        3
-#define VBAT_ADC_MIN_MV       1550
+#  define VBAT_ADC_SCALE      3
+#  define VBAT_ADC_MIN_MV     1550
 /* l4 */
 #elif defined(CPU_LINE_STM32L412xx) || defined(CPU_LINE_STM32L422xx)    || \
       defined(CPU_LINE_STM32L431xx) || defined(CPU_LINE_STM32L432xx)    || \
@@ -113,30 +113,30 @@
       defined(CPU_LINE_STM32L4R7xx) || defined(CPU_LINE_STM32L4R9xx)    || \
       defined(CPU_LINE_STM32L4S5xx) || defined(CPU_LINE_STM32L4S7xx)    || \
       defined(CPU_LINE_STM32L4S9xx)
-#define VBAT_ADC_SCALE        3
-#define VBAT_ADC_MIN_MV       1550
+#  define VBAT_ADC_SCALE      3
+#  define VBAT_ADC_MIN_MV     1550
 /* l5 */
 #elif defined(CPU_LINE_STM32L552xx) || defined(CPU_LINE_STM32L562xx)
-#define VBAT_ADC_SCALE        3
-#define VBAT_ADC_MIN_MV       1550
+#  define VBAT_ADC_SCALE      3
+#  define VBAT_ADC_MIN_MV     1550
 /* u5 */
 #elif defined(CPU_LINE_STM32U575xx) || defined(CPU_LINE_STM32U585xx)
-#define VBAT_ADC_SCALE        4
-#define VBAT_ADC_MIN_MV       1650
+#  define VBAT_ADC_SCALE      4
+#  define VBAT_ADC_MIN_MV     1650
 /* wb */
 #elif defined(CPU_LINE_STM32WB10xx) || defined(CPU_LINE_STM32WB15xx)    || \
       defined(CPU_LINE_STM32WB30xx) || defined(CPU_LINE_STM32WB35xx)    || \
       defined(CPU_LINE_STM32WB50xx) || defined(CPU_LINE_STM32WB55xx)    || \
       defined(CPU_LINE_STM32WB5Mxx)
-#define VBAT_ADC_SCALE        3
-#define VBAT_ADC_MIN_MV       1550
+#  define VBAT_ADC_SCALE      3
+#  define VBAT_ADC_MIN_MV     1550
 /* wl */
 #elif defined(CPU_LINE_STM32WL54xx) || defined(CPU_LINE_STM32WL55xx)    || \
       defined(CPU_LINE_STM32WLE4xx) || defined(CPU_LINE_STM32WLE5xx)
-#define VBAT_ADC_SCALE        3
-#define VBAT_ADC_MIN_MV       1550
+#  define VBAT_ADC_SCALE      3
+#  define VBAT_ADC_MIN_MV     1550
 #else
-#error "VBAT: CPU line is not supported so far."
+#  error "VBAT: CPU line is not supported so far."
 #endif
 /** @} */
 
@@ -145,21 +145,21 @@
  * @{
  */
 #if defined(CPU_LINE_STM32F373xC) || defined(CPU_LINE_STM32F378xx)
-#define ADC_CCR_REG (SYSCFG->CFGR1) /* ADCx_COMMON is also defined */
+#  define ADC_CCR_REG (SYSCFG->CFGR1) /* ADCx_COMMON is also defined */
 #elif defined(ADC_COMMON)
-#define ADC_CCR_REG (ADC_COMMON->CCR)
+#  define ADC_CCR_REG (ADC_COMMON->CCR)
 #elif defined(ADC1_COMMON)
-#define ADC_CCR_REG (ADC1_COMMON->CCR)
+#  define ADC_CCR_REG (ADC1_COMMON->CCR)
 #elif defined(ADC12_COMMON)
-#define ADC_CCR_REG (ADC12_COMMON->CCR)
+#  define ADC_CCR_REG (ADC12_COMMON->CCR)
 #elif defined(ADC123_COMMON)
-#define ADC_CCR_REG (ADC123_COMMON->CCR)
+#  define ADC_CCR_REG (ADC123_COMMON->CCR)
 #elif defined(ADC12_COMMON_NS)
-#define ADC_CCR_REG (ADC12_COMMON_NS->CCR)
+#  define ADC_CCR_REG (ADC12_COMMON_NS->CCR)
 #elif defined(ADC)
-#define ADC_CCR_REG (ADC->CCR)
+#  define ADC_CCR_REG (ADC->CCR)
 #else
-#error "VBAT: CPU line is not supported so far."
+#  error "VBAT: CPU line is not supported so far."
 #endif
 /** @} */
 
@@ -168,20 +168,20 @@
  * @{
  */
 #if defined(ADC_CCR_VBATEN)
-#define VBAT_ENABLE ADC_CCR_VBATEN;
+#  define VBAT_ENABLE ADC_CCR_VBATEN
 #elif defined(ADC_CCR_VBATE)
-#define VBAT_ENABLE ADC_CCR_VBATE;
+#  define VBAT_ENABLE ADC_CCR_VBATE
 #elif defined(ADC_CCR_VBATSEL)
-#define VBAT_ENABLE ADC_CCR_VBATSEL;
+#  define VBAT_ENABLE ADC_CCR_VBATSEL
 #elif defined(SYSCFG_CFGR1_VBAT)
-#define VBAT_ENABLE SYSCFG_CFGR1_VBAT;
+#  define VBAT_ENABLE SYSCFG_CFGR1_VBAT
 #else
-#error "VBAT: CPU line is not supported so far."
+#  error "VBAT: CPU line is not supported so far."
 #endif
 /** @} */
 
 #ifndef CONFIG_VBAT_ADC_VREF_MV
-#define CONFIG_VBAT_ADC_VREF_MV 3300            /**< ADC reference voltage */
+#  define CONFIG_VBAT_ADC_VREF_MV 3300          /**< ADC reference voltage */
 #endif
 
 /**
@@ -196,7 +196,7 @@ int32_t __attribute__((weak)) vref_mv(void) {
 }
 
 #ifndef VBAT_ADC
-#error "VBAT: Add internal VBAT ADC line to adc_config[] and #define VBAT_ADC."
+#  error "VBAT: Add internal VBAT ADC line to adc_config[] and #define VBAT_ADC."
 #endif
 
 int vbat_init(void)


### PR DESCRIPTION
### Contribution description

While doing the review of #22076, I played around with adding `periph_vbat` as a supported peripheral.

During the process I noticed that the sampling registers are overridden every time a new channel is configured, which kind of defeats the purpose.

Also some indentation updates were done.


### Testing procedure

To see the sampling register bug, I added a `printf` statement after setting the SMPS registers:
```
printf("ADC%d: SMPR1: %ld, SMPR2: %ld\n", adc_config[line].dev+1, dev(line)->SMPR1, dev(line)->SMPR2);
```

This is the behavior in the current master branch when running the `tests/periph/adc` on the `nucleo-h753zi`. Note that you might have to reset the board in order to catch the initial message.
As you can see, the SMPR registers are reset/overridden by every new entry. Not quite what we want.
```
2026-02-18 13:34:51,236 #
2026-02-18 13:34:51,443 # main(): This is RIOT! (Version: 2026.04-devel-109-g2bba1-add_stm32h7_advance_1)
2026-02-18 13:34:51,443 #
2026-02-18 13:34:51,446 # RIOT ADC peripheral driver test
2026-02-18 13:34:51,446 #
2026-02-18 13:34:51,453 # This test will sample all available ADC lines once every 100ms with
2026-02-18 13:34:51,457 # 6 to 16-bit resolution and print the sampled results to STDOUT.
2026-02-18 13:34:51,463 # Not all MCUs support all resolutions, unsupported resolutions
2026-02-18 13:34:51,464 # are printed as -1.
2026-02-18 13:34:51,465 #
2026-02-18 13:34:51,470 # ADC1: SMPR1: 0, SMPR2: 65536
2026-02-18 13:34:51,473 # Successfully initialized ADC_LINE(0)
2026-02-18 13:34:51,479 # ADC2: SMPR1: 0, SMPR2: 2
2026-02-18 13:34:51,481 # Successfully initialized ADC_LINE(1)
2026-02-18 13:34:51,485 # ADC1: SMPR1: 0, SMPR2: 1024
2026-02-18 13:34:51,487 # Successfully initialized ADC_LINE(2)
2026-02-18 13:34:51,489 # ADC2: SMPR1: 65536, SMPR2: 2
2026-02-18 13:34:51,493 # Successfully initialized ADC_LINE(3)
2026-02-18 13:34:51,495 # ADC1: SMPR1: 0, SMPR2: 128
2026-02-18 13:34:51,498 # Successfully initialized ADC_LINE(4)
2026-02-18 13:34:51,504 # ADC3: SMPR1: 524288, SMPR2: 0
2026-02-18 13:34:51,507 # Successfully initialized ADC_LINE(5)
2026-02-18 13:34:51,510 # ADC3: SMPR1: 524288, SMPR2: 4194304
2026-02-18 13:34:51,513 # Successfully initialized ADC_LINE(6)
2026-02-18 13:34:51,518 # ADC_LINE(0): -1  31  149  669  2928 12678
2026-02-18 13:34:51,520 # ADC_LINE(1): -1   4   67  371  2102  9449
2026-02-18 13:34:51,524 # ADC_LINE(2): -1  13   91  479  2329 10660
...
```

This is the behavior with the fix applied. The initial message is from the auto initialization of `periph_vbat`.
As you can see, the SMPR values are not overridden anymore.
The values change because `master` does not support the `periph_vbat` and I called the test with `USEMODULE=periph_vbat BOARD=nucleo-h753zi make -C tests/periph/adc flash term -j`.
```
2026-02-18 13:30:03,610 #
2026-02-18 13:30:03,793 # ADC3: SMPR1: 0, SMPR2: 14680064
2026-02-18 13:30:03,801 # main(): This is RIOT! (Version: 2026.04-devel-111-gac9f9-pr/stm32h7_vbat)
2026-02-18 13:30:03,802 #
2026-02-18 13:30:03,805 # RIOT ADC peripheral driver test
2026-02-18 13:30:03,806 #
2026-02-18 13:30:03,809 # This test will sample all available ADC lines once every 100ms with
2026-02-18 13:30:03,816 # 6 to 16-bit resolution and print the sampled results to STDOUT.
2026-02-18 13:30:03,821 # Not all MCUs support all resolutions, unsupported resolutions
2026-02-18 13:30:03,823 # are printed as -1.
2026-02-18 13:30:03,824 #
2026-02-18 13:30:03,830 # ADC1: SMPR1: 0, SMPR2: 65536
2026-02-18 13:30:03,833 # Successfully initialized ADC_LINE(0)
2026-02-18 13:30:03,836 # ADC2: SMPR1: 0, SMPR2: 2
2026-02-18 13:30:03,841 # Successfully initialized ADC_LINE(1)
2026-02-18 13:30:03,843 # ADC1: SMPR1: 0, SMPR2: 66560
2026-02-18 13:30:03,844 # Successfully initialized ADC_LINE(2)
2026-02-18 13:30:03,848 # ADC2: SMPR1: 65536, SMPR2: 2
2026-02-18 13:30:03,852 # Successfully initialized ADC_LINE(3)
2026-02-18 13:30:03,854 # ADC1: SMPR1: 0, SMPR2: 66688
2026-02-18 13:30:03,857 # Successfully initialized ADC_LINE(4)
2026-02-18 13:30:03,860 # ADC3: SMPR1: 524288, SMPR2: 14680064
2026-02-18 13:30:03,861 # Successfully initialized ADC_LINE(5)
2026-02-18 13:30:03,865 # ADC3: SMPR1: 524288, SMPR2: 14680064
2026-02-18 13:30:03,867 # Successfully initialized ADC_LINE(6)
2026-02-18 13:30:03,872 # ADC_LINE(0): -1  30  143  641  2822 12310
2026-02-18 13:30:03,875 # ADC_LINE(1): -1   5   65  382  1962  9789
2026-02-18 13:30:03,880 # ADC_LINE(2): -1  15   94  494  2392 11008
...
```

Also, here is a test trace running the `tests/periph/vbat` test. `VBat` is connected to 3.3V on the Nucleo-H753ZI.
```
2026-02-18 14:05:29,548 # main(): This is RIOT! (Version: 2026.04-devel-144-g91ccc-pr/stm32h7_vbat)
2026-02-18 14:05:29,548 #
2026-02-18 14:05:29,550 # RIOT backup battery monitoring test
2026-02-18 14:05:29,551 #
2026-02-18 14:05:29,555 # This test will sample the backup battery once a second
2026-02-18 14:05:29,555 #
2026-02-18 14:05:29,555 #
2026-02-18 14:05:29,556 # VBAT: 3316[mV]
2026-02-18 14:05:30,556 # VBAT: 3323[mV]
2026-02-18 14:05:31,556 # VBAT: 3326[mV]
2026-02-18 14:05:32,558 # VBAT: 3316[mV]
2026-02-18 14:05:33,557 # VBAT: 3320[mV]
2026-02-18 14:05:34,557 # VBAT: 3316[mV]
2026-02-18 14:05:35,557 # VBAT: 3329[mV]
2026-02-18 14:05:36,555 # VBAT: 3313[mV]
2026-02-18 14:05:37,556 # VBAT: 3320[mV]
```


### Issues/PRs references

Currently still includes #22076, has to be rebased once that is merged.
