### PR TITLE
doc/doxygen: set TYPEDEF_HIDES_STRUCT=YES

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -491,7 +491,7 @@ INLINE_SIMPLE_STRUCTS  = NO
 # types are typedef'ed and only the typedef is referenced, never the tag name.
 # The default value is: NO.
 
-TYPEDEF_HIDES_STRUCT   = NO
+TYPEDEF_HIDES_STRUCT   = YES
 
 # The size of the symbol lookup cache can be set using LOOKUP_CACHE_SIZE. This
 # cache is used to resolve symbols given their name and scope. Since this can be


### PR DESCRIPTION
To quote the explanation inside of the doxyfile:

```
# When TYPEDEF_HIDES_STRUCT tag is enabled, a typedef of a struct, union, or
# enum is documented as struct, union, or enum with the name of the typedef. So
# typedef struct TypeS {} TypeT, will appear in the documentation as a struct
# with name TypeT. When disabled the typedef will appear as a member of a file,
# namespace, or class. And the struct will be named TypeS. This can typically be
# useful for C code in case the coding convention dictates that all compound
# types are typedef'ed and only the typedef is referenced, never the tag name.
# The default value is: NO.
```

I personally need this configuration, because in my upcomming `runtime_config` module I have a lot of typedef with `_` prefixes to work around the circular reference dilemma.
In doxygen that creates a lot of useless documentation about these types, even though they are not supposed to be used outside of my header file.

E.g.:
<img width="539" height="301" alt="image" src="https://github.com/user-attachments/assets/953727ca-287e-4ff1-a524-69f727f22f83" />
