### PR TITLE
tools/uf2conv: enforce .hex or .elf flashfile format

### DIFF
--- a/makefiles/tools/uf2conv.inc.mk
+++ b/makefiles/tools/uf2conv.inc.mk
@@ -7,6 +7,16 @@ FFLAGS  ?= $(UF2CONV_FLAGS) $(FLASHFILE) --base $(IMAGE_OFFSET)
 
 PREFLASH_DELAY ?= 2
 
+# Enforce FLASHFILE formats that include address information.
+# This ensures correct address offsets even if the flashfile was compile with a different
+# UF2_SOFTDEV value (and thus ROM_OFFSET) than the one that is currently set.
+flashfile-format-check:
+	@if ! echo "$(FLASHFILE)" | grep -E '\.(hex|elf)$$'; then \
+		echo "Please use a FLASHFILE format that includes address information (HEX or ELF)."; \
+		exit 1; \
+	fi
+
+
 # Execute the SoftDevice check. It verifies that the SoftDevice is present if
 # needed, that the versions match and that it is not accidentally overridden.
 uf2-softdevice-check:
@@ -17,6 +27,7 @@ uf2-softdevice-check:
 
 ifeq ($(RIOTTOOLS)/uf2/uf2conv.py,$(FLASHER))
   FLASHDEPS += $(FLASHER)
+  FLASHDEPS += flashfile-format-check
   FLASHDEPS += uf2-softdevice-check
 endif
 


### PR DESCRIPTION
### Contribution description

Enforce flashfile formats that include address information (HEX or ELF) when using the uf2conv.

This prevents footguns regarding address offsets when using a manual `FLASHFILE` and `UF2_SOFTDEV=DROP`.

Is there any reason why one would want to use the bin format?

cc @mguetschow.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
