### PR TITLE
makefiles: use TZ instead of mounting /etc/localtime for Docker

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -155,10 +155,10 @@ DOCKER_RUN_FLAGS += --platform linux/amd64
 # allow setting make args from command line like '-j'
 DOCKER_MAKE_ARGS ?=
 
-# Resolve symlink of /etc/localtime to its real path
-# This is a workaround for docker on macOS, for more information see:
-# https://github.com/docker/for-mac/issues/2396
-ETC_LOCALTIME = $(realpath /etc/localtime)
+# Extract timezone name from /etc/localtime, for passing to the container. This
+# avoids mounting /etc/localtime which fails for some container runtimes under
+# macOS.
+HOST_TIMEZONE = $(shell readlink /etc/localtime 2>/dev/null | sed 's|.*/zoneinfo/||')
 
 # Fetch the number of jobs from the MAKEFLAGS
 # With $MAKE_VERSION < 4.2, the amount of parallelism is not available in
@@ -290,13 +290,13 @@ DOCKER_APPDIR = $(DOCKER_RIOTPROJECT)/$(BUILDRELPATH)
 
 
 # Directory mapping in docker and directories environment variable configuration
-DOCKER_VOLUMES_AND_ENV += $(call docker_volume,$(ETC_LOCALTIME),/etc/localtime,ro)
 DOCKER_VOLUMES_AND_ENV += $(call docker_volume,$(RIOTBASE),$(DOCKER_RIOTBASE))
 # Selective components of Cargo to ensure crates are not re-downloaded (and
 # subsequently rebuilt) on every run. Not using all of ~/.cargo as ~/.cargo/bin
 # would be run by Cargo and that'd be very weird.
 DOCKER_VOLUMES_AND_ENV += $(call docker_volume,$(HOME)/.cargo/registry,$(DOCKER_BUILD_ROOT)/.cargo/registry)
 DOCKER_VOLUMES_AND_ENV += $(call docker_volume,$(HOME)/.cargo/git,$(DOCKER_BUILD_ROOT)/.cargo/git)
+DOCKER_VOLUMES_AND_ENV += -e 'TZ=$(HOST_TIMEZONE)'
 DOCKER_VOLUMES_AND_ENV += -e 'RIOTBASE=$(DOCKER_RIOTBASE)'
 DOCKER_VOLUMES_AND_ENV += -e 'CCACHE_BASEDIR=$(DOCKER_RIOTBASE)'
 


### PR DESCRIPTION
### Contribution description

Under macOS, using [colima](https://github.com/abiosoft/colima) (another container runtime), BUILD_IN_DOCKER does not work correctly. This (probably) has to do with [sandboxing](https://github.com/RIOT-OS/RIOT/issues/20853#issuecomment-2407733494), which Docker Desktop seems to do OK.

```
runc create failed: unable to start container process: error during container init: error mounting "/private/var/db/timezone/tz/2025c.1.0/zoneinfo/Europe/Amsterdam" to rootfs at "/etc/localtime": create mountpoint for /etc/localtime mount: cannot create subdirectories in "/var/lib/docker/rootfs/overlayfs/e7036978508cbce7dc55955754091131cca573e53875421efbb16b97908e24bf/usr/share/zoneinfo/Etc/UTC": not a directory
```

Instead, read the host timezone, then pass it as the TZ environment to the docker container. This seems to be a more universal approach. `/etc/localtime` is not mentioned anywhere else in the repository, so I don't believe it is relied upon. Also, the use of `TZ` environment variable is mentioned in the documentation of `boards/common/native`.

### Testing procedure

I tested

* macOS (ARM64)
  * Colima (v0.10)
  * Docker Desktop (v29)
  * Podman (5.8.0)
* Ubuntu 25.10
  * Docker (v27)

Using `BUILD_IN_DOCKER=1 make -C examples/basic/default`. 

They all work OK. Here is some proof (note the new TZ environment variable):

Docker (macOS):

<img width="1962" height="1274" alt="Scherm­afbeelding 2026-03-05 om 12 47 13" src="https://github.com/user-attachments/assets/71684f6b-8fd9-4f75-bdd9-2ed4d93fbd18" />

Podman (macOS):

<img width="1962" height="1274" alt="Scherm­afbeelding 2026-03-05 om 12 47 57" src="https://github.com/user-attachments/assets/da51e4b0-e1cc-4dca-9c95-c93aef538d72" />

Docker (Ubuntu):

<img width="1962" height="1274" alt="Scherm­afbeelding 2026-03-05 om 12 51 05" src="https://github.com/user-attachments/assets/f338ae9f-d587-4fc7-a1a5-dc05f0d95a04" />

### Issues/PRs references

#20853