### PR TITLE
pkg/libsocketcan: fix build on native

### DIFF
--- a/pkg/libsocketcan/Makefile.include
+++ b/pkg/libsocketcan/Makefile.include
@@ -1,1 +1,4 @@
+# libsocketcan.h is needed by common RIOT code
+INCLUDES += -I"$(PKGDIRBASE)/libsocketcan/include"
+# libsocketcan.h is also needed by cpu/native code
 NATIVEINCLUDES += -I"$(PKGDIRBASE)/libsocketcan/include"


### PR DESCRIPTION
### Contribution description

The include paths for `libsocketcan.h` needs to be in both `NATIVEINCLUDES` (for e.g. `periph_can` in `cpu/native`, where a `INCLUDES = $(NATIVEINCLUDES)` statement wipes contests from `$(INCLUDES)`) as well in `$(INCLUDES)` (because it is included in `sys/include/can/can.h`). This simply adds it to both.

### Testing procedure

```
make BOARD=native64 -j32 -C tests/sys/conn_can
```

success on Ubuntu LTS 24.04 with this PR, but fails in `master`.

### Issues/PRs references

Fixes regression from https://github.com/RIOT-OS/RIOT/pull/21955