### PR TITLE
sys/ztimer: fix boolean logic on constant ints

### DIFF
--- a/sys/ztimer/init.c
+++ b/sys/ztimer/init.c
@@ -384,7 +384,7 @@ void ztimer_init(void)
 
     /* warm-up time if set and needed */
     if (IS_USED(MODULE_ZTIMER_AUTO_ADJUST) &&
-        !(CONFIG_ZTIMER_USEC_ADJUST_SET && CONFIG_ZTIMER_USEC_ADJUST_SLEEP)) {
+        !(CONFIG_ZTIMER_USEC_ADJUST_SET != 0 && CONFIG_ZTIMER_USEC_ADJUST_SLEEP != 0)) {
         if (CONFIG_ZTIMER_AUTO_ADJUST_SETTLE) {
             ztimer_sleep(ZTIMER_USEC, CONFIG_ZTIMER_AUTO_ADJUST_SETTLE);
         }
@@ -398,7 +398,7 @@ void ztimer_init(void)
 #  endif
 
     /* calculate or set 'adjust_set' */
-    if (CONFIG_ZTIMER_USEC_ADJUST_SET) {
+    if (CONFIG_ZTIMER_USEC_ADJUST_SET != 0) {
         ZTIMER_USEC->adjust_set = CONFIG_ZTIMER_USEC_ADJUST_SET;
     }
     else if (IS_USED(MODULE_ZTIMER_AUTO_ADJUST)) {
@@ -411,7 +411,7 @@ void ztimer_init(void)
     }
 
     /* calculate or set 'adjust_sleep' */
-    if (CONFIG_ZTIMER_USEC_ADJUST_SLEEP) {
+    if (CONFIG_ZTIMER_USEC_ADJUST_SLEEP != 0) {
         ZTIMER_USEC->adjust_sleep = CONFIG_ZTIMER_USEC_ADJUST_SLEEP;
     }
     else if (IS_USED(MODULE_ZTIMER_AUTO_ADJUST)) {


### PR DESCRIPTION
### Contribution description

Compiling with LLVM raises the following error:

`error: use of logical '&&' with constant operand [-Werror,-Wconstant-logical-operand`

This commit explicitly compares the constant adjustment values, to mitigate this error.

### Testing procedure

Noticed this when #22099 was put on the merge queue.

On current master, compile `TOOLCHAIN=llvm BOARD=pro-micro-nrf52840 make -C tests/drivers/dht`

Then, apply this patch, and compile again.

I chose `pro-micro-nrf52840`, because it has nothing to do with #22099. I chose `tests/drivers/dht` because that is what failed first.

### Issues/PRs references

* #22099
* [Failing build](https://ci.riot-os.org/details/6357bc0ab4bd4ecda6cf64cd8f73ce2e)