### PR TITLE
nimble/rpble: clear rpble ctx if DODAG is cleared

### DIFF
--- a/pkg/nimble/rpble/include/nimble_rpble.h
+++ b/pkg/nimble/rpble/include/nimble_rpble.h
@@ -166,7 +166,7 @@ int nimble_rpble_eventcb(nimble_netif_eventcb_t cb);
  *
  * @note    This function is meant to be called only by the RPL implementation
  *
- * @param[in] ctx       current DODAG state
+ * @param[in] ctx       current DODAG state or NULL if the DODAG was cleared.
 
  * @return  0 on success
  * @return  -EALREADY if the given context did not change

--- a/pkg/nimble/rpble/nimble_rpble.c
+++ b/pkg/nimble/rpble/nimble_rpble.c
@@ -356,8 +356,12 @@ int nimble_rpble_eventcb(nimble_netif_eventcb_t cb)
 
 int nimble_rpble_update(const nimble_rpble_ctx_t *ctx)
 {
-    assert(ctx != NULL);
     int ret = 0;
+
+    if (ctx == NULL) {
+        memset(&_local_rpl_ctx, 0, sizeof(_local_rpl_ctx));
+        return ret;
+    }
 
     /* if the update context is equal to what we have, ignore it */
     if (memcmp(&_local_rpl_ctx, ctx, sizeof(nimble_rpble_ctx_t)) == 0) {

--- a/sys/include/net/gnrc/rpl/rpble.h
+++ b/sys/include/net/gnrc/rpl/rpble.h
@@ -31,6 +31,12 @@ extern "C" {
 static inline void gnrc_rpl_rpble_update(const gnrc_rpl_dodag_t *dodag)
 {
     nimble_rpble_ctx_t ctx;
+
+    if (dodag == NULL) {
+        nimble_rpble_update(NULL);
+        return;
+    }
+
     ctx.inst_id = dodag->instance->id;
     memcpy(ctx.dodag_id, &dodag->dodag_id, 16);
     ctx.version = dodag->version;

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -85,6 +85,7 @@ void gnrc_rpl_poison_routes(gnrc_rpl_dodag_t *dodag)
         /* Poison routes by advertising infinity rank */
         dodag->my_rank = GNRC_RPL_INFINITE_RANK;
         trickle_reset_timer(&dodag->trickle);
+        gnrc_rpl_rpble_update(NULL);
         gnrc_rpl_cleanup_start(dodag);
     }
 }


### PR DESCRIPTION
### Contribution description

The `rpble` module constructs BLE connections analogous to the RPL topology. 
Each node scans until it finds a RPL parent, then starts advertising itself to potential children. When a parent is lost, it starts scanning again for a new parent and compares potential parents not only against each other, but also against its own former RPL rank `_local_rpl_ctx.rank`.

We should clear the `_local_rpl_ctx` if a node's DODAG is deconstructed (e.g., because its old parent became unavailable). Otherwise the node won't accept any new parents that have a worse rank than the node's former parent.

**Note:**

At first I thought we can immediately clear `_local_rpl_ctx` when losing a parent, but then we'd risk connecting to our own children and forming a loop. If we wait until the DODAG is cleared, it will have been cleared from our children as well and a loop isn't possible anymore.

### Testing procedure

Run the `gnrc_networking` example with 3 BLE-capable nodes (`A`, `B`, `C`) and `CFLAGS="-DCONFIG_GNRC_RPL_DODAG_FLOAT_TIMEOUT=0"` (so that DODAGs are immediately deconstructed after loosing a parent)
1. Init node `A` as RPL root -> it'll start advertising, `B` and `C` will connect as children
2. Make `A` unavailable to `C` (move away physically, or restart `A` with `NIMBLE_MAX_CONN=1`)
3. Without the fix, `C` won't accept `B` as new parent

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
