### PR TITLE
cdc/ecm: add TX timeout

### DIFF
--- a/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
@@ -27,10 +27,22 @@
 #include "net/eui_provider.h"
 #include "net/netdev.h"
 #include "net/netdev/eth.h"
+#include "time_units.h"
 #include "usb/usbus/cdc/ecm.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
+
+/**
+ * @brief Timeout [us] for sending a packet down the bus.
+ *
+ * Packet sending blocks until the host issues an IN token. If the host is
+ * misbehaving and doesn't do that, we will time out instead of stalling the
+ * netif thread and any others that sync with it.
+ */
+#ifndef CONFIG_USBUS_CDC_ECM_TX_TIMEOUT_US
+#  define CONFIG_USBUS_CDC_ECM_TX_TIMEOUT_US    (50 * US_PER_MS)
+#endif
 
 static const netdev_driver_t netdev_driver_cdcecm;
 
@@ -75,7 +87,11 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     size_t usb_remain = cdcecm->ep_in->maxpacketsize;
     DEBUG("CDC_ECM_netdev: cur iol: %d\n", iolist->iol_len);
     while (len) {
-        mutex_lock(&cdcecm->out_lock);
+        if (ztimer_mutex_lock_timeout(ZTIMER_USEC, &cdcecm->out_lock,
+                                      CONFIG_USBUS_CDC_ECM_TX_TIMEOUT_US) != 0) {
+            DEBUG("out_lock timeout!\n");
+            return -EBUSY;
+        }
         if (cdcecm->active_iface != 1) {
             /* Link went down while waiting. */
             mutex_unlock(&cdcecm->out_lock);
@@ -125,7 +141,11 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     }
     /* Zero length USB packet required */
     if ((iolist_size(iolist_start) % cdcecm->ep_in->maxpacketsize) == 0) {
-        mutex_lock(&cdcecm->out_lock);
+        if (ztimer_mutex_lock_timeout(ZTIMER_USEC, &cdcecm->out_lock,
+                                      CONFIG_USBUS_CDC_ECM_TX_TIMEOUT_US) != 0) {
+            DEBUG("out_lock timeout!\n");
+            return -EBUSY;
+        }
         if (cdcecm->active_iface != 1) {
             /* Link went down while waiting. */
             mutex_unlock(&cdcecm->out_lock);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Packet sending blocks until the host issues an IN token. If the host is
misbehaving and doesn't do that, we will time out instead of stalling the
netif thread and any others that sync with it.

See #21996 for the original problem description. For some reason I cannot re-open that PR, plus it shows old, wrong diffs. 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I tested this on a same54 board connected to a Linux USB host.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
See #21996.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
