### PR TITLE
boards/pro-micro-nrf52840: add support

### DIFF
--- a/boards/pro-micro-nrf52840/Kconfig
+++ b/boards/pro-micro-nrf52840/Kconfig
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+# SPDX-License-Identifier: LGPL-2.1-only
+
+config BOARD
+    default "pro-micro-nrf52840" if BOARD_PRO_MICRO_NRF52840
+
+config BOARD_PRO_MICRO_NRF52840
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52840XXAA
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/pro-micro-nrf52840/Makefile
+++ b/boards/pro-micro-nrf52840/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/pro-micro-nrf52840/Makefile.dep
+++ b/boards/pro-micro-nrf52840/Makefile.dep
@@ -1,0 +1,8 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+USEMODULE += boards_common_adafruit-nrf52-bootloader
+
+# include common nrf52 dependencies
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/pro-micro-nrf52840/Makefile.features
+++ b/boards/pro-micro-nrf52840/Makefile.features
@@ -1,0 +1,17 @@
+CPU_MODEL = nrf52840xxaa
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# Various other features (if any)
+FEATURES_PROVIDED += arduino_analog
+FEATURES_PROVIDED += arduino_i2c
+FEATURES_PROVIDED += arduino_pins
+FEATURES_PROVIDED += arduino_spi
+FEATURES_PROVIDED += arduino_uart
+FEATURES_PROVIDED += highlevel_stdio
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/pro-micro-nrf52840/Makefile.include
+++ b/boards/pro-micro-nrf52840/Makefile.include
@@ -1,0 +1,1 @@
+UF2_SOFTDEV ?= SD611

--- a/boards/pro-micro-nrf52840/doc.md
+++ b/boards/pro-micro-nrf52840/doc.md
@@ -1,0 +1,98 @@
+@defgroup    boards_pro-micro-nrf52840 Pro Micro nRF52840
+@ingroup     boards
+@brief       Support for Pro Micro nRF52840-compatible development boards
+
+## Overview
+
+Pro Micro nRF52840 boards are Arduino Pro Micro-compatible development boards
+based on the nRF52840 SoC. This is a generic board definition that supports
+multiple variants with compatible pinouts. There are many variants available,
+including:
+
+* Compatible:
+  * Nice!Nano V2 (official, open-source)
+  * SuperMini nRF52840
+  * ProMicro nRF52840
+  * Mikoto
+  * 52840nano (more GPIO)
+
+* Similar:
+  * nRFMicro
+  * BlueMicro
+
+All these boards are largely the same in terms of functionality. They vary
+slightly in pinouts, LED colors, battery charging capabilities and antenna
+design. Though the board definition is generic, it follows the most common
+pinout of the Nice!Nano V2.
+
+This board definition is frequently used for building battery-powered custom
+wireless keyboards. A comprehensive overview of various compatible variants,
+including their specific features and known issues, can be found at
+[NRF Micro Wiki - Alternatives](https://github.com/joric/nrfmicro/wiki/Alternatives).
+
+## Hardware
+
+The board is pin-compatible with the Arduino Pro Micro and features:
+
+- nRF52840 SoC with ARM Cortex-M4F CPU
+- 1 MiB Flash, 256 KiB RAM
+- Bluetooth Low Energy 5.0
+- USB-C connector with USB device support (some variants use USB Micro)
+- Single board-provided LED (color varies by variant: blue, red, or green)
+- Arduino Pro Micro form factor
+
+### Pin Layout
+
+The board follows the Pro Micro pinout. The following tables show the complete pin mapping:
+
+#### Complete Pin Mapping
+
+| nRF52840 Pin | Arduino Pin | Function | Notes           |
+|--------------|-------------|----------|-----------------|
+| P0.08        | D0          | UART RX  | Serial receive  |
+| P0.06        | D1          | UART TX  | Serial transmit |
+| P0.17        | D2          | I2C SDA  | I2C0 data line  |
+| P0.20        | D3          | I2C SCL  | I2C0 clock      |
+| P0.22        | D4          | GPIO     |                 |
+| P0.24        | D5          | GPIO     |                 |
+| P1.00        | D6          | GPIO     |                 |
+| P0.11        | D7          | GPIO     |                 |
+| P1.04        | D8          | GPIO     |                 |
+| P1.06        | D9          | GPIO     |                 |
+| P0.09        | D10         | GPIO     |                 |
+| -            | D11         | -        | Not available   |
+| -            | D12         | -        | Not available   |
+| P0.15        | D13         | GPIO     | LED             |
+| P1.11        | D14         | SPI MISO | SPI0 MISO       |
+| P1.13        | D15         | SPI SCK  | SPI0 SCK        |
+| P0.10        | D16         | SPI MOSI | SPI0 MOSI       |
+| -            | D17         | -        | Not available   |
+| P1.15        | D18         | GPIO     |                 |
+| P0.02        | D19         | GPIO     |                 |
+| P0.29        | D20         | GPIO     |                 |
+| P0.31        | D21         | GPIO     |                 |
+
+#### Primary Peripherals
+
+| Peripheral    | nRF52840 Pins       | Arduino Pins  | Description            |
+|---------------|---------------------|---------------|------------------------|
+| UART (USB)    |                     |               | Used for STDIO         |
+| UART (Serial) | P0.08, P0.06        | D0, D1        | RX, TX                 |
+| I2C0          | P0.17, P0.20        | D2, D3        | SDA, SCL               |
+| SPI0          | P0.10, P1.11, P1.13 | D16, D14, D15 | MOSI, MISO, SCK        |
+
+The color of the LED may vary between board variants.
+
+## Flashing, Bootloader, and Terminal
+
+The board uses the Adafruit nRF52 Bootloader. Refer to the
+[Adafruit nRF52 Bootloader](@ref boards_common_adafruit-nrf52-bootloader)
+documentation for further details on the flashing process.
+
+Example with `hello-world` application:
+
+```shell
+make BOARD=pro-micro-nrf52840 -C examples/basic/hello-world flash term
+```
+
+The terminal will connect to STDIO over USB (USB-CDC).

--- a/boards/pro-micro-nrf52840/include/arduino_iomap.h
+++ b/boards/pro-micro-nrf52840/include/arduino_iomap.h
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_pro-micro-nrf52840
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins for Pro Micro nRF52840 boards
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ */
+
+#include "periph/adc.h"
+#include "periph/gpio.h"
+#include "periph/i2c.h"
+#include "periph/spi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Pro Micro's UART devices
+ * @{
+ */
+#define ARDUINO_UART_DEV    UART_UNDEF  /**< Board uses USB-CDC-ACM by default */
+/** @} */
+
+/**
+ * @name    Pro Micro's SPI buses
+ * @{
+ */
+#define ARDUINO_SPI_DEV     SPI_DEV(0)  /**< Standard SPI bus for general purpose use */
+/** @} */
+
+/**
+ * @name    Pro Micro's I2C buses
+ * @{
+ */
+#define ARDUINO_I2C_DEV     I2C_DEV(0)  /**< Standard I2C bus for general purpose use */
+/** @} */
+
+/**
+ * @name    Pro Micro's on-board LED (LED_BUILTIN)
+ * @{
+ */
+#define ARDUINO_LED         (13)        /**< Internal LED pin (not on header) */
+/** @} */
+
+/**
+ * @name   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0       GPIO_PIN(0,  8)     /**< Pin definition for D0 (RX) */
+#define ARDUINO_PIN_1       GPIO_PIN(0,  6)     /**< Pin definition for D1 (TX) */
+#define ARDUINO_PIN_2       GPIO_PIN(0, 17)     /**< Pin definition for D2 (SDA) */
+#define ARDUINO_PIN_3       GPIO_PIN(0, 20)     /**< Pin definition for D3 (SCL) */
+#define ARDUINO_PIN_4       GPIO_PIN(0, 22)     /**< Pin definition for D4 */
+#define ARDUINO_PIN_5       GPIO_PIN(0, 24)     /**< Pin definition for D5 */
+#define ARDUINO_PIN_6       GPIO_PIN(1,  0)     /**< Pin definition for D6 */
+#define ARDUINO_PIN_7       GPIO_PIN(0, 11)     /**< Pin definition for D7 */
+#define ARDUINO_PIN_8       GPIO_PIN(1,  4)     /**< Pin definition for D8 */
+#define ARDUINO_PIN_9       GPIO_PIN(1,  6)     /**< Pin definition for D9 */
+#define ARDUINO_PIN_10      GPIO_PIN(0,  9)     /**< Pin definition for D10 */
+#define ARDUINO_PIN_11      GPIO_UNDEF          /**< Pin undefined */
+#define ARDUINO_PIN_12      GPIO_UNDEF          /**< Pin undefined */
+#define ARDUINO_PIN_13      GPIO_PIN(0, 15)     /**< Pin definition for D13 (LED) */
+#define ARDUINO_PIN_14      GPIO_PIN(1, 11)     /**< Pin definition for D14 (MISO) */
+#define ARDUINO_PIN_15      GPIO_PIN(1, 13)     /**< Pin definition for D15 (SCLK) */
+#define ARDUINO_PIN_16      GPIO_PIN(0, 10)     /**< Pin definition for D11 (MOSI) */
+#define ARDUINO_PIN_17      GPIO_UNDEF          /**< Pin undefined */
+#define ARDUINO_PIN_18      GPIO_PIN(1, 15)     /**< Pin definition for D18 */
+#define ARDUINO_PIN_19      GPIO_PIN(0, 2)      /**< Pin definition for D19 */
+#define ARDUINO_PIN_20      GPIO_PIN(0, 29)     /**< Pin definition for D20 */
+#define ARDUINO_PIN_21      GPIO_PIN(0, 31)     /**< Pin definition for D21 */
+
+#define ARDUINO_PIN_LAST    21                  /**< Last Arduino Pin */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/pro-micro-nrf52840/include/board.h
+++ b/boards/pro-micro-nrf52840/include/board.h
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_pro-micro-nrf52840
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for Pro Micro nRF52840-compatible
+ *              development boards
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ */
+
+#include "cpu.h"
+#include "board_common.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    ztimer configuration values
+ * @{
+ */
+#define CONFIG_ZTIMER_USEC_ADJUST_SET    7      /**< Overhead for the ztimer_set function in us */
+#define CONFIG_ZTIMER_USEC_ADJUST_SLEEP  21     /**< Overhead for the ztimer_sleep function in us */
+/** @} */
+
+/**
+ * @name    LED pin configuration
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 15)     /**< Pin Definition for the LED */
+
+#define LED_PORT            (NRF_P0)            /**< GPIO Port of the LED GPIOs */
+#define LED0_MASK           (1 << 15)           /**< Bit position of the LED GPIO output bit */
+
+#define LED0_ON             (LED_PORT->OUTSET = LED0_MASK)      /**< Turn the LED on */
+#define LED0_OFF            (LED_PORT->OUTCLR = LED0_MASK)      /**< Turn the LED off */
+#define LED0_TOGGLE         (LED_PORT->OUT   ^= LED0_MASK)      /**< Toggle the LED */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/pro-micro-nrf52840/include/gpio_params.h
+++ b/boards/pro-micro-nrf52840/include/gpio_params.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_pro-micro-nrf52840
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "LED",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = SAUL_GPIO_INIT_CLEAR,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/pro-micro-nrf52840/include/periph_conf.h
+++ b/boards/pro-micro-nrf52840/include/periph_conf.h
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_pro-micro-nrf52840
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for Pro Micro nRF52840-compatible
+ *              development boards
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ */
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(0, 8),
+        .tx_pin     = GPIO_PIN(0, 6),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin    = GPIO_UNDEF,
+        .cts_pin    = GPIO_UNDEF,
+#endif
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_uart0)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPIM0,
+        .sclk = GPIO_PIN(1, 13),
+        .mosi = GPIO_PIN(0, 10),
+        .miso = GPIO_PIN(1, 11),
+    }
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = NRF_TWIM0,
+        .scl = GPIO_PIN(0, 20),
+        .sda = GPIO_PIN(0, 17),
+        .speed = I2C_SPEED_NORMAL
+    }
+};
+
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */


### PR DESCRIPTION
### Contribution description

The Pro Micro nRF52840 is a board that has many commercially available variants around the nRF52840. Most of them have a pin-compatible design. While there are other subtle differences, this commit adds support for the common set of features based on the 'Nice!Nano', that seems to be the first and most common board.

Pro Micro therefore not refers to a specific board, but to the form factor adopted from the Arduino Pro Micro.

More info about the different boards can be found [here](https://github.com/joric/nrfmicro/wiki/Alternatives).

### Testing procedure

The nRF52 is already well-supported, so I mainly tested applications to check the pinouts. Below are a few screenshots as proof. I used a variant that was labeled as ProMicro nRF52840 (bought off Amazon).

Flashing happens via the Adafruit DFU bootloader. Shorting the RST with GND twice boots it into the bootloader.

<details>
<summary>Networking</summary>

Tested the networking chip by broadcasting from one to another. Don't have much experience with networking. Also tested BLE and that works (not on screenshot).

<img width="1962" height="1274" alt="Scherm­afbeelding 2026-02-18 om 21 12 04" src="https://github.com/user-attachments/assets/788e6f09-ebac-417a-b74e-bbbb15fd2bed" />

![IMG_6424](https://github.com/user-attachments/assets/64982c30-4fa2-4d38-8985-cf138a8b5bf3)
</details>

<details>
<summary>I2C</summary>

Connected a BME280 to validate the I2C pins.

<img width="1962" height="1274" alt="Scherm­afbeelding 2026-02-18 om 21 41 26" src="https://github.com/user-attachments/assets/d3f2c10a-3238-429a-8180-d11ddec923ce" />

![IMG_6425](https://github.com/user-attachments/assets/9f2229d1-3ee5-44ca-b3f0-d5790fb3ef13)
</details>

<details>
<summary>SPI</summary>

Connected a nRF24L01+ to validate SPI (I did not have something else simpler to test).

<img width="1962" height="1274" alt="Scherm­afbeelding 2026-02-18 om 22 17 52" src="https://github.com/user-attachments/assets/5a258132-e61d-4bcf-8a23-50a4e0f122e9" />

![IMG_6426](https://github.com/user-attachments/assets/0dd7e012-e09b-4c2e-9870-edd18a9a8575)
</details>

### Issues/PRs references

None
