### PR TITLE
sys/suit: check length of URL in suit_worker_trigger()

### DIFF
--- a/sys/suit/transport/worker.c
+++ b/sys/suit/transport/worker.c
@@ -218,6 +218,11 @@ bool suit_worker_trigger(const char *url, size_t len)
 
     assert(len != 0); /* A zero-length URI is invalid, but _url[0] == '\0' is
                          special to _suit_worker_thread */
+
+    if (len == 0 || len > sizeof(_url)) {
+        return false;
+    }
+
     memcpy(_url, url, len);
     _url[len] = '\0';
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Check if the `url` fits the `_url` buffer before `memcpy`ing it.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/security/advisories/GHSA-x98f-vvf4-256q
