### PR TITLE
drivers/cst816s: Fix touch_dev compatibility

### DIFF
--- a/drivers/cst816s/cst816s.c
+++ b/drivers/cst816s/cst816s.c
@@ -30,19 +30,20 @@
 #include "debug.h"
 
 const char *cst816s_gesture_str[] = {
-    [CST816S_GESTURE_NONE]         = "none",
-    [CST816S_GESTURE_SLIDE_DOWN]   = "slide down",
-    [CST816S_GESTURE_SLIDE_UP]     = "slide up",
-    [CST816S_GESTURE_SLIDE_LEFT]   = "slide left",
-    [CST816S_GESTURE_SLIDE_RIGHT]  = "slide right",
+    [CST816S_GESTURE_NONE] = "none",
+    [CST816S_GESTURE_SLIDE_DOWN] = "slide down",
+    [CST816S_GESTURE_SLIDE_UP] = "slide up",
+    [CST816S_GESTURE_SLIDE_LEFT] = "slide left",
+    [CST816S_GESTURE_SLIDE_RIGHT] = "slide right",
     [CST816S_GESTURE_SINGLE_CLICK] = "single click",
     [CST816S_GESTURE_DOUBLE_CLICK] = "double click",
-    [CST816S_GESTURE_LONG_PRESS]   = "long press",
+    [CST816S_GESTURE_LONG_PRESS] = "long press",
 };
 
 static void _gpio_irq(void *arg)
 {
     cst816s_t *dev = arg;
+
     assert(dev);
 
     if (dev->cb) {
@@ -73,10 +74,11 @@ int cst816s_read(const cst816s_t *dev, cst816s_touch_data_t *data)
         return res;
     }
 
-    data->gesture = buf[1];
-    data->action = buf[3] >> 6;
-    data->x = ((buf[3] & 0x0f) << 8) | buf[4];
-    data->y = ((buf[5] & 0x0f) << 8) | buf[6];
+    data->gesture = buf[1];                         /* Gesture ID */
+    data->valid = buf[2] > 0;                       /* Number of touch points */
+    data->action = buf[3] >> 6;                     /* Current touch event */
+    data->x = ((buf[3] & 0x0f) << 8) | buf[4];      /* X coordinate */
+    data->y = ((buf[5] & 0x0f) << 8) | buf[6];      /* Y coordinate */
 
     return 0;
 }
@@ -94,7 +96,7 @@ int cst816s_init(cst816s_t *dev, const cst816s_params_t *params,
         _cst816s_reset(dev);
     }
 
-    if (gpio_is_valid(dev->params->irq) && cb) {
+    if (gpio_is_valid(dev->params->irq)) {
         if (gpio_init_int(dev->params->irq, GPIO_IN,
                           dev->params->irq_flank,
                           _gpio_irq, dev) < 0) {

--- a/drivers/cst816s/cst816s_touch_dev.c
+++ b/drivers/cst816s/cst816s_touch_dev.c
@@ -39,18 +39,20 @@
 #define CST816S_YMAX    240
 #endif
 
-uint16_t _cst816s_height(const touch_dev_t *touch_dev)
+static uint16_t _cst816s_height(const touch_dev_t *touch_dev)
 {
     const cst816s_t *dev = (const cst816s_t *)touch_dev;
+
     assert(dev);
     (void)dev;  /* avoid compilation problems with NDEBUG */
 
     return CST816S_YMAX;
 }
 
-uint16_t _cst816s_width(const touch_dev_t *touch_dev)
+static uint16_t _cst816s_width(const touch_dev_t *touch_dev)
 {
     const cst816s_t *dev = (const cst816s_t *)touch_dev;
+
     assert(dev);
     (void)dev;  /* avoid compilation problems with NDEBUG */
 
@@ -65,22 +67,27 @@ uint8_t _cst816s_touches(const touch_dev_t *touch_dev, touch_t *touches, size_t 
     assert(dev);
 
     cst816s_touch_data_t data;
-    cst816s_read(dev, &data);
-    uint8_t ret = (data.action == CST816S_TOUCH_DOWN);
+    if (cst816s_read(dev, &data) < 0) {
+        return 0;   /* No data from device, assume no touch points */
+    }
+    if (!data.valid) {
+        return 0;
+    }
 
-    if (ret && touches != NULL) {
+    if (touches != NULL) {
         touches[0].x = data.x;
         touches[0].y = data.y;
 
         DEBUG("X: %i, Y: %i\n", touches[0].x, touches[0].y);
     }
 
-    return ret;
+    return data.valid;
 }
 
 void _cst816s_set_event_callback(const touch_dev_t *touch_dev, touch_event_cb_t cb, void *arg)
 {
     cst816s_t *dev = (cst816s_t *)touch_dev;
+
     assert(dev);
 
     dev->cb = (cst816s_irq_cb_t)cb;
@@ -88,8 +95,8 @@ void _cst816s_set_event_callback(const touch_dev_t *touch_dev, touch_event_cb_t 
 }
 
 const touch_dev_driver_t cst816s_touch_dev_driver = {
-    .height     = _cst816s_height,
-    .width      = _cst816s_width,
-    .touches    = _cst816s_touches,
+    .height = _cst816s_height,
+    .width = _cst816s_width,
+    .touches = _cst816s_touches,
     .set_event_callback = _cst816s_set_event_callback,
 };

--- a/drivers/include/cst816s.h
+++ b/drivers/include/cst816s.h
@@ -90,6 +90,7 @@ extern const char *cst816s_gesture_str[];
  * @brief cst816s touch event data
  */
 typedef struct {
+    bool valid;                 /**< Sample contains valid touch point */
     cst816s_gesture_t gesture;  /**< Detected gesture */
     cst816s_touch_t action;     /**< Press or release event */
     uint16_t x;                 /**< X coordinate */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This PR fixes 2 bugs in the current implementation of the driver for the CST816S touch chip.
#### Bug 1
According to the touch_dev API, `touch_dev_touches()` should return the number of current touch positions on the display. The CST816S driver (cst816s_touch_dev.c) instead returns whether a "touch down" event occured in the last sample, and also updates the given data struct only in that case. So only a single sample of data is reported per touch event.

My solution is to use the already available FingerNum register which stores how many fingers are currently detected (1 or 0). This way the driver works as expected and reports data as long as a touch input is present.

Register description: [CST816S_register_declaration.pdf](https://files.waveshare.com/wiki/common/CST816S_register_declaration.pdf)

#### Bug 2
The touch_dev module exposes the `touch_dev_set_touch_event_callback()` function which registers a callback function to be called on every touch event interrupt signal. In the current implementation of the CST816S driver, this does not work because the GPIO interrupt is only set up if a callback is defined at initialization:

cst816s_init:
 ```c
...

if (gpio_is_valid(dev->params->irq) && cb) {
        if (gpio_init_int(dev->params->irq, GPIO_IN,
                          dev->params->irq_flank,
                          _gpio_irq, dev) < 0) {
            return CST816S_ERR_IRQ;
        }
    }

...
```
I just removed the check if `cb` is valid from the init function since it is already being checked in `_gpio_irq`. This way, the GPIO interrupt is set up (if a valid IRQ pin is given) and it is possible to set the callback after initialization.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

My testing was done on [this board from Waveshare](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-1.28#Overview) which features the touch chip. After the proposed changes, the touch_dev driver tests are again functional on the hardware.
