### PR TITLE
drivers/slipdev: Split out networking/coap into files

### DIFF
--- a/drivers/slipdev/Makefile
+++ b/drivers/slipdev/Makefile
@@ -1,7 +1,11 @@
-# exclude submodule sources from *.c wildcard source selection
-SRC := $(filter-out stdio.c,$(wildcard *.c))
+SRC := slipdev.c net.c
 
-# enable submodules
-SUBMODULES := 1
+ifneq (,$(filter slipdev_stdio,$(USEMODULE)))
+	SRC += stdio.c
+endif
+
+ifneq (,$(filter slipdev_config,$(USEMODULE)))
+	SRC += coap.c
+endif
 
 include $(RIOTBASE)/Makefile.base

--- a/drivers/slipdev/coap.c
+++ b/drivers/slipdev/coap.c
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Bennet Hattesen <bennet.hattesen@haw-hamburg.de>
+ */
+#include "checksum/crc16_ccitt.h"
+#include "net/nanocoap.h"
+#include "slipdev.h"
+#include "slipdev_internal.h"
+
+/* The special init is the result of normal fcs init combined with slipmux config start (0xa9) */
+#define SPECIAL_INIT_FCS (0x374cU)
+#define COAP_STACKSIZE (1024)
+
+static char coap_stack[COAP_STACKSIZE];
+
+static inline void _slipdev_lock(void)
+{
+    mutex_lock(&slipdev_mutex);
+}
+
+static inline void _slipdev_unlock(void)
+{
+    mutex_unlock(&slipdev_mutex);
+}
+
+void *_coap_server_thread(void *arg)
+{
+    static uint8_t buf[512];
+    slipdev_t *dev = arg;
+
+    while (1) {
+        thread_flags_wait_any(1);
+        size_t len;
+        while (crb_get_chunk_size(&dev->rb_config, &len)) {
+            if (len > sizeof(buf)) {
+                crb_consume_chunk(&dev->rb_config, NULL, len);
+                continue;
+            }
+            crb_consume_chunk(&dev->rb_config, buf, len);
+
+            /* Is the crc correct via residue(=0xF0B8) test */
+            if (crc16_ccitt_fcs_update(SPECIAL_INIT_FCS, buf, len) != 0xF0B8) {
+                break;
+            }
+
+            /* cut off the FCS checksum at the end */
+            size_t pktlen = len - 2;
+
+            coap_pkt_t pkt;
+            sock_udp_ep_t remote;
+            coap_request_ctx_t ctx = {
+                .remote = &remote,
+            };
+            if (coap_parse(&pkt, buf, pktlen) < 0) {
+                break;
+            }
+            unsigned int res = 0;
+            if ((res = coap_handle_req(&pkt, buf, sizeof(buf), &ctx)) <= 0) {
+                break;
+            }
+
+            uint16_t fcs_sum = crc16_ccitt_fcs_finish(SPECIAL_INIT_FCS, buf, res);
+
+            _slipdev_lock();
+            slipdev_write_byte(dev->config.uart, SLIPDEV_START_COAP);
+            slipdev_write_bytes(dev->config.uart, buf, res);
+            slipdev_write_bytes(dev->config.uart, (uint8_t *)&fcs_sum, 2);
+            slipdev_write_byte(dev->config.uart, SLIPDEV_END);
+            _slipdev_unlock();
+        }
+    }
+
+    return NULL;
+}
+
+void slipdev_setup_coap(slipdev_t *dev) {
+    crb_init(&dev->rb_config, dev->rxmem_config, sizeof(dev->rxmem_config));
+
+    dev->coap_server_pid = thread_create(coap_stack, sizeof(coap_stack), THREAD_PRIORITY_MAIN - 1,
+                                         THREAD_CREATE_STACKTEST, _coap_server_thread,
+                                         (void *)dev, "Slipmux CoAP server");
+}
+
+/** @} */

--- a/drivers/slipdev/net.c
+++ b/drivers/slipdev/net.c
@@ -1,0 +1,246 @@
+/*
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @author  Bennet Hattesen <bennet.hattesen@haw-hamburg.de>
+ */
+
+#include "log.h"
+#include "slipdev.h"
+#include "slipdev_internal.h"
+#include "slipdev_params.h"
+#include "net/eui_provider.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+void _slip_rx_cb(void *arg, uint8_t byte);
+
+static inline void _slipdev_lock(void)
+{
+    if (IS_USED(MODULE_SLIPDEV_STDIO) || IS_USED(MODULE_SLIPDEV_CONFIG)) {
+        mutex_lock(&slipdev_mutex);
+    }
+}
+
+static inline void _slipdev_unlock(void)
+{
+    if (IS_USED(MODULE_SLIPDEV_STDIO) || IS_USED(MODULE_SLIPDEV_CONFIG)) {
+        mutex_unlock(&slipdev_mutex);
+    }
+}
+
+static void _poweron(slipdev_t *dev)
+{
+    if ((dev->state != SLIPDEV_STATE_STANDBY) &&
+        (dev->state != SLIPDEV_STATE_SLEEP)) {
+        return;
+    }
+
+    dev->state = 0;
+    uart_init(dev->config.uart, dev->config.baudrate, _slip_rx_cb, dev);
+}
+
+static inline void _poweroff(slipdev_t *dev, uint8_t state)
+{
+    uart_poweroff(dev->config.uart);
+    dev->state = state;
+}
+
+static int _init(netdev_t *netdev)
+{
+    slipdev_t *dev = (slipdev_t *)netdev;
+
+    DEBUG("slipdev: initializing device %p on UART %i with baudrate %" PRIu32 "\n",
+          (void *)dev, dev->config.uart, dev->config.baudrate);
+    /* initialize buffers */
+    crb_init(&dev->rb, dev->rxmem, sizeof(dev->rxmem));
+    if (uart_init(dev->config.uart, dev->config.baudrate, _slip_rx_cb,
+                  dev) != UART_OK) {
+        LOG_ERROR("slipdev: error initializing UART %i with baudrate %" PRIu32 "\n",
+                  dev->config.uart, dev->config.baudrate);
+        return -ENODEV;
+    }
+
+    /* signal link UP */
+    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
+
+    return 0;
+}
+
+static int _check_state(slipdev_t *dev)
+{
+    /* power states not supported when multiplexing stdio / configuration */
+    if (IS_USED(MODULE_SLIPDEV_STDIO) || IS_USED(MODULE_SLIPDEV_CONFIG)) {
+        return 0;
+    }
+
+    /* discard data when interface is in SLEEP mode */
+    if (dev->state == SLIPDEV_STATE_SLEEP) {
+        return -ENETDOWN;
+    }
+
+    /* sending data wakes the interface from STANDBY */
+    if (dev->state == SLIPDEV_STATE_STANDBY) {
+        _poweron(dev);
+    }
+
+    return 0;
+}
+
+static int _send(netdev_t *netdev, const iolist_t *iolist)
+{
+    slipdev_t *dev = (slipdev_t *)netdev;
+    int bytes = _check_state(dev);
+
+    if (bytes) {
+        return bytes;
+    }
+
+    DEBUG("slipdev: sending iolist\n");
+    _slipdev_lock();
+    for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
+        uint8_t *data = iol->iol_base;
+        slipdev_write_bytes(dev->config.uart, data, iol->iol_len);
+        bytes += iol->iol_len;
+    }
+    slipdev_write_byte(dev->config.uart, SLIPDEV_END);
+    _slipdev_unlock();
+
+    return bytes;
+}
+
+static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
+{
+    slipdev_t *dev = (slipdev_t *)netdev;
+    size_t res = 0;
+
+    (void)info;
+    if (buf == NULL) {
+        if (len > 0) {
+            /* remove data */
+            crb_consume_chunk(&dev->rb, NULL, len);
+        }
+        else {
+            /* the user was warned not to use a buffer size > `INT_MAX` ;-) */
+            crb_get_chunk_size(&dev->rb, &res);
+        }
+    }
+    else {
+        crb_consume_chunk(&dev->rb, buf, len);
+        res = len;
+    }
+    return res;
+}
+
+static void _isr(netdev_t *netdev)
+{
+    slipdev_t *dev = (slipdev_t *)netdev;
+
+    DEBUG("slipdev: handling ISR event\n");
+
+    size_t len;
+    while (crb_get_chunk_size(&dev->rb, &len)) {
+        DEBUG("slipdev: event handler set, issuing RX_COMPLETE event\n");
+        netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
+    }
+}
+
+#if !(IS_USED(MODULE_SLIPDEV_STDIO) ||  IS_USED(MODULE_SLIPDEV_CONFIG))
+static int _set_state(slipdev_t *dev, netopt_state_t state)
+{
+    if (IS_USED(MODULE_SLIPDEV_STDIO)) {
+        return -ENOTSUP;
+    }
+
+    switch (state) {
+    case NETOPT_STATE_STANDBY:
+        _poweroff(dev, SLIPDEV_STATE_STANDBY);
+        break;
+    case NETOPT_STATE_SLEEP:
+        _poweroff(dev, SLIPDEV_STATE_SLEEP);
+        break;
+    case NETOPT_STATE_IDLE:
+        _poweron(dev);
+        break;
+    default:
+        return -ENOTSUP;
+    }
+
+    return sizeof(netopt_state_t);
+}
+
+static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t max_len)
+{
+    (void)max_len;
+
+    slipdev_t *dev = (slipdev_t *)netdev;
+    switch (opt) {
+    case NETOPT_STATE:
+        assert(max_len <= sizeof(netopt_state_t));
+        return _set_state(dev, *((const netopt_state_t *)value));
+    default:
+        return -ENOTSUP;
+    }
+}
+#endif /* !(MODULE_SLIPDEV_STDIO || MODULE_SLIPDEV_CONFIG) */
+
+static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
+{
+    (void)netdev;
+    (void)value;
+    (void)max_len;
+    switch (opt) {
+    case NETOPT_IS_WIRED:
+        return 1;
+    case NETOPT_DEVICE_TYPE:
+        assert(max_len == sizeof(uint16_t));
+        *((uint16_t *)value) = NETDEV_TYPE_SLIP;
+        return sizeof(uint16_t);
+#if IS_USED(MODULE_SLIPDEV_L2ADDR)
+    case NETOPT_ADDRESS_LONG:
+        assert(max_len == sizeof(eui64_t));
+        netdev_eui64_get(netdev, value);
+        return sizeof(eui64_t);
+#endif
+    default:
+        return -ENOTSUP;
+    }
+}
+
+static int _confirm_send(netdev_t *netdev, void *info)
+{
+    (void)netdev;
+    (void)info;
+    return -EOPNOTSUPP;
+}
+
+static const netdev_driver_t slip_driver = {
+    .send = _send,
+    .recv = _recv,
+    .init = _init,
+    .isr = _isr,
+    .get = _get,
+    .confirm_send = _confirm_send,
+#if (IS_USED(MODULE_SLIPDEV_STDIO) || IS_USED(MODULE_SLIPDEV_CONFIG))
+    .set = netdev_set_notsup,
+#else
+    .set = _set,
+#endif
+};
+
+void slipdev_setup_net(slipdev_t *dev, uint8_t index) {
+    dev->netdev.driver = &slip_driver;
+
+    netdev_register(&dev->netdev, NETDEV_SLIPDEV, index);
+}
+
+/** @} */

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -33,40 +33,17 @@
 
 #include "isrpipe.h"
 #include "mutex.h"
-#if IS_USED(MODULE_SLIPDEV_CONFIG)
-#include "checksum/crc16_ccitt.h"
-#include "net/nanocoap.h"
-#endif
+
 #include "stdio_uart.h"
+
+/* forward declarations, implementation is in net/coap */
+void slipdev_setup_net(slipdev_t *dev, uint8_t index);
+void slipdev_setup_coap(slipdev_t *dev);
 
 #if (IS_USED(MODULE_SLIPDEV_STDIO) || IS_USED(MODULE_SLIPDEV_CONFIG))
 /* For synchronization with stdio/config threads */
 mutex_t slipdev_mutex = MUTEX_INIT;
 #endif
-
-#if IS_USED(MODULE_SLIPDEV_CONFIG)
-/* The special init is the result of normal fcs init combined with slipmux config start (0xa9) */
-#define SPECIAL_INIT_FCS (0x374cU)
-#define COAP_STACKSIZE (1024)
-
-static char coap_stack[COAP_STACKSIZE];
-#endif /* IS_USED(MODULE_SLIPDEV_CONFIG) */
-
-static int _check_state(slipdev_t *dev);
-
-static inline void slipdev_lock(void)
-{
-    if (IS_USED(MODULE_SLIPDEV_STDIO) || IS_USED(MODULE_SLIPDEV_CONFIG)) {
-        mutex_lock(&slipdev_mutex);
-    }
-}
-
-static inline void slipdev_unlock(void)
-{
-    if (IS_USED(MODULE_SLIPDEV_STDIO) || IS_USED(MODULE_SLIPDEV_CONFIG)) {
-        mutex_unlock(&slipdev_mutex);
-    }
-}
 
 static inline void _slipdev_stdio_add_to_frame(slipdev_t *dev, uint8_t byte)
 {
@@ -84,6 +61,7 @@ static inline bool _slipdev_config_start_frame(slipdev_t *dev)
     return crb_start_chunk(&dev->rb_config);
 #else
     (void)dev;
+    DEBUG("Ignoring new configuration frame as support is not enabled\n");
     return 1;
 #endif
 }
@@ -290,44 +268,6 @@ void _slip_rx_cb(void *arg, uint8_t byte)
     }
 }
 
-static void _poweron(slipdev_t *dev)
-{
-    if ((dev->state != SLIPDEV_STATE_STANDBY) &&
-        (dev->state != SLIPDEV_STATE_SLEEP)) {
-        return;
-    }
-
-    dev->state = 0;
-    uart_init(dev->config.uart, dev->config.baudrate, _slip_rx_cb, dev);
-}
-
-static inline void _poweroff(slipdev_t *dev, uint8_t state)
-{
-    uart_poweroff(dev->config.uart);
-    dev->state = state;
-}
-
-static int _init(netdev_t *netdev)
-{
-    slipdev_t *dev = (slipdev_t *)netdev;
-
-    DEBUG("slipdev: initializing device %p on UART %i with baudrate %" PRIu32 "\n",
-          (void *)dev, dev->config.uart, dev->config.baudrate);
-    /* initialize buffers */
-    crb_init(&dev->rb, dev->rxmem, sizeof(dev->rxmem));
-    if (uart_init(dev->config.uart, dev->config.baudrate, _slip_rx_cb,
-                  dev) != UART_OK) {
-        LOG_ERROR("slipdev: error initializing UART %i with baudrate %" PRIu32 "\n",
-                  dev->config.uart, dev->config.baudrate);
-        return -ENODEV;
-    }
-
-    /* signal link UP */
-    netdev->event_callback(netdev, NETDEV_EVENT_LINK_UP);
-
-    return 0;
-}
-
 void slipdev_write_bytes(uart_t uart, const uint8_t *data, size_t len)
 {
     for (unsigned j = 0; j < len; j++, data++) {
@@ -348,234 +288,19 @@ void slipdev_write_bytes(uart_t uart, const uint8_t *data, size_t len)
     }
 }
 
-static int _check_state(slipdev_t *dev)
-{
-    /* power states not supported when multiplexing stdio / configuration */
-    if (IS_USED(MODULE_SLIPDEV_STDIO) || IS_USED(MODULE_SLIPDEV_CONFIG)) {
-        return 0;
-    }
-
-    /* discard data when interface is in SLEEP mode */
-    if (dev->state == SLIPDEV_STATE_SLEEP) {
-        return -ENETDOWN;
-    }
-
-    /* sending data wakes the interface from STANDBY */
-    if (dev->state == SLIPDEV_STATE_STANDBY) {
-        _poweron(dev);
-    }
-
-    return 0;
-}
-
-static int _send(netdev_t *netdev, const iolist_t *iolist)
-{
-    slipdev_t *dev = (slipdev_t *)netdev;
-    int bytes = _check_state(dev);
-
-    if (bytes) {
-        return bytes;
-    }
-
-    DEBUG("slipdev: sending iolist\n");
-    slipdev_lock();
-    for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
-        uint8_t *data = iol->iol_base;
-        slipdev_write_bytes(dev->config.uart, data, iol->iol_len);
-        bytes += iol->iol_len;
-    }
-    slipdev_write_byte(dev->config.uart, SLIPDEV_END);
-    slipdev_unlock();
-
-    return bytes;
-}
-
-static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
-{
-    slipdev_t *dev = (slipdev_t *)netdev;
-    size_t res = 0;
-
-    (void)info;
-    if (buf == NULL) {
-        if (len > 0) {
-            /* remove data */
-            crb_consume_chunk(&dev->rb, NULL, len);
-        }
-        else {
-            /* the user was warned not to use a buffer size > `INT_MAX` ;-) */
-            crb_get_chunk_size(&dev->rb, &res);
-        }
-    }
-    else {
-        crb_consume_chunk(&dev->rb, buf, len);
-        res = len;
-    }
-    return res;
-}
-
-static void _isr(netdev_t *netdev)
-{
-    slipdev_t *dev = (slipdev_t *)netdev;
-
-    DEBUG("slipdev: handling ISR event\n");
-
-    size_t len;
-    while (crb_get_chunk_size(&dev->rb, &len)) {
-        DEBUG("slipdev: event handler set, issuing RX_COMPLETE event\n");
-        netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
-    }
-}
-
-#if !(IS_USED(MODULE_SLIPDEV_STDIO) ||  IS_USED(MODULE_SLIPDEV_CONFIG))
-static int _set_state(slipdev_t *dev, netopt_state_t state)
-{
-    if (IS_USED(MODULE_SLIPDEV_STDIO)) {
-        return -ENOTSUP;
-    }
-
-    switch (state) {
-    case NETOPT_STATE_STANDBY:
-        _poweroff(dev, SLIPDEV_STATE_STANDBY);
-        break;
-    case NETOPT_STATE_SLEEP:
-        _poweroff(dev, SLIPDEV_STATE_SLEEP);
-        break;
-    case NETOPT_STATE_IDLE:
-        _poweron(dev);
-        break;
-    default:
-        return -ENOTSUP;
-    }
-
-    return sizeof(netopt_state_t);
-}
-
-static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t max_len)
-{
-    (void)max_len;
-
-    slipdev_t *dev = (slipdev_t *)netdev;
-    switch (opt) {
-    case NETOPT_STATE:
-        assert(max_len <= sizeof(netopt_state_t));
-        return _set_state(dev, *((const netopt_state_t *)value));
-    default:
-        return -ENOTSUP;
-    }
-}
-#endif /* !(MODULE_SLIPDEV_STDIO || MODULE_SLIPDEV_CONFIG) */
-
-static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
-{
-    (void)netdev;
-    (void)value;
-    (void)max_len;
-    switch (opt) {
-    case NETOPT_IS_WIRED:
-        return 1;
-    case NETOPT_DEVICE_TYPE:
-        assert(max_len == sizeof(uint16_t));
-        *((uint16_t *)value) = NETDEV_TYPE_SLIP;
-        return sizeof(uint16_t);
-#if IS_USED(MODULE_SLIPDEV_L2ADDR)
-    case NETOPT_ADDRESS_LONG:
-        assert(max_len == sizeof(eui64_t));
-        netdev_eui64_get(netdev, value);
-        return sizeof(eui64_t);
-#endif
-    default:
-        return -ENOTSUP;
-    }
-}
-
-static int _confirm_send(netdev_t *netdev, void *info)
-{
-    (void)netdev;
-    (void)info;
-    return -EOPNOTSUPP;
-}
-
-static const netdev_driver_t slip_driver = {
-    .send = _send,
-    .recv = _recv,
-    .init = _init,
-    .isr = _isr,
-    .get = _get,
-    .confirm_send = _confirm_send,
-#if (IS_USED(MODULE_SLIPDEV_STDIO) || IS_USED(MODULE_SLIPDEV_CONFIG))
-    .set = netdev_set_notsup,
-#else
-    .set = _set,
-#endif
-};
-
-#if IS_USED(MODULE_SLIPDEV_CONFIG)
-static void *_coap_server_thread(void *arg)
-{
-    static uint8_t buf[512];
-    slipdev_t *dev = arg;
-
-    while (1) {
-        thread_flags_wait_any(1);
-        size_t len;
-        while (crb_get_chunk_size(&dev->rb_config, &len)) {
-            if (len > sizeof(buf)) {
-                crb_consume_chunk(&dev->rb_config, NULL, len);
-                continue;
-            }
-            crb_consume_chunk(&dev->rb_config, buf, len);
-
-            /* Is the crc correct via residue(=0xF0B8) test */
-            if (crc16_ccitt_fcs_update(SPECIAL_INIT_FCS, buf, len) != 0xF0B8) {
-                break;
-            }
-
-            /* cut off the FCS checksum at the end */
-            size_t pktlen = len - 2;
-
-            coap_pkt_t pkt;
-            sock_udp_ep_t remote;
-            coap_request_ctx_t ctx = {
-                .remote = &remote,
-            };
-            if (coap_parse(&pkt, buf, pktlen) < 0) {
-                break;
-            }
-            unsigned int res = 0;
-            if ((res = coap_handle_req(&pkt, buf, sizeof(buf), &ctx)) <= 0) {
-                break;
-            }
-
-            uint16_t fcs_sum = crc16_ccitt_fcs_finish(SPECIAL_INIT_FCS, buf, res);
-
-            slipdev_lock();
-            slipdev_write_byte(dev->config.uart, SLIPDEV_START_COAP);
-            slipdev_write_bytes(dev->config.uart, buf, res);
-            slipdev_write_bytes(dev->config.uart, (uint8_t *)&fcs_sum, 2);
-            slipdev_write_byte(dev->config.uart, SLIPDEV_END);
-            slipdev_unlock();
-        }
-    }
-
-    return NULL;
-}
-#endif /* MODULE_SLIPDEV_CONFIG */
-
 void slipdev_setup(slipdev_t *dev, const slipdev_params_t *params, uint8_t index)
 {
-#if IS_USED(MODULE_SLIPDEV_CONFIG)
-    crb_init(&dev->rb_config, dev->rxmem_config, sizeof(dev->rxmem_config));
-
-    dev->coap_server_pid = thread_create(coap_stack, sizeof(coap_stack), THREAD_PRIORITY_MAIN - 1,
-                                         THREAD_CREATE_STACKTEST, _coap_server_thread,
-                                         (void *)dev, "Slipmux CoAP server");
-#endif
     /* set device descriptor fields */
     dev->config = *params;
     dev->state = 0;
-    dev->netdev.driver = &slip_driver;
 
-    netdev_register(&dev->netdev, NETDEV_SLIPDEV, index);
+#if IS_USED(MODULE_SLIPDEV_CONFIG)
+    /* we only support one coap server at the moment */
+    if (index == 0) {
+        slipdev_setup_coap(dev);
+    }
+#endif
+    slipdev_setup_net(dev, index);
 }
 
 /** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hello :frog: 

since @benpicco gave his blessing for my dependency change proposal in #22109, here is some related foundational refactoring. This does *not* change the dependencies in any way. It merely splits networking and coap handling into their own files. This will significantly reduce the need for `#if IS_USED(foo)` for the planned dependency cleanup. 


### Testing procedure

What ever one does for testing slip/slipmux. I tested various configuration on my machine. Since I only move stuff around, a compile test should be enough by reviewers. 


### Issues/PRs references

#22109
