### PR TITLE
sys/net: fix strchr calls on native

### DIFF
--- a/sys/net/netutils/util.c
+++ b/sys/net/netutils/util.c
@@ -82,7 +82,7 @@ int netutils_get_ipv6(ipv6_addr_t *addr, netif_t **netif, const char *hostname)
 
     /* search for interface ID */
     size_t len = strlen(hostname);
-    char *iface = strchr(hostname, '%');
+    const char *iface = strchr(hostname, '%');
     if (iface) {
         *netif = netif_get_by_name(iface + 1);
         len -= strlen(iface);

--- a/sys/net/sock/sock_util.c
+++ b/sys/net/sock/sock_util.c
@@ -287,7 +287,7 @@ int sock_tl_name2ep(struct _sock_tl_ep *ep_out, const char *str)
     int family;
     char hostbuf[CONFIG_SOCK_HOSTPORT_MAXLEN];
     const char *host;
-    char *hostend = strchr(str, ':');
+    const char *hostend = strchr(str, ':');
     if (hostend == NULL) {
         host = str;
         ep_out->port = 0;


### PR DESCRIPTION
### Contribution description

`strchr` on native returns a **`const`** `char *str`.


### Testing procedure

`BOARD=native make -C examples/networking/gnrc/networking all`


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
