### PR TITLE
doc/rp2350: fix naming problems

### DIFF
--- a/boards/common/rpi-pico-2/include/board.h
+++ b/boards/common/rpi-pico-2/include/board.h
@@ -7,7 +7,7 @@
 #pragma once
 
 /**
- * @ingroup         boards_rpi_pico_2_arm
+ * @ingroup         boards_rpi_pico_2
  * @{
  *
  * @file

--- a/boards/common/rpi-pico-2/include/periph_conf.h
+++ b/boards/common/rpi-pico-2/include/periph_conf.h
@@ -7,7 +7,7 @@
 #pragma once
 
 /**
- * @ingroup         boards_rpi_pico_2_arm
+ * @ingroup         boards_rpi_pico_2
  * @{
  *
  * @file

--- a/boards/rpi-pico-2-arm/doc.md
+++ b/boards/rpi-pico-2-arm/doc.md
@@ -1,5 +1,5 @@
-@defgroup    boards_rpi_pico_2_arm Raspberry Pi Pico 2
-@ingroup     boards
-@brief       Support for the RP2350 based Raspberry Pi Pico board
+@defgroup    boards_rpi_pico_2_arm Raspberry Pi Pico 2 Cortex-M33 ARM
+@ingroup     boards_rpi_pico_2
+@brief       Support for the RP2350 based Raspberry Pi Pico Cortex-M33 ARM board
 
-See @ref boards_rpi_pico_2_riscv for further information.
+See @ref boards_rpi_pico_2 for further information.

--- a/boards/rpi-pico-2-riscv/doc.md
+++ b/boards/rpi-pico-2-riscv/doc.md
@@ -1,9 +1,15 @@
-@defgroup    boards_rpi_pico_2_riscv Raspberry Pi Pico 2
+@defgroup    boards_rpi_pico_2_riscv Raspberry Pi Pico 2 Hazard3 RISC-V
+@ingroup     boards_rpi_pico_2
+@brief       Support for the RP2350 based Raspberry Pi Pico Hazard3 RISC-V board
+
+See @ref boards_rpi_pico_2 for further information.
+
+@defgroup    boards_rpi_pico_2 Raspberry Pi Pico 2
 @ingroup     boards
-@brief       Support for the RP2350 RISCV based Raspberry Pi Pico board
+@brief       Support for the RP2350 based Raspberry Pi Pico board
 
 @warning The support for the Raspberry Pi Pico 2 is still in a very early stage!
-See [Known Issues](#rpi_pico_2_riscv_known_issues).
+See [Known Issues](#rpi_pico_2_known_issues).
 
 ## Overview
 
@@ -124,7 +130,7 @@ However, it does not allow for debugging using GDB.
 RIOT will download and install the Picotool locally in the RIOT folder.
 This process will take some minutes to complete.
 
-## Known Issues {#rpi_pico_2_riscv_known_issues}
+## Known Issues {#rpi_pico_2_known_issues}
 
 Currently RP2350 support is rather minimal,
 as such peripheral support is extremely limited.

--- a/cpu/rp2350_arm/doc.md
+++ b/cpu/rp2350_arm/doc.md
@@ -1,5 +1,5 @@
-@defgroup        cpu_rp2350_arm RP2350 MCUs
-@ingroup         cpu
-@brief           RP2350 MCU code and definitions
+@defgroup        cpu_rp2350_arm RP2350 ARM
+@ingroup         cpu_rp2350
+@brief           RP2350 ARM code and definitions
 
-This module contains the code and definitions for MCUs of the RP2350 family used by the Raspberry Pi Pico 2.
+This module contains the code and definitions for RP2350 ARM used by the Raspberry Pi Pico 2.

--- a/cpu/rp2350_riscv/doc.md
+++ b/cpu/rp2350_riscv/doc.md
@@ -1,5 +1,5 @@
-@defgroup        cpu_rp2350_riscv RP2350 RISCV MCUs
-@ingroup         cpu
-@brief           RP2350 RISCV MCU code and definitions
+@defgroup        cpu_rp2350_riscv RP2350 RISC-V
+@ingroup         cpu_rp2350
+@brief           RP2350 RISC-V code and definitions
 
-This module contains the code and definitions for MCUs of the RP2350 RISCV family used by the Raspberry Pi Pico 2.
+This module contains the code and definitions for the RP2350 RISC-V used by the Raspberry Pi Pico 2.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently the RP2350, thanks to the :sparkles:  _heterogeneous architecture_ :sparkles:  clashes with the way doxygen groups work, causing two "RP2350" cpus and two "rpi-pico-2" boards to exist. This PR simply groups them together into a super-group (and also gives them proper names to make them more distinct)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`make doc` and look at the boards and cpus.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

#21745 follow-up