### PR TITLE
pkg/lvgl: Fix LVGL bug when using SDL on native

### DIFF
--- a/pkg/lvgl/contrib/lvgl.c
+++ b/pkg/lvgl/contrib/lvgl.c
@@ -139,7 +139,8 @@ static void _touch_read(lv_indev_drv_t *indev_driver, lv_indev_data_t *data)
 #endif
 
 /* Pixel placement for monochrome displays where color depth is 1 bit, and each bit represents
-   a pixel */
+ * a pixel */
+MAYBE_UNUSED
 static void _monochrome_1bit_set_px_cb(lv_disp_drv_t *disp_drv, uint8_t *buf, lv_coord_t buf_w,
                                        lv_coord_t x, lv_coord_t y, lv_color_t color, lv_opa_t opa)
 {
@@ -183,12 +184,12 @@ void lvgl_init(screen_dev_t *screen_dev)
        underlying display device parameters */
     disp_drv.hor_res = disp_dev_width(screen_dev->display);
     disp_drv.ver_res = disp_dev_height(screen_dev->display);
-#endif
 
     if (disp_dev_color_depth(screen_dev->display) == 1) {
         disp_drv.full_refresh = 1;
         disp_drv.set_px_cb = _monochrome_1bit_set_px_cb;
     }
+#endif
 
     lv_disp_drv_register(&disp_drv);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR fixes a bug in the LVGL package which breaks the native board simulation using SDL.
The current implementation of pkg/lvgl/contrib/lvgl.c checks the color depth of the used display with disp_dev_color_depth(). If SDL is used, screen_dev->screen is undefined and it explodes an assertion in disp_dev:
`2026-03-16 16:47:47,862 # drivers/disp_dev/disp_dev.c:90 => FAILED ASSERTION.`

The fix is to only check the display color depth if SDL is not used.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Running the tests/pkg/lvgl test with `BOARD = native` reproduces the error. The test runs again after the proposed change.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Bug was introduced by PR #21726
