### PR TITLE
sys/walltime: implement alarm functions

### DIFF
--- a/boards/same54-xpro/Makefile.dep
+++ b/boards/same54-xpro/Makefile.dep
@@ -31,3 +31,8 @@ ifneq (,$(filter vfs_default,$(USEMODULE)))
   endif
   USEMODULE += mtd
 endif
+
+ifneq (,$(filter walltime_default,$(USEMODULE)))
+  USEMODULE += walltime_impl_rtc
+  USEMODULE += ztimer_no_periph_rtt
+endif

--- a/drivers/ds3231/ds3231.c
+++ b/drivers/ds3231/ds3231.c
@@ -444,6 +444,7 @@ int ds3231_disable_bat(const ds3231_t *dev)
 
 #ifdef MODULE_WALLTIME_IMPL_DS3231
 #include "ds3231_params.h"
+#include "walltime.h"
 
 static ds3231_t walltime_dev;
 static bool _init_done;
@@ -470,4 +471,30 @@ int walltime_impl_set(struct tm *time)
     }
     return ds3231_set_time(&walltime_dev, time);
 }
-#endif
+
+#  ifdef MODULE_DS3231_INT
+int walltime_impl_alarm_set(struct tm *time, walltime_alarm_cb_t cb, void *arg)
+{
+    if (!_init_done) {
+        return -ENODEV;
+    }
+
+    if (!cb) {
+        return ds3231_toggle_alarm_1(&walltime_dev, false);
+    }
+
+    int res = ds3231_set_alarm_1(&walltime_dev, time, DS3231_AL1_TRIG_D_H_M_S);
+    if (res) {
+        return res;
+    }
+
+    /* clear stale interrupt flag */
+    uint8_t status;
+    _read(&walltime_dev, REG_STATUS, &status, 1, 1, 0);
+    status &= ~STAT_A1F;
+    _write(&walltime_dev, REG_STATUS, &status, 1, 0, 1);
+
+    return gpio_init_int(walltime_dev.int_pin, GPIO_IN, GPIO_FALLING, cb, arg);
+}
+#  endif /* MODULE_DS3231_INT */
+#endif /* MODULE_WALLTIME_IMPL_DS3231 */

--- a/sys/include/walltime.h
+++ b/sys/include/walltime.h
@@ -43,6 +43,13 @@ extern "C" {
 typedef void (*walltime_change_cb_t)(void *ctx, int32_t diff_sec, int16_t diff_ms);
 
 /**
+ * @brief Signature for alarm Callback
+ *
+ * @param[in] arg           optional argument to put the callback in the right context
+ */
+typedef void(*walltime_alarm_cb_t)(void *arg);
+
+/**
  * @brief   Time change notification subscription
  * @{
  */
@@ -116,6 +123,33 @@ uint32_t walltime_get_riot(uint16_t *ms);
 time_t walltime_get_unix(uint16_t *ms);
 
 /**
+ * @brief Set an alarm for RTC to the specified value.
+ *
+ * @note Any already set alarm will be overwritten.
+ *
+ * @param[in] time      The value to trigger an alarm when hit.
+ * @param[in] cb        Callback executed when alarm is hit.
+ *                      Set this to NULL to clear the alarm.
+ * @param[in] arg       Argument passed to callback when alarm is hit.
+ *
+ * @retval  0           success
+ * @retval  -EINVAL     @p time was invalid (e.g. in the past, out of range)
+ * @retval  <0          other error (negative errno code to indicate cause)
+ */
+int walltime_set_alarm(struct tm *time, walltime_alarm_cb_t cb, void *arg);
+
+/**
+ * @brief Gets the current alarm setting
+ *
+ * @param[out]  time    Pointer to structure to receive alarm time
+ *
+ * @retval  0           success
+ * @retval  -EINVAL     no alarm is configured
+ * @retval  <0          other error (negative errno code to indicate cause)
+ */
+int walltime_get_alarm(struct tm *time);
+
+/**
  * @brief   Get seconds elapsed since last reset
  *
  * @note    The @p full option will only have an effect if @ref BACKUP_RAM
@@ -150,6 +184,33 @@ int walltime_impl_set(struct tm *time);
  * @returns 0 on success
  */
 int walltime_impl_get(struct tm *time, uint16_t *ms);
+
+/**
+ * @brief   Backend implementation to set the alarm
+ *
+ * @note    The @p time value is normalized by the upper layer.
+ *
+ * @param[in] time      The value to trigger an alarm when hit.
+ * @param[in] cb        Callback executed when alarm is hit.
+ *                      Set this to NULL to clear the alarm.
+ * @param[in] arg       Argument passed to callback when alarm is hit.
+ *
+ * @retval  0           success
+ * @retval  -EINVAL     @p time was invalid (e.g. in the past, out of range)
+ * @retval  <0          other error (negative errno code to indicate cause)
+ */
+int walltime_impl_alarm_set(struct tm *time, walltime_alarm_cb_t cb, void *arg);
+
+/**
+ * @brief Gets the current alarm setting
+ *
+ * @param[out]  time    Pointer to structure to receive alarm time
+ *
+ * @retval  0           success
+ * @retval  -EINVAL     no alarm is configured
+ * @retval  <0          other error (negative errno code to indicate cause)
+ */
+int walltime_impl_alarm_get(struct tm *time);
 
 #ifdef __cplusplus
 }

--- a/sys/walltime/fallback.c
+++ b/sys/walltime/fallback.c
@@ -15,6 +15,7 @@
  * @}
  */
 
+#include <errno.h>
 #include <stdint.h>
 #include <time.h>
 
@@ -41,6 +42,23 @@ int walltime_impl_set(struct tm *time)
 {
     ztimer_offset = rtc_mktime(time) - ztimer_now(ZTIMER_MSEC) / 1000;
     return 0;
+}
+
+__attribute__((weak))
+int walltime_impl_alarm_set(struct tm *time, walltime_alarm_cb_t cb, void *arg)
+{
+    (void)time;
+    (void)cb;
+    (void)arg;
+
+    return -ENOTSUP;
+}
+
+__attribute__((weak))
+int walltime_impl_alarm_get(struct tm *time)
+{
+    (void)time;
+    return -ENOTSUP;
 }
 
 __attribute__((weak))

--- a/sys/walltime/rtc.c
+++ b/sys/walltime/rtc.c
@@ -20,6 +20,7 @@
 
 #include "periph/rtc.h"
 #include "modules.h"
+#include "walltime.h"
 
 #ifdef MODULE_WALLTIME_IMPL_RTC
 
@@ -38,6 +39,21 @@ int walltime_impl_set(struct tm *time)
 {
     rtc_set_time(time);
     return 0;
+}
+
+int walltime_impl_alarm_set(struct tm *time, walltime_alarm_cb_t cb, void *arg)
+{
+    if (cb) {
+        return rtc_set_alarm(time, cb, arg);
+    } else {
+        rtc_clear_alarm();
+        return 0;
+    }
+}
+
+int walltime_impl_alarm_get(struct tm *time)
+{
+    return rtc_get_alarm(time);
 }
 
 #endif

--- a/sys/walltime/walltime.c
+++ b/sys/walltime/walltime.c
@@ -124,6 +124,17 @@ int walltime_get(struct tm *time, uint16_t *ms)
     return res;
 }
 
+int walltime_set_alarm(struct tm *time, walltime_alarm_cb_t cb, void *arg)
+{
+    rtc_tm_normalize(time);
+    return walltime_impl_alarm_set(time, cb, arg);
+}
+
+int walltime_get_alarm(struct tm *time)
+{
+    return walltime_impl_alarm_get(time);
+}
+
 uint32_t walltime_uptime(bool full)
 {
     uint32_t now = walltime_get_riot(NULL);

--- a/tests/sys/walltime/Makefile.ci
+++ b/tests/sys/walltime/Makefile.ci
@@ -1,3 +1,4 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
+    samd10-xmini \
     #

--- a/tests/sys/walltime/main.c
+++ b/tests/sys/walltime/main.c
@@ -11,10 +11,13 @@
  *
  */
 
+#include <errno.h>
 #include "shell.h"
+#include "time_units.h"
 #include "fmt.h"
 #include "rtc_utils.h"
 #include "walltime.h"
+#include "ztimer.h"
 
 static void _time_change_cb(void *ctx, int32_t diff_sec, int16_t diff_ms)
 {
@@ -54,6 +57,11 @@ static void _add_and_remove_dummy_cb(void)
         goto fail;                                                  \
     }
 
+static void _unlock(void *ctx)
+{
+    mutex_unlock(ctx);
+}
+
 static int _cmd_test(int argc, char **argv)
 {
     (void)argc;
@@ -79,6 +87,34 @@ static int _cmd_test(int argc, char **argv)
     TEST_RES(res, "walltime_get()");
     res = rtc_tm_compare(&now, &expect);
     TEST_RES(res, "rtc_tm_compare()");
+
+    mutex_t lock = MUTEX_INIT_LOCKED;
+    uint32_t now_ms = ztimer_now(ZTIMER_MSEC);
+
+    now.tm_sec += 5;
+    res = walltime_set_alarm(&now, _unlock, &lock);
+    if (res != -ENOTSUP) {
+        TEST_RES(res, "walltime_set_alarm()");
+
+        struct tm alarm;
+        res = walltime_get_alarm(&alarm);
+        if (res != -ENOTSUP) {
+            TEST_RES(res, "walltime_get_alarm()");
+            res = rtc_tm_compare(&now, &alarm);
+            TEST_RES(res, "rtc_tm_compare()");
+        }
+
+        puts("wait for alarm");
+
+        res = ztimer_mutex_lock_timeout(ZTIMER_MSEC, &lock, 6 * MS_PER_SEC);
+        TEST_RES(res, "wait for alarm");
+
+        int diff = 5 * MS_PER_SEC - (ztimer_now(ZTIMER_MSEC) - now_ms);
+        if (diff < -1000) {
+            printf("alarm %d ms early\n", -diff);
+            goto fail;
+        }
+    }
 
     puts("TEST PASSED");
     return res;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Walltime backends can provide an alarm functionality.
Provide an API to make this a drop-in replacement for the `periph_rtc` API.


### Testing procedure

I extended the automatic test in `tests/sys/walltime` to also exercise the new alarm function.
Works on `same54-xpro` with the RTC backend.

```
2026-03-10 17:05:54,638 # > test
2026-03-10 17:05:54,643 # time changed by 45294 sec, 0 ms
2026-03-10 17:05:54,648 # time changed by 820540800 sec, 0 ms
2026-03-10 17:05:54,649 # wait for alarm
2026-03-10 17:05:59,983 # TEST PASSED
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
