### PR TITLE
core/lib/macros: CONCAT with expansion

### DIFF
--- a/core/lib/include/macros/utils.h
+++ b/core/lib/include/macros/utils.h
@@ -22,17 +22,32 @@ extern "C" {
 /**
  * @brief   Concatenate the tokens @p a and @p b
  */
-#define CONCAT(a, b) a ## b
+#define CONCAT_NOEXPAND(a, b) a ## b
+
+/**
+ * @brief   Concatenate the tokens @p a and @p b with expansion
+ */
+#define CONCAT(a, b) CONCAT_NOEXPAND(a, b)
 
 /**
  * @brief   Concatenate the tokens @p a , @p b , and @p c
  */
-#define CONCAT3(a, b, c) a ## b ## c
+#define CONCAT3_NOEXPAND(a, b, c) a ## b ## c
+
+/**
+ * @brief   Concatenate the tokens @p a , @p b , and @p c with expansion
+ */
+#define CONCAT3(a, b, c) CONCAT3_NOEXPAND(a, b, c)
 
 /**
  * @brief   Concatenate the tokens @p a , @p b , @p c , and @p d
  */
-#define CONCAT4(a, b, c, d) a ## b ## c ## d
+#define CONCAT4_NOEXPAND(a, b, c, d) a ## b ## c ## d
+
+/**
+ * @brief   Concatenate the tokens @p a , @p b , @p c , and @p d with expansion
+ */
+#define CONCAT4(a, b, c, d) CONCAT4_NOEXPAND(a, b, c, d)
 
 /* For compatibility with vendor headers, only provide MAX() and MIN() if not
  * provided. (The alternative approach of using #undef has the downside that


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

I think when using `CONCAT()` we want the arguments to expand.
Else the result of `CONCAT(CONFIG_SOME_PREFIX, _variable_name) `will look like `CONFIG_SOME_PREFIX_variable_name`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
