### PR TITLE
.github/workflows: do not run workflows on forks

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -43,8 +43,27 @@ env:
 # split up native and IoT-LAB tasks to parallelize somewhat and prevent
 # to hit Github Limit of 6h per job.
 jobs:
+  check-secret:
+    runs-on: ubuntu-22.04
+    outputs:
+      secret-configured: ${{ steps.secret-exists-check.outputs.defined }}
+    steps:
+      - name: Check if Secret is configured
+        id: secret-exists-check
+        # check if the secrets are configured before running the tasks
+        # see: https://stackoverflow.com/a/70249520
+        shell: bash
+        run: |
+          if [ "${{ secrets.IOTLABRC }}" != '' ]; then
+            echo "defined=true" >> $GITHUB_OUTPUT;
+          else
+            echo "defined=false" >> $GITHUB_OUTPUT;
+          fi
+
   tasks:
     runs-on: ubuntu-22.04
+    needs: [check-secret]
+    if: needs.check-secret.outputs.secret-configured == 'true'
     timeout-minutes: 360
     strategy:
       fail-fast: false

--- a/.github/workflows/sync_codeberg.yml
+++ b/.github/workflows/sync_codeberg.yml
@@ -6,8 +6,27 @@ on:
       - '[0-9][0-9][0-9][0-9].[0-9][0-9]-branch'
 
 jobs:
+  check-secret:
+    runs-on: ubuntu-22.04
+    outputs:
+      secret-configured: ${{ steps.secret-exists-check.outputs.defined }}
+    steps:
+      - name: Check if Secret is configured
+        id: secret-exists-check
+        # check if the secrets are configured before running the tasks
+        # see: https://stackoverflow.com/a/70249520
+        shell: bash
+        run: |
+          if [ "${{ secrets.CODEBERG_TOKEN }}" != '' ]; then
+            echo "defined=true" >> $GITHUB_OUTPUT;
+          else
+            echo "defined=false" >> $GITHUB_OUTPUT;
+          fi
+
   sync-repo-to-codeberg:
     runs-on: ubuntu-latest
+    needs: [check-secret]
+    if: needs.check-secret.outputs.secret-configured == 'true'
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2

--- a/.github/workflows/test-on-iotlab.yml
+++ b/.github/workflows/test-on-iotlab.yml
@@ -26,8 +26,27 @@ on:
         default: 'master'
 
 jobs:
+  check-secret:
+    runs-on: ubuntu-22.04
+    outputs:
+      secret-configured: ${{ steps.secret-exists-check.outputs.defined }}
+    steps:
+      - name: Check if Secret is configured
+        id: secret-exists-check
+        # check if the secrets are configured before running the tasks
+        # see: https://stackoverflow.com/a/70249520
+        shell: bash
+        run: |
+          if [ "${{ secrets.IOTLABRC }}" != '' ]; then
+            echo "defined=true" >> $GITHUB_OUTPUT;
+          else
+            echo "defined=false" >> $GITHUB_OUTPUT;
+          fi
+
   # Runs all tests on IoT-LAB boards
   compile_and_test_for_board:
+    needs: [check-secret]
+    if: needs.check-secret.outputs.secret-configured == 'true'
     strategy:
       max-parallel: 8
       fail-fast: false


### PR DESCRIPTION
### Contribution description

Currently the Github Workflows we have run unconditionally on the main repository as well as forks. This creates (IMO) unnecessary email spam every time the `master` branch is synced (`[crasbe/RIOT] Run failed: Sync to Codeberg - master (e833835)`) as well as scheduled mails (`[crasbe/RIOT] Run failed: release-tests - master (ba9d67e)`, `[crasbe/RIOT] Run failed: test-on-iotlab - master (ba9d67e)`).

Not the end of the world, but avoidable and it would save resources (setting up docker containers for them to fail after 30-40s 😅 ).

The solution was inspired by https://hugovk.dev/blog/2023/til-how-to-disable-cron-for-github-forks/ and ChatGPT.

### Testing procedure

None that I know of?

### Issues/PRs references

This got a bit worse due to #21997, but I don't want to blame @AnnsAnns in any way shape or form.