### PR TITLE
cpu/rpx0xx: wait for transmission to be completed

### DIFF
--- a/cpu/rpx0xx/periph/uart.c
+++ b/cpu/rpx0xx/periph/uart.c
@@ -229,9 +229,12 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
     UART0_Type *dev = uart_config[uart].dev;
 
     for (size_t i = 0; i < len; i++) {
+        /* wait while the TX FIFO is full (TXFF) before writing the next byte */
+        while (dev->UARTFR & UART0_UARTFR_TXFF_Msk) { }
         dev->UARTDR = data[i];
-        while (!(dev->UARTRIS & UART0_UARTRIS_TXRIS_Msk)) { }
     }
+    /* wait for the TX FIFO and shift register to drain (BUSY cleared) */
+    while (dev->UARTFR & UART0_UARTFR_BUSY_Msk) { }
 }
 
 gpio_t uart_pin_rx(uart_t uart)


### PR DESCRIPTION
### Contribution description

The UART driver did not check if the transmission completed, which causes problems with drivers that expect bytes to be sent completely.

This commit modifies the driver to use the flag register (FR) instead of the raw interrupt status register (RIS). It first checks if there is room left in the FIFO, then writes the bytes and finally checks if all the bytes have been sent over the wire.

Asserting TXRIS isn't sufficient, as it does not check if the bytes have been sent over the wire.

<img width="1024" height="1053" alt="Scherm­afbeelding 2026-02-22 om 15 17 51" src="https://github.com/user-attachments/assets/5062b7df-e679-4a53-9895-06df991fb39b" />

I noticed this while testing my Modbus PR with other platforms. Screenshots below demonstrate this for the Modbus driver, where request-to-send (RTS) line is toggled while sending.

Without patch (RTS is toggled low too soon):

<img width="889" height="451" alt="Scherm­afbeelding 2026-02-22 om 14 23 06" src="https://github.com/user-attachments/assets/237fa24f-1553-4f24-ae33-030b449a9c32" />

With patch (RTS is properly toggled after all bytes have been sent):

<img width="906" height="460" alt="Scherm­afbeelding 2026-02-22 om 14 24 59" src="https://github.com/user-attachments/assets/de98136c-70ff-4ebd-a774-aaf053592dec" />


### Testing procedure

Apart from Modbus testing, I used `tests/periph/uart` for validation, with GPIO8 and GPIO9 connected.

<img width="1962" height="1274" alt="Scherm­afbeelding 2026-02-22 om 15 12 42" src="https://github.com/user-attachments/assets/434512a1-2de3-464c-8c5c-2be0be8e9800" />

### Issues/PRs references

Similar to #22082.