### PR TITLE
makefiles/arch/native: add debug server config

### DIFF
--- a/makefiles/arch/native.inc.mk
+++ b/makefiles/arch/native.inc.mk
@@ -12,6 +12,7 @@ ifeq ($(OS),Darwin)
   DEBUGGER ?= lldb
 else
   DEBUGGER ?= gdb
+  DEBUGSERVER ?= gdbserver
 endif
 
 
@@ -102,6 +103,9 @@ ifeq ($(shell basename $(DEBUGGER)),lldb)
   DEBUGGER_FLAGS = -- $(ELFFILE) $(TERMFLAGS)
 else
   DEBUGGER_FLAGS = -q --args $(ELFFILE) $(TERMFLAGS)
+  DEBUGSERVER_BIND_ADDR ?= 127.0.0.1
+  DEBUGSERVER_PORT ?= 3333
+  DEBUGSERVER_FLAGS = --no-startup-with-shell --disable-randomization $(DEBUGSERVER_BIND_ADDR):$(DEBUGSERVER_PORT) $(ELFFILE) $(TERMFLAGS)
 endif
 term-valgrind: export VALGRIND_FLAGS ?= \
 	--leak-check=full \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Enable use of debug server for native builds.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`make debug-server` should start up a gdbserver on port 3333 for a native build that one can attach to.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
