### PR TITLE
drivers/at86rf2xx: fix misleading TX power getter value

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -163,8 +163,6 @@ void at86rf2xx_configure_phy(at86rf2xx_t *dev, uint8_t chan, uint8_t page, int16
     /* we must be in TRX_OFF before changing the PHY configuration */
     uint8_t prev_state = at86rf2xx_set_state(dev, AT86RF2XX_STATE_TRX_OFF);
     (void) page;
-    (void) chan;
-    (void) txpower;
 
 #if AT86RF2XX_HAVE_SUBGHZ
     /* The TX power register must be updated after changing the channel if

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -32,6 +32,7 @@
 
 #include "architecture.h"
 #include "iolist.h"
+#include "macros/utils.h"
 
 #include "net/eui64.h"
 #include "net/ieee802154.h"
@@ -688,11 +689,14 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 
         case NETOPT_TX_POWER:
             assert(len <= sizeof(int16_t));
-            netdev_ieee802154->txpower = *((const int16_t *)val);
+            int16_t txpower = *((const int16_t *)val);
+            txpower = MAX(txpower, -(int16_t)AT86RF2XX_TXPOWER_OFF);
+            txpower = MIN(txpower,  (int16_t)(AT86RF2XX_TXPOWER_MAX - AT86RF2XX_TXPOWER_OFF));
+            netdev_ieee802154->txpower = txpower;
 #if AT86RF2XX_HAVE_SUBGHZ
-            at86rf2xx_configure_phy(dev, dev->netdev.chan, dev->page, *((const int16_t *)val));
+            at86rf2xx_configure_phy(dev, dev->netdev.chan, dev->page, txpower);
 #else
-            at86rf2xx_configure_phy(dev, dev->netdev.chan, 0, *((const int16_t *)val));
+            at86rf2xx_configure_phy(dev, dev->netdev.chan, 0, txpower);
 #endif
             res = sizeof(uint16_t);
             break;


### PR DESCRIPTION
Fixes #22117

## Problem

`NETOPT_TX_POWER` setter stored the raw value in `netdev_ieee802154->txpower`
without clamping, while `_set_txpower()` silently clamped it to the hardware
range. The getter therefore reported a value that did not match the hardware.

## Changes

- `at86rf2xx_netdev.c`: clamp `txpower` to the valid hardware range before
  storing, so getter and hardware always agree
- `at86rf2xx_getset.c`: remove misleading `(void) chan` and `(void) txpower`
  casts — both variables are used outside the `AT86RF2XX_HAVE_SUBGHZ` guard

## Testing

Not yet tested on hardware. Unit test follow-up tracked in #22125.