### PR TITLE
makefiles/tools/openocd-adapters: use non-deprecated 'adapter serial'

### DIFF
--- a/makefiles/tools/openocd-adapters/dap.inc.mk
+++ b/makefiles/tools/openocd-adapters/dap.inc.mk
@@ -3,8 +3,3 @@ OPENOCD_ADAPTER_INIT ?= -c 'source [find interface/cmsis-dap.cfg]'
 
 # default to SWD
 OPENOCD_TRANSPORT ?= swd
-
-# Add serial matching command, only if DEBUG_ADAPTER_ID was specified
-ifneq (,$(DEBUG_ADAPTER_ID))
-  OPENOCD_ADAPTER_INIT += -c 'cmsis_dap_serial $(DEBUG_ADAPTER_ID)'
-endif

--- a/makefiles/tools/openocd-adapters/ftdi.inc.mk
+++ b/makefiles/tools/openocd-adapters/ftdi.inc.mk
@@ -7,11 +7,6 @@ OPENOCD_ADAPTER_INIT ?= -c 'source [find interface/ftdi/$(OPENOCD_FTDI_ADAPTER).
 # default to SWD
 OPENOCD_TRANSPORT ?= swd
 
-# Add serial matching command, only if DEBUG_ADAPTER_ID was specified
-ifneq (,$(DEBUG_ADAPTER_ID))
-  OPENOCD_ADAPTER_INIT += -c 'ftdi_serial $(DEBUG_ADAPTER_ID)'
-endif
-
 ifeq (swd, $(OPENOCD_TRANSPORT))
   ifeq (tigard, $(OPENOCD_FTDI_ADAPTER))
     # Add dummy SWD_EN signal

--- a/makefiles/tools/openocd-adapters/iotlab.inc.mk
+++ b/makefiles/tools/openocd-adapters/iotlab.inc.mk
@@ -3,8 +3,3 @@ OPENOCD_ADAPTER_INIT ?= -c 'source [find interface/ftdi/iotlab-usb.cfg]'
 
 # default to JTAG
 OPENOCD_TRANSPORT ?= jtag
-
-# Add serial matching command, only if DEBUG_ADAPTER_ID was specified
-ifneq (,$(DEBUG_ADAPTER_ID))
-  OPENOCD_ADAPTER_INIT += -c 'ftdi_serial $(DEBUG_ADAPTER_ID)'
-endif

--- a/makefiles/tools/openocd-adapters/jlink.inc.mk
+++ b/makefiles/tools/openocd-adapters/jlink.inc.mk
@@ -3,8 +3,3 @@ OPENOCD_ADAPTER_INIT ?= -c 'source [find interface/jlink.cfg]'
 
 # default to SWD
 OPENOCD_TRANSPORT ?= swd
-
-# Add serial matching command, only if DEBUG_ADAPTER_ID was specified
-ifneq (,$(DEBUG_ADAPTER_ID))
-  OPENOCD_ADAPTER_INIT += -c 'jlink serial $(DEBUG_ADAPTER_ID)'
-endif

--- a/makefiles/tools/openocd-adapters/mulle.inc.mk
+++ b/makefiles/tools/openocd-adapters/mulle.inc.mk
@@ -28,8 +28,3 @@ OPENOCD_ADAPTER_INIT ?= -f '$(RIOTBASE)/boards/mulle/dist/openocd/mulle-programm
 
 # Default to SWD
 OPENOCD_TRANSPORT ?= swd
-
-# Add serial matching command, only if DEBUG_ADAPTER_ID was specified
-ifneq (,$(DEBUG_ADAPTER_ID))
-  OPENOCD_ADAPTER_INIT += -c 'ftdi_serial $(DEBUG_ADAPTER_ID)'
-endif

--- a/makefiles/tools/openocd-adapters/stlink.inc.mk
+++ b/makefiles/tools/openocd-adapters/stlink.inc.mk
@@ -11,11 +11,6 @@ OPENOCD_ADAPTER_INIT ?= -c 'set stlink_version $(STLINK_VERSION);source $(RIOTBA
 # an incompatibility with different versions of OpenOCD
 OPENOCD_TRANSPORT ?=
 
-# Add serial matching command, only if DEBUG_ADAPTER_ID was specified
-ifneq (,$(DEBUG_ADAPTER_ID))
-  OPENOCD_ADAPTER_INIT += -c 'hla_serial $(DEBUG_ADAPTER_ID)'
-endif
-
 # Some stlink clones cannot signal reset properly,
 # In this case, use SRST=none
 ifneq (,$(SRST))

--- a/makefiles/tools/openocd.inc.mk
+++ b/makefiles/tools/openocd.inc.mk
@@ -20,6 +20,11 @@ ifneq (,$(OPENOCD_DEBUG_ADAPTER))
   endif
 endif
 
+# Add serial matching command, only if DEBUG_ADAPTER_ID was specified
+ifneq (,$(DEBUG_ADAPTER_ID))
+  OPENOCD_ADAPTER_INIT += -c 'adapter serial $(DEBUG_ADAPTER_ID)'
+endif
+
 # Use the board's custom OpenOCD by default, if present in the file system.
 OPENOCD_CONFIG ?= $(wildcard $(BOARDDIR)/dist/openocd.cfg)
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The adapter specific serial commands are deprecated as OpenOCD will tell you each time you use them:

```
### Flashing Target ###
Open On-Chip Debugger 0.12.0
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
none separate

DEPRECATED! use 'adapter serial' not 'ftdi_serial'
```

Use the generic `adapter serial` as suggested by OpenOCD.

 - [ftdi commit](https://sourceforge.net/p/openocd/code/ci/b1afd3dba4f046843d0c7c583c0b4ed56122d757/)

### Testing procedure

You should still be able to flash your device when specifying the debugger ID with `DEBUG_ADAPTER_ID=` on the command line.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
