### PR TITLE
examples/basic/filesystem: don't set main stack size on native

### DIFF
--- a/examples/basic/filesystem/Makefile
+++ b/examples/basic/filesystem/Makefile
@@ -34,6 +34,8 @@ USEMODULE += constfs
 
 # For LittleFS on real devices, the main stack size has to be
 # increased:
-CFLAGS += -DTHREAD_STACKSIZE_MAIN=2048
+ifeq (,$(filter native%,$(BOARD)))
+  CFLAGS += -DTHREAD_STACKSIZE_MAIN=2048
+endif
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

`native` already has ample stack size, setting it to 2048 bytes is actually a decrease.
While this still works on `native32`, running this on `native64` will overflow the stack.


### Testing procedure

Run `examples/basic/filesystem` on `native64`.
It should no longer crash when switching the thread. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
