### PR TITLE
boards/ulanzi-tc001: add board

### DIFF
--- a/boards/ulanzi-tc001/Makefile
+++ b/boards/ulanzi-tc001/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/ulanzi-tc001/Makefile.dep
+++ b/boards/ulanzi-tc001/Makefile.dep
@@ -1,0 +1,6 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+  USEMODULE += sht3x
+endif
+
+USEMODULE += boards_common_esp32

--- a/boards/ulanzi-tc001/Makefile.features
+++ b/boards/ulanzi-tc001/Makefile.features
@@ -1,0 +1,10 @@
+CPU_MODEL = esp32-wroom_32
+
+# common board and CPU features
+include $(RIOTBOARD)/common/esp32/Makefile.features
+
+# additional features provided by the board
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm

--- a/boards/ulanzi-tc001/Makefile.include
+++ b/boards/ulanzi-tc001/Makefile.include
@@ -1,0 +1,3 @@
+# Only consider TTYs matching the following filter when auto-selecting the TTY
+# with `MOST_RECENT_PORT=1`.
+TTY_BOARD_FILTER := --driver 'ch341' --vendor '1a86' --model 'USB Serial'

--- a/boards/ulanzi-tc001/board.c
+++ b/boards/ulanzi-tc001/board.c
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     boards_ulanzi-tc001
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for Ulanzi TC001 digital Clock
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* silence buzzer */
+    gpio_init(GPIO15, GPIO_OUT);
+}

--- a/boards/ulanzi-tc001/doc.md
+++ b/boards/ulanzi-tc001/doc.md
@@ -1,0 +1,22 @@
+<!--
+SPDX-FileCopyrightText: 2026 Benjamin Valentin
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+
+@defgroup   boards/ulanzi-tc001 Ulanzi TC001
+@ingroup    boards_esp32
+@brief      Support for Ulanzi TC001 digital Clock
+@author     Benjamin Valentin <benjamin.valentin@ml-pa.com>
+
+Information taken form https://github.com/rroels/ulanzi_tc001_hardware
+
+## Flashing the Device {#esp32_wroom_32_flashing}
+
+Flashing RIOT is quite easy. The board has a USB-C connector with
+reset/boot/flash logic. Just connect the board to your host computer
+and type using the programming port:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+make flash BOARD=ulanzi-tc001 ...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For detailed information about ESP32 as well as configuring and compiling
+RIOT for ESP32 boards, see \ref esp32_riot.

--- a/boards/ulanzi-tc001/include/board.h
+++ b/boards/ulanzi-tc001/include/board.h
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_ulanzi-tc001
+ * @brief       Board specific definitions for Ulanzi TC001
+ * @{
+ *
+ * @file
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#include <stdint.h>
+
+/**
+ * @name    Button pin definitions
+ * @{
+ */
+#define BTN0_PIN        GPIO26
+#define BTN0_MODE       GPIO_IN_PU
+#define BTN0_INT_FLANK  GPIO_FALLING
+
+#define BTN1_PIN        GPIO27
+#define BTN1_MODE       GPIO_IN_PU
+#define BTN1_INT_FLANK  GPIO_FALLING
+
+#define BTN2_PIN        GPIO14
+#define BTN2_MODE       GPIO_IN_PU
+#define BTN2_INT_FLANK  GPIO_FALLING
+/** @} */
+
+/**
+ * @name    WS281x LED matrix definitions
+ * @{
+ */
+#define WS281X_PARAM_PIN    GPIO32
+#define WS281X_PARAM_NUMOF  (32*8)
+/** @} */
+
+/**
+ * @brief   SHTC30 temperature / humidity sensor
+ */
+#define SHT3X_PARAM_I2C_ADDR SHT3X_I2C_ADDR_1
+
+/**
+ * @name    LED (on-board) configuration
+ *
+ * Generic ESP32 boards usually do not have on-board LEDs.
+ * @{
+ */
+/** @} */
+
+/* include common board definitions as last step */
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/** @} */

--- a/boards/ulanzi-tc001/include/gpio_params.h
+++ b/boards/ulanzi-tc001/include/gpio_params.h
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_ulanzi-tc001
+ * @brief       Board specific configuration of direct mapped GPIOs
+ * @file
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @{
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   LED and Button configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "left",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+    {
+        .name = "center",
+        .pin = BTN1_PIN,
+        .mode = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+    {
+        .name = "right",
+        .pin = BTN2_PIN,
+        .mode = BTN2_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/ulanzi-tc001/include/periph_conf.h
+++ b/boards/ulanzi-tc001/include/periph_conf.h
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_ulanzi-tc001
+ * @brief       Peripheral MCU configuration for Ulanzi TC001
+ * @{
+ *
+ * @file
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    ADC and DAC channel configuration
+ * @{
+ */
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ */
+#ifndef ADC_GPIOS
+#define ADC_GPIOS   { GPIO34,   /* Battery Voltage */       \
+                      GPIO35,   /* GL5516 Light Sensor */   \
+                    }
+#endif
+
+/**
+ * @name   I2C configuration
+ *
+ * SHT31 and DS1307 are connected to this bus.
+ *
+ * @{
+ */
+#ifndef I2C0_SPEED
+#define I2C0_SPEED  I2C_SPEED_FAST  /**< I2C bus speed of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SCL
+#define I2C0_SCL    GPIO22          /**< SCL signal of I2C_DEV(0) [UEXT1] */
+#endif
+#ifndef I2C0_SDA
+#define I2C0_SDA    GPIO21          /**< SDA signal of I2C_DEV(0) [UEXT1] */
+#endif
+/** @} */
+
+/**
+ * @name   PWM channel configuration
+ *
+ * @{
+ */
+
+/**
+ * @brief We connect the buzzer to the first PWM channel
+ */
+#ifndef PWM0_GPIOS
+#define PWM0_GPIOS  { GPIO15 }
+#endif
+/** @} */
+
+/**
+ * @name   UART configuration
+ * @{
+ */
+#define UART0_TXD   GPIO1  /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO3  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/* include common peripheral definitions as last step */
+#include "periph_conf_common.h"
+
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds basic support for the Ulanzi TC-0001 pixel clock.


### Testing procedure

`tests/drivers/ws281x` should light up the display.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
