### PR TITLE
sys/net/nanocoap_fileserver: only set payload marker if payload exists

### DIFF
--- a/sys/net/application_layer/nanocoap/fileserver.c
+++ b/sys/net/application_layer/nanocoap/fileserver.c
@@ -486,7 +486,6 @@ static ssize_t _get_directory(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                &block2);
     coap_block_slicer_init(&slicer, block2.blknum, coap_szx2size(block2.szx));
     coap_opt_add_block2(pdu, &slicer, true);
-    coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);
 
     size_t root_len = root ? strlen(root) : 0;
     const char *root_dir = &request->namebuf[root_len];
@@ -505,6 +504,9 @@ static ssize_t _get_directory(coap_pkt_t *pdu, uint8_t *buf, size_t len,
 
         if (slicer.cur) {
             coap_blockwise_put_char_pkt(pdu, &slicer, ',');
+        } else {
+            /* no payload written yet - set payload marker */
+            coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);
         }
         coap_blockwise_put_char_pkt(pdu, &slicer, '<');
         coap_blockwise_put_bytes_pkt(pdu, &slicer, resource_dir, resource_dir_len);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When we query the directory listing of an empty directory we currently respond with an empty payload but still set the payload marker anyway.

Some CoAP clients don't like this:

```
$ coap-client-notls coap://[fe80::809a:bfff:fef7:e261%tapbr0]/vfs/         
Mar 12 16:37:38.260 WARN discard malformed PDU
```


### Testing procedure

Run `examples/networking/coap/nanocoap_server`.
The native file-system can be found in the `native/` folder.

If you delete the folder / remove files in it the request for `/vfs/` will get an empty response:

```
$ coap-client-notls coap://[fe80::809a:bfff:fef7:e261%tapbr0]/vfs/

```

If you add a file, you should get that listed

```
$ touch native/something 
$ coap-client-notls coap://[fe80::809a:bfff:fef7:e261%tapbr0]/vfs/
</vfs/something>
```



### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
