### PR TITLE
sys/net/nanocoap: fix message corruption `coap_build_reply()`

### DIFF
--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -739,17 +739,18 @@ ssize_t coap_build_reply(coap_pkt_t *pkt, unsigned code,
 {
     unsigned tkl = coap_get_token_len(pkt);
     unsigned type = COAP_TYPE_NON;
+    unsigned len = coap_get_total_hdr_len(pkt);
 
     if (!code) {
         /* if code is COAP_CODE_EMPTY (zero), assume Reset (RST) type.
          * RST message have no token */
         type = COAP_TYPE_RST;
+        len = sizeof(coap_udp_hdr_t);
         tkl = 0;
     }
     else if (coap_get_type(pkt) == COAP_TYPE_CON) {
         type = COAP_TYPE_ACK;
     }
-    unsigned len = sizeof(coap_udp_hdr_t) + tkl;
 
     if ((len + payload_len) > rlen) {
         return -ENOSPC;

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -1152,8 +1152,13 @@ static void test_nanocoap__token_length_ext_16(void)
     /* now build the corresponding reply and check that it parses back as
      * expected */
     uint8_t rbuf[sizeof(buf)];
-    ssize_t len = coap_build_reply_header(&pkt, COAP_CODE_DELETED, rbuf,
-                                          sizeof(rbuf), 0, NULL, NULL);
+    /* build first using coap_build_reply() */
+    ssize_t len = coap_build_reply(&pkt, COAP_CODE_DELETED,
+                                   rbuf, sizeof(rbuf), 0);
+    TEST_ASSERT_EQUAL_INT(21, len);
+    /* build again using coap_build_reply_header() */
+    len = coap_build_reply_header(&pkt, COAP_CODE_DELETED, rbuf,
+                                  sizeof(rbuf), 0, NULL, NULL);
     TEST_ASSERT_EQUAL_INT(21, len);
     res = coap_parse_udp(&pkt, rbuf, 21);
     TEST_ASSERT_EQUAL_INT(21, res);
@@ -1201,8 +1206,12 @@ static void test_nanocoap__token_length_ext_269(void)
     /* now build the corresponding reply and check that it parses back as
      * expected */
     uint8_t rbuf[sizeof(buf)];
-    ssize_t len = coap_build_reply_header(&pkt, COAP_CODE_DELETED, rbuf,
-                                          sizeof(rbuf), 0, NULL, NULL);
+    /* build first using coap_build_reply() */
+    ssize_t len = coap_build_reply(&pkt, COAP_CODE_DELETED,
+                                   rbuf, sizeof(rbuf), 0);
+    /* build again using coap_build_reply_header() */
+    len = coap_build_reply_header(&pkt, COAP_CODE_DELETED, rbuf,
+                                  sizeof(rbuf), 0, NULL, NULL);
 
     TEST_ASSERT_EQUAL_INT(275, len);
     res = coap_parse_udp(&pkt, rbuf, 275);


### PR DESCRIPTION
### Contribution description

When the request contained an extended TKL field, using `coap_build_reply()` to generate the response would cause message corruption, as the size of the reported header would be short by one or two bytes. The caller would add options or payload one or two bytes to early in the response buffer, overwriting the last one or two bytes of the payload.

### Testing procedure

A unit test has been added that would have caught the bug. It passes with this PR, but fails with `master`.

### Issues/PRs references

- [x] Depends on and includes: https://github.com/RIOT-OS/RIOT/pull/22093