### PR TITLE
drivers/[a-e]*: Change license headers to SPDX format

### DIFF
--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "Drivers"
 

--- a/drivers/Kconfig.net
+++ b/drivers/Kconfig.net
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "Network Device Drivers"
 

--- a/drivers/abp2/abp2.c
+++ b/drivers/abp2/abp2.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 CNRS, France
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 CNRS, France
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/abp2/abp2_saul.c
+++ b/drivers/abp2/abp2_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 CNRS, France
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 CNRS, France
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/abp2/include/abp2_params.h
+++ b/drivers/abp2/include/abp2_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 CNRS, France
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 CNRS, France
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ad7746/ad7746.c
+++ b/drivers/ad7746/ad7746.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ad7746/ad7746_saul.c
+++ b/drivers/ad7746/ad7746_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ad7746/include/ad7746_internal.h
+++ b/drivers/ad7746/include/ad7746_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ad7746/include/ad7746_params.h
+++ b/drivers/ad7746/include/ad7746_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/adcxx1c/adcxx1c.c
+++ b/drivers/adcxx1c/adcxx1c.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/adcxx1c/adcxx1c_saul.c
+++ b/drivers/adcxx1c/adcxx1c_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/adcxx1c/include/adcxx1c_params.h
+++ b/drivers/adcxx1c/include/adcxx1c_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/adcxx1c/include/adcxx1c_regs.h
+++ b/drivers/adcxx1c/include/adcxx1c_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/adt7310/adt7310.c
+++ b/drivers/adt7310/adt7310.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2015 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2015 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/adxl345/adxl345.c
+++ b/drivers/adxl345/adxl345.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017-2018 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017-2018 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/adxl345/adxl345_saul.c
+++ b/drivers/adxl345/adxl345_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/adxl345/include/adxl345_params.h
+++ b/drivers/adxl345/include/adxl345_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/adxl345/include/adxl345_regs.h
+++ b/drivers/adxl345/include/adxl345_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/aip31068/aip31068.c
+++ b/drivers/aip31068/aip31068.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/aip31068/include/aip31068_internal.h
+++ b/drivers/aip31068/include/aip31068_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/aip31068/include/aip31068_params.h
+++ b/drivers/aip31068/include/aip31068_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/aip31068/include/aip31068_regs.h
+++ b/drivers/aip31068/include/aip31068_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/apa102/apa102.c
+++ b/drivers/apa102/apa102.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/apa102/include/apa102_params.h
+++ b/drivers/apa102/include/apa102_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/apds99xx/apds99xx.c
+++ b/drivers/apds99xx/apds99xx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/apds99xx/apds99xx_saul.c
+++ b/drivers/apds99xx/apds99xx_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/apds99xx/include/apds99xx_params.h
+++ b/drivers/apds99xx/include/apds99xx_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/apds99xx/include/apds99xx_regs.h
+++ b/drivers/apds99xx/include/apds99xx_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/at/Kconfig
+++ b/drivers/at/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universitaet Berlin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "AT driver"
     depends on USEMODULE_AT

--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include <assert.h>

--- a/drivers/at24cxxx/at24cxxx.c
+++ b/drivers/at24cxxx/at24cxxx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/at24cxxx/include/at24cxxx_defines.h
+++ b/drivers/at24cxxx/include/at24cxxx_defines.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/at24cxxx/include/at24cxxx_params.h
+++ b/drivers/at24cxxx/include/at24cxxx_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/at24mac/at24mac.c
+++ b/drivers/at24mac/at24mac.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/at24mac/include/at24mac_params.h
+++ b/drivers/at24mac/include/at24mac_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/at25xxx/at25xxx.c
+++ b/drivers/at25xxx/at25xxx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/at25xxx/include/at25xxx_constants.h
+++ b/drivers/at25xxx/include/at25xxx_constants.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/at25xxx/include/at25xxx_params.h
+++ b/drivers/at25xxx/include/at25xxx_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/at25xxx/mtd/mtd.c
+++ b/drivers/at25xxx/mtd/mtd.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2020 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2020 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/at30tse75x/at30tse75x.c
+++ b/drivers/at30tse75x/at30tse75x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) Daniel Krebs
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: Daniel Krebs
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/at86rf215/Kconfig
+++ b/drivers/at86rf215/Kconfig
@@ -1,10 +1,6 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#               2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universitaet Berlin
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_AT86RF215
 

--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/at86rf215/at86rf215_fsk.c
+++ b/drivers/at86rf215/at86rf215_fsk.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/at86rf215/at86rf215_getset.c
+++ b/drivers/at86rf215/at86rf215_getset.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/at86rf215/at86rf215_internal.c
+++ b/drivers/at86rf215/at86rf215_internal.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/at86rf215/at86rf215_o-qpsk.c
+++ b/drivers/at86rf215/at86rf215_o-qpsk.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/at86rf215/at86rf215_ofdm.c
+++ b/drivers/at86rf215/at86rf215_ofdm.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/at86rf215/include/at86rf215_internal.h
+++ b/drivers/at86rf215/include/at86rf215_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/at86rf215/include/at86rf215_netdev.h
+++ b/drivers/at86rf215/include/at86rf215_netdev.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/at86rf215/include/at86rf215_params.h
+++ b/drivers/at86rf215/include/at86rf215_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/at86rf215/include/at86rf215_registers.h
+++ b/drivers/at86rf215/include/at86rf215_registers.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/at86rf2xx/aes_spi.c
+++ b/drivers/at86rf2xx/aes_spi.c
@@ -1,8 +1,6 @@
-/* Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+/*
+ * SPDX-FileCopyrightText: 2020 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2013 Alaeddine Weslati <alaeddine.weslati@inria.fr>
- * Copyright (C) 2015 Freie Universität Berlin
- *               2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Alaeddine Weslati <alaeddine.weslati@inria.fr>
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *               2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2013 Alaeddine Weslati <alaeddine.weslati@inria.fr>
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Alaeddine Weslati <alaeddine.weslati@inria.fr>
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2018 Kaspar Schleiser <kaspar@schleiser.de>
- *               2015 Freie Universität Berlin
- *               2023 Gerson Fernando Budke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2023 Gerson Fernando Budke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/at86rf2xx/include/at86rf2xx_aes.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_aes.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2013 Alaeddine Weslati <alaeddine.weslati@inria.fr>
- * Copyright (C) 2015 Freie Universität Berlin
- *               2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2013 Alaeddine Weslati <alaeddine.weslati@inria.fr>
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/at86rf2xx/include/at86rf2xx_netdev.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_netdev.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/at86rf2xx/include/at86rf2xx_params.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- *               2015 Hauke Petersen <hauke.petersen@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2015 Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/at86rf2xx/include/at86rf2xx_registers.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_registers.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2013 Alaeddine Weslati <alaeddine.weslati@inria.fr>
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Alaeddine Weslati <alaeddine.weslati@inria.fr>
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ata8520e/ata8520e.c
+++ b/drivers/ata8520e/ata8520e.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ata8520e/include/ata8520e_internals.h
+++ b/drivers/ata8520e/include/ata8520e_internals.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ata8520e/include/ata8520e_params.h
+++ b/drivers/ata8520e/include/ata8520e_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/atwinc15x0/atwinc15x0_bsp.c
+++ b/drivers/atwinc15x0/atwinc15x0_bsp.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/atwinc15x0/atwinc15x0_bus.c
+++ b/drivers/atwinc15x0/atwinc15x0_bus.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/atwinc15x0/atwinc15x0_netdev.c
+++ b/drivers/atwinc15x0/atwinc15x0_netdev.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2020 Gunar Schorcht
- *               2023 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Gunar Schorcht
+ * SPDX-FileCopyrightText: 2023 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/atwinc15x0/include/atwinc15x0_internal.h
+++ b/drivers/atwinc15x0/include/atwinc15x0_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/atwinc15x0/include/atwinc15x0_params.h
+++ b/drivers/atwinc15x0/include/atwinc15x0_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/atwinc15x0/include/bsp/include/nm_bsp_internal.h
+++ b/drivers/atwinc15x0/include/bsp/include/nm_bsp_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/bh1750fvi/bh1750fvi.c
+++ b/drivers/bh1750fvi/bh1750fvi.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/bh1750fvi/include/bh1750fvi_internal.h
+++ b/drivers/bh1750fvi/include/bh1750fvi_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/bh1750fvi/include/bh1750fvi_params.h
+++ b/drivers/bh1750fvi/include/bh1750fvi_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/bh1900nux/bh1900nux.c
+++ b/drivers/bh1900nux/bh1900nux.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Nalys
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Nalys
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/bh1900nux/include/bh1900nux_params.h
+++ b/drivers/bh1900nux/include/bh1900nux_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Nalys
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Nalys
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/bme680/bme680.c
+++ b/drivers/bme680/bme680.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2019 Mesotic SAS
- *               2020 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Mesotic SAS
+ * SPDX-FileCopyrightText: 2020 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/bme680/bme680_saul.c
+++ b/drivers/bme680/bme680_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/bme680/include/bme680_params.h
+++ b/drivers/bme680/include/bme680_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2019 Mesotic SAS
- *               2020 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Mesotic SAS
+ * SPDX-FileCopyrightText: 2020 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/bmp180/bmp180.c
+++ b/drivers/bmp180/bmp180.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/bmp180/bmp180_saul.c
+++ b/drivers/bmp180/bmp180_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/bmp180/include/bmp180_internals.h
+++ b/drivers/bmp180/include/bmp180_internals.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/bmp180/include/bmp180_params.h
+++ b/drivers/bmp180/include/bmp180_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Inria
- *               2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/bmx055/Kconfig
+++ b/drivers/bmx055/Kconfig
@@ -1,10 +1,6 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#               2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universitaet Berlin
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "BMX055 driver"
     depends on USEMODULE_BMX055

--- a/drivers/bmx055/bmx055.c
+++ b/drivers/bmx055/bmx055.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/bmx055/bmx055_internal.h
+++ b/drivers/bmx055/bmx055_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/bmx055/bmx055_saul.c
+++ b/drivers/bmx055/bmx055_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/bmx055/include/bmx055_params.h
+++ b/drivers/bmx055/include/bmx055_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/bmx280/bmx280.c
+++ b/drivers/bmx280/bmx280.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2016 Kees Bakker, SODAQ
- *               2017 Inria
- *               2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kees Bakker, SODAQ
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/bmx280/bmx280_saul.c
+++ b/drivers/bmx280/bmx280_saul.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Kees Bakker, SODAQ
- *               2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kees Bakker, SODAQ
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/bmx280/include/bmx280_internals.h
+++ b/drivers/bmx280/include/bmx280_internals.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Kees Bakker, SODAQ
- *               2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kees Bakker, SODAQ
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/bmx280/include/bmx280_params.h
+++ b/drivers/bmx280/include/bmx280_params.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2016 Kees Bakker, SODAQ
- *               2017 Inria
- *               2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kees Bakker, SODAQ
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/bq2429x/bq2429x.c
+++ b/drivers/bq2429x/bq2429x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Locha Inc
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Locha Inc
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/bq2429x/include/bq2429x_internal.h
+++ b/drivers/bq2429x/include/bq2429x_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Locha Inc
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Locha Inc
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/bq2429x/include/bq2429x_params.h
+++ b/drivers/bq2429x/include/bq2429x_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Locha Inc
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Locha Inc
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/can_trx/can_trx.c
+++ b/drivers/can_trx/can_trx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016  OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/cc110x/Kconfig
+++ b/drivers/cc110x/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universitaet Berlin
+# SPDX-License-Identifier: LGPL-2.1-only
+
 menu "CC110X driver"
     depends on USEMODULE_CC110X
 

--- a/drivers/cc110x/cc110x.c
+++ b/drivers/cc110x/cc110x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/cc110x/cc110x_calibration.c
+++ b/drivers/cc110x/cc110x_calibration.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/cc110x/cc110x_chanmaps.c
+++ b/drivers/cc110x/cc110x_chanmaps.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/cc110x/cc110x_communication.c
+++ b/drivers/cc110x/cc110x_communication.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/cc110x/cc110x_configs.c
+++ b/drivers/cc110x/cc110x_configs.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/cc110x/cc110x_netdev.c
+++ b/drivers/cc110x/cc110x_netdev.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/cc110x/cc110x_patables.c
+++ b/drivers/cc110x/cc110x_patables.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/cc110x/cc110x_rx_tx.c
+++ b/drivers/cc110x/cc110x_rx_tx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/cc110x/cc110x_settings.c
+++ b/drivers/cc110x/cc110x_settings.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/cc110x/include/cc110x_calibration.h
+++ b/drivers/cc110x/include/cc110x_calibration.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/cc110x/include/cc110x_communication.h
+++ b/drivers/cc110x/include/cc110x_communication.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/cc110x/include/cc110x_constants.h
+++ b/drivers/cc110x/include/cc110x_constants.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/cc110x/include/cc110x_internal.h
+++ b/drivers/cc110x/include/cc110x_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/cc110x/include/cc110x_netdev.h
+++ b/drivers/cc110x/include/cc110x_netdev.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/cc110x/include/cc110x_params.h
+++ b/drivers/cc110x/include/cc110x_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/cc110x/include/cc110x_rx_tx.h
+++ b/drivers/cc110x/include/cc110x_rx_tx.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/cc110x/include/cc110x_settings.h
+++ b/drivers/cc110x/include/cc110x_settings.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
+++ b/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016-17 Freie Universität Berlin
- *               2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-17 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015-2016 Freie Universität Berlin
- *               2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/cc2420/cc2420_getset.c
+++ b/drivers/cc2420/cc2420_getset.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *               2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/cc2420/cc2420_internal.c
+++ b/drivers/cc2420/cc2420_internal.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015-2016 Freie Universität Berlin
- *               2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *               2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/cc2420/include/cc2420_internal.h
+++ b/drivers/cc2420/include/cc2420_internal.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2014 Milan Babel <babel@inf.fu-berlin.de> and INRIA
- *               2015-2016 Freie Universität Berlin
- *               2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Milan Babel <babel@inf.fu-berlin.de> and INRIA
+ * SPDX-FileCopyrightText: 2015-2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/cc2420/include/cc2420_netdev.h
+++ b/drivers/cc2420/include/cc2420_netdev.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Inria
- *               2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/cc2420/include/cc2420_params.h
+++ b/drivers/cc2420/include/cc2420_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/cc2420/include/cc2420_registers.h
+++ b/drivers/cc2420/include/cc2420_registers.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *               2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ccs811/ccs811.c
+++ b/drivers/ccs811/ccs811.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ccs811/ccs811_saul.c
+++ b/drivers/ccs811/ccs811_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ccs811/include/ccs811_params.h
+++ b/drivers/ccs811/include/ccs811_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ccs811/include/ccs811_regs.h
+++ b/drivers/ccs811/include/ccs811_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/cst816s/cst816s.c
+++ b/drivers/cst816s/cst816s.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/cst816s/cst816s_touch_dev.c
+++ b/drivers/cst816s/cst816s_touch_dev.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/cst816s/include/cst816s_internal.h
+++ b/drivers/cst816s/include/cst816s_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/cst816s/include/cst816s_params.h
+++ b/drivers/cst816s/include/cst816s_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/cst816s/include/cst816s_touch_dev.h
+++ b/drivers/cst816s/include/cst816s_touch_dev.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/dac_dds/dac_dds.c
+++ b/drivers/dac_dds/dac_dds.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Beuth Hochschule für Technik Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Beuth Hochschule für Technik Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/dac_dds/include/dac_dds_params.h
+++ b/drivers/dac_dds/include/dac_dds_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Beuth Hochschule für Technik Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Beuth Hochschule für Technik Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/dcf77/dcf77.c
+++ b/drivers/dcf77/dcf77.c
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup     drivers_dcf77
  * @{

--- a/drivers/dcf77/include/dcf77_internal.h
+++ b/drivers/dcf77/include/dcf77_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/dcf77/include/dcf77_params.h
+++ b/drivers/dcf77/include/dcf77_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/dfplayer/dfplayer.c
+++ b/drivers/dfplayer/dfplayer.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2019 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/dfplayer/dfplayer_internal.c
+++ b/drivers/dfplayer/dfplayer_internal.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2019 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/dfplayer/include/dfplayer_constants.h
+++ b/drivers/dfplayer/include/dfplayer_constants.h
@@ -1,9 +1,6 @@
 /*
- * Copyright 2019 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/dfplayer/include/dfplayer_implementation.h
+++ b/drivers/dfplayer/include/dfplayer_implementation.h
@@ -1,9 +1,6 @@
 /*
- * Copyright 2019 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/dfplayer/include/dfplayer_internal.h
+++ b/drivers/dfplayer/include/dfplayer_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright 2019 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/dfplayer/include/dfplayer_params.h
+++ b/drivers/dfplayer/include/dfplayer_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright 2019 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/dfplayer/include/dfplayer_types.h
+++ b/drivers/dfplayer/include/dfplayer_types.h
@@ -1,9 +1,6 @@
 /*
- * Copyright 2019 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/dht/dht.c
+++ b/drivers/dht/dht.c
@@ -1,12 +1,9 @@
 /*
- * Copyright 2015 Ludwig Knüpfer
- *           2015 Christian Mehlis
- *           2016-2017 Freie Universität Berlin
- *           2023 Hugues Larrive
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Ludwig Knüpfer
+ * SPDX-FileCopyrightText: 2015 Christian Mehlis
+ * SPDX-FileCopyrightText: 2016-2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2023 Hugues Larrive
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/dht/dht_saul.c
+++ b/drivers/dht/dht_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/dht/include/dht_params.h
+++ b/drivers/dht/include/dht_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/disp_dev/disp_dev.c
+++ b/drivers/disp_dev/disp_dev.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/dose/Kconfig
+++ b/drivers/dose/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universitaet Berlin
+# SPDX-License-Identifier: LGPL-2.1-only
+
 menu "DOSE driver"
     depends on USEMODULE_DOSE
 

--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Juergen Fitschen <me@jue.yt>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Juergen Fitschen <me@jue.yt>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/dose/include/dose_params.h
+++ b/drivers/dose/include/dose_params.h
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2019 Juergen Fitschen <me@jue.yt>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2019 Juergen Fitschen <me@jue.yt>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ds1307/ds1307.c
+++ b/drivers/ds1307/ds1307.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ds1307/include/ds1307_internal.h
+++ b/drivers/ds1307/include/ds1307_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ds1307/include/ds1307_params.h
+++ b/drivers/ds1307/include/ds1307_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ds18/include/ds18_params.h
+++ b/drivers/ds18/include/ds18_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Frits Kuipers
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Frits Kuipers
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ds3231/ds3231.c
+++ b/drivers/ds3231/ds3231.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ds3231/include/ds3231_params.h
+++ b/drivers/ds3231/include/ds3231_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ds3234/ds3234.c
+++ b/drivers/ds3234/ds3234.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2018 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2018 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ds3234/include/ds3234_params.h
+++ b/drivers/ds3234/include/ds3234_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 SKF AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 SKF AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ds3234/include/ds3234_regs.h
+++ b/drivers/ds3234/include/ds3234_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright 2018 SKF AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 SKF AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ds75lx/ds75lx.c
+++ b/drivers/ds75lx/ds75lx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ds75lx/ds75lx_saul.c
+++ b/drivers/ds75lx/ds75lx_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ds75lx/include/ds75lx_internals.h
+++ b/drivers/ds75lx/include/ds75lx_internals.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ds75lx/include/ds75lx_params.h
+++ b/drivers/ds75lx/include/ds75lx_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/dsp0401/dsp0401.c
+++ b/drivers/dsp0401/dsp0401.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/dsp0401/include/dsp0401_params.h
+++ b/drivers/dsp0401/include/dsp0401_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/dynamixel/crc.c
+++ b/drivers/dynamixel/crc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/dynamixel/dynamixel.c
+++ b/drivers/dynamixel/dynamixel.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/dynamixel/include/dynamixel_crc.h
+++ b/drivers/dynamixel/include/dynamixel_crc.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/dynamixel/include/dynamixel_protocol.h
+++ b/drivers/dynamixel/include/dynamixel_protocol.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/dynamixel/include/dynamixel_reader.h
+++ b/drivers/dynamixel/include/dynamixel_reader.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/dynamixel/include/dynamixel_writer.h
+++ b/drivers/dynamixel/include/dynamixel_writer.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/dynamixel/reader.c
+++ b/drivers/dynamixel/reader.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/dynamixel/writer.c
+++ b/drivers/dynamixel/writer.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/edbg_eui/edbg_eui.c
+++ b/drivers/edbg_eui/edbg_eui.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/enc28j60/include/enc28j60_params.h
+++ b/drivers/enc28j60/include/enc28j60_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/enc28j60/include/enc28j60_regs.h
+++ b/drivers/enc28j60/include/enc28j60_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Ell-i open source co-operative
- *                    Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Ell-i open source co-operative
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/encx24j600/include/encx24j600_defines.h
+++ b/drivers/encx24j600/include/encx24j600_defines.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Ell-i open source co-operative
- *                    Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2015 Ell-i open source co-operative
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/encx24j600/include/encx24j600_internal.h
+++ b/drivers/encx24j600/include/encx24j600_internal.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Ell-i open source co-operative
- *                    Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2015 Ell-i open source co-operative
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/encx24j600/include/encx24j600_params.h
+++ b/drivers/encx24j600/include/encx24j600_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/epd_bw_spi/epd_bw_spi.c
+++ b/drivers/epd_bw_spi/epd_bw_spi.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Silke Hofstra
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Silke Hofstra
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/epd_bw_spi/epd_bw_spi_disp_dev.c
+++ b/drivers/epd_bw_spi/epd_bw_spi_disp_dev.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Silke Hofstra
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Silke Hofstra
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/epd_bw_spi/include/epd_bw_spi_internal.h
+++ b/drivers/epd_bw_spi/include/epd_bw_spi_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Silke Hofstra
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Silke Hofstra
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/epd_bw_spi/include/epd_bw_spi_params.h
+++ b/drivers/epd_bw_spi/include/epd_bw_spi_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Silke Hofstra
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Silke Hofstra
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ethos/include/ethos_params.h
+++ b/drivers/ethos/include/ethos_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ethos/stdio.c
+++ b/drivers/ethos/stdio.c
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2013 INRIA
- *               2015 Kaspar Schleiser <kaspar@schleiser.de>
- *               2016 Eistec AB
- *               2018-21 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 INRIA
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-FileCopyrightText: 2018-21 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR attempts to convert all license headers for all folders inside the `drivers/` directory starting with the letters A to E. Vendor specific files are left untouched as well as some files missing some copyright or license information.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
To check for correct license/copyright information in all c and h files that are not vendor provided, use this command:

`reuse lint -l | grep "^drivers/" | grep -E '\.(c|h):' | grep -v "/vendor/"`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
This PR splits up #21516 and therefore closes it 
Tracking #21515 
Next PR #22163  
