### PR TITLE
.clang-tidy: allow use of shorter variable names

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -59,6 +59,7 @@ Checks: "clang-analyzer-*,
          linuxkernel-*,
          -bugprone-reserved-identifier,
          -bugprone-easily-swappable-parameters,
+         -readability-identifier-length,
         "
 WarningsAsErrors: "bugprone-*,
                    portability-*,


### PR DESCRIPTION
### Contribution description

A use of parameter names or variable names such `id` for an ID, `fd` for a file descriptor etc. is common practice.

The signal to noise ratio of the linter check enforcing variable lengths to be longer than two chars isn't too great, so let's rather disable it again.

### Testing procedure

Open a random large C file in RIOT with an LSP capable editor and `clangd` + `clang-tidy` installed. In `master`, it will be full of warnings. With this PRs, the amount of warnings should be lower.

### Issues/PRs references

None