### PR TITLE
CODING_CONVENTIONS: Add reference to Commit Conventions

### DIFF
--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -654,8 +654,10 @@ not a string literal`.
 
 ## Git
 
-* Make one commit per change.
-* The first line of the commit message describes the main feature of the commit.
+* Try to group your changes into commits that focus on a certain area,
+  for example: "cpu/stm32: fix ADC resolution check"
+* For more information about using Git and our Commit Conventions see
+  https://github.com/RIOT-OS/RIOT/blob/master/CONTRIBUTING.md#commit-conventions
 
 ## Continuous Integration
 * If the CI tests fail due to errors these errors need to be addressed.


### PR DESCRIPTION
### Contribution description

There is currently no reference from the Coding Conventions to the Commit Conventions and the description of the commit message format was wrong and incomplete.

### Testing procedure

Take a gooooood look with yo eyes 👀 

### Issues/PRs references

None.