### PR TITLE
pkg/pkg.mk: Evaluate Sparse Paths for Non-Cache too

### DIFF
--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -3,6 +3,10 @@ PKG_URL=https://github.com/basilfx/RIOT-gecko-sdk
 PKG_VERSION=91ebaf05d173ba0a9ba86b6e5078f6159ba8bc2a
 PKG_LICENSE=Zlib
 
+RIOTBASE ?= ../../
+
+include $(RIOTBASE)/makefiles/utils/strings.mk
+
 PKG_SPARSE_PATHS += dist/Makefile
 
 PKG_SPARSE_PATHS += dist/platform/common

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -181,7 +181,7 @@ $(PKG_SOURCE_DIR)/.git: | $(PKG_CUSTOM_PREPARED)
 	$(Q)$(GITCACHE) clone $(PKG_URL) $(PKG_VERSION) $(PKG_SOURCE_DIR)
 else
 # redirect stderr so git sees a pipe and not a terminal see https://github.com/git/git/blob/master/progress.c#L138
-$(PKG_SOURCE_DIR)/.git: | $(PKG_CUSTOM_PREPARED)
+$(PKG_SOURCE_DIR)/.git: $(PKG_SPARSE_TAG) | $(PKG_CUSTOM_PREPARED)
 	$(if $(QUIETER),,$(info [INFO] cloning $(PKG_NAME) without cache))
 	@echo "$(COLOR_YELLOW)[INFO] Consider using git-cache-rs to speed up your build" \
 	  "and reduce network traffic! See:" \


### PR DESCRIPTION
### Contribution description

When generating the `Makefile.ci` for #22083, I noticed that it would fail for EFM32 based boards if EFM32 based boards from a different platform have been built before.

The cause was twofold: `pkg/pkg.mk` did not run the `PKG_SPARSE_TAG` recipe for non-cached operations (that's why it did not make the CI fail, that uses `git-cache-rs`. My local installation too, but `skyleaf` does not.). I simply forgot to add that in #22039.

Furthermore, the Sparse Paths were not fully generated, because the `pkg/gecko_sdk/Makefile` did not include the actual file that contains the `uppercase_and_underscore` function.

The reason why it worked for `git-cache-rs` (I think?) is that `PKG_SPARSE_PATHS` is evaluated at a later time for `git-cache-rs`, so the function call actually works then, but it does not at an earlier stage.


### Testing procedure

I added some debug messages to confirm the evaluation theory. Current master with `git-cache-rs`:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ BOARD=stk3700 make -C examples/lang_support/community/forth_blinky/
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/examples/lang_support/community/forth_blinky'
Building application "ficl_blinky" for "stk3700" with CPU "efm32".

PKG_SPARSE_PATHS outside a recipe: CMSIS/Core/Include
PKG_SPARSE_PATHS outside a recipe:
dist/Makefile dist/platform/common dist/platform/Device/SiliconLabs/ dist/platform/emlib-extra dist/platform/emlib
PKG_SPARSE_PATHS outside a recipe: dist/Makefile dist/platform/common dist/platform/Device/SiliconLabs/ dist/platform/emlib-extra dist/platform/emlib
PKG_SPARSE_PATHS before git-cache-rs: dist/Makefile dist/platform/common dist/platform/Device/SiliconLabs/EFM32GG dist/platform/emlib-extra dist/platform/emlib
...
```

Current master without cache:
```
buechse@skyleaf:~/RIOTstuff/riot-vanillaice/RIOT$ BUILD_IN_DOCKER=1 BOARD=stk3700 make -C tests/sys/shell
make: Entering directory '/home/buechse/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell'
Launching build container using image "docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736".
docker run ...
Building application "tests_shell" for "stk3700" with CPU "efm32".

PKG_SPARSE_PATHS outside a recipe: CMSIS/Core/Include
PKG_SPARSE_PATHS outside a recipe: dist/Makefile dist/platform/common dist/platform/Device/SiliconLabs/ dist/platform/emlib-extra dist/platform/emlib
[INFO] Consider using git-cache-rs to speed up your build and reduce network traffic! See: https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs
PKG_SPARSE_PATHS before non-cache git: dist/Makefile dist/platform/common dist/platform/Device/SiliconLabs/EFM32GG dist/platform/emlib-extra dist/platform/emlib
PKG_SPARSE_PATHS outside a recipe:
"make" -C /data/riotbuild/riotbase/pkg/cmsis/
PKG_SPARSE_PATHS outside a recipe: CMSIS/Core/Include
"make" -C /data/riotbuild/riotbase/pkg/gecko_sdk/
PKG_SPARSE_PATHS outside a recipe: dist/Makefile dist/platform/common dist/platform/Device/SiliconLabs/ dist/platform/emlib-extra dist/platform/emlib
"make" -C /data/riotbuild/riotbase/build/pkg/gecko_sdk/dist
"make" -C /data/riotbuild/riotbase/build/pkg/gecko_sdk/dist/platform/common
"make" -C /data/riotbuild/riotbase/build/pkg/gecko_sdk/dist/platform/emlib
```

This PR without cache:
```
buechse@skyleaf:~/RIOTstuff/riot-vanillaice/RIOT$ BUILD_IN_DOCKER=1 BOARD=stk3700 make -C tests/sys/shell
make: Entering directory '/home/buechse/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell'
Launching build container using image "docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736".
docker run ...
Building application "tests_shell" for "stk3700" with CPU "efm32".

PKG_SPARSE_PATHS outside a recipe: CMSIS/Core/Include
PKG_SPARSE_PATHS outside a recipe: dist/Makefile dist/platform/common dist/platform/Device/SiliconLabs/EFM32GG dist/platform/emlib-extra dist/platform/emlib
[INFO] Consider using git-cache-rs to speed up your build and reduce network traffic! See: https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs
PKG_SPARSE_PATHS before non-cache git: dist/Makefile dist/platform/common dist/platform/Device/SiliconLabs/EFM32GG dist/platform/emlib-extra dist/platform/emlib
PKG_SPARSE_PATHS outside a recipe:
"make" -C /data/riotbuild/riotbase/pkg/cmsis/
PKG_SPARSE_PATHS outside a recipe: CMSIS/Core/Include
"make" -C /data/riotbuild/riotbase/pkg/gecko_sdk/
PKG_SPARSE_PATHS outside a recipe: dist/Makefile dist/platform/common dist/platform/Device/SiliconLabs/EFM32GG dist/platform/emlib-extra dist/platform/emlib
"make" -C /data/riotbuild/riotbase/build/pkg/gecko_sdk/dist
"make" -C /data/riotbuild/riotbase/build/pkg/gecko_sdk/dist/platform/common
"make" -C /data/riotbuild/riotbase/build/pkg/gecko_sdk/dist/platform/emlib
```

This PR with `git-cache-rs`:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ BOARD=stk3700 make -C examples/lang_support/community/forth_blinky/
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/examples/lang_support/community/forth_blinky'
Building application "ficl_blinky" for "stk3700" with CPU "efm32".

PKG_SPARSE_PATHS outside a recipe: CMSIS/Core/Include
PKG_SPARSE_PATHS outside a recipe:
PKG_SPARSE_PATHS outside a recipe: dist/Makefile dist/platform/common dist/platform/Device/SiliconLabs/EFM32GG dist/platform/emlib-extra dist/platform/emlib
PKG_SPARSE_PATHS before git-cache-rs: dist/Makefile dist/platform/common dist/platform/Device/SiliconLabs/EFM32GG dist/platform/emlib-extra dist/platform/emlib
Cloning into '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/gecko_sdk'...
done.
HEAD is now at 91ebaf0 Merge pull request #6 from basilfx/feature/gecko_sdk_450
PKG_SPARSE_PATHS outside a recipe:
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/pkg/cmsis/
PKG_SPARSE_PATHS outside a recipe: CMSIS/Core/Include
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/pkg/ficl/
PKG_SPARSE_PATHS outside a recipe:
make -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/ficl/softwords softcore.c
python3 softcore.py softcore.fr jhlocal.fr marker.fr prefix.fr ifbrack.fr oo.fr classes.fr string.fr fileaccess.fr >./softcore.c
cp /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/ficl/softwords/softcore.c /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/ficl/softcore.c
make -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/ficl -f /home/cbuec/RIOTstuff/riot-vanilla/RIOT/Makefile.base
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/pkg/gecko_sdk/
PKG_SPARSE_PATHS outside a recipe: dist/Makefile dist/platform/common dist/platform/Device/SiliconLabs/EFM32GG dist/platform/emlib-extra dist/platform/emlib
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/gecko_sdk/dist
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/gecko_sdk/dist/platform/common
"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/build/pkg/gecko_sdk/dist/platform/emlib
...
```


Most importantly: You can run `make generate-Makefile.ci` also on a non-cached system now without consecutive EFM32 platforms biting each other :D
Usually the `ikea-tradfri` would fail.

```
buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ make -C examples/lang_support/community/forth_REPL/ generate-Makefile.ci
make: Entering directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/examples/lang_support/community/forth_REPL'
using BOARD="native64" as "native" on a 64-bit system
using BOARD="native64" as "native" on a 64-bit system
...
e104-bt5010a-tb                         OK
e104-bt5011a-tb                         OK
e180-zg120b-tb                          OK
...
ikea-tradfri                            OK
...
```

### Issues/PRs references

Fixup for #22039 and #22040.