### PR TITLE
gnrc/rpl: Revision of Minimum Rank with Hysteresis Objective Function implementation

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -197,6 +197,8 @@ PSEUDOMODULES += gnrc_nettype_udp
 ## @}
 
 
+PSEUDOMODULES += gnrc_rpl_mrhof%
+PSEUDOMODULES += gnrc_rpl_of0
 PSEUDOMODULES += gnrc_sixloenc
 PSEUDOMODULES += gnrc_sixlowpan_border_router_default
 PSEUDOMODULES += gnrc_sixlowpan_default

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -245,11 +245,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Number of implemented Objective Functions
- */
-#define GNRC_RPL_IMPLEMENTED_OFS_NUMOF (2)
-
-/**
  * @brief   Default Objective Code Point (OF0)
  */
 #ifndef CONFIG_GNRC_RPL_DEFAULT_OCP

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -247,7 +247,7 @@ extern "C" {
 /**
  * @brief   Number of implemented Objective Functions
  */
-#define GNRC_RPL_IMPLEMENTED_OFS_NUMOF (1)
+#define GNRC_RPL_IMPLEMENTED_OFS_NUMOF (2)
 
 /**
  * @brief   Default Objective Code Point (OF0)

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -253,7 +253,11 @@ extern "C" {
  * @brief   Default Objective Code Point (OF0)
  */
 #ifndef CONFIG_GNRC_RPL_DEFAULT_OCP
+#ifdef MODULE_GNRC_RPL_MRHOF
+#define CONFIG_GNRC_RPL_DEFAULT_OCP (1)
+#else
 #define CONFIG_GNRC_RPL_DEFAULT_OCP (0)
+#endif
 #endif
 
 /**

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -252,7 +252,9 @@ extern "C" {
 /**
  * @brief   Default Objective Code Point (OF0)
  */
-#define GNRC_RPL_DEFAULT_OCP (0)
+#ifndef CONFIG_GNRC_RPL_DEFAULT_OCP
+#define CONFIG_GNRC_RPL_DEFAULT_OCP (0)
+#endif
 
 /**
  * @brief   Default Instance ID

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -248,11 +248,11 @@ extern "C" {
  * @brief   Default Objective Code Point (OF0)
  */
 #ifndef CONFIG_GNRC_RPL_DEFAULT_OCP
-#ifdef MODULE_GNRC_RPL_MRHOF
-#define CONFIG_GNRC_RPL_DEFAULT_OCP (1)
-#else
-#define CONFIG_GNRC_RPL_DEFAULT_OCP (0)
-#endif
+#  ifdef MODULE_GNRC_RPL_MRHOF
+#    define CONFIG_GNRC_RPL_DEFAULT_OCP (1)
+#  else
+#    define CONFIG_GNRC_RPL_DEFAULT_OCP (0)
+#  endif
 #endif
 
 /**

--- a/sys/include/net/gnrc/rpl/structs.h
+++ b/sys/include/net/gnrc/rpl/structs.h
@@ -286,7 +286,7 @@ typedef struct {
      * @return      Negative, if the first parent is preferred.
      */
     int (*parent_cmp)(gnrc_rpl_parent_t *parent1, gnrc_rpl_parent_t *parent2);
-    int (*which_dodag)(gnrc_rpl_dodag_t *, gnrc_rpl_dio_t *); /**< compare for dodags */
+    int (*which_dodag)(gnrc_rpl_dodag_t *, gnrc_rpl_dio_t *, kernel_pid_t iface, ipv6_addr_t addr); /**< compare for dodags */
 
     /**
      * @brief Reset the state of the objective function.

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -101,7 +101,26 @@ ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
     USEMODULE += xtimer
   endif
   USEMODULE += evtimer
-  USEMODULE += netstats_neighbor_etx
+
+  ifeq (,$(filter gnrc_rpl_mrhof%,$(USEMODULE)))
+    USEMODULE += gnrc_rpl_of0
+  endif
+endif
+
+ifneq (,$(filter gnrc_rpl_mrhof%,$(USEMODULE)))
+  USEMODULE += gnrc_rpl_mrhof
+
+  ifeq (,$(filter gnrc_rpl_mrhof_%,$(USEMODULE)))
+    USEMODULE += gnrc_rpl_mrhof_etx
+  endif
+
+  ifneq (,$(filter gnrc_rpl_mrhof_etx,$(USEMODULE)))
+    USEMODULE += netstats_neighbor_etx
+  endif
+
+  ifneq (,$(filter gnrc_rpl_mrhof_lqi,$(USEMODULE)))
+    USEMODULE += netstats_neighbor_lqi
+  endif
 endif
 
 ifneq (,$(filter gnrc_ipv6_auto_subnets_eui,$(USEMODULE)))

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -101,6 +101,7 @@ ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
     USEMODULE += xtimer
   endif
   USEMODULE += evtimer
+  USEMODULE += netstats_neighbor_etx
 endif
 
 ifneq (,$(filter gnrc_ipv6_auto_subnets_eui,$(USEMODULE)))

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -546,7 +546,7 @@ static bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt
             }
             else {
                 DEBUG("RPL: Unsupported OCP 0x%02x\n", byteorder_ntohs(dc->ocp));
-                inst->of = gnrc_rpl_get_of_for_ocp(GNRC_RPL_DEFAULT_OCP);
+                inst->of = gnrc_rpl_get_of_for_ocp(CONFIG_GNRC_RPL_DEFAULT_OCP);
             }
             dodag->dio_interval_doubl = dc->dio_int_doubl;
             dodag->dio_min = dc->dio_int_min;
@@ -636,26 +636,6 @@ static bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt
                                  dodag->iface,
                                  dodag->default_lifetime * dodag->lifetime_unit);
             break;
-
-        case (GNRC_RPL_OPT_TARGET):
-            DEBUG("RPL: RPL TARGET DAO option parsed\n");
-            *included_opts |= ((uint32_t) 1) << GNRC_RPL_OPT_TARGET;
-
-            gnrc_rpl_opt_target_t *target = (gnrc_rpl_opt_target_t *) opt;
-            if (first_target == NULL) {
-                first_target = target;
-            }
-
-            DEBUG("RPL: adding FT entry %s/%d\n",
-                    ipv6_addr_to_str(addr_str, &(target->target), (unsigned)sizeof(addr_str)),
-                    target->prefix_length);
-
-            gnrc_ipv6_nib_ft_del(&(target->target), target->prefix_length);
-            gnrc_ipv6_nib_ft_add(&(target->target), target->prefix_length, src,
-                                    dodag->iface,
-                                    dodag->default_lifetime * dodag->lifetime_unit);
-            break;
-
         case (GNRC_RPL_OPT_TRANSIT):
             DEBUG("RPL: RPL TRANSIT INFO DAO option parsed\n");
             *included_opts |= ((uint32_t) 1) << GNRC_RPL_OPT_TRANSIT;
@@ -896,7 +876,7 @@ void _recv_DIO_for_new_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_dio_t *dio, ker
     assert(netif != NULL);
 
     inst->mop = (dio->g_mop_prf >> GNRC_RPL_MOP_SHIFT) & GNRC_RPL_SHIFTED_MOP_MASK;
-    inst->of = gnrc_rpl_get_of_for_ocp(GNRC_RPL_DEFAULT_OCP);
+    inst->of = gnrc_rpl_get_of_for_ocp(CONFIG_GNRC_RPL_DEFAULT_OCP);
 
     gnrc_rpl_dodag_init(inst, &dio->dodag_id, netif->pid);
 

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -570,7 +570,6 @@ static bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt
             gnrc_rpl_opt_prefix_info_t *pi = (gnrc_rpl_opt_prefix_info_t *)opt;
             /* check for the auto address-configuration flag */
             gnrc_netif_t *netif = gnrc_netif_get_by_pid(dodag->iface);
-            
             assert(netif != NULL);
             if ((gnrc_netif_ipv6_get_iid(netif, &iid) < 0)
                 && !(pi->LAR_flags & GNRC_RPL_PREFIX_AUTO_ADDRESS_BIT)) {
@@ -597,7 +596,7 @@ static bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt
                 return false;
             }
 
-             /* check the DODAG Version */
+            /* check the DODAG Version */
             if ((sol->VID_flags & GNRC_RPL_DIS_SOLICITED_INFO_FLAG_V)
                 && (sol->version_number != inst->dodag.version)) {
                 DEBUG("RPL: RPL SOLICITED INFO option, ignore DIS cause: DODAG Version mismatch\n");
@@ -642,7 +641,7 @@ static bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt
             gnrc_rpl_opt_transit_t *transit = (gnrc_rpl_opt_transit_t *) opt;
             if (first_target == NULL) {
                 DEBUG("RPL: Encountered a RPL TRANSIT DAO option without "
-                        "a preceding RPL TARGET DAO option\n");
+                      "a preceding RPL TARGET DAO option\n");
                 break;
             }
 
@@ -652,11 +651,11 @@ static bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt
                         first_target->prefix_length);
 
                 gnrc_ipv6_nib_ft_del(&(first_target->target),
-                                        first_target->prefix_length);
+                                       first_target->prefix_length);
                 gnrc_ipv6_nib_ft_add(&(first_target->target),
-                                        first_target->prefix_length, src,
-                                        dodag->iface,
-                                        transit->path_lifetime * dodag->lifetime_unit);
+                                       first_target->prefix_length, src,
+                                       dodag->iface,
+                                       transit->path_lifetime * dodag->lifetime_unit);
 
                 first_target = (gnrc_rpl_opt_target_t *)(((uint8_t *)(first_target)) +
                                 sizeof(gnrc_rpl_opt_t) + first_target->length);
@@ -667,9 +666,9 @@ static bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt
             break;
 
 #ifdef MODULE_GNRC_RPL_P2P
-            case (GNRC_RPL_P2P_OPT_RDO):
-                gnrc_rpl_p2p_rdo_parse((gnrc_rpl_p2p_opt_rdo_t *) opt, gnrc_rpl_p2p_ext_get(dodag));
-                break;
+        case (GNRC_RPL_P2P_OPT_RDO):
+            gnrc_rpl_p2p_rdo_parse((gnrc_rpl_p2p_opt_rdo_t *) opt, gnrc_rpl_p2p_ext_get(dodag));
+            break;
 #endif
         }
         len_parsed += opt->length + sizeof(gnrc_rpl_opt_t);
@@ -697,7 +696,7 @@ void gnrc_rpl_recv_DIS(gnrc_rpl_dis_t *dis, kernel_pid_t iface, ipv6_addr_t *src
         for (uint8_t i = 0; i < GNRC_RPL_INSTANCES_NUMOF; ++i) {
             if ((gnrc_rpl_instances[i].state != 0)
                 /* a leaf node should only react to unicast DIS */
-                 && (gnrc_rpl_instances[i].dodag.node_status != GNRC_RPL_LEAF_NODE)) {
+                && (gnrc_rpl_instances[i].dodag.node_status != GNRC_RPL_LEAF_NODE)) {
 #ifdef MODULE_GNRC_RPL_P2P
                 if (gnrc_rpl_instances[i].mop == GNRC_RPL_P2P_MOP) {
                     DEBUG("RPL: Not responding to DIS for P2P-RPL DODAG\n");
@@ -715,7 +714,7 @@ void gnrc_rpl_recv_DIS(gnrc_rpl_dis_t *dis, kernel_pid_t iface, ipv6_addr_t *src
                 uint32_t included_opts = 0;
                 size_t opt_len = len - sizeof(gnrc_rpl_dis_t) - sizeof(icmpv6_hdr_t);
                 if (!_parse_options(GNRC_RPL_ICMPV6_CODE_DIS, &gnrc_rpl_instances[i],
-                                   (gnrc_rpl_opt_t *)(dis + 1), opt_len, src, &included_opts)) {
+                                  (gnrc_rpl_opt_t *)(dis + 1), opt_len, src, &included_opts)) {
                     DEBUG("RPL: DIS option parsing error - skip processing the DIS\n");
                     continue;
                 }
@@ -1005,12 +1004,13 @@ void gnrc_rpl_recv_DIO(gnrc_rpl_dio_t *dio, kernel_pid_t iface, ipv6_addr_t *src
     }
 }
 
-static gnrc_pktsnip_t *_dao_target_build(gnrc_pktsnip_t *pkt, ipv6_addr_t *addr, uint8_t prefix_length)
+static gnrc_pktsnip_t *_dao_target_build(gnrc_pktsnip_t *pkt, ipv6_addr_t *addr,
+                                         uint8_t prefix_length)
 {
     gnrc_rpl_opt_target_t *target;
     gnrc_pktsnip_t *opt_snip;
     if ((opt_snip = gnrc_pktbuf_add(pkt, NULL, sizeof(gnrc_rpl_opt_target_t),
-                               GNRC_NETTYPE_UNDEF)) == NULL) {
+                                    GNRC_NETTYPE_UNDEF)) == NULL) {
         DEBUG("RPL: Send DAO - no space left in packet buffer\n");
         gnrc_pktbuf_release(pkt);
         return NULL;
@@ -1029,7 +1029,7 @@ static gnrc_pktsnip_t *_dao_transit_build(gnrc_pktsnip_t *pkt, uint8_t lifetime,
     gnrc_rpl_opt_transit_t *transit;
     gnrc_pktsnip_t *opt_snip;
     if ((opt_snip = gnrc_pktbuf_add(pkt, NULL, sizeof(gnrc_rpl_opt_transit_t),
-                               GNRC_NETTYPE_UNDEF)) == NULL) {
+                                    GNRC_NETTYPE_UNDEF)) == NULL) {
         DEBUG("RPL: Send DAO - no space left in packet buffer\n");
         gnrc_pktbuf_release(pkt);
         return NULL;
@@ -1329,7 +1329,7 @@ void gnrc_rpl_recv_DAO_ACK(gnrc_rpl_dao_ack_t *dao_ack, kernel_pid_t iface, ipv6
 
     if ((dao_ack->status != 0) && (dao_ack->dao_sequence != dodag->dao_seq)) {
         DEBUG("RPL: DAO-ACK sequence (%d) does not match expected sequence (%d)\n",
-                dao_ack->dao_sequence, dodag->dao_seq);
+              dao_ack->dao_sequence, dodag->dao_seq);
         return;
     }
 

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -537,7 +537,7 @@ static bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt
 
         case (GNRC_RPL_OPT_DODAG_CONF):
             DEBUG("RPL: DODAG CONF DIO option parsed\n");
-            *included_opts |= ((uint32_t) 1) << GNRC_RPL_OPT_DODAG_CONF;
+            bit_set32(included_opts, GNRC_RPL_OPT_DODAG_CONF);
             dodag->dio_opts |= GNRC_RPL_REQ_DIO_OPT_DODAG_CONF;
             gnrc_rpl_opt_dodag_conf_t *dc = (gnrc_rpl_opt_dodag_conf_t *) opt;
             gnrc_rpl_of_t *of = gnrc_rpl_get_of_for_ocp(byteorder_ntohs(dc->ocp));
@@ -637,7 +637,7 @@ static bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt
             break;
         case (GNRC_RPL_OPT_TRANSIT):
             DEBUG("RPL: RPL TRANSIT INFO DAO option parsed\n");
-            *included_opts |= ((uint32_t) 1) << GNRC_RPL_OPT_TRANSIT;
+            bit_set32(included_opts, GNRC_RPL_OPT_TRANSIT);
             gnrc_rpl_opt_transit_t *transit = (gnrc_rpl_opt_transit_t *) opt;
             if (first_target == NULL) {
                 DEBUG("RPL: Encountered a RPL TRANSIT DAO option without "
@@ -917,7 +917,8 @@ static void _recv_DIO_for_different_dodag(gnrc_rpl_instance_t *inst, gnrc_rpl_di
     }
 
     /* decide between old and new dodag */
-    if (gnrc_rpl_get_of0()->which_dodag(dodag, dio) > 0) {
+    const gnrc_rpl_of_t *of = gnrc_rpl_get_of_for_ocp(CONFIG_GNRC_RPL_DEFAULT_OCP);
+    if (of->which_dodag(dodag, dio, iface, *src) > 0) {
         DEBUG("RPL: switch to new DODAG.\n");
         gnrc_rpl_dodag_remove(dodag);
         _recv_DIO_for_new_dodag(inst, dio, iface, src, len);

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -403,7 +403,7 @@ gnrc_rpl_instance_t *gnrc_rpl_root_instance_init(uint8_t instance_id, const ipv6
     }
 
     if (gnrc_rpl_instance_add(instance_id, &inst)) {
-        inst->of = (gnrc_rpl_of_t *) gnrc_rpl_get_of_for_ocp(GNRC_RPL_DEFAULT_OCP);
+        inst->of = (gnrc_rpl_of_t *) gnrc_rpl_get_of_for_ocp(CONFIG_GNRC_RPL_DEFAULT_OCP);
         inst->mop = mop;
         inst->min_hop_rank_inc = CONFIG_GNRC_RPL_DEFAULT_MIN_HOP_RANK_INCREASE;
         inst->max_rank_inc = CONFIG_GNRC_RPL_DEFAULT_MAX_RANK_INCREASE;

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_of_manager.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_of_manager.c
@@ -31,8 +31,12 @@ static gnrc_rpl_of_t *objective_functions[GNRC_RPL_IMPLEMENTED_OFS_NUMOF];
 void gnrc_rpl_of_manager_init(void)
 {
     /* insert new objective functions here */
-    objective_functions[0] = gnrc_rpl_get_of0();
-    objective_functions[1] = gnrc_rpl_get_of_mrhof();
+    if (IS_USED(MODULE_GNRC_RPL_OF0)) {
+        objective_functions[0] = gnrc_rpl_get_of0();
+    }
+    if (IS_USED(MODULE_GNRC_RPL_MRHOF)) {
+        objective_functions[1] = gnrc_rpl_get_of_mrhof();
+    }
 }
 
 /* find implemented OF via objective code point */
@@ -40,12 +44,16 @@ gnrc_rpl_of_t *gnrc_rpl_get_of_for_ocp(uint16_t ocp)
 {
     for (uint16_t i = 0; i < GNRC_RPL_IMPLEMENTED_OFS_NUMOF; i++) {
         if (objective_functions[i] == NULL) {
-            /* fallback if something goes wrong */
-            return gnrc_rpl_get_of0();
+            continue;
         }
         else if (ocp == objective_functions[i]->ocp) {
             return objective_functions[i];
         }
+    }
+
+    /* fallback if something goes wrong */
+    if (IS_USED(MODULE_GNRC_RPL_OF0)) {
+        return gnrc_rpl_get_of0();
     }
 
     return NULL;

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_of_manager.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_of_manager.c
@@ -21,10 +21,10 @@
 #include "net/gnrc/rpl.h"
 #include "net/gnrc/rpl/of_manager.h"
 #include "of0.h"
+#include "mrhof.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
-/* !!! TODO: port etx/mrhof to the new network stack */
 
 static gnrc_rpl_of_t *objective_functions[GNRC_RPL_IMPLEMENTED_OFS_NUMOF];
 
@@ -32,7 +32,7 @@ void gnrc_rpl_of_manager_init(void)
 {
     /* insert new objective functions here */
     objective_functions[0] = gnrc_rpl_get_of0();
-    /*objective_functions[1] = gnrc_rpl_get_of_mrhof(); */
+    objective_functions[1] = gnrc_rpl_get_of_mrhof();
 }
 
 /* find implemented OF via objective code point */

--- a/sys/net/gnrc/routing/rpl/mrhof.c
+++ b/sys/net/gnrc/routing/rpl/mrhof.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/net/gnrc/routing/rpl/mrhof.c
+++ b/sys/net/gnrc/routing/rpl/mrhof.c
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_gnrc_rpl
+ * @{
+ * @file
+ * @brief       Minimum Rank with Hysteresis Objective Function
+ *
+ * Defines all functions for the implementation of Minimum Rank
+ * with Hysteresis Objective Function. (RFC 6719)
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ * @author      Benjamin Valentin <benpicco@beuth-hochschule.de>
+ * @}
+ */
+
+#include <string.h>
+#include "mrhof.h"
+#include "net/gnrc/rpl.h"
+#include "net/gnrc/rpl/structs.h"
+#include "net/netstats.h"
+#include "net/netstats/neighbor.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/**
+ * Retrieve parent statistics from the netstats neighbor module
+ */
+static bool _mrhof_get_stats(gnrc_rpl_parent_t *parent, netstats_nb_t *out)
+{
+    gnrc_ipv6_nib_nc_t nce;
+
+    gnrc_netif_t *iface = gnrc_netif_get_by_pid(parent->dodag->iface);
+
+    if (gnrc_ipv6_nib_get_next_hop_l2addr(&parent->addr, iface, NULL, &nce)) {
+        return false;
+    }
+
+    return netstats_nb_get(&iface->netif, nce.l2addr, nce.l2addr_len, out);
+}
+
+/**
+ * Retrieve parent etx from the netstats neighbor module
+ */
+static uint16_t _mrhof_get_etx(netstats_nb_t *stats)
+{
+    if (stats == NULL) {
+        return MRHOF_MAX_PATH_COST;
+    }
+    return stats->etx;
+}
+
+/**
+ * Retrieve the full path cost of a parent
+ */
+static uint16_t _mrhof_get_path_cost(gnrc_rpl_parent_t *parent, netstats_nb_t *stats)
+{
+    uint16_t etx = _mrhof_get_etx(stats);
+
+    if (etx == MRHOF_MAX_PATH_COST) {
+        return etx;
+    }
+    return parent->rank + etx;
+}
+
+/**
+ * Check if a parent is within MAX_LINK_METRIC and MAX_PATH_COST
+ */
+static bool _mrhof_is_acceptable(gnrc_rpl_parent_t *parent, netstats_nb_t *stats)
+{
+    uint16_t etx = _mrhof_get_etx(stats);
+
+    return (etx < MRHOF_MAX_LINK_METRIC &&
+            _mrhof_get_path_cost(parent, stats) < MRHOF_MAX_PATH_COST);
+}
+
+/**
+ * Check if a parent is fresh
+ */
+static bool _mrhof_isfresh(netif_t *netif, netstats_nb_t *stats)
+{
+    /* No statistics is not fresh */
+    if (stats == NULL) {
+        return false;
+    }
+    return netstats_nb_isfresh(netif, stats);
+}
+
+/* Compare acceptability of two parents */
+static int _mrhof_cmp_acceptable(gnrc_rpl_parent_t *p1, netstats_nb_t *p1_stats,
+                                 gnrc_rpl_parent_t *p2, netstats_nb_t *p2_stats)
+{
+    bool p1_acceptable = _mrhof_is_acceptable(p1, p1_stats);
+    bool p2_acceptable = _mrhof_is_acceptable(p2, p2_stats);
+
+    if (p1_acceptable == p2_acceptable) {
+        return 0;
+    }
+
+    /* One of the two parents is not acceptable */
+    if (p1_acceptable == false) {
+        /* p2 is acceptable and p1 not */
+        return 1;
+    }
+
+    if (p2_acceptable == false) {
+        /* p1 is acceptable and p2 not */
+        return -1;
+    }
+
+    return 0;
+}
+
+/* Compare freshness of two parents */
+static int _mrhof_cmp_fresh(netif_t *netif,
+                            netstats_nb_t *p1_stats,
+                            netstats_nb_t *p2_stats)
+{
+    bool p1_isfresh = _mrhof_isfresh(netif, p1_stats);
+    bool p2_isfresh = _mrhof_isfresh(netif, p2_stats);
+
+    if (p1_isfresh == p2_isfresh) {
+        return 0;
+    }
+
+    /* One of the two parents is not acceptable */
+    if (p1_isfresh == false) {
+        /* p2 is acceptable and p1 not */
+        return 1;
+    }
+
+    if (p2_isfresh == false) {
+        /* p1 is acceptable and p2 not */
+        return -1;
+    }
+
+    return 0;
+}
+
+void reset(gnrc_rpl_dodag_t *dodag)
+{
+    /* Nothing to do in MRHOF */
+    (void) dodag;
+}
+
+/**
+ * Calculate rank additive based on the rank of the parent and the etx to the parent
+ * computed via MAX(pref_parent->rank, 1 + floor(MAX(parents->rank)/MinHopRankIncrease),
+ */
+uint16_t calc_rank(gnrc_rpl_dodag_t *dodag, uint16_t base_rank)
+{
+    (void) base_rank;
+    DEBUG("MRHOF: Calculating rank\n");
+
+    /* TODO: consider a parent set of more than 1 parent */
+    if (dodag == NULL) {
+        DEBUG("MRHOF: No dodag, assuming max rank\n");
+        return GNRC_RPL_INFINITE_RANK;
+    }
+    else {
+        gnrc_rpl_parent_t *elt = NULL;
+        netstats_nb_t elt_stats;
+        uint8_t cnt = 0;
+        uint8_t max_dagrank = 0;
+        uint16_t cost_rank, minhoprankincr = dodag->instance->min_hop_rank_inc;
+
+        /* Determine the path cost through the preferred parent */
+        if (!_mrhof_get_stats(dodag->parents, &elt_stats)) {
+            DEBUG("MRHOF: No stats for parent, assuming max rank\n");
+            return GNRC_RPL_INFINITE_RANK;
+        }
+        cost_rank = _mrhof_get_path_cost(dodag->parents, &elt_stats);
+
+        /* Determine the largest dagrank in the parent set */
+        LL_FOREACH(dodag->parents, elt) {
+            if (cnt >= MRHOF_PARENT_SET_SIZE) {
+                break;
+            }
+            _mrhof_get_stats(elt, &elt_stats);
+            /* Only include parent in the parent set if the statistics are acceptable
+             * and the path cost is not significantly worse than the current preferred parent */
+            if (_mrhof_is_acceptable(elt, &elt_stats) && \
+                (_mrhof_get_path_cost(elt, &elt_stats) <= cost_rank + MRHOF_PARENT_SWITCH_THRESHOLD)) {
+                uint8_t new_dagrank = DAGRANK(elt->rank, minhoprankincr);
+                if (max_dagrank < new_dagrank) {
+                    max_dagrank = new_dagrank;
+                }
+            }
+            else {
+                /* Break when parents are no longer acceptable */
+                break;
+            }
+            cnt++;
+        }
+        uint16_t monotonic_rank = minhoprankincr * (max_dagrank + 1);
+        DEBUG("MRHOF: Path cost: %u, monotonic cost: %u\n", cost_rank, monotonic_rank);
+        return (cost_rank > monotonic_rank) ? cost_rank : monotonic_rank;
+    }
+}
+
+/**
+ * Decision based on
+ * * If one parent is not acceptable, the other is better
+ * * If one parent is not fresh, the other is better
+ * * ETX
+ */
+int which_parent(gnrc_rpl_parent_t *p1, gnrc_rpl_parent_t *p2)
+{
+    /* Only return p2 if the rank (full etx path) is better than p1 and better
+     * than the preferred parent full path etx by PARENT_SWITCH_THRESHOLD */
+    int cmp;
+    netstats_nb_t p1_stats, p2_stats;
+
+    assert(p1->dodag->iface == p2->dodag->iface);
+    gnrc_netif_t *netif = gnrc_netif_get_by_pid(p1->dodag->iface);
+
+    if (!_mrhof_get_stats(p1, &p1_stats) || !_mrhof_get_stats(p2, &p2_stats)) {
+        return 0;
+    }
+
+    /* Compare acceptability of parents */
+    cmp = _mrhof_cmp_acceptable(p1, &p1_stats, p2, &p2_stats);
+    if (cmp != 0) {
+        return cmp;
+    }
+
+    /* Compare freshness of parents */
+    cmp = _mrhof_cmp_fresh(&netif->netif, &p1_stats, &p2_stats);
+    if (cmp != 0) {
+        return cmp;
+    }
+
+    uint16_t p1_path_cost = _mrhof_get_path_cost(p1, &p1_stats);
+    uint16_t p2_path_cost = _mrhof_get_path_cost(p2, &p2_stats);
+
+    /* Compare ETX of parents */
+    if (p1_path_cost > p2_path_cost) {
+        if (p1 == p1->dodag->parents) {
+            /* p1 is the preferred parent */
+            if (p2_path_cost + MRHOF_PARENT_SWITCH_THRESHOLD < p1_path_cost) {
+                return 1;
+            }
+            else {
+                return -1;
+            }
+        }
+        else {
+            return 1;
+        }
+    }
+    else if (p1_path_cost == p2_path_cost) {
+        return 0;
+    }
+    return -1;
+}
+
+/* Prefer d2 if d2 is grounded and d1 is not */
+gnrc_rpl_dodag_t *which_dodag(gnrc_rpl_dodag_t *d1, gnrc_rpl_dodag_t *d2)
+{
+    if (!(d1->grounded) && d2->grounded) {
+        return d2;
+    }
+    return d1;
+}
+
+static gnrc_rpl_of_t gnrc_rpl_mrhof = {
+    .ocp         = 0x1,
+    .calc_rank   = calc_rank,
+    .parent_cmp  = which_parent,
+    .which_dodag = which_dodag,
+    .reset       = reset,
+    .parent_state_callback = NULL,
+    .init        = NULL,
+    .process_dio = NULL
+};
+
+gnrc_rpl_of_t *gnrc_rpl_get_of_mrhof(void)
+{
+    return &gnrc_rpl_mrhof;
+}

--- a/sys/net/gnrc/routing/rpl/mrhof.c
+++ b/sys/net/gnrc/routing/rpl/mrhof.c
@@ -266,13 +266,14 @@ static int which_parent(gnrc_rpl_parent_t *p1, gnrc_rpl_parent_t *p2)
     return -1;
 }
 
-/* Prefer d2 if d2 is grounded and d1 is not */
-static gnrc_rpl_dodag_t *which_dodag(gnrc_rpl_dodag_t *d1, gnrc_rpl_dodag_t *d2)
+/* prefer dio if dio is grounded dodag */
+int which_dodag(gnrc_rpl_dodag_t *d1, gnrc_rpl_dio_t *dio)
 {
-    if (!(d1->grounded) && d2->grounded) {
-        return d2;
+    int dio_grounded = dio->g_mop_prf >> GNRC_RPL_GROUNDED_SHIFT;
+    if (d1->grounded > dio_grounded) {
+        return -1;
     }
-    return d1;
+    return 1;
 }
 
 static gnrc_rpl_of_t gnrc_rpl_mrhof = {

--- a/sys/net/gnrc/routing/rpl/mrhof.c
+++ b/sys/net/gnrc/routing/rpl/mrhof.c
@@ -28,15 +28,15 @@
 #include "debug.h"
 
 /**
- * Retrieve parent statistics from the netstats neighbor module
+ * Retrieve statistics from the netstats neighbor module
  */
-static bool _mrhof_get_stats(gnrc_rpl_parent_t *parent, netstats_nb_t *out)
+static bool _mrhof_get_stats(kernel_pid_t iface_parent, ipv6_addr_t addr, netstats_nb_t *out)
 {
     gnrc_ipv6_nib_nc_t nce;
 
-    gnrc_netif_t *iface = gnrc_netif_get_by_pid(parent->dodag->iface);
+    gnrc_netif_t *iface = gnrc_netif_get_by_pid(iface_parent);
 
-    if (gnrc_ipv6_nib_get_next_hop_l2addr(&parent->addr, iface, NULL, &nce)) {
+    if (gnrc_ipv6_nib_get_next_hop_l2addr(&addr, iface, NULL, &nce)) {
         return false;
     }
 
@@ -63,11 +63,11 @@ static inline uint16_t _link_metric(netstats_nb_t *stats)
 }
 
 /**
- * Retrieve the full path cost of a parent
+ * Retrieve the full path cost
  */
-static uint16_t _mrhof_get_path_cost(gnrc_rpl_parent_t *parent, netstats_nb_t *stats)
+static uint16_t _mrhof_get_path_cost(uint16_t rank, netstats_nb_t *stats)
 {
-    return parent->rank + _link_metric(stats);
+    return rank + _link_metric(stats);
 }
 
 /**
@@ -76,7 +76,7 @@ static uint16_t _mrhof_get_path_cost(gnrc_rpl_parent_t *parent, netstats_nb_t *s
 static bool _mrhof_is_acceptable(gnrc_rpl_parent_t *parent, netstats_nb_t *stats)
 {
     return (_link_metric(stats) < MRHOF_MAX_LINK_METRIC) &&
-           (_mrhof_get_path_cost(parent, stats) < MRHOF_MAX_PATH_COST);
+           (_mrhof_get_path_cost(parent->rank, stats) < MRHOF_MAX_PATH_COST);
 }
 
 /**
@@ -169,27 +169,24 @@ static uint16_t calc_rank(gnrc_rpl_dodag_t *dodag, uint16_t base_rank)
     uint16_t cost_rank, minhoprankincr = dodag->instance->min_hop_rank_inc;
 
     /* Determine the path cost through the preferred parent */
-    if (!_mrhof_get_stats(dodag->parents, &elt_stats)) {
+    if (!_mrhof_get_stats(dodag->iface, dodag->parents->addr, &elt_stats)) {
         DEBUG("MRHOF: No stats for parent, assuming max rank\n");
         return GNRC_RPL_INFINITE_RANK;
     }
 
     /* calculate rank for path through the preferred parent */
-    cost_rank = _mrhof_get_path_cost(dodag->parents, &elt_stats);
+    cost_rank = _mrhof_get_path_cost(dodag->parents->rank, &elt_stats);
 
     /* Determine the Rank of the member of the parent set with the highest
      * advertised Rank, rounded to the next higher integral Rank, i.e.,
      * to MinHopRankIncrease * (1 + floor(Rank/MinHopRankIncrease)).
      */
     LL_FOREACH(dodag->parents, elt) {
-        if (cnt >= MRHOF_PARENT_SET_SIZE) {
-            break;
-        }
-        _mrhof_get_stats(elt, &elt_stats);
+        _mrhof_get_stats(elt->dodag->iface, elt->addr, &elt_stats);
         /* Only include parent in the parent set if the statistics are acceptable
          * and the path cost is not significantly worse than the current preferred parent */
         if (_mrhof_is_acceptable(elt, &elt_stats) && \
-            (_mrhof_get_path_cost(elt, &elt_stats) <= cost_rank + MRHOF_PARENT_SWITCH_THRESHOLD)) {
+            (_mrhof_get_path_cost(elt->rank, &elt_stats) <= cost_rank + MRHOF_PARENT_SWITCH_THRESHOLD)) {
             uint8_t new_dagrank = elt->rank / minhoprankincr;
             if (max_dagrank < new_dagrank) {
                 max_dagrank = new_dagrank;
@@ -223,7 +220,7 @@ static int which_parent(gnrc_rpl_parent_t *p1, gnrc_rpl_parent_t *p2)
     assert(p1->dodag->iface == p2->dodag->iface);
     gnrc_netif_t *netif = gnrc_netif_get_by_pid(p1->dodag->iface);
 
-    if (!_mrhof_get_stats(p1, &p1_stats) || !_mrhof_get_stats(p2, &p2_stats)) {
+    if (!_mrhof_get_stats(p1->dodag->iface, p1->addr, &p1_stats) || !_mrhof_get_stats(p2->dodag->iface, p2->addr, &p2_stats)) {
         return 0;
     }
 
@@ -239,8 +236,8 @@ static int which_parent(gnrc_rpl_parent_t *p1, gnrc_rpl_parent_t *p2)
         return cmp;
     }
 
-    uint16_t p1_path_cost = _mrhof_get_path_cost(p1, &p1_stats);
-    uint16_t p2_path_cost = _mrhof_get_path_cost(p2, &p2_stats);
+    uint16_t p1_path_cost = _mrhof_get_path_cost(p1->rank, &p1_stats);
+    uint16_t p2_path_cost = _mrhof_get_path_cost(p2->rank, &p2_stats);
 
     /* Compare ETX of parents */
     if (p1_path_cost > p2_path_cost) {
@@ -263,8 +260,13 @@ static int which_parent(gnrc_rpl_parent_t *p1, gnrc_rpl_parent_t *p2)
     return -1;
 }
 
-/* prefer dio if dio is grounded dodag */
-int which_dodag(gnrc_rpl_dodag_t *d1, gnrc_rpl_dio_t *dio)
+/**
+ * Decision based on
+ * * whether dodag is grounded
+ * * wether root more preferable
+ * * selected metric (default: ETX)
+ */
+static int which_dodag(gnrc_rpl_dodag_t *d1, gnrc_rpl_dio_t *dio, kernel_pid_t dio_iface, ipv6_addr_t dio_addr)
 {
     /* parent set must not be empty */
     if ((d1->node_status != GNRC_RPL_ROOT_NODE) && !d1->parents) {
@@ -285,8 +287,34 @@ int which_dodag(gnrc_rpl_dodag_t *d1, gnrc_rpl_dio_t *dio)
     else if (dio_prf > d1->prf) {
         return 1;
     }
-    
-    return 1;
+
+    /* prefer dodag with lesser resulting rank */
+    // get neighbour stats
+    netstats_nb_t d1_stats, dio_stats;
+    gnrc_rpl_parent_t *d1_parent = d1->parents;
+    if (d1_parent == NULL) {
+        return 1;
+    }
+    if (!_mrhof_get_stats(d1_parent->dodag->iface, d1_parent->addr, &d1_stats) || !_mrhof_get_stats(dio_iface, dio_addr, &dio_stats)) {
+        return -1;
+    }
+
+    // get path cost
+    uint16_t d1_path_cost = _mrhof_get_path_cost(d1_parent->rank, &d1_stats);
+    uint16_t dio_rank = byteorder_ntohs(dio->rank);
+    uint16_t dio_path_cost = _mrhof_get_path_cost(dio_rank, &dio_stats);
+
+    // compare while using hysteresis
+    if (d1_path_cost > dio_path_cost) {
+        if (dio_path_cost + MRHOF_PARENT_SWITCH_THRESHOLD < d1_path_cost) {
+            return 1;
+        }
+        else {
+            return -1;
+        }
+    }
+
+    return -1;
 }
 
 static gnrc_rpl_of_t gnrc_rpl_mrhof = {

--- a/sys/net/gnrc/routing/rpl/mrhof.h
+++ b/sys/net/gnrc/routing/rpl/mrhof.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_gnrc_rpl
+ * @{
+ * @file
+ * @brief       Minimum Rank with Hysteresis Objective Function
+ *
+ * Header-file, which defines all functions for the implementation of Minimum Rank with Hysteresis Objective Function.
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ */
+
+#ifndef MRHOF_H
+#define MRHOF_H
+
+#include "net/gnrc/rpl/structs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Minimal improvement over old route needed to switch parent
+ */
+#define MRHOF_PARENT_SWITCH_THRESHOLD   192
+
+/**
+ * @brief   Highest per-hop cost
+ */
+#define MRHOF_MAX_LINK_METRIC           512
+
+/**
+ * @brief   Highest path cost
+ */
+#define MRHOF_MAX_PATH_COST           32768
+
+/**
+ * @brief   Number of possible parents
+ */
+#define MRHOF_PARENT_SET_SIZE             3
+
+/**
+ * @brief   Return the address to the MRH objective function
+ *
+ * @return  Address of the MRH objective function
+ */
+gnrc_rpl_of_t *gnrc_rpl_get_of_mrhof(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MRHOF_H */
+/**
+ * @}
+ */

--- a/sys/net/gnrc/routing/rpl/mrhof.h
+++ b/sys/net/gnrc/routing/rpl/mrhof.h
@@ -1,10 +1,9 @@
 /*
- * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
+#pragma once
 
 /**
  * @ingroup     net_gnrc_rpl
@@ -12,13 +11,11 @@
  * @file
  * @brief       Minimum Rank with Hysteresis Objective Function
  *
- * Header-file, which defines all functions for the implementation of Minimum Rank with Hysteresis Objective Function.
+ * Header-file, which defines all functions for the implementation of Minimum Rank
+ * with Hysteresis Objective Function.
  *
  * @author      Koen Zandberg <koen@bergzand.net>
  */
-
-#ifndef MRHOF_H
-#define MRHOF_H
 
 #include "net/gnrc/rpl/structs.h"
 
@@ -56,8 +53,6 @@ gnrc_rpl_of_t *gnrc_rpl_get_of_mrhof(void);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* MRHOF_H */
 /**
  * @}
  */

--- a/sys/net/gnrc/routing/rpl/mrhof.h
+++ b/sys/net/gnrc/routing/rpl/mrhof.h
@@ -36,12 +36,7 @@ extern "C" {
 /**
  * @brief   Highest path cost
  */
-#define MRHOF_MAX_PATH_COST           32768
-
-/**
- * @brief   Number of possible parents
- */
-#define MRHOF_PARENT_SET_SIZE             3
+#define MRHOF_MAX_PATH_COST           3276
 
 /**
  * @brief   Return the address to the MRH objective function

--- a/sys/net/gnrc/routing/rpl/of0.c
+++ b/sys/net/gnrc/routing/rpl/of0.c
@@ -25,7 +25,7 @@
 
 static uint16_t calc_rank(gnrc_rpl_dodag_t *, uint16_t);
 static int parent_cmp(gnrc_rpl_parent_t *, gnrc_rpl_parent_t *);
-static int which_dodag(gnrc_rpl_dodag_t *, gnrc_rpl_dio_t *);
+static int which_dodag(gnrc_rpl_dodag_t *, gnrc_rpl_dio_t *, kernel_pid_t iface, ipv6_addr_t addr);
 static void reset(gnrc_rpl_dodag_t *);
 
 static gnrc_rpl_of_t gnrc_rpl_of0 = {
@@ -87,8 +87,11 @@ int parent_cmp(gnrc_rpl_parent_t *parent1, gnrc_rpl_parent_t *parent2)
     return 0;
 }
 
-int which_dodag(gnrc_rpl_dodag_t *d1, gnrc_rpl_dio_t *dio)
+int which_dodag(gnrc_rpl_dodag_t *d1, gnrc_rpl_dio_t *dio, kernel_pid_t iface, ipv6_addr_t addr)
 {
+    (void) iface;
+    (void) addr;
+    
     /* RFC 6552, Section 4.2 */
 
     /* parent set must not be empty */


### PR DESCRIPTION
### Contribution description

This is a rebase of the following pull request: in pull request ([#14623](https://github.com/RIOT-OS/RIOT/pull/14623)) the Minimum Rank with Hysteresis Objective Function ([rfc 6719](https://tools.ietf.org/html/rfc6719)) is added to the current implementation of the RPL protocol where until now only OF0 (Objective Function 0) was implemented.

MRHOF uses specific link metrics, as defined in ([rfc 6551](https://tools.ietf.org/html/rfc6551)), to calculate the rank and decides on a parent using a hysteresis to prevent excessive churn on the network.

Two metrics were implemented to choose from to be used as routing metrics: ETX and LQI.

### Testing procedure

To test the functionality of RPL using MRHOF, you can flash the example application in examples/networking/gnrc/networking onto different nodes.

### Issues/PRs references

taken over from https://github.com/RIOT-OS/RIOT/pull/14623