### PR TITLE
dist/tools/bmp: remove requirements.txt

### DIFF
--- a/dist/tools/bmp/bmp.py
+++ b/dist/tools/bmp/bmp.py
@@ -9,8 +9,6 @@
 # @author   Maximilian Deubel <maximilian.deubel@ovgu.de>
 # @author   Bas Stottelaar <basstottelaar@gmail.com>
 
-# Dependencies are also listed in `requirements.txt` for compatibility reasons.
-#
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [

--- a/dist/tools/bmp/requirements.txt
+++ b/dist/tools/bmp/requirements.txt
@@ -1,7 +1,0 @@
-# Dependencies are listed as PEP 723 metadata in `bmp.py`. This file exists
-# for compatibility reasons.
-humanize
-packaging
-progressbar
-pygdbmi
-pyserial


### PR DESCRIPTION
### Contribution description

Support for PEP-723 in-line script metadata was merged a while ago, with the limitation that PIP did not support this. An open issue to support reading requirements from the in-line script metadata was recently [closed](https://github.com/pypa/pip/issues/12891) as implemented, and is now supported by PIP 26.0 or later.

Dependencies can now be installed using the following command:

`pip install --requirements-from-script bmp.py`

Note that this feature is only relevant for local development, the script already uses `pipx` when used normally.


### Testing procedure

Make sure to have PIP 26.0 or later installed (`pip install --upgrade pip`).

Then, test it out:

```
$ pip --version            
                                   
pip 26.0.1 from env/lib/python3.13/site-packages/pip (python 3.13)

$ pip install --requirements-from-script dist/tools/bmp/bmp.py

Requirement already satisfied: humanize in env/lib/python3.13/site-packages (4.11.0)
Requirement already satisfied: packaging in env/lib/python3.13/site-packages (24.2)
Requirement already satisfied: progressbar in env/lib/python3.13/site-packages (2.5)
Requirement already satisfied: pygdbmi in env/lib/python3.13/site-packages (0.11.0.0)
Requirement already satisfied: pyserial in env/lib/python3.13/site-packages (3.5)
```


### Issues/PRs references

Follow-up of #21131.
