### PR TITLE
boards: migrate EFM32-based board config to ztimer

### DIFF
--- a/boards/common/slwstk6000b/include/board.h
+++ b/boards/common/slwstk6000b/include/board.h
@@ -22,28 +22,32 @@
 #include "periph/adc.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
+#include "periph/timer.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @name    Xtimer configuration
+ * @name    ztimer configuration
  *
  * The timer runs at 250 kHz to increase accuracy, or at 32.768 kHz if
  * LETIMER is used.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
-#define XTIMER_DEV          (TIMER_DEV(1))
-#define XTIMER_HZ           (32768UL)
-#define XTIMER_WIDTH        (16)
+#if IS_ACTIVE(CONFIG_EFM32_ZTIMER_USE_LETIMER)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(1))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (32768UL)       /**< Running at 32.768 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (37)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (37)            /**< Overhead for ztimer_sleep */
 #else
-#define XTIMER_DEV          (TIMER_DEV(0))
-#define XTIMER_HZ           (250000UL)
-#define XTIMER_WIDTH        (16)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(0))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (250000UL)      /**< Running at 250 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (24)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (24)            /**< Overhead for ztimer_sleep */
 #endif
-#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/e180-zg120b-tb/include/board.h
+++ b/boards/e180-zg120b-tb/include/board.h
@@ -20,28 +20,32 @@
 #include "periph_conf.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
+#include "periph/timer.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @name    Xtimer configuration
+ * @name    ztimer configuration
  *
  * The timer runs at 250 kHz to increase accuracy, or at 32.768 kHz if
  * LETIMER is used.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
-#define XTIMER_DEV          (TIMER_DEV(1))
-#define XTIMER_HZ           (32768UL)
-#define XTIMER_WIDTH        (16)
+#if IS_ACTIVE(CONFIG_EFM32_ZTIMER_USE_LETIMER)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(1))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (32768UL)       /**< Running at 32.768 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (37)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (37)            /**< Overhead for ztimer_sleep */
 #else
-#define XTIMER_DEV          (TIMER_DEV(0))
-#define XTIMER_HZ           (250000UL)
-#define XTIMER_WIDTH        (16)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(0))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (250000UL)      /**< Running at 250 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (24)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (24)            /**< Overhead for ztimer_sleep */
 #endif
-#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/ikea-tradfri/include/board.h
+++ b/boards/ikea-tradfri/include/board.h
@@ -20,28 +20,32 @@
 #include "periph/adc.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
+#include "periph/timer.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @name    Xtimer configuration
+ * @name    ztimer configuration
  *
  * The timer runs at 250 kHz to increase accuracy, or at 32.768 kHz if
  * LETIMER is used.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
-#define XTIMER_DEV          (TIMER_DEV(1))
-#define XTIMER_HZ           (32768UL)
-#define XTIMER_WIDTH        (16)
+#if IS_ACTIVE(CONFIG_EFM32_ZTIMER_USE_LETIMER)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(1))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (32768UL)       /**< Running at 32.768 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (68)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (37)            /**< Overhead for ztimer_sleep */
 #else
-#define XTIMER_DEV          (TIMER_DEV(0))
-#define XTIMER_HZ           (250000UL)
-#define XTIMER_WIDTH        (16)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(0))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (250000UL)      /**< Running at 250 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (44)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (44)            /**< Overhead for ztimer_sleep */
 #endif
-#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/slstk3301a/include/board.h
+++ b/boards/slstk3301a/include/board.h
@@ -33,7 +33,7 @@ extern "C" {
  * LETIMER is used.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
+#if IS_ACTIVE(CONFIG_EFM32_ZTIMER_USE_LETIMER)
 #  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(1))  /**< Timer peripheral for ztimer */
 #  define CONFIG_ZTIMER_USEC_BASE_FREQ      (32768UL)       /**< Running at 32.768 kHz */
 #  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */

--- a/boards/slstk3400a/include/board.h
+++ b/boards/slstk3400a/include/board.h
@@ -29,13 +29,14 @@ extern "C" {
 /**
  * @name    Xtimer configuration
  *
- * The timer runs at 250 kHz.
+ * The timer runs at 250 kHz to increase accuracy.
  * @{
  */
-#define XTIMER_DEV          (TIMER_DEV(0))
-#define XTIMER_HZ           (250000UL)
-#define XTIMER_WIDTH        (16)
-#define XTIMER_CHAN         (0)
+#define CONFIG_ZTIMER_USEC_DEV              (TIMER_DEV(0))  /**< Timer peripheral for ztimer */
+#define CONFIG_ZTIMER_USEC_BASE_FREQ        (250000UL)      /**< Running at 250 kHz */
+#define CONFIG_ZTIMER_USEC_WIDTH            (16)            /**< Running on a 16-bit timer */
+#define CONFIG_ZTIMER_USEC_ADJUST_SET       (56)            /**< Overhead for ztimer_set */
+#define CONFIG_ZTIMER_USEC_ADJUST_SLEEP     (64)            /**< Overhead for ztimer_sleep */
 /** @} */
 
 /**

--- a/boards/slstk3401a/include/board.h
+++ b/boards/slstk3401a/include/board.h
@@ -21,28 +21,32 @@
 #include "periph/adc.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
+#include "periph/timer.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @name    Xtimer configuration
+ * @name    ztimer configuration
  *
  * The timer runs at 250 kHz to increase accuracy, or at 32.768 kHz if
  * LETIMER is used.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
-#define XTIMER_DEV          (TIMER_DEV(1))
-#define XTIMER_HZ           (32768UL)
-#define XTIMER_WIDTH        (16)
+#if IS_ACTIVE(CONFIG_EFM32_ZTIMER_USE_LETIMER)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(1))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (32768UL)       /**< Running at 32.768 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (37)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (37)            /**< Overhead for ztimer_sleep */
 #else
-#define XTIMER_DEV          (TIMER_DEV(0))
-#define XTIMER_HZ           (250000UL)
-#define XTIMER_WIDTH        (16)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(0))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (250000UL)      /**< Running at 250 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (24)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (24)            /**< Overhead for ztimer_sleep */
 #endif
-#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/slstk3402a/include/board.h
+++ b/boards/slstk3402a/include/board.h
@@ -21,28 +21,32 @@
 #include "periph/adc.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
+#include "periph/timer.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @name    Xtimer configuration
+ * @name    ztimer configuration
  *
  * The timer runs at 1000 kHz to increase accuracy, or at 32.768 kHz if
  * LETIMER is used.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
-#define XTIMER_DEV          (TIMER_DEV(2))
-#define XTIMER_HZ           (32768UL)
-#define XTIMER_WIDTH        (16)
+#if IS_ACTIVE(CONFIG_EFM32_ZTIMER_USE_LETIMER)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(2))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (32768UL)       /**< Running at 32.768 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (38)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (37)            /**< Overhead for ztimer_sleep */
 #else
-#define XTIMER_DEV          (TIMER_DEV(0))
-#define XTIMER_HZ           (1000000UL)
-#define XTIMER_WIDTH        (32)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(0))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (1000000UL)     /**< Running at 1000 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (32)            /**< Running on a 32-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (10)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (12)            /**< Overhead for ztimer_sleep */
 #endif
-#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/slstk3701a/include/board.h
+++ b/boards/slstk3701a/include/board.h
@@ -20,28 +20,32 @@
 #include "periph_conf.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
+#include "periph/timer.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @name    Xtimer configuration
+ * @name    ztimer configuration
  *
  * The timer runs at 1000 kHz to increase accuracy, or at 32.768 kHz if
  * LETIMER is used.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
-#define XTIMER_DEV          (TIMER_DEV(2))
-#define XTIMER_HZ           (32768UL)
-#define XTIMER_WIDTH        (16)
+#if IS_ACTIVE(CONFIG_EFM32_ZTIMER_USE_LETIMER)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(2))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (32768UL)       /**< Running at 32.768 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (37)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (37)            /**< Overhead for ztimer_sleep */
 #else
-#define XTIMER_DEV          (TIMER_DEV(0))
-#define XTIMER_HZ           (1000000UL)
-#define XTIMER_WIDTH        (32)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(0))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (1000000UL)     /**< Running at 1000 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (32)            /**< Running on a 32-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (8)             /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (14)            /**< Overhead for ztimer_sleep */
 #endif
-#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/sltb001a/include/board.h
+++ b/boards/sltb001a/include/board.h
@@ -21,28 +21,32 @@
 #include "periph/adc.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
+#include "periph/timer.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @name    Xtimer configuration
+ * @name    ztimer configuration
  *
  * The timer runs at 250 kHz to increase accuracy, or at 32.768 kHz if
  * LETIMER is used.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
-#define XTIMER_DEV          (TIMER_DEV(1))
-#define XTIMER_HZ           (32768UL)
-#define XTIMER_WIDTH        (16)
+#if IS_ACTIVE(CONFIG_EFM32_ZTIMER_USE_LETIMER)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(1))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (32768UL)       /**< Running at 32.768 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (37)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (37)            /**< Overhead for ztimer_sleep */
 #else
-#define XTIMER_DEV          (TIMER_DEV(0))
-#define XTIMER_HZ           (250000UL)
-#define XTIMER_WIDTH        (16)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(0))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (250000UL)      /**< Running at 250 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (24)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (24)            /**< Overhead for ztimer_sleep */
 #endif
-#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/sltb009a/doc.md
+++ b/boards/sltb009a/doc.md
@@ -77,8 +77,9 @@ PIN 1 is the top-left contact.
 | RTT         | -       | RTCC       |                  | 1 Hz interval, either RTT or RTC    |
 | RTC         | -       | RTCC       |                  | 1 Hz interval, either RTT or RTC    |
 | SPI         | 0       | USART3     | MOSI:PA0, MISO:PA1, CLK:PA2 |                          |
-| Timer       | 0       | TIMER0 + TIMER1 |             | TIMER0 is used as prescaler         |
-| Timer       | 1       | LETIMER0   |                  |                                     |
+| Timer       | 0       | WTIMER0 + WTIMER1 |           | WTIMER0 is used as prescaler        |
+| Timer       | 1       | TIMER0 + TIMER1   |           | TIMER0 is used as prescaler         |
+| Timer       | 2       | LETIMER0   |                  |                                     |
 | UART        | 0       | USART0     | RX:PE6, TX:PE7   | Default STDIO                       |
 | UART        | 1       | UART0      | RX:PC5, TX:PC4   |                                     |
 

--- a/boards/sltb009a/include/board.h
+++ b/boards/sltb009a/include/board.h
@@ -20,28 +20,32 @@
 #include "periph_conf.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
+#include "periph/timer.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @name    Xtimer configuration
+ * @name    ztimer configuration
  *
- * The timer runs at 250 kHz to increase accuracy, or at 32.768 kHz if
+ * The timer runs at 1000 kHz to increase accuracy, or at 32.768 kHz if
  * LETIMER is used.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
-#define XTIMER_DEV          (TIMER_DEV(1))
-#define XTIMER_HZ           (32768UL)
-#define XTIMER_WIDTH        (16)
+#if IS_ACTIVE(CONFIG_EFM32_ZTIMER_USE_LETIMER)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(2))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (32768UL)       /**< Running at 32.768 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (38)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (37)            /**< Overhead for ztimer_sleep */
 #else
-#define XTIMER_DEV          (TIMER_DEV(0))
-#define XTIMER_HZ           (250000UL)
-#define XTIMER_WIDTH        (16)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(0))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (1000000UL)     /**< Running at 1000 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (32)            /**< Running on a 32-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (10)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (12)            /**< Overhead for ztimer_sleep */
 #endif
-#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/sltb009a/include/periph_conf.h
+++ b/boards/sltb009a/include/periph_conf.h
@@ -160,6 +160,18 @@ static const spi_dev_t spi_config[] = {
 static const timer_conf_t timer_config[] = {
     {
         .prescaler = {
+            .dev = WTIMER0,
+            .cmu = cmuClock_WTIMER0
+        },
+        .timer = {
+            .dev = WTIMER1,
+            .cmu = cmuClock_WTIMER1
+        },
+        .irq = WTIMER1_IRQn,
+        .channel_numof = 3
+    },
+    {
+        .prescaler = {
             .dev = TIMER0,
             .cmu = cmuClock_TIMER0
         },
@@ -185,8 +197,9 @@ static const timer_conf_t timer_config[] = {
 };
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
-#define TIMER_0_ISR         isr_timer1
-#define TIMER_1_ISR         isr_letimer0
+#define TIMER_0_ISR         isr_wtimer1
+#define TIMER_1_ISR         isr_timer1
+#define TIMER_2_ISR         isr_letimer0
 /** @} */
 
 /**

--- a/boards/slwstk6220a/include/board.h
+++ b/boards/slwstk6220a/include/board.h
@@ -21,28 +21,32 @@
 #include "periph/adc.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
+#include "periph/timer.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @name    Xtimer configuration
+ * @name    ztimer configuration
  *
  * The timer runs at 250 kHz to increase accuracy, or at 32.768 kHz if
  * LETIMER is used.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
-#define XTIMER_DEV          (TIMER_DEV(1))
-#define XTIMER_HZ           (32768UL)
-#define XTIMER_WIDTH        (16)
+#if IS_ACTIVE(CONFIG_EFM32_ZTIMER_USE_LETIMER)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(1))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (32768UL)       /**< Running at 32.768 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (37)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (37)            /**< Overhead for ztimer_sleep */
 #else
-#define XTIMER_DEV          (TIMER_DEV(0))
-#define XTIMER_HZ           (250000UL)
-#define XTIMER_WIDTH        (16)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(0))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (250000UL)      /**< Running at 250 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (24)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (28)            /**< Overhead for ztimer_sleep */
 #endif
-#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/stk3200/include/board.h
+++ b/boards/stk3200/include/board.h
@@ -29,13 +29,14 @@ extern "C" {
 /**
  * @name    Xtimer configuration
  *
- * The timer runs at 250 kHz.
+ * The timer runs at 250 kHz to increase accuracy.
  * @{
  */
-#define XTIMER_DEV          (TIMER_DEV(0))
-#define XTIMER_HZ           (250000UL)
-#define XTIMER_WIDTH        (16)
-#define XTIMER_CHAN         (0)
+#define CONFIG_ZTIMER_USEC_DEV              (TIMER_DEV(0))  /**< Timer peripheral for ztimer */
+#define CONFIG_ZTIMER_USEC_BASE_FREQ        (250000UL)      /**< Running at 250 kHz */
+#define CONFIG_ZTIMER_USEC_WIDTH            (16)            /**< Running on a 16-bit timer */
+#define CONFIG_ZTIMER_USEC_ADJUST_SET       (56)            /**< Overhead for ztimer_set */
+#define CONFIG_ZTIMER_USEC_ADJUST_SLEEP     (64)            /**< Overhead for ztimer_sleep */
 /** @} */
 
 /**

--- a/boards/stk3600/include/board.h
+++ b/boards/stk3600/include/board.h
@@ -21,28 +21,32 @@
 #include "periph/adc.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
+#include "periph/timer.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @name    Xtimer configuration
+ * @name    ztimer configuration
  *
  * The timer runs at 250 kHz to increase accuracy, or at 32.768 kHz if
  * LETIMER is used.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
-#define XTIMER_DEV          (TIMER_DEV(1))
-#define XTIMER_HZ           (32768UL)
-#define XTIMER_WIDTH        (16)
+#if IS_ACTIVE(CONFIG_EFM32_ZTIMER_USE_LETIMER)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(1))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (32768UL)       /**< Running at 32.768 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (37)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (37)            /**< Overhead for ztimer_sleep */
 #else
-#define XTIMER_DEV          (TIMER_DEV(0))
-#define XTIMER_HZ           (250000UL)
-#define XTIMER_WIDTH        (16)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(0))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (250000UL)      /**< Running at 250 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (24)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (28)            /**< Overhead for ztimer_sleep */
 #endif
-#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/boards/stk3700/include/board.h
+++ b/boards/stk3700/include/board.h
@@ -21,28 +21,32 @@
 #include "periph/adc.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
+#include "periph/timer.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @name    Xtimer configuration
+ * @name    ztimer configuration
  *
  * The timer runs at 250 kHz to increase accuracy, or at 32.768 kHz if
  * LETIMER is used.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
-#define XTIMER_DEV          (TIMER_DEV(1))
-#define XTIMER_HZ           (32768UL)
-#define XTIMER_WIDTH        (16)
+#if IS_ACTIVE(CONFIG_EFM32_ZTIMER_USE_LETIMER)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(1))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (32768UL)       /**< Running at 32.768 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (37)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (37)            /**< Overhead for ztimer_sleep */
 #else
-#define XTIMER_DEV          (TIMER_DEV(0))
-#define XTIMER_HZ           (250000UL)
-#define XTIMER_WIDTH        (16)
+#  define CONFIG_ZTIMER_USEC_DEV            (TIMER_DEV(0))  /**< Timer peripheral for ztimer */
+#  define CONFIG_ZTIMER_USEC_BASE_FREQ      (250000UL)      /**< Running at 250 kHz */
+#  define CONFIG_ZTIMER_USEC_WIDTH          (16)            /**< Running on a 16-bit timer */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SET     (24)            /**< Overhead for ztimer_set */
+#  define CONFIG_ZTIMER_USEC_ADJUST_SLEEP   (28)            /**< Overhead for ztimer_sleep */
 #endif
-#define XTIMER_CHAN         (0)
 /** @} */
 
 /**

--- a/cpu/efm32/include/config.h
+++ b/cpu/efm32/include/config.h
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     cpu_efm32
+ * @{
+ *
+ * @file
+ * @brief       EFM32 default configuration
+ *
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Use LETIMER as the base timer for xtimer (effectively ztimer)
+ *
+ * @deprecated  This option is deprecated and should be replaced by
+ *              @ref CONFIG_EFM32_ZTIMER_USE_LETIMER.
+ */
+#ifndef CONFIG_EFM32_XTIMER_USE_LETIMER
+#  define CONFIG_EFM32_XTIMER_USE_LETIMER       0
+#endif
+
+/**
+ * @brief   Use LETIMER as the base timer for ztimer
+ */
+#ifndef CONFIG_EFM32_ZTIMER_USE_LETIMER
+#  if CONFIG_EFM32_XTIMER_USE_LETIMER
+#    define CONFIG_EFM32_ZTIMER_USE_LETIMER     1
+#  else
+#    define CONFIG_EFM32_ZTIMER_USE_LETIMER     0
+#  endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -19,6 +19,7 @@
 #include "kernel_defines.h"
 #include "mutex.h"
 
+#include "config.h"
 #include "cpu.h"
 #include "cpu_conf.h"
 
@@ -564,13 +565,6 @@ typedef struct {
 #define LETIMER_MAX_VALUE _LETIMER_TOP_MASK  /**< max timer value of LETIMER peripheral */
 #define TIMER_MAX_VALUE _TIMER_TOP_MASK      /**< max timer value of TIMER peripheral */
 /** @} */
-
-/**
- * @brief   Use LETIMER as the base timer for XTIMER
- */
-#ifndef CONFIG_EFM32_XTIMER_USE_LETIMER
-#define CONFIG_EFM32_XTIMER_USE_LETIMER   0
-#endif
 
 /**
  * @brief   UART device configuration.

--- a/cpu/efm32/periph/Kconfig.timer
+++ b/cpu/efm32/periph/Kconfig.timer
@@ -5,8 +5,17 @@
 # directory for more details.
 
 config EFM32_XTIMER_USE_LETIMER
-    bool "Xtimer uses letimer"
-    depends on CPU_COMMON_EFM32 && USEMODULE_XTIMER
+    bool "xtimer uses LETIMER (effectively ztimer)"
+    depends on CPU_COMMON_EFM32 && USEMODULE_ZTIMER
     default n
     help
-        Xtimer will use EFM32 Low Energy Timer as its low level timer.
+        xtimer (effectively ztimer) will use EFM32 Low Energy Timer (LETIMER)
+        as its low level timer.
+
+config EFM32_ZTIMER_USE_LETIMER
+    bool "ztimer uses LETIMER"
+    depends on CPU_COMMON_EFM32 && USEMODULE_ZTIMER
+    default n
+    help
+        ztimer will use EFM32 Low Energy Timer (LETIMER) as its low level
+        timer.


### PR DESCRIPTION
### Contribution description

This migrates the EFM32-based boards from xtimer to ztimer configuration (except for the xg23-pk6068a, already migrated).


### Testing procedure

I calibrated the overhead for the boards I own using `tests/sys/ztimer_overhead`:

* `e180-zg120b-tb`
* `ikea-tradfri`
* `slstk3401a`
* `slstk3402a`
* `slstk3701a`
* `sltb001a`
* `stk3600`

I do not own the following boards:

* `slwstk6000b-*` - used `sltb001a` config, but it will depend on the daughter board used.
* `sltb009a` - used `slstk3402a` config, the HFXO is slightly faster, but the CPU is a Cortex M4F too.
* `slwstk6220a` - used `stk3600` config, the HFXO is the same speed, but the CPU is Cortex M4F.
* `stk3700` - used `stk3600` config, the HFXO is the same speed and the CPU is a Cortex M3 too.

I also updated the timer configuration of:

* `sltb009a` - this has a 32-bit timer, which improves resolution.

### Issues/PRs references

#22069 
