### PR TITLE
pkg/qcbor: bump version

### DIFF
--- a/pkg/qcbor/Makefile
+++ b/pkg/qcbor/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME    = qcbor
 PKG_URL     = https://github.com/laurencelundblade/QCBOR
-# v1.2
-PKG_VERSION = 92d3f89030baff4af7be8396c563e6c8ef263622
+# v1.6
+PKG_VERSION = 590a23daf65af068cee81555c597063150e23539
 PKG_LICENSE = BSD-3-Clause
 
 include $(RIOTBASE)/pkg/pkg.mk
@@ -11,6 +11,7 @@ include $(RIOTBASE)/pkg/pkg.mk
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=42145
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90710#c1
 CFLAGS += -Wno-maybe-uninitialized
+CFLAGS += -Wno-type-limits
 
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Bump the version of QCBOR to the latest 1.x version (1.6)

There is a compiler warning which I suppressed `-Wno-type-limits`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Run QCBOR tests in `tests/pkg/qcbor` on `native`, this still works.

According to QCBOR repo:

> Changes over the last few years have been only minor bug fixes, minor feature additions and documentation improvements. QCBOR 1.x is highly stable.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Required for #22091. Split off of that PR.