### PR TITLE
drivers/slipdev: make default param selection less insane

### DIFF
--- a/drivers/slipdev/include/slipdev_params.h
+++ b/drivers/slipdev/include/slipdev_params.h
@@ -20,9 +20,7 @@
 
 #include "board.h"
 #include "slipdev.h"
-#ifdef MODULE_SLIPDEV_STDIO
 #include "stdio_uart.h"
-#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,22 +31,15 @@ extern "C" {
  * @{
  */
 #ifndef SLIPDEV_PARAM_UART
-# ifndef MODULE_SLIPDEV_STDIO
-#  ifdef MODULE_USBUS_CDC_ACM
-#   define SLIPDEV_PARAM_UART       UART_DEV(0)
-#  else
-#   define SLIPDEV_PARAM_UART       UART_DEV(1)
-#  endif
-# else  /* MODULE_SLIPDEV_STDIO */
+# ifdef MODULE_STDIO_UART
+#  define SLIPDEV_PARAM_UART        UART_DEV(1)
+# else
 #  define SLIPDEV_PARAM_UART        STDIO_UART_DEV
-# endif /* MODULE_SLIPDEV_STDIO */
+# endif
 #endif  /* SLIPDEV_PARAM_UART */
+
 #ifndef SLIPDEV_PARAM_BAUDRATE
-# ifndef MODULE_SLIPDEV_STDIO
-#  define SLIPDEV_PARAM_BAUDRATE    (115200U)
-# else  /* MODULE_SLIPDEV_STDIO */
-#  define SLIPDEV_PARAM_BAUDRATE    (STDIO_UART_BAUDRATE)
-# endif /* MODULE_SLIPDEV_STDIO */
+# define SLIPDEV_PARAM_BAUDRATE     STDIO_UART_BAUDRATE
 #endif  /* SLIPDEV_PARAM_BAUDRATE */
 
 #ifndef SLIPDEV_PARAMS


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The default parameters of `slipdev` change depending on the stdio method used.
The indented use case was likely to select something other than `STDIO_UART_DEV` when `stdio_uart` was used to avoid the conflict, but that's not what the file does.

Simplify the logic to only select a different *default* UART when `stdio_uart` is used, instead of checking for stdio methods like CDC ACM.


### Testing procedure

The defaults do not change, but now you can also use `stdio_null` and still have a working slip connection. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
