### PR TITLE
drivers/sgp30: use event_timeout, to avoid long ISR code block

### DIFF
--- a/drivers/include/sgp30.h
+++ b/drivers/include/sgp30.h
@@ -58,6 +58,14 @@
 extern "C" {
 #endif
 
+
+/**
+ * @brief   The event queue if 'sgp30_strict' is used
+ */
+#ifndef SGP30_STRICT_EVENT_THREAD_QUEUE
+#define SGP30_STRICT_EVENT_THREAD_QUEUE     EVENT_PRIO_MEDIUM
+#endif
+
 /**
  * @brief     Set of measured values
  */

--- a/drivers/include/sgp30.h
+++ b/drivers/include/sgp30.h
@@ -49,9 +49,9 @@
 #include "ztimer.h"
 
 #ifdef MODULE_SGP30_STRICT
-#include "event/thread.h"
-#include "event/callback.h"
-#include "event/timeout.h"
+#  include "event/thread.h"
+#  include "event/callback.h"
+#  include "event/timeout.h"
 #endif
 
 #ifdef __cplusplus
@@ -62,9 +62,9 @@ extern "C" {
  * @brief     Set of measured values
  */
 typedef struct {
-    uint16_t tvoc;      /**< The last measurement of the IAQ-calculated Total
+    uint16_t tvoc; /**< The last measurement of the IAQ-calculated Total
                              Volatile Organic Compounds in ppb. */
-    uint16_t eco2;      /**< The last measurement of the IAQ-calculated
+    uint16_t eco2; /**< The last measurement of the IAQ-calculated
                              equivalent CO2 in ppm */
 #ifdef MODULE_SGP30_STRICT
     uint32_t timestamp; /**< Timestamp of last measured value */
@@ -75,27 +75,27 @@ typedef struct {
  * @brief     Set of measured raw values
  */
 typedef struct {
-    uint16_t raw_h2;        /**< raw H2 signal, only for testing purposes */
-    uint16_t raw_ethanol;   /**< raw Ethanol signal, only for testing purposes */
+    uint16_t raw_h2;      /**< raw H2 signal, only for testing purposes */
+    uint16_t raw_ethanol; /**< raw Ethanol signal, only for testing purposes */
 } sgp30_raw_data_t;
 
 /**
  * @brief   Device initialization parameters
  */
 typedef struct {
-    i2c_t i2c_dev;              /**< I2C dev the sensor is connected to */
+    i2c_t i2c_dev; /**< I2C dev the sensor is connected to */
 } sgp30_params_t;
 
 /**
  * @brief   Device descriptor for the driver
  */
 typedef struct {
-    sgp30_params_t params;      /**< parameters of the sensor device */
+    sgp30_params_t params; /**< parameters of the sensor device */
 #ifdef MODULE_SGP30_STRICT
-    bool ready;                 /**< if initialization phase is over*/
-    event_callback_t _event;    /**< event callback */
-    event_timeout_t _timeout;   /**< event timeout */
-    sgp30_data_t _data;         /**< internal current data */
+    bool ready;               /**< if initialization phase is over*/
+    event_callback_t _event;  /**< event callback */
+    event_timeout_t _timeout; /**< event timeout */
+    sgp30_data_t _data;       /**< internal current data */
 #endif
 } sgp30_t;
 

--- a/drivers/include/sgp30.h
+++ b/drivers/include/sgp30.h
@@ -48,6 +48,12 @@
 #include "periph/i2c.h"
 #include "ztimer.h"
 
+#ifdef MODULE_SGP30_STRICT
+#include "event/thread.h"
+#include "event/callback.h"
+#include "event/timeout.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -87,7 +93,8 @@ typedef struct {
     sgp30_params_t params;      /**< parameters of the sensor device */
 #ifdef MODULE_SGP30_STRICT
     bool ready;                 /**< if initialization phase is over*/
-    ztimer_t _timer;            /**< timer */
+    event_callback_t _event;    /**< event callback */
+    event_timeout_t _timeout;   /**< event timeout */
     sgp30_data_t _data;         /**< internal current data */
 #endif
 } sgp30_t;

--- a/drivers/include/sgp30.h
+++ b/drivers/include/sgp30.h
@@ -58,12 +58,11 @@
 extern "C" {
 #endif
 
-
 /**
  * @brief   The event queue if 'sgp30_strict' is used
  */
-#ifndef SGP30_STRICT_EVENT_THREAD_QUEUE
-#define SGP30_STRICT_EVENT_THREAD_QUEUE     EVENT_PRIO_MEDIUM
+#ifndef CONFIG_SGP30_STRICT_EVENT_THREAD_QUEUE
+#define CONFIG_SGP30_STRICT_EVENT_THREAD_QUEUE     EVENT_PRIO_MEDIUM
 #endif
 
 /**

--- a/drivers/include/sgp30.h
+++ b/drivers/include/sgp30.h
@@ -62,7 +62,7 @@ extern "C" {
  * @brief   The event queue if 'sgp30_strict' is used
  */
 #ifndef CONFIG_SGP30_STRICT_EVENT_THREAD_QUEUE
-#define CONFIG_SGP30_STRICT_EVENT_THREAD_QUEUE     EVENT_PRIO_MEDIUM
+#  define CONFIG_SGP30_STRICT_EVENT_THREAD_QUEUE     EVENT_PRIO_MEDIUM
 #endif
 
 /**

--- a/drivers/sgp30/Makefile.dep
+++ b/drivers/sgp30/Makefile.dep
@@ -4,3 +4,7 @@ USEMODULE += ztimer_usec
 FEATURES_REQUIRED += periph_i2c
 
 DEFAULT_MODULE += sgp30_strict
+
+USEMODULE += event_timeout
+USEMODULE += event_callback
+USEMODULE += event_thread

--- a/drivers/sgp30/include/sgp30_constants.h
+++ b/drivers/sgp30/include/sgp30_constants.h
@@ -27,27 +27,27 @@ extern "C" {
 /**
  * @brief     SGP30 I2C address, only one is defined
  */
-#define SGP30_I2C_ADDRESS                   (0x58)
+#define SGP30_I2C_ADDRESS                 (0x58)
 
 /**
  * @brief     Minimum required feature set version for this driver
  */
-#define SGP30_REQUIRED_FEATURE_SET          (0x0020)
+#define SGP30_REQUIRED_FEATURE_SET        (0x0020)
 
 /**
  * @brief     Length of serial id
  */
-#define SGP30_SERIAL_ID_LEN                 (6U)
+#define SGP30_SERIAL_ID_LEN               (6U)
 
 /**
  * @brief     Initialization time
  */
-#define SGP30_AIR_QUALITY_INIT_DELAY_US     (15 * US_PER_SEC)
+#define SGP30_AIR_QUALITY_INIT_DELAY_US   (15 * US_PER_SEC)
 
 /**
  * @brief     Sampling for dynamic baseline compensation algorithm
  */
-#define SGP30_RECOMMENDED_SAMPLING_PERIOD        (1 * US_PER_SEC)
+#define SGP30_RECOMMENDED_SAMPLING_PERIOD (1 * US_PER_SEC)
 
 #ifdef __cplusplus
 }

--- a/drivers/sgp30/include/sgp30_params.h
+++ b/drivers/sgp30/include/sgp30_params.h
@@ -32,34 +32,38 @@ extern "C" {
  * @{
  */
 #ifndef SGP30_PARAM_I2C_DEV
-#define SGP30_PARAM_I2C_DEV  (I2C_DEV(0))
+#  define SGP30_PARAM_I2C_DEV (I2C_DEV(0))
 #endif
 #ifndef SGP30_PARAMS
-#define SGP30_PARAMS         { .i2c_dev = SGP30_PARAM_I2C_DEV }
+#  define SGP30_PARAMS                   \
+      {                                  \
+          .i2c_dev = SGP30_PARAM_I2C_DEV \
+      }
 #endif
 #ifndef SGP30_SAUL_INFO
-#define SGP30_SAUL_INFO      { .name = "sgp30" }
+#  define SGP30_SAUL_INFO \
+      {                   \
+          .name = "sgp30" \
+      }
 #endif
 /**@}*/
 
 /**
  * @brief   SGP30 configuration
  */
-static const sgp30_params_t sgp30_params[] =
-{
+static const sgp30_params_t sgp30_params[] = {
     SGP30_PARAMS
 };
 
 /**
  * @brief   Define the number of configured sensors
  */
-#define SGP30_NUM               ARRAY_SIZE(sgp30_params)
+#define SGP30_NUM ARRAY_SIZE(sgp30_params)
 
 /**
  * @brief   Additional meta information to keep in the SAUL registry
  */
-static const saul_reg_info_t sgp30_saul_info[] =
-{
+static const saul_reg_info_t sgp30_saul_info[] = {
     SGP30_SAUL_INFO
 };
 

--- a/drivers/sgp30/sgp30.c
+++ b/drivers/sgp30/sgp30.c
@@ -211,7 +211,7 @@ int sgp30_init(sgp30_t *dev, const sgp30_params_t *params)
         DEBUG_PUTS("\n");
     }
 
-       /* start air quality measurement */
+    /* start air quality measurement */
     if (sgp30_start_air_quality(dev)) {
         DEBUG_PUTS("[sgp30]: could not start air quality measurements ");
         return -1;
@@ -235,7 +235,7 @@ int sgp30_reset(sgp30_t *dev)
 
 int sgp30_read_serial_number(sgp30_t *dev, uint8_t *buf, size_t len)
 {
-    (void) len;
+    (void)len;
     assert(dev && buf && (len == SGP30_SERIAL_ID_LEN));
     uint8_t frame[9];
     if (_rx_tx_data(dev, SGP30_CMD_READ_SERIAL, (uint8_t *)frame, sizeof(frame),
@@ -244,7 +244,7 @@ int sgp30_read_serial_number(sgp30_t *dev, uint8_t *buf, size_t len)
         return -EPROTO;
     }
     /* the serial id is in big endian format */
-    uint16_t tmp[SGP30_SERIAL_ID_LEN/2];
+    uint16_t tmp[SGP30_SERIAL_ID_LEN / 2];
     if (_get_uint16_and_check_crc(&frame[0], &tmp[2]) ||
         _get_uint16_and_check_crc(&frame[3], &tmp[1]) ||
         _get_uint16_and_check_crc(&frame[6], &tmp[0])) {

--- a/drivers/sgp30/sgp30.c
+++ b/drivers/sgp30/sgp30.c
@@ -183,7 +183,6 @@ int sgp30_init(sgp30_t *dev, const sgp30_params_t *params)
     dev->ready = false;
     event_callback_init(&dev->_event, _read_cb, dev);
     event_timeout_init(&dev->_timeout, SGP30_STRICT_EVENT_THREAD_QUEUE, (event_t *)&dev->_event);
-#error
 #endif
 
     /* delay while powering up */

--- a/drivers/sgp30/sgp30.c
+++ b/drivers/sgp30/sgp30.c
@@ -182,7 +182,8 @@ int sgp30_init(sgp30_t *dev, const sgp30_params_t *params)
 #ifdef MODULE_SGP30_STRICT
     dev->ready = false;
     event_callback_init(&dev->_event, _read_cb, dev);
-    event_timeout_init(&dev->_timeout, EVENT_PRIO_MEDIUM, (event_t *)&dev->_event);
+    event_timeout_init(&dev->_timeout, SGP30_STRICT_EVENT_THREAD_QUEUE, (event_t *)&dev->_event);
+#error
 #endif
 
     /* delay while powering up */

--- a/drivers/sgp30/sgp30.c
+++ b/drivers/sgp30/sgp30.c
@@ -182,7 +182,7 @@ int sgp30_init(sgp30_t *dev, const sgp30_params_t *params)
 #ifdef MODULE_SGP30_STRICT
     dev->ready = false;
     event_callback_init(&dev->_event, _read_cb, dev);
-    event_timeout_init(&dev->_timeout, EVENT_PRIO_LOWEST, (event_t *)&dev->_event);
+    event_timeout_init(&dev->_timeout, EVENT_PRIO_MEDIUM, (event_t *)&dev->_event);
 #endif
 
     /* delay while powering up */

--- a/drivers/sgp30/sgp30.c
+++ b/drivers/sgp30/sgp30.c
@@ -158,7 +158,7 @@ static void _read_cb(void *arg)
     }
     _read_measurements(dev, &dev->_data);
     dev->_data.timestamp = ztimer_now(ZTIMER_USEC);
-    ztimer_set(ZTIMER_USEC, &dev->_timer, SGP30_RECOMMENDED_SAMPLING_PERIOD);
+    event_timeout_set(&dev->_timeout, SGP30_RECOMMENDED_SAMPLING_PERIOD);
 }
 #endif
 
@@ -169,7 +169,7 @@ int sgp30_start_air_quality(sgp30_t *dev)
 
 #ifdef MODULE_SGP30_STRICT
     if (ret == 0) {
-        ztimer_set(ZTIMER_USEC, &dev->_timer, SGP30_AIR_QUALITY_INIT_DELAY_US);
+        event_timeout_set(&dev->_timeout, SGP30_AIR_QUALITY_INIT_DELAY_US);
     }
 #endif
     return ret ? -EPROTO : 0;
@@ -181,8 +181,8 @@ int sgp30_init(sgp30_t *dev, const sgp30_params_t *params)
     dev->params = *params;
 #ifdef MODULE_SGP30_STRICT
     dev->ready = false;
-    dev->_timer.callback = _read_cb;
-    dev->_timer.arg = dev;
+    event_callback_init(&dev->_event, _read_cb, dev);
+    event_timeout_init(&dev->_timeout, EVENT_PRIO_LOWEST, (event_t *)&dev->_event);
 #endif
 
     /* delay while powering up */
@@ -226,7 +226,7 @@ int sgp30_reset(sgp30_t *dev)
     int ret = _rx_tx_data(dev, SGP30_CMD_SOFT_RESET, NULL, 0, SGP30_DELAY_SOFT_RESET, false);
 #ifdef MODULE_SGP30_STRICT
     if (ret == 0) {
-        ztimer_remove(ZTIMER_USEC, &dev->_timer);
+        event_timeout_clear(&dev->_timeout);
         dev->ready = false;
     }
 #endif


### PR DESCRIPTION
### Contribution description

This avoid reading measurements in ISR context, which will behave differently depending on the ISR context size. To avoid this use events posting to the lowest priority event loop.

I've been away for a while so maybe there is a better way of handling this now?

### Testing procedure

I have an `nrf52840-mdk` with the an `sgp30` connected, after waiting for 15s I get readings:

```
2026-03-22 20:30:08,589 # eCO2 [ppm]: 439
2026-03-22 20:30:08,592 # +-------------------------------------+
2026-03-22 20:30:08,695 # TVOC [ppb]: 4
2026-03-22 20:30:08,696 # eCO2 [ppm]: 439
2026-03-22 20:30:08,706 # +-------------------------------------+
2026-03-22 20:30:08,802 # TVOC [ppb]: 4
2026-03-22 20:30:08,804 # eCO2 [ppm]: 439
2026-03-22 20:30:08,807 # +-------------------------------------+
```

Without this PR hardfault:

```
2026-03-22 20:31:28,124 # Device is not yet ready
2026-03-22 20:31:28,226 # TVOC [ppb]: 86
2026-03-22 20:31:28,228 # Context before hardfault:
2026-03-22 20:31:28,234 # main(): This is RIOT! (Version: 2017.10-devel-34759-g66dbcd)
2026-03-22 20:31:28,236 # SGP30 test application
2026-03-22 20:31:28,236 #
2026-03-22 20:31:28,239 # +------------Initializing------------+
```

### Issues/PRs references

None
