### PR TITLE
cpu/native: fix syscall return values for fwrite() and getpid()

### DIFF
--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -250,7 +250,12 @@ int fputs(const char *s, FILE *fp)
 
 size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *fp)
 {
-    return _native_write(fileno(fp), ptr, size * nmemb);
+    ssize_t r = _native_write(fileno(fp), ptr, size * nmemb);
+
+    if (r < 0 || size == 0) {
+        return 0;
+    }
+    return (size_t)r / size;
 }
 #endif
 
@@ -447,8 +452,7 @@ void errx(int eval, const char *fmt, ...)
 
 int getpid(void)
 {
-    warnx("getpid(): not implemented");
-    return -1;
+    return real_getpid();
 }
 
 #if (IS_USED(MODULE_LIBC_GETTIMEOFDAY))


### PR DESCRIPTION
## Summary

Fix two POSIX correctness issues in `cpu/native/syscalls.c`:

### `fwrite()` — return item count, not byte count

The C standard requires `fwrite()` to return the number of complete
items written (`nmemb`), not the number of bytes.  The previous
implementation returned the raw byte count from `_native_write()`,
which breaks any caller that checks the return value against `nmemb`.

A concrete breakage: gcov's `gcov_write_block()` calls
`fwrite(buf, size, 1, fp)` and checks `return == 1` (one item
written).  The byte-count return caused every profiling write to be
flagged as an error, so no `.gcda` coverage data was ever saved.

### `getpid()` — delegate to `real_getpid()` instead of returning -1

The previous stub returned -1 with a warning, which is incorrect for
any caller that relies on a valid PID.  gcov uses `getpid()` to
construct unique `.gcda` filenames for parallel runs.  Delegating to
`real_getpid()` gives the correct host PID with no overhead.

## Context

Both issues were discovered while implementing gcov-based coverage
reporting for the native board (issue #22137).  They are standalone
POSIX correctness fixes independent of that feature.

## Test plan

- Build `tests/unittests` for `native` and verify it compiles and runs cleanly
- Verify no regression in existing native test suite