### PR TITLE
drivers/[j-o]*: change license headers to SPDX format

### DIFF
--- a/drivers/jc42/include/jc42_internal.h
+++ b/drivers/jc42/include/jc42_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/jc42/include/jc42_params.h
+++ b/drivers/jc42/include/jc42_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
- *               2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Koen Zandberg <koen@bergzand.net>
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/jc42/jc42.c
+++ b/drivers/jc42/jc42.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/jc42/jc42_saul.c
+++ b/drivers/jc42/jc42_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/kw2xrf/include/kw2xrf_getset.h
+++ b/drivers/kw2xrf/include/kw2xrf_getset.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Phytec Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Phytec Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/kw2xrf/include/kw2xrf_intern.h
+++ b/drivers/kw2xrf/include/kw2xrf_intern.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Phytec Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Phytec Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/kw2xrf/include/kw2xrf_netdev.h
+++ b/drivers/kw2xrf/include/kw2xrf_netdev.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Phytec Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Phytec Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/kw2xrf/include/kw2xrf_params.h
+++ b/drivers/kw2xrf/include/kw2xrf_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Hamburg University of Applied Sciences
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Hamburg University of Applied Sciences
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/kw2xrf/include/kw2xrf_spi.h
+++ b/drivers/kw2xrf/include/kw2xrf_spi.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 PHYTEC Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2015 PHYTEC Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/kw2xrf/include/kw2xrf_tm.h
+++ b/drivers/kw2xrf/include/kw2xrf_tm.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Phytec Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Phytec Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 PHYTEC Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 PHYTEC Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/kw2xrf/kw2xrf_getset.c
+++ b/drivers/kw2xrf/kw2xrf_getset.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 PHYTEC Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 PHYTEC Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/kw2xrf/kw2xrf_intern.c
+++ b/drivers/kw2xrf/kw2xrf_intern.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 PHYTEC Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 PHYTEC Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/kw2xrf/kw2xrf_radio_hal.c
+++ b/drivers/kw2xrf/kw2xrf_radio_hal.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/kw2xrf/kw2xrf_spi.c
+++ b/drivers/kw2xrf/kw2xrf_spi.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 PHYTEC Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2015 PHYTEC Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/kw2xrf/kw2xrf_tm.c
+++ b/drivers/kw2xrf/kw2xrf_tm.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Phytec Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Phytec Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/kw41zrf/include/kw41zrf_getset.h
+++ b/drivers/kw41zrf/include/kw41zrf_getset.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 SKF AB
- * Copyright (C) 2016 Phytec Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 SKF AB
+ * SPDX-FileCopyrightText: 2016 Phytec Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/kw41zrf/include/kw41zrf_intern.h
+++ b/drivers/kw41zrf/include/kw41zrf_intern.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 SKF AB
- * Copyright (C) 2016 Phytec Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 SKF AB
+ * SPDX-FileCopyrightText: 2016 Phytec Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/kw41zrf/include/kw41zrf_netdev.h
+++ b/drivers/kw41zrf/include/kw41zrf_netdev.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 SKF AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 SKF AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/kw41zrf/kw41zrf.c
+++ b/drivers/kw41zrf/kw41zrf.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 SKF AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 SKF AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/kw41zrf/kw41zrf_getset.c
+++ b/drivers/kw41zrf/kw41zrf_getset.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 SKF AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 SKF AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/kw41zrf/kw41zrf_intern.c
+++ b/drivers/kw41zrf/kw41zrf_intern.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 SKF AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 SKF AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/kw41zrf/kw41zrf_netdev.c
+++ b/drivers/kw41zrf/kw41zrf_netdev.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 SKF AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 SKF AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/l3g4200d/Kconfig
+++ b/drivers/l3g4200d/Kconfig
@@ -1,10 +1,6 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#               2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universitaet Berlin
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "L3G4200D driver"
     depends on USEMODULE_L3G4200D

--- a/drivers/l3g4200d/include/l3g4200d-regs.h
+++ b/drivers/l3g4200d/include/l3g4200d-regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/l3g4200d/include/l3g4200d_params.h
+++ b/drivers/l3g4200d/include/l3g4200d_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/l3g4200d/l3g4200d.c
+++ b/drivers/l3g4200d/l3g4200d.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/l3g4200d/l3g4200d_saul.c
+++ b/drivers/l3g4200d/l3g4200d_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/l3gxxxx/Kconfig
+++ b/drivers/l3gxxxx/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_L3GXXXX
 

--- a/drivers/l3gxxxx/include/l3gxxxx_params.h
+++ b/drivers/l3gxxxx/include/l3gxxxx_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/l3gxxxx/include/l3gxxxx_regs.h
+++ b/drivers/l3gxxxx/include/l3gxxxx_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/l3gxxxx/l3gxxxx.c
+++ b/drivers/l3gxxxx/l3gxxxx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/l3gxxxx/l3gxxxx_saul.c
+++ b/drivers/l3gxxxx/l3gxxxx_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lc709203f/lc709203f.c
+++ b/drivers/lc709203f/lc709203f.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 RWTH Aachen, Steffen Robertz, Josua Arndt
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 RWTH Aachen, Steffen Robertz, Josua Arndt
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lcd/Kconfig
+++ b/drivers/lcd/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "LCD"
     depends on USEMODULE_LCD

--- a/drivers/lcd/include/lcd_disp_dev.h
+++ b/drivers/lcd/include/lcd_disp_dev.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lcd/include/lcd_internal.h
+++ b/drivers/lcd/include/lcd_internal.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Koen Zandberg
- *               2021 Francisco Molina
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-FileCopyrightText: 2021 Francisco Molina
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lcd/include/lcd_ll_par_gpio.h
+++ b/drivers/lcd/include/lcd_ll_par_gpio.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lcd/lcd.c
+++ b/drivers/lcd/lcd.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2018 Koen Zandberg
- *               2021 Francisco Molina
- *               2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-FileCopyrightText: 2021 Francisco Molina
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lcd/lcd_disp_dev.c
+++ b/drivers/lcd/lcd_disp_dev.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lcd/lcd_ll_par_gpio.c
+++ b/drivers/lcd/lcd_ll_par_gpio.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lis2dh12/include/lis2dh12_params.h
+++ b/drivers/lis2dh12/include/lis2dh12_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lis2dh12/include/lis2dh12_registers.h
+++ b/drivers/lis2dh12/include/lis2dh12_registers.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lis2dh12/lis2dh12.c
+++ b/drivers/lis2dh12/lis2dh12.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lis2dh12/lis2dh12_internal.h
+++ b/drivers/lis2dh12/lis2dh12_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lis2dh12/lis2dh12_saul.c
+++ b/drivers/lis2dh12/lis2dh12_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lis3dh/include/lis3dh_params.h
+++ b/drivers/lis3dh/include/lis3dh_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lis3dh/lis3dh.c
+++ b/drivers/lis3dh/lis3dh.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Eistec AB
- *               2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Eistec AB
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lis3dh/lis3dh_saul.c
+++ b/drivers/lis3dh/lis3dh_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lis3mdl/include/lis3mdl-internal.h
+++ b/drivers/lis3mdl/include/lis3mdl-internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lis3mdl/include/lis3mdl_params.h
+++ b/drivers/lis3mdl/include/lis3mdl_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lis3mdl/lis3mdl.c
+++ b/drivers/lis3mdl/lis3mdl.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lis3mdl/lis3mdl_saul.c
+++ b/drivers/lis3mdl/lis3mdl_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lm75/include/lm75_params.h
+++ b/drivers/lm75/include/lm75_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lm75/include/lm75_regs.h
+++ b/drivers/lm75/include/lm75_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lm75/lm75.c
+++ b/drivers/lm75/lm75.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lm75/lm75_saul.c
+++ b/drivers/lm75/lm75_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lpd8808/include/lpd8808_params.h
+++ b/drivers/lpd8808/include/lpd8808_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Hauke Petersen <devel@haukepetersen.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Hauke Petersen <devel@haukepetersen.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lpd8808/lpd8808.c
+++ b/drivers/lpd8808/lpd8808.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lpsxxx/Kconfig
+++ b/drivers/lpsxxx/Kconfig
@@ -1,10 +1,6 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#               2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universitaet Berlin
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "LPSXXX driver"
     depends on USEMODULE_LPSXXX

--- a/drivers/lpsxxx/include/lpsxxx_internal.h
+++ b/drivers/lpsxxx/include/lpsxxx_internal.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *               2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lpsxxx/include/lpsxxx_params.h
+++ b/drivers/lpsxxx/include/lpsxxx_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *               2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lpsxxx/lpsxxx.c
+++ b/drivers/lpsxxx/lpsxxx.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *               2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lpsxxx/lpsxxx_saul.c
+++ b/drivers/lpsxxx/lpsxxx_saul.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *               2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lsm303dlhc/include/lsm303dlhc-internal.h
+++ b/drivers/lsm303dlhc/include/lsm303dlhc-internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lsm303dlhc/include/lsm303dlhc_params.h
+++ b/drivers/lsm303dlhc/include/lsm303dlhc_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lsm303dlhc/lsm303dlhc.c
+++ b/drivers/lsm303dlhc/lsm303dlhc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lsm303dlhc/lsm303dlhc_saul.c
+++ b/drivers/lsm303dlhc/lsm303dlhc_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lsm6dsxx/include/lsm6dsxx_internal.h
+++ b/drivers/lsm6dsxx/include/lsm6dsxx_internal.h
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- * Copyright (C) 2024 HAW Hamburg.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2024 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lsm6dsxx/include/lsm6dsxx_params.h
+++ b/drivers/lsm6dsxx/include/lsm6dsxx_params.h
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- * Copyright (C) 2024 HAW Hamburg.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2024 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/lsm6dsxx/lsm6dsxx.c
+++ b/drivers/lsm6dsxx/lsm6dsxx.c
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- * Copyright (C) 2024 HAW Hamburg.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2024 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/lsm6dsxx/lsm6dsxx_saul.c
+++ b/drivers/lsm6dsxx/lsm6dsxx_saul.c
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- * Copyright (C) 2024 HAW Hamburg.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2024 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ltc4150/include/ltc4150_params.h
+++ b/drivers/ltc4150/include/ltc4150_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ltc4150/ltc4150.c
+++ b/drivers/ltc4150/ltc4150.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ltc4150/ltc4150_last_minute.c
+++ b/drivers/ltc4150/ltc4150_last_minute.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ltc4150/ltc4150_saul.c
+++ b/drivers/ltc4150/ltc4150_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mag3110/Kconfig
+++ b/drivers/mag3110/Kconfig
@@ -1,10 +1,6 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#               2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universitaet Berlin
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "MAG3110 driver"
     depends on USEMODULE_MAG3110

--- a/drivers/mag3110/include/mag3110_params.h
+++ b/drivers/mag3110/include/mag3110_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017   HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mag3110/include/mag3110_reg.h
+++ b/drivers/mag3110/include/mag3110_reg.h
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2014 PHYTEC Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2014 PHYTEC Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mag3110/mag3110.c
+++ b/drivers/mag3110/mag3110.c
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2014 PHYTEC Messtechnik GmbH
- *               2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2014 PHYTEC Messtechnik GmbH
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mag3110/mag3110_saul.c
+++ b/drivers/mag3110/mag3110_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/matrix_keypad/Kconfig
+++ b/drivers/matrix_keypad/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2021 Koen Zandberg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2021 Koen Zandberg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_MATRIX_KEYPAD
 

--- a/drivers/matrix_keypad/include/matrix_keypad_params.h
+++ b/drivers/matrix_keypad/include/matrix_keypad_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/matrix_keypad/matrix_keypad.c
+++ b/drivers/matrix_keypad/matrix_keypad.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/max31855/include/max31855_constants.h
+++ b/drivers/max31855/include/max31855_constants.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/max31855/include/max31855_params.h
+++ b/drivers/max31855/include/max31855_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/max31855/max31855.c
+++ b/drivers/max31855/max31855.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/max31855/max31855_saul.c
+++ b/drivers/max31855/max31855_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/max31865/include/max31865_internal.h
+++ b/drivers/max31865/include/max31865_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 David Picard
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 David Picard
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/max31865/include/max31865_lut.h
+++ b/drivers/max31865/include/max31865_lut.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 David Picard
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 David Picard
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/max31865/include/max31865_params.h
+++ b/drivers/max31865/include/max31865_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 David Picard
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 David Picard
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/max31865/max31865.c
+++ b/drivers/max31865/max31865.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 David Picard
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 David Picard
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/max31865/max31865_saul.c
+++ b/drivers/max31865/max31865_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 David Picard
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 David Picard
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mcp23x17/include/mcp23x17_params.h
+++ b/drivers/mcp23x17/include/mcp23x17_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mcp23x17/include/mcp23x17_regs.h
+++ b/drivers/mcp23x17/include/mcp23x17_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mcp23x17/mcp23x17.c
+++ b/drivers/mcp23x17/mcp23x17.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mcp23x17/mcp23x17_saul.c
+++ b/drivers/mcp23x17/mcp23x17_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mcp2515/candev_mcp2515.c
+++ b/drivers/mcp2515/candev_mcp2515.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mcp2515/include/mcp2515_params.h
+++ b/drivers/mcp2515/include/mcp2515_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mcp2515/mcp2515.c
+++ b/drivers/mcp2515/mcp2515.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mcp2515/mcp2515.h
+++ b/drivers/mcp2515/mcp2515.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mcp2515/mcp2515_defines.h
+++ b/drivers/mcp2515/mcp2515_defines.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mcp2515/mcp2515_spi.c
+++ b/drivers/mcp2515/mcp2515_spi.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mcp2515/mcp2515_spi.h
+++ b/drivers/mcp2515/mcp2515_spi.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mcp47xx/include/mcp47xx_params.h
+++ b/drivers/mcp47xx/include/mcp47xx_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mcp47xx/mcp47xx.c
+++ b/drivers/mcp47xx/mcp47xx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mcp47xx/mcp47xx_saul.c
+++ b/drivers/mcp47xx/mcp47xx_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mfrc522/include/mfrc522_params.h
+++ b/drivers/mfrc522/include/mfrc522_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mfrc522/include/mfrc522_regs.h
+++ b/drivers/mfrc522/include/mfrc522_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mfrc522/mfrc522.c
+++ b/drivers/mfrc522/mfrc522.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mhz19/include/mhz19_internals.h
+++ b/drivers/mhz19/include/mhz19_internals.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mhz19/include/mhz19_params.h
+++ b/drivers/mhz19/include/mhz19_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Koen Zandberg <koen@bergzand.net>
- * Copyright (C) 2018 Beduino Master Projekt - University of Bremen
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg <koen@bergzand.net>
+ * SPDX-FileCopyrightText: 2018 Beduino Master Projekt - University of Bremen
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mhz19/mhz19_pwm.c
+++ b/drivers/mhz19/mhz19_pwm.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Koen Zandberg <koen@bergzand.net>
- * Copyright (C) 2018 Beduino Master Projekt - University of Bremen
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg <koen@bergzand.net>
+ * SPDX-FileCopyrightText: 2018 Beduino Master Projekt - University of Bremen
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mhz19/mhz19_saul.c
+++ b/drivers/mhz19/mhz19_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mhz19/mhz19_uart.c
+++ b/drivers/mhz19/mhz19_uart.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2018 Koen Zandberg <koen@bergzand.net>
- * Copyright (C) 2018 Beduino Master Projekt - University of Bremen
- * Copyright (C) 2020 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg <koen@bergzand.net>
+ * SPDX-FileCopyrightText: 2018 Beduino Master Projekt - University of Bremen
+ * SPDX-FileCopyrightText: 2020 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mma7660/include/mma7660_params.h
+++ b/drivers/mma7660/include/mma7660_params.h
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2016 University of California, Berkeley
- * Copyright (C) 2016 Michael Andersen <m.andersen@cs.berkeley.edu>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2016 University of California, Berkeley
+ * SPDX-FileCopyrightText: 2016 Michael Andersen <m.andersen@cs.berkeley.edu>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mma7660/include/mma7660_reg.h
+++ b/drivers/mma7660/include/mma7660_reg.h
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2016 University of California, Berkeley
- * Copyright (C) 2016 Michael Andersen <m.andersen@cs.berkeley.edu>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2016 University of California, Berkeley
+ * SPDX-FileCopyrightText: 2016 Michael Andersen <m.andersen@cs.berkeley.edu>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mma7660/mma7660.c
+++ b/drivers/mma7660/mma7660.c
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2016 University of California, Berkeley
- *               2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2016 University of California, Berkeley
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mma7660/mma7660_saul.c
+++ b/drivers/mma7660/mma7660_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mma8x5x/Kconfig
+++ b/drivers/mma8x5x/Kconfig
@@ -1,10 +1,6 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#               2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universitaet Berlin
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "MMA8X5X driver"
     depends on USEMODULE_MMA8X5X

--- a/drivers/mma8x5x/include/mma8x5x_params.h
+++ b/drivers/mma8x5x/include/mma8x5x_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mma8x5x/include/mma8x5x_regs.h
+++ b/drivers/mma8x5x/include/mma8x5x_regs.h
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2014 PHYTEC Messtechnik GmbH
- *               2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2014 PHYTEC Messtechnik GmbH
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mma8x5x/mma8x5x.c
+++ b/drivers/mma8x5x/mma8x5x.c
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2014 PHYTEC Messtechnik GmbH
- *               2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2014 PHYTEC Messtechnik GmbH
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mma8x5x/mma8x5x_saul.c
+++ b/drivers/mma8x5x/mma8x5x_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/motor_driver/Kconfig
+++ b/drivers/motor_driver/Kconfig
@@ -1,10 +1,6 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#               2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universitaet Berlin
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "MOTOR_DRIVER: DC Motor driver"
     depends on USEMODULE_MOTOR_DRIVER

--- a/drivers/mpl3115a2/include/mpl3115a2_params.h
+++ b/drivers/mpl3115a2/include/mpl3115a2_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017   HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mpl3115a2/include/mpl3115a2_reg.h
+++ b/drivers/mpl3115a2/include/mpl3115a2_reg.h
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2014 PHYTEC Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2014 PHYTEC Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mpl3115a2/mpl3115a2.c
+++ b/drivers/mpl3115a2/mpl3115a2.c
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2014 PHYTEC Messtechnik GmbH
- *               2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2014 PHYTEC Messtechnik GmbH
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mpl3115a2/mpl3115a2_saul.c
+++ b/drivers/mpl3115a2/mpl3115a2_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mpu9x50/include/mpu9x50_internal.h
+++ b/drivers/mpu9x50/include/mpu9x50_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mpu9x50/include/mpu9x50_params.h
+++ b/drivers/mpu9x50/include/mpu9x50_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017   Inria
- *               2019   HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mpu9x50/include/mpu9x50_regs.h
+++ b/drivers/mpu9x50/include/mpu9x50_regs.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *               2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mpu9x50/mpu9x50.c
+++ b/drivers/mpu9x50/mpu9x50.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *               2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mpu9x50/mpu9x50_saul.c
+++ b/drivers/mpu9x50/mpu9x50_saul.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Inria
- *               2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mq3/mq3.c
+++ b/drivers/mq3/mq3.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mrf24j40/Kconfig
+++ b/drivers/mrf24j40/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "MRF24J40 driver"
     depends on USEMODULE_MRF24J40

--- a/drivers/mrf24j40/include/mrf24j40_internal.h
+++ b/drivers/mrf24j40/include/mrf24j40_internal.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Neo Nenaco <neo@nenaco.de>
- * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Neo Nenaco <neo@nenaco.de>
+ * SPDX-FileCopyrightText: 2017 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mrf24j40/include/mrf24j40_netdev.h
+++ b/drivers/mrf24j40/include/mrf24j40_netdev.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Neo Nenaco <neo@nenaco.de>
- * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Neo Nenaco <neo@nenaco.de>
+ * SPDX-FileCopyrightText: 2017 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mrf24j40/include/mrf24j40_params.h
+++ b/drivers/mrf24j40/include/mrf24j40_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Neo Nenaco <neo@nenaco.de>
- * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Neo Nenaco <neo@nenaco.de>
+ * SPDX-FileCopyrightText: 2017 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mrf24j40/include/mrf24j40_registers.h
+++ b/drivers/mrf24j40/include/mrf24j40_registers.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Neo Nenaco <neo@nenaco.de>
- * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Neo Nenaco <neo@nenaco.de>
+ * SPDX-FileCopyrightText: 2017 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Neo Nenaco <neo@nenaco.de>
- * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Neo Nenaco <neo@nenaco.de>
+ * SPDX-FileCopyrightText: 2017 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mrf24j40/mrf24j40_getset.c
+++ b/drivers/mrf24j40/mrf24j40_getset.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Neo Nenaco <neo@nenaco.de>
- * Copyright (C) 2016 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Neo Nenaco <neo@nenaco.de>
+ * SPDX-FileCopyrightText: 2016 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mrf24j40/mrf24j40_internal.c
+++ b/drivers/mrf24j40/mrf24j40_internal.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Neo Nenaco <neo@nenaco.de>
- * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Neo Nenaco <neo@nenaco.de>
+ * SPDX-FileCopyrightText: 2017 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mtd/mtd-vfs.c
+++ b/drivers/mtd/mtd-vfs.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #if MODULE_VFS

--- a/drivers/mtd/mtd.c
+++ b/drivers/mtd/mtd.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016  OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mtd_emulated/mtd_emulated.c
+++ b/drivers/mtd_emulated/mtd_emulated.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include <errno.h>

--- a/drivers/mtd_flashpage/mtd_flashpage.c
+++ b/drivers/mtd_flashpage/mtd_flashpage.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mtd_mapper/mtd_mapper.c
+++ b/drivers/mtd_mapper/mtd_mapper.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mtd_mci/mtd_mci.c
+++ b/drivers/mtd_mci/mtd_mci.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2020 Beuth Hochschule für Technik Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2020 Beuth Hochschule für Technik Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mtd_sdcard/Kconfig
+++ b/drivers/mtd_sdcard/Kconfig
@@ -1,10 +1,7 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#               2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universitaet Berlin
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
+
 menu "MTD_SDCARD driver"
     depends on USEMODULE_MTD_SDCARD
 

--- a/drivers/mtd_sdcard/mtd_sdcard.c
+++ b/drivers/mtd_sdcard/mtd_sdcard.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 HAW-Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 HAW-Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mtd_sdmmc/Kconfig
+++ b/drivers/mtd_sdmmc/Kconfig
@@ -1,11 +1,8 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#               2020 HAW Hamburg
-#               2023 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universitaet Berlin
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-FileCopyrightText: 2023 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
+
 menu "MTD_SDMMC driver"
     depends on USEMODULE_MTD_SDMMC
 

--- a/drivers/mtd_sdmmc/mtd_sdmmc.c
+++ b/drivers/mtd_sdmmc/mtd_sdmmc.c
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2017 HAW-Hamburg
- *               2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *               2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/mtd_spi_nor/mtd_spi_nor_configs.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor_configs.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/my9221/include/my9221_internal.h
+++ b/drivers/my9221/include/my9221_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/my9221/my9221.c
+++ b/drivers/my9221/my9221.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ncv7356/ncv7356.c
+++ b/drivers/ncv7356/ncv7356.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2018  OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2018 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/netdev/Kconfig
+++ b/drivers/netdev/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2022 Otto-von-Guericke-Universität Magdeburg
-#               2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2022 Otto-von-Guericke-Universität Magdeburg
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_NETDEV
 

--- a/drivers/netdev/eth.c
+++ b/drivers/netdev/eth.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/netdev/ieee802154.c
+++ b/drivers/netdev/ieee802154.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/netdev/layer.c
+++ b/drivers/netdev/layer.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include "net/netdev.h"

--- a/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
+++ b/drivers/netdev_ieee802154_submac/netdev_ieee802154_submac.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/nrf24l01p/include/nrf24l01p_settings.h
+++ b/drivers/nrf24l01p/include/nrf24l01p_settings.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Hamburg University of Applied Sciences
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Hamburg University of Applied Sciences
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Hamburg University of Applied Sciences
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Hamburg University of Applied Sciences
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/nrf24l01p_ng/diagnostics.c
+++ b/drivers/nrf24l01p_ng/diagnostics.c
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup drivers_nrf24l01p_ng
  * @{

--- a/drivers/nrf24l01p_ng/gnrc_netif_nrf24l01p_ng.c
+++ b/drivers/nrf24l01p_ng/gnrc_netif_nrf24l01p_ng.c
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup drivers_nrf24l01p_ng
  * @{

--- a/drivers/nrf24l01p_ng/include/gnrc_netif_nrf24l01p_ng.h
+++ b/drivers/nrf24l01p_ng/include/gnrc_netif_nrf24l01p_ng.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/nrf24l01p_ng/include/nrf24l01p_ng_communication.h
+++ b/drivers/nrf24l01p_ng/include/nrf24l01p_ng_communication.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/nrf24l01p_ng/include/nrf24l01p_ng_constants.h
+++ b/drivers/nrf24l01p_ng/include/nrf24l01p_ng_constants.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/nrf24l01p_ng/include/nrf24l01p_ng_diagnostics.h
+++ b/drivers/nrf24l01p_ng/include/nrf24l01p_ng_diagnostics.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/nrf24l01p_ng/include/nrf24l01p_ng_netdev.h
+++ b/drivers/nrf24l01p_ng/include/nrf24l01p_ng_netdev.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/nrf24l01p_ng/include/nrf24l01p_ng_params.h
+++ b/drivers/nrf24l01p_ng/include/nrf24l01p_ng_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/nrf24l01p_ng/include/nrf24l01p_ng_registers.h
+++ b/drivers/nrf24l01p_ng/include/nrf24l01p_ng_registers.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/nrf24l01p_ng/include/nrf24l01p_ng_states.h
+++ b/drivers/nrf24l01p_ng/include/nrf24l01p_ng_states.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/nrf24l01p_ng/include/nrf24l01p_ng_types.h
+++ b/drivers/nrf24l01p_ng/include/nrf24l01p_ng_types.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/nrf24l01p_ng/nrf24l01p_ng.c
+++ b/drivers/nrf24l01p_ng/nrf24l01p_ng.c
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup drivers_nrf24l01p_ng
  * @{

--- a/drivers/nrf24l01p_ng/nrf24l01p_ng_communication.c
+++ b/drivers/nrf24l01p_ng/nrf24l01p_ng_communication.c
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup drivers_nrf24l01p_ng
  * @{

--- a/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
+++ b/drivers/nrf24l01p_ng/nrf24l01p_ng_netdev.c
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup drivers_nrf24l01p_ng
  * @{

--- a/drivers/nrf24l01p_ng/nrf24l01p_ng_states.c
+++ b/drivers/nrf24l01p_ng/nrf24l01p_ng_states.c
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup drivers_nrf24l01p_ng
  * @{

--- a/drivers/nvram/nvram-vfs.c
+++ b/drivers/nvram/nvram-vfs.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #if MODULE_VFS

--- a/drivers/nvram_spi/nvram-spi.c
+++ b/drivers/nvram_spi/nvram-spi.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Eistec AB
- *               2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2015 Eistec AB
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include <stdint.h>

--- a/drivers/opt3001/Kconfig
+++ b/drivers/opt3001/Kconfig
@@ -1,10 +1,6 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#               2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universitaet Berlin
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "OPT3001 driver"
     depends on USEMODULE_OPT3001

--- a/drivers/opt3001/include/opt3001_params.h
+++ b/drivers/opt3001/include/opt3001_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/opt3001/include/opt3001_regs.h
+++ b/drivers/opt3001/include/opt3001_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/opt3001/opt3001.c
+++ b/drivers/opt3001/opt3001.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/opt3001/opt3001_saul.c
+++ b/drivers/opt3001/opt3001_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR attempts to convert all license headers for all folders inside the `drivers/` directory starting with the letters J to O. Vendor specific files are left untouched as well as some files missing some copyright or license information.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
To check for correct license/copyright information in all c and h files that are not vendor provided, use this command:

`reuse lint -l | grep "^drivers/" | grep -E '\.(c|h):' | grep -v "/vendor/"`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
This PR splits up #21516 and therefore closes it 
Tracking #21515 
