### PR TITLE
build system: handle unsupported `make debug*`

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -882,17 +882,44 @@ list-ttys:
 doc doc-man doc-latex:
 	$(MAKE) -C $(RIOTBASE) $@
 
+ifeq (, $(DEBUGGER))
+debug:
+	@echo '$$(DEBUGGER) is not set. This means that `make debug` is not'\
+	' supported by your current setup. A common reason is that PROGRAMMER'\
+	' is set to something like flashing via bootloader, where debugging is'\
+	' not possible.'
+	@false
+else
 debug: $(DEBUGDEPS)
 	$(call check_cmd,$(DEBUGGER),Debug program)
 	$(DEBUGGER) $(DEBUGGER_FLAGS)
+endif
 
+ifeq (, $(DEBUGCLIENT))
+debug-client:
+	@echo '$$(DEBUGCLIENT) is not set. This means that `make debug` is not'\
+	' supported by your current setup. A common reason is that PROGRAMMER'\
+	' is set to something like flashing via bootloader, where debugging is'\
+	' not possible.'
+	@false
+else
 debug-client:
 	$(call check_cmd,$(DEBUGCLIENT),Debug client program)
 	$(DEBUGCLIENT) $(DEBUGCLIENT_FLAGS)
+endif
 
+ifeq (, $(DEBUGSERVER))
+debug-server:
+	@echo '$$(DEBUGSERVER) is not set. This means that `make debug` is not'\
+	' supported by your current setup. A common reason is that PROGRAMMER'\
+	' is set to something like flashing via bootloader, where debugging is'\
+	' not possible.'
+	@false
+else
 debug-server:
 	$(call check_cmd,$(DEBUGSERVER),Debug server program)
 	$(DEBUGSERVER) $(DEBUGSERVER_FLAGS)
+endif
 
 ifeq (1,$(EMULATE))
 emulate:


### PR DESCRIPTION
### Contribution description

This changes the build system to print an error when running `make debug-server`, `make debug`, or `make debug-client` but no build system integration is provided by the current setup.

### Testing procedure

Running `make debug-server`, `make debug`, and `make debug-client` should work as before for setups it did work before. But for those it did not work before, a helpful message is printed and the make command fails, where before nothing was printed and the command exited with a success status code.

### Issues/PRs references

None