### PR TITLE
makefiles/tools: fix esptool installation for riotdocker

### DIFF
--- a/dist/tools/esptools/.gitignore
+++ b/dist/tools/esptools/.gitignore
@@ -1,1 +1,2 @@
 venv
+venv_docker

--- a/makefiles/tools/esptool.inc.mk
+++ b/makefiles/tools/esptool.inc.mk
@@ -1,6 +1,10 @@
-ESPTOOL_VERSION = 5.0.0
-ESPTOOL_VENV = $(RIOTTOOLS)/esptools/venv
+ifeq (1,$(INSIDE_DOCKER))
+  ESPTOOL_VENV = $(RIOTTOOLS)/esptools/venv_docker
+else
+  ESPTOOL_VENV = $(RIOTTOOLS)/esptools/venv
+endif
 ESPTOOL = $(ESPTOOL_VENV)/bin/esptool
+ESPTOOL_VERSION = 5.0.0
 
 # ESP-IDF uses dio as flash mode for esptool.py when qout or qio mode are
 # configured to always boot in dual SPI mode


### PR DESCRIPTION
### Contribution description

This PR fixes an `esptool` installation problem introduced with PR #21619 that happens when RIOT is compiled within `riotdocker` and flashed afterwards on host. 

To use the `esptool` within `riotdocker` for RIOT compilation and on the host for flashing, a separate Python virtual environment has to be used for `esptool` within `riotdocker`.

### Testing procedure

Use the following commands to test:
```python
BOARD=esp32-wroom-32 make -j8 -C tests/sys/shell BUILD_IN_DOCKER=1
BOARD=esp32-wroom-32 make -j8 -C tests/sys/shell flash-only
```
If `esptool` is already installed within a Python virtual environment, remove it before by the following command:
```python
rm -rf dist/tools/esptools/venv*
```

Without the PR, `esptool` is installed during the compilation in `riotdocker` by the first `make` command with paths and Shebangs pointing to a Python virtual environment in `/data/riotbuild/riotbase/dist/tools/esptool/venv`. When trying to use the target `flash-only` on host, `/data/riotbuild/riotbase/dist/tools/esptool/venv` doesn't exist and executing the `esptool` command fails.
```python
make: Verzeichnis „tests/sys/shell“ wird betreten
dist/tools/esptools/venv/bin/esptool --chip esp32 --port /dev/ttyUSB0 --baud 460800 --before default-reset write-flash -z --flash-mode dout --flash-freq 40m --flash-size detect 0x1000 tests/sys/shell/bin/esp32-wroom-32/esp_bootloader/bootloader.bin 0x8000 tests/sys/shell/bin/esp32-wroom-32/partitions.bin 0x10000 tests/sys/shell/bin/esp32-wroom-32/tests_shell.elf.bin
make: dist/tools/esptools/venv/bin/esptool: Datei oder Verzeichnis nicht gefunden
make: *** [tests/sys/shell/../../../Makefile.include:845: flash-only] Fehler 127
make: Verzeichnis „tests/sys/shell“ wird verlassen
```
With the PR, `esptool` and the Python virtual environment is installed within `riotdocker` in a separate directory. The compilation and flashing should succeed.

### Issues/PRs references

Fixes PR #21619 