### PR TITLE
cpu/stm32: fix STM32G4 flash writes failing after timer init

### DIFF
--- a/cpu/stm32/periph/flash_common.c
+++ b/cpu/stm32/periph/flash_common.c
@@ -72,6 +72,15 @@
 #define FLASH_SR_REG            (FLASH->SR)
 #endif
 
+/* Flash status register error flags */
+#if defined(CPU_FAM_STM32G4)
+#  define FLASH_SR_ERRORS        (FLASH_SR_OPERR | FLASH_SR_PROGERR | \
+                                  FLASH_SR_WRPERR | FLASH_SR_PGAERR | \
+                                  FLASH_SR_SIZERR | FLASH_SR_PGSERR | \
+                                  FLASH_SR_MISERR | FLASH_SR_FASTERR | \
+                                  FLASH_SR_RDERR | FLASH_SR_OPTVERR)
+#endif
+
 void _unlock(void)
 {
     if (CNTRL_REG & CNTRL_REG_LOCK) {
@@ -95,6 +104,16 @@ void _wait_for_pending_operations(void)
         DEBUG("[flash-common] waiting for any pending operation to finish\n");
         while (FLASH_SR_REG & FLASH_SR_BSY) {}
     }
+
+#if defined(CPU_FAM_STM32G4)
+    /* Check FLASH operation error flags */
+    uint32_t error = (FLASH_SR_REG & FLASH_SR_ERRORS);
+    /* Clear error programming flags */
+    if (error != 0) {
+        DEBUG("[flash-common] flash error flags set: 0x%" PRIx32 "\n", error);
+        FLASH_SR_REG = error;
+    }
+#endif
 
     /* Clear 'end of operation' bit in status register, for other STM32 boards
        this bit is set only if EOPIE is set, which is currently not done */


### PR DESCRIPTION
### Contribution description

- **Area:** `cpu/stm32/periph/flash_common.c`
- **Bug:** On STM32G4, initializing HW timer peripherals (e.g. PWM via `motor_driver_init()`) sets sticky error flags in `FLASH->SR`  as a side effect. Because `_wait_for_pending_operations()` never  clears these flags, all subsequent flash writes/erases fail permanently.
`flashpage_write_and_verify` seems to correctly reports the error, but there is no way to recover.
- **Fix:** Add a `FLASH_SR_ERRORS` bitmask covering all STM32G4 SR register error flags and clear them in `_wait_for_pending_operations()` before proceeding with flash operations. This follows the same pattern used in the ST HAL.
- **Other STM32 families with sticky SR flags are likely affected but  the fix is scoped to STM32G4 only, as it is the only hardware available for testing.**

### Testing procedure

1. Build and flash the following minimal test on an STM32G4-based
   board (e.g. nucleo-g474re):

```c
#include <stdio.h>
#include <string.h>

#include "board.h"
#include "motor_driver.h"
#include "periph/flashpage.h"

#define TEST_PAGE    (FLASHPAGE_NUMOF - 1)
#define TEST_PATTERN 0xBB

static const motor_driver_params_t motion_motors_params = {
    .mode = MOTOR_DRIVER_1_DIR_BRAKE,
    .pwm_dev = 0,
    .pwm_mode = PWM_LEFT,
    .pwm_frequency = 20000U,
    .pwm_resolution = 500U,
    .brake_inverted = true,
    .enable_inverted = false,
    .nb_motors = 2,
    .motors = {
        { .pwm_channel = 0, .gpio_enable = GPIO_PIN(PORT_A, 10),
          .gpio_dir0 = GPIO_PIN(PORT_C, 6),
          .gpio_brake = GPIO_PIN(PORT_C, 8), .gpio_dir_reverse = 1 },
        { .pwm_channel = 1, .gpio_enable = GPIO_PIN(PORT_B, 1),
          .gpio_dir0 = GPIO_PIN(PORT_B, 10),
          .gpio_brake = GPIO_PIN(PORT_B, 2), .gpio_dir_reverse = 0 },
    },
    .motor_set_post_cb = NULL,
};

static motor_driver_t motor_driver;
static uint8_t buf[FLASHPAGE_SIZE]
    __attribute__((aligned(FLASHPAGE_WRITE_BLOCK_ALIGNMENT)));

int main(void)
{
    printf("FLASH->SR before init:    0x%08lX\n", (unsigned long)FLASH->SR);

    motor_driver_init(&motor_driver, &motion_motors_params);

    printf("FLASH->SR after PWM init: 0x%08lX\n", (unsigned long)FLASH->SR);

    memset(buf, TEST_PATTERN, sizeof(buf));
    int rc = flashpage_write_and_verify(TEST_PAGE, buf);
    printf("write_and_verify: %s\n", (rc == FLASHPAGE_OK) ? "OK" : "FAIL");

    printf("FLASH->SR after flash op: 0x%08lX\n", (unsigned long)FLASH->SR);

    memset(buf, 0x00, sizeof(buf));
    flashpage_read(TEST_PAGE, buf);
    printf("first byte: 0x%02X (expected 0x%02X)\n", buf[0], TEST_PATTERN);

    return 0;
}
```

2. Without the fix:
   
```text
FLASH->SR before init:    0x00000000
FLASH->SR after PWM init: 0x000000A0  <-- sticky error flags set
write_and_verify: FAIL
FLASH->SR after flash op: 0x000000A0  <-- flags still present
first byte: 0x00 (expected 0xBB)      <-- stale data
```

3. With the fix applied:

```text
FLASH->SR before init:    0x00000000
FLASH->SR after PWM init: 0x000000A0  <-- flags set by PWM init
write_and_verify: OK
FLASH->SR after flash op: 0x00000000  <-- flags cleared
first byte: 0xBB (expected 0xBB)      <-- OK
```

### Issues/PRs references

Fixes #22151

*Note: the example code was generated by an LLM (Claude). The English content of this PR was proofread/corrected by an LLM. The bug investigation and fix were done manually, inspired by the ST HAL implementation.*
