### PR TITLE
drivers/at86rf2xx: fix sub-ghz page setting

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -97,9 +97,15 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
         at86rf2xx_set_option(dev, AT86RF2XX_OPT_CSMA, true);
     }
 
-    /* enable safe mode (protect RX FIFO until reading data starts) */
-    at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2,
-                        AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE);
+    /**
+     * enable safe mode (protect RX FIFO until reading data starts)
+     *
+     * NOTE: sub-ghz settings in TRX_CTRL_2 are configured in
+     *       at86rf2xx_configure_phy() so use read-modify-write
+     */
+    tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_2);
+    tmp |= AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE;
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2, tmp);
 
 #if !AT86RF2XX_IS_PERIPH
     /* don't populate masked interrupt flags to IRQ_STATUS register */

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -97,16 +97,6 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
         at86rf2xx_set_option(dev, AT86RF2XX_OPT_CSMA, true);
     }
 
-    /**
-     * enable safe mode (protect RX FIFO until reading data starts)
-     *
-     * NOTE: sub-ghz settings in TRX_CTRL_2 are configured in
-     *       at86rf2xx_configure_phy() so use read-modify-write
-     */
-    tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_2);
-    tmp |= AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE;
-    at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2, tmp);
-
 #if !AT86RF2XX_IS_PERIPH
     /* don't populate masked interrupt flags to IRQ_STATUS register */
     tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_1);

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -166,11 +166,12 @@ void at86rf2xx_configure_phy(at86rf2xx_t *dev, uint8_t chan, uint8_t page, int16
     (void) chan;
     (void) txpower;
 
+    uint8_t trx_ctrl2 = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_2);
+
 #if AT86RF2XX_HAVE_SUBGHZ
     /* The TX power register must be updated after changing the channel if
      * moving between bands. */
 
-    uint8_t trx_ctrl2 = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_2);
     uint8_t rf_ctrl0 = at86rf2xx_reg_read(dev, AT86RF2XX_REG__RF_CTRL_0);
 
     /* Clear previous configuration for PHY mode */
@@ -195,9 +196,13 @@ void at86rf2xx_configure_phy(at86rf2xx_t *dev, uint8_t chan, uint8_t page, int16
         rf_ctrl0 |= AT86RF2XX_RF_CTRL_0_GC_TX_OFFS__1DB;
     }
 
-    at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2, trx_ctrl2);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__RF_CTRL_0, rf_ctrl0);
 #endif
+
+    /* enable safe mode (protect RX FIFO until reading data starts) */
+    trx_ctrl2 |= AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE;
+
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2, trx_ctrl2);
 
     uint8_t phy_cc_cca = at86rf2xx_reg_read(dev, AT86RF2XX_REG__PHY_CC_CCA);
     /* Clear previous configuration for channel number */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
In [5207a82](https://github.com/riot-os/RIOT/commit/5207a82e031699f3fc6edb4ad5da0c661a846cd5) the configuration of the sub-GHz page moved to the `at86rf2xx_configure_phy` function. As the "RX Safe Mode" writes to the `TRX_CTRL_2` register without read-modify-write, the page setting will be overwritten. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
I noticed that I wasn´t receiving ping responses on my SAMR30 after upgrading my project from 2022.10 to 2023.01. With a packet sniffer on another board (using an EFR32FG23), I wasn't seeing any packet from my SAMR30 anymore. I managed to trace it down to #5207a82 and noticed this bug.

Changing the RX safe mode configuration to read-modify-write fixed the issue for me.

EDIT:

Based on the feedback of @benpicco, I have moved the configuration of the safe mode (setting the bit) to `at86rf2xx_configure_phy`.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
