### PR TITLE
drivers/[f-h]*: change license headers to SPDX format

### DIFF
--- a/drivers/feetech/feetech.c
+++ b/drivers/feetech/feetech.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/feetech/include/feetech_protocol.h
+++ b/drivers/feetech/include/feetech_protocol.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/feetech/include/feetech_reader.h
+++ b/drivers/feetech/include/feetech_reader.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/feetech/include/feetech_writer.h
+++ b/drivers/feetech/include/feetech_writer.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/feetech/reader.c
+++ b/drivers/feetech/reader.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/feetech/writer.c
+++ b/drivers/feetech/writer.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ft5x06/ft5x06.c
+++ b/drivers/ft5x06/ft5x06.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ft5x06/ft5x06_internal.c
+++ b/drivers/ft5x06/ft5x06_internal.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (c) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ft5x06/ft5x06_touch_dev.c
+++ b/drivers/ft5x06/ft5x06_touch_dev.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ft5x06/include/ft5x06_constants.h
+++ b/drivers/ft5x06/include/ft5x06_constants.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ft5x06/include/ft5x06_internal.h
+++ b/drivers/ft5x06/include/ft5x06_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ft5x06/include/ft5x06_params.h
+++ b/drivers/ft5x06/include/ft5x06_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ft5x06/include/ft5x06_touch_dev.h
+++ b/drivers/ft5x06/include/ft5x06_touch_dev.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/fxos8700/Kconfig
+++ b/drivers/fxos8700/Kconfig
@@ -1,10 +1,6 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#               2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universitaet Berlin
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "FXOS8700 driver"
     depends on USEMODULE_FXOS8700

--- a/drivers/fxos8700/fxos8700.c
+++ b/drivers/fxos8700/fxos8700.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 UC Berkeley
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 UC Berkeley
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/fxos8700/fxos8700_saul.c
+++ b/drivers/fxos8700/fxos8700_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 UC Berkeley
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 UC Berkeley
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/fxos8700/include/fxos8700_params.h
+++ b/drivers/fxos8700/include/fxos8700_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 UC Berkeley
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 UC Berkeley
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/fxos8700/include/fxos8700_regs.h
+++ b/drivers/fxos8700/include/fxos8700_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 UC Berkeley
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 UC Berkeley
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/gp2y10xx/Kconfig
+++ b/drivers/gp2y10xx/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Locha Inc
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Locha Inc
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "GP2Y10xx driver"
     depends on USEMODULE_GP2Y10XX

--- a/drivers/gp2y10xx/gp2y10xx.c
+++ b/drivers/gp2y10xx/gp2y10xx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Locha Inc
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Locha Inc
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/gp2y10xx/gp2y10xx_saul.c
+++ b/drivers/gp2y10xx/gp2y10xx_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Locha Inc
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Locha Inc
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/gp2y10xx/include/gp2y10xx_params.h
+++ b/drivers/gp2y10xx/include/gp2y10xx_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Locha Inc
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Locha Inc
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/grove_ledbar/grove_ledbar.c
+++ b/drivers/grove_ledbar/grove_ledbar.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/grove_ledbar/grove_ledbar_saul.c
+++ b/drivers/grove_ledbar/grove_ledbar_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/grove_ledbar/include/grove_ledbar_params.h
+++ b/drivers/grove_ledbar/include/grove_ledbar_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/hd44780/hd44780.c
+++ b/drivers/hd44780/hd44780.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/hd44780/include/hd44780_internal.h
+++ b/drivers/hd44780/include/hd44780_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/hd44780/include/hd44780_params.h
+++ b/drivers/hd44780/include/hd44780_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/hdc1000/Kconfig
+++ b/drivers/hdc1000/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universitaet Berlin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "HDC1000 driver"
     depends on USEMODULE_HDC1000

--- a/drivers/hdc1000/hdc1000.c
+++ b/drivers/hdc1000/hdc1000.c
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2014 PHYTEC Messtechnik GmbH
- *               2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2014 PHYTEC Messtechnik GmbH
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/hdc1000/hdc1000_saul.c
+++ b/drivers/hdc1000/hdc1000_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/hdc1000/include/hdc1000_params.h
+++ b/drivers/hdc1000/include/hdc1000_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/hdc1000/include/hdc1000_regs.h
+++ b/drivers/hdc1000/include/hdc1000_regs.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 PHYTEC Messtechnik GmbH
- *               2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 PHYTEC Messtechnik GmbH
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/hih6130/hih6130.c
+++ b/drivers/hih6130/hih6130.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/hm330x/Kconfig
+++ b/drivers/hm330x/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "HM330X driver"
     depends on USEMODULE_HM330X

--- a/drivers/hm330x/hm330x.c
+++ b/drivers/hm330x/hm330x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/hm330x/hm330x_saul.c
+++ b/drivers/hm330x/hm330x_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/hm330x/include/hm330x_constants.h
+++ b/drivers/hm330x/include/hm330x_constants.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/hm330x/include/hm330x_params.h
+++ b/drivers/hm330x/include/hm330x_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/hmc5883l/hmc5883l.c
+++ b/drivers/hmc5883l/hmc5883l.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/hmc5883l/hmc5883l_saul.c
+++ b/drivers/hmc5883l/hmc5883l_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/hmc5883l/include/hmc5883l_params.h
+++ b/drivers/hmc5883l/include/hmc5883l_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/hmc5883l/include/hmc5883l_regs.h
+++ b/drivers/hmc5883l/include/hmc5883l_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/hsc/Kconfig
+++ b/drivers/hsc/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 Deutsches Zentrum für Luft- und Raumfahrt e.V. (DLR)
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Deutsches Zentrum für Luft- und Raumfahrt e.V. (DLR)
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "HSC pressure and temperature sensor driver"
     depends on USEMODULE_HSC

--- a/drivers/hsc/hsc.c
+++ b/drivers/hsc/hsc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Deutsches Zentrum für Luft- und Raumfahrt e.V. (DLR)
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Deutsches Zentrum für Luft- und Raumfahrt e.V. (DLR)
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/hsc/hsc_saul.c
+++ b/drivers/hsc/hsc_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Deutsches Zentrum für Luft- und Raumfahrt e.V. (DLR)
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Deutsches Zentrum für Luft- und Raumfahrt e.V. (DLR)
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/hsc/include/hsc_internals.h
+++ b/drivers/hsc/include/hsc_internals.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Deutsches Zentrum für Luft- und Raumfahrt e.V. (DLR)
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Deutsches Zentrum für Luft- und Raumfahrt e.V. (DLR)
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/hsc/include/hsc_params.h
+++ b/drivers/hsc/include/hsc_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Deutsches Zentrum für Luft- und Raumfahrt e.V. (DLR)
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Deutsches Zentrum für Luft- und Raumfahrt e.V. (DLR)
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/hts221/hts221.c
+++ b/drivers/hts221/hts221.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/hts221/hts221_saul.c
+++ b/drivers/hts221/hts221_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/hts221/include/hts221_params.h
+++ b/drivers/hts221/include/hts221_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/hts221/include/hts221_regs.h
+++ b/drivers/hts221/include/hts221_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR attempts to convert all license headers for all folders inside the `drivers/` directory starting with the letters F to H. Vendor specific files are left untouched as well as some files missing some copyright or license information.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
To check for correct license/copyright information in all c and h files that are not vendor provided, use this command:

`reuse lint -l | grep "^drivers/" | grep -E '\.(c|h):' | grep -v "/vendor/"`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
This PR splits up #21516 and therefore closes it 
Tracking #21515 
