### PR TITLE
make: add enableable sarif output

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -86,6 +86,11 @@ ifeq (1,$(STATIC_ANALYSIS))
   endif
 endif
 
+WRITE_SARIF ?= 0
+ifeq (1,$(WRITE_SARIF))
+  RCFLAGS += $(RCFLAGS_WRITE_SARIF)
+endif
+
 compile-commands: | $(DIRS:%=COMPILE-COMMANDS--%)
 	$(file >$(BINDIR)/$(MODULE)/compile_cmds.txt,SRC: $(sort $(SRC) $(SRC_NO_LTO)))
 	$(file >>$(BINDIR)/$(MODULE)/compile_cmds.txt,SRC_NO_LTO: $(sort $(SRC_NO_LTO)))
@@ -155,7 +160,7 @@ OBJ_DEPS += $(RIOTBUILD_CONFIG_HEADER_C)
 
 $(OBJC): $(BINDIR)/$(MODULE)/%.o: %.c $(OBJ_DEPS) | $(if $(SHOULD_RUN_KCONFIG),$(KCONFIG_GENERATED_AUTOCONF_HEADER_C))
 	$(Q)$(CCACHE) $(CC) \
-		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
+		$(CFLAGS) $(RCFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
 ifneq (,$(SHOULD_RUN_KCONFIG))
 	$(Q)$(FIXDEP) $(@:.o=.d) $@ $(KCONFIG_SYNC_DIR) > $(@:.o=.tmp)
 	$(Q)mv $(@:.o=.tmp) $(@:.o=.d)
@@ -163,7 +168,7 @@ endif
 
 $(GENOBJC): %.o: %.c $(OBJ_DEPS) | $(if $(SHOULD_RUN_KCONFIG),$(KCONFIG_GENERATED_AUTOCONF_HEADER_C))
 	$(Q) $(CCACHE) $(CC) \
-		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $<
+		$(CFLAGS) $(RCFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $<
 ifneq (,$(SHOULD_RUN_KCONFIG))
 	$(Q)$(FIXDEP) $(@:.o=.d) $@ $(KCONFIG_SYNC_DIR) > $(@:.o=.tmp)
 	$(Q)mv $(@:.o=.tmp) $(@:.o=.d)
@@ -171,7 +176,7 @@ endif
 
 $(OBJCXX): $(BINDIR)/$(MODULE)/%.o: %.$(SRCXXEXT) $(OBJ_DEPS) | $(if $(SHOULD_RUN_KCONFIG),$(KCONFIG_GENERATED_AUTOCONF_HEADER_C))
 	$(Q)$(CCACHE) $(CXX) \
-		$(CXXFLAGS) $(CXXINCLUDES) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
+		$(CXXFLAGS) $(RCFLAGS) $(CXXINCLUDES) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
 ifneq (,$(SHOULD_RUN_KCONFIG))
 	$(Q)$(FIXDEP) $(@:.o=.d) $@ $(KCONFIG_SYNC_DIR) > $(@:.o=.tmp)
 	$(Q)mv $(@:.o=.tmp) $(@:.o=.d)

--- a/Makefile.base
+++ b/Makefile.base
@@ -1,5 +1,5 @@
 ifeq (, $(__RIOTBUILD_FLAG))
-  $(error You cannot build a module on its own. Use "make" in your application's directory instead.)
+  $(error You cannot build a module on its own. Use "make" in your application directory instead.)
 endif
 
 #

--- a/makefiles/toolchain/gnu.inc.mk
+++ b/makefiles/toolchain/gnu.inc.mk
@@ -39,6 +39,9 @@ include $(RIOTMAKE)/tools/gdb.inc.mk
 # GCC's static analysis tools can be enabled using -fanalyzer
 CFLAGS_STATIC_ANALYSIS := -fanalyzer
 
+# this needs to be recursively evaluated
+RCFLAGS_WRITE_SARIF = -fdiagnostics-set-output=sarif:file='$$@.sarif'
+
 # Data address spaces starts at zero for all supported architectures. This fixes
 # compilation at least on MSP430 and AVR.
 # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -70,8 +70,10 @@ export CC                    # The C compiler to use.
 export CXX                   # The CXX compiler to use.
 export CCAS                  # The C compiler to use for assembler files, typically the same as CC.
 export CFLAGS                # The compiler flags. Must only ever be used with `+=`.
+unexport RCFLAGS             # recursively (late) evaluated compiler flags for target specific addition
 export CFLAGS_CPU            # CPU architecture specific compiler flags
 export CFLAGS_STATIC_ANALYSIS# Additional CFLAGS to use when static analysis should be enabled
+export RCFLAGS_WRITE_SARIF	 # recursively evaluated CFLAG to write diagnostic messages to sarif
 export CXXUWFLAGS            # (Patterns of) flags in CFLAGS that should not be passed to CXX.
 export CXXEXFLAGS            # Additional flags that should be passed to CXX.
 export CCASUWFLAGS           # (Patterns of) flags in CFLAGS that should not be passed to CCAS.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

- adds WRITE_SARIF: (requires gcc>=15  for file redirect)
  - write your gcc output into sarif files 

 - ~adds WWARN_STATIC_ANALYSIS~
  - ~removes -Werror  CFLAG to~
  - ~enables -fanalyser~
   
### Testing procedure

on a system with a recent gcc (>15) (not our docker)

for a empty static analysis report run 
```
examples/basic/hello-world/ >make -j STATIC_ANALYSIS=1 WRITE_SARIF=1 clean elffile
```

for a complete static analysis with out an warnings elevated to error run

```
examples/basic/hello-world/ >make -j STATIC_ANALYSIS=1 MODULE_SUPPORTS_STATIC_ANALYSIS=1 WRITE_SARIF=1 clean elffile
```

~do not:`examples/basic/hello-world/ > CFLAGS=-fanalyzer make -j WERROR=0 WRITE_SARIF=1 clean elffile`~
instead of adding CFLAGS=-fanalyzer see bove 

see 
```
examples/basic/hello-world/ > find -iname '*sarif' 

./bin/native64/application_hello-world/main.o.sarif
./bin/native64/core/msg.o.sarif
./bin/native64/core/sched.o.sarif
./bin/native64/core/thread.o.sarif
./bin/native64/core/mutex.o.sarif
./bin/native64/core/cond.o.sarif
./bin/native64/core_lib/assert.o.sarif
./bin/native64/core_lib/ringbuffer.o.sarif
./bin/native64/core_lib/atomic_sync.o.sarif
./bin/native64/core_lib/panic.o.sarif
./bin/native64/core_lib/priority_queue.o.sarif
./bin/native64/core_lib/rmutex.o.sarif
./bin/native64/core_lib/clist.o.sarif
./bin/native64/core_lib/init.o.sarif
./bin/native64/core_lib/bitarithm.o.sarif
./bin/native64/core_lib/atomic_c11.o.sarif
./bin/native64/cpu/async_read.o.sarif
./bin/native64/cpu/cpu.o.sarif
./bin/native64/cpu/irq.o.sarif
./bin/native64/cpu/startup.o.sarif
./bin/native64/cpu/panic.o.sarif
./bin/native64/cpu/syscalls.o.sarif
./bin/native64/periph/pm.o.sarif
./bin/native64/periph/gpio_linux.o.sarif
./bin/native64/periph/uart.o.sarif
./bin/native64/boards_common_native/board_init.o.sarif
./bin/native64/board_common_init/board_common.o.sarif
./bin/native64/stdio_native/stdio_native.o.sarif
./bin/native64/stdio/stdio.o.sarif
./bin/native64/auto_init/auto_init.o.sarif
./bin/native64/libc/string.o.sarif
./bin/native64/native_drivers/native-led.o.sarif
./bin/native64/periph_common/init_buttons.o.sarif
./bin/native64/periph_common/init_leds.o.sarif
./bin/native64/periph_common/init.o.sarif
./bin/native64/periph_common/pm.o.sarif
./bin/native64/periph_common/gpio.o.sarif
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
