### PR TITLE
sys/ztimer: fix LOG_*(..) placeholders

### DIFF
--- a/sys/ztimer/init.c
+++ b/sys/ztimer/init.c
@@ -350,19 +350,21 @@ void ztimer_init(void)
 #  if (ZTIMER_TIMER_FREQ != FREQ_1MHZ) || CONFIG_ZTIMER_PERIPH_TIMER_FORCE_CONVERSION
 #    if (ZTIMER_TIMER_FREQ == FREQ_250KHZ) && !(CONFIG_ZTIMER_PERIPH_TIMER_FORCE_CONVERSION)
     if (IS_ACTIVE(DEVELHELP) && ((periph_timer_freq < 237500) || (periph_timer_freq > 262500))) {
-        LOG_WARNING("ZTIMER_USEC from %" PRIu32 " Hz clock with \"left-shift by 2\" frequency conversion\n",
-                    periph_timer_freq);
+        LOG_WARNING(
+            "ZTIMER_USEC from %" PRIu32 " Hz clock with \"left-shift by 2\" frequency conversion\n",
+            periph_timer_freq);
     }
-    LOG_DEBUG("ztimer_init(): ZTIMER_USEC convert_shift %lu to 1000000\n",
+    LOG_DEBUG("ztimer_init(): ZTIMER_USEC convert_shift %" PRIu32 " to 1000000\n",
               periph_timer_freq);
     ztimer_convert_shift_up_init(&_ztimer_convert_shift_usec,
                                  ZTIMER_USEC_BASE, 2);
 #    elif (ZTIMER_TIMER_FREQ == FREQ_500KHZ) && !(CONFIG_ZTIMER_PERIPH_TIMER_FORCE_CONVERSION)
     if (IS_ACTIVE(DEVELHELP) && ((periph_timer_freq < 487500) || (periph_timer_freq > 512500))) {
-        LOG_WARNING("ZTIMER_USEC from %" PRIu32 " Hz clock with \"left-shift by 1\" frequency conversion\n",
-                    periph_timer_freq);
+        LOG_WARNING(
+            "ZTIMER_USEC from %" PRIu32 " Hz clock with \"left-shift by 1\" frequency conversion\n",
+            periph_timer_freq);
     }
-    LOG_DEBUG("ztimer_init(): ZTIMER_USEC convert_shift %lu to 1000000\n",
+    LOG_DEBUG("ztimer_init(): ZTIMER_USEC convert_shift %" PRIu32 " to 1000000\n",
               periph_timer_freq);
     ztimer_convert_shift_up_init(&_ztimer_convert_shift_usec,
                                  ZTIMER_USEC_BASE, 1);


### PR DESCRIPTION
### Contribution description

Two uses of `LOG_*(..)` did not use `PRIu32` for `periph_timer_freq`, while other ocurrences close-by did.

This resulted in compilation errors using LLVM.

```
RIOT/sys/ztimer/init.c:357:15: error: format specifies type 'unsigned long' but the argument has type 'uint32_t' (aka 'unsigned int') [-Werror,-Wformat]
              periph_timer_freq);
              ^~~~~~~~~~~~~~~~~
RIOT/core/lib/include/log.h:119:39: note: expanded from macro 'LOG_DEBUG'
#define LOG_DEBUG(...) LOG(LOG_DEBUG, __VA_ARGS__)
                                      ^~~~~~~~~~~
RIOT/core/lib/include/log.h:91:54: note: expanded from macro 'LOG'
        if ((level) <= LOG_LEVEL) LOG_WRITE((level), __VA_ARGS__); } while (0U) \
                                                     ^~~~~~~~~~~
RIOT/core/lib/include/log.h:81:52: note: expanded from macro 'LOG_WRITE'
#  define LOG_WRITE(level, ...) log_write((level), __VA_ARGS__)
                                                   ^~~~~~~~~~~
RIOT/core/lib/include/log.h:130:38: note: expanded from macro 'log_write'
#define log_write(level, ...) printf(__VA_ARGS__)
                                     ^~~~~~~~~~~
1 error generated.
```

### Testing procedure

I don't exactly know what triggered this error in my application. I'm working on an out-of-tree application ([reviving](https://github.com/basilfx/RIOT-applications/blob/master/game_of_life/main.c) 10 year old code) that is not too fancy. There are no recent changes to `sys/ztimer/init.c`, so something in my application triggered this today.

I compiled this for the STK3600 with DEVELHELP=1 (which is basically the default).

Murdock should be happy. Other uses of `LOG_*(..)` already used `PRIu32` for the same variable.

### Issues/PRs references

None
