### PR TITLE
boards/native: use 'nvm0' for native fs folder name

### DIFF
--- a/boards/common/native/include/board.h
+++ b/boards/common/native/include/board.h
@@ -88,7 +88,7 @@ void _native_LED_RED_TOGGLE(void);
  * @{
  */
 #ifndef FS_NATIVE_DIR
-#define FS_NATIVE_DIR           "native"  /**< Folder on the host fs exported to RIOT */
+#define FS_NATIVE_DIR           "nvm0"  /**< Folder on the host fs exported to RIOT */
 #endif
 /** @} */
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Currently the `native` target can access the host file system via the `native/` folder.
It turns out that this is not such an obvious name.

So change it to `nvm0` to better tell what this folder does.


### Testing procedure

Run e.g. `examples/basic/filesystem` on `native`.

This should now create a `nvm0` folder instead of a `native` folder that contains the native filesystem contents.

Inside RIOT this is mounted as `/nvm0`:

```
$ touch native_fs/something

2026-03-12 17:11:15,820 # > ls /nvm0
2026-03-12 17:11:15,820 # something
2026-03-12 17:11:15,821 # ./
2026-03-12 17:11:15,821 # ../
2026-03-12 17:11:15,821 # total 1 files
```



### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
