### PR TITLE
boards/common/nrf52: include adafruit-nrf52-bootloader dependency early

### DIFF
--- a/boards/common/nrf52/Makefile.dep
+++ b/boards/common/nrf52/Makefile.dep
@@ -1,3 +1,10 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_nrf_temperature
 endif
+
+ifneq (,$(filter boards_common_adafruit-nrf52-bootloader,$(USEMODULE)))
+  # If this only gets included in the 2nd round of dependency resolution
+  # we will already have included stdio_uart by default.
+  # Include this here to select stdio_cdc_acm early.
+  include $(RIOTBOARD)/common/adafruit-nrf52-bootloader/Makefile.dep
+endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The multi-round dependency resolution leads to an interesting artifact:

When no stdio provider is selected by the board, we automatically select `stdio_uart`.

Boards that select `boards_common_adafruit-nrf52-bootloader` will select `stdio_cdc_acm` in the 2nd round of dependency resolution (since that is a dependency of `boards_common_adafruit-nrf52-bootloader`) but at that point we already have `stdio_uart` selected in the previous round, so we end up with two stdio providers.

While this is not a problem, as `stdio_dispatch` gets auto-selected in such cases, it is not the intention. A user might want to use the UART interface for something else and will be surprised if it also is already used for stdio when that is already available via USB.

As an easy fix, resolve the `boards_common_adafruit-nrf52-bootloader` dependency early so we do get the `stdio_cdc_acm` module selected in the same round.


### Testing procedure

On `master` we get two stdio providers for all boards that use `boards_common_adafruit-nrf52-bootloader`:

```
$ make BOARD=pro-micro-nrf52840 info-modules | grep stdio

stdio
stdio_available
stdio_cdc_acm
stdio_default
stdio_dispatch
stdio_uart
```

With this patch, only `stdio_cdc_acm` gets selected

```
$ make BOARD=pro-micro-nrf52840 info-modules | grep stdio

stdio
stdio_available
stdio_cdc_acm
stdio_default

```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
