### PR TITLE
drivers/[s-z]*: change license headers to SPDX format

### DIFF
--- a/drivers/saul/adc_saul.c
+++ b/drivers/saul/adc_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/bat_voltage_saul.c
+++ b/drivers/saul/bat_voltage_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/gpio_saul.c
+++ b/drivers/saul/gpio_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_abp2.c
+++ b/drivers/saul/init_devs/auto_init_abp2.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 CNRS, France
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 CNRS, France
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_ad7746.c
+++ b/drivers/saul/init_devs/auto_init_ad7746.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_adcxx1c.c
+++ b/drivers/saul/init_devs/auto_init_adcxx1c.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_adxl345.c
+++ b/drivers/saul/init_devs/auto_init_adxl345.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_apds99xx.c
+++ b/drivers/saul/init_devs/auto_init_apds99xx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_bme680.c
+++ b/drivers/saul/init_devs/auto_init_bme680.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_bmp180.c
+++ b/drivers/saul/init_devs/auto_init_bmp180.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_bmx055.c
+++ b/drivers/saul/init_devs/auto_init_bmx055.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_bmx280.c
+++ b/drivers/saul/init_devs/auto_init_bmx280.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Kees Bakker, SODAQ
- *               2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kees Bakker, SODAQ
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_ccs811.c
+++ b/drivers/saul/init_devs/auto_init_ccs811.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_dht.c
+++ b/drivers/saul/init_devs/auto_init_dht.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_ds18.c
+++ b/drivers/saul/init_devs/auto_init_ds18.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Frits Kuipers
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Frits Kuipers
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_ds75lx.c
+++ b/drivers/saul/init_devs/auto_init_ds75lx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_efm32_coretemp.c
+++ b/drivers/saul/init_devs/auto_init_efm32_coretemp.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2020 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2020 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_fxos8700.c
+++ b/drivers/saul/init_devs/auto_init_fxos8700.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2018 UC Berkeley
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2018 UC Berkeley
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_gp2y10xx.c
+++ b/drivers/saul/init_devs/auto_init_gp2y10xx.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2020 Locha Inc
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2020 Locha Inc
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_grove_ledbar.c
+++ b/drivers/saul/init_devs/auto_init_grove_ledbar.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_hdc1000.c
+++ b/drivers/saul/init_devs/auto_init_hdc1000.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_hm330x.c
+++ b/drivers/saul/init_devs/auto_init_hm330x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_hmc5883l.c
+++ b/drivers/saul/init_devs/auto_init_hmc5883l.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_hsc.c
+++ b/drivers/saul/init_devs/auto_init_hsc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Deutsches Zentrum für Luft- und Raumfahrt e.V. (DLR)
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Deutsches Zentrum für Luft- und Raumfahrt e.V. (DLR)
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_hts221.c
+++ b/drivers/saul/init_devs/auto_init_hts221.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_ina2xx.c
+++ b/drivers/saul/init_devs/auto_init_ina2xx.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_ina3221.c
+++ b/drivers/saul/init_devs/auto_init_ina3221.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_io1_xplained.c
+++ b/drivers/saul/init_devs/auto_init_io1_xplained.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_isl29020.c
+++ b/drivers/saul/init_devs/auto_init_isl29020.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_itg320x.c
+++ b/drivers/saul/init_devs/auto_init_itg320x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_jc42.c
+++ b/drivers/saul/init_devs/auto_init_jc42.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_l3g4200d.c
+++ b/drivers/saul/init_devs/auto_init_l3g4200d.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_l3gxxxx.c
+++ b/drivers/saul/init_devs/auto_init_l3gxxxx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_lis2dh12.c
+++ b/drivers/saul/init_devs/auto_init_lis2dh12.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_lis3dh.c
+++ b/drivers/saul/init_devs/auto_init_lis3dh.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_lis3mdl.c
+++ b/drivers/saul/init_devs/auto_init_lis3mdl.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_lm75.c
+++ b/drivers/saul/init_devs/auto_init_lm75.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_lpsxxx.c
+++ b/drivers/saul/init_devs/auto_init_lpsxxx.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_lsm303dlhc.c
+++ b/drivers/saul/init_devs/auto_init_lsm303dlhc.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_lsm6dsxx.c
+++ b/drivers/saul/init_devs/auto_init_lsm6dsxx.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_ltc4150.c
+++ b/drivers/saul/init_devs/auto_init_ltc4150.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_mag3110.c
+++ b/drivers/saul/init_devs/auto_init_mag3110.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_max31855.c
+++ b/drivers/saul/init_devs/auto_init_max31855.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2024 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2024 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_max31865.c
+++ b/drivers/saul/init_devs/auto_init_max31865.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 David Picard
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 David Picard
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_mcp23x17.c
+++ b/drivers/saul/init_devs/auto_init_mcp23x17.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_mcp47xx.c
+++ b/drivers/saul/init_devs/auto_init_mcp47xx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_mhz19.c
+++ b/drivers/saul/init_devs/auto_init_mhz19.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_mma7660.c
+++ b/drivers/saul/init_devs/auto_init_mma7660.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_mma8x5x.c
+++ b/drivers/saul/init_devs/auto_init_mma8x5x.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_mpl3115a2.c
+++ b/drivers/saul/init_devs/auto_init_mpl3115a2.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_mpu9x50.c
+++ b/drivers/saul/init_devs/auto_init_mpu9x50.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_opt3001.c
+++ b/drivers/saul/init_devs/auto_init_opt3001.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_pca9685.c
+++ b/drivers/saul/init_devs/auto_init_pca9685.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_pcf857x.c
+++ b/drivers/saul/init_devs/auto_init_pcf857x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_ph_oem.c
+++ b/drivers/saul/init_devs/auto_init_ph_oem.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2019 University of Applied Sciences Emden / Leer
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2019 University of Applied Sciences Emden / Leer
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_pir.c
+++ b/drivers/saul/init_devs/auto_init_pir.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2018 UC Berkeley
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2018 UC Berkeley
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_pulse_counter.c
+++ b/drivers/saul/init_devs/auto_init_pulse_counter.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 UC Berkeley
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 UC Berkeley
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_qmc5883l.c
+++ b/drivers/saul/init_devs/auto_init_qmc5883l.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2019 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_saul_adc.c
+++ b/drivers/saul/init_devs/auto_init_saul_adc.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_saul_bat_voltage.c
+++ b/drivers/saul/init_devs/auto_init_saul_bat_voltage.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_saul_gpio.c
+++ b/drivers/saul/init_devs/auto_init_saul_gpio.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_saul_nrf_temperature.c
+++ b/drivers/saul/init_devs/auto_init_saul_nrf_temperature.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_saul_nrf_vddh.c
+++ b/drivers/saul/init_devs/auto_init_saul_nrf_vddh.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_saul_pwm.c
+++ b/drivers/saul/init_devs/auto_init_saul_pwm.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_scd30.c
+++ b/drivers/saul/init_devs/auto_init_scd30.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2020 Puhang Ding
- *               2020 Nishchay Agrawal
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Puhang Ding
+ * SPDX-FileCopyrightText: 2020 Nishchay Agrawal
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_sdp3x.c
+++ b/drivers/saul/init_devs/auto_init_sdp3x.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2019 Dirk Ehmen
- *               2020 Nishchay Agrawal
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Dirk Ehmen
+ * SPDX-FileCopyrightText: 2020 Nishchay Agrawal
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_sds011.c
+++ b/drivers/saul/init_devs/auto_init_sds011.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2018 HAW-Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_seesaw_soil.c
+++ b/drivers/saul/init_devs/auto_init_seesaw_soil.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2020 Viktor Gal
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2020 Viktor Gal
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_sen5x.c
+++ b/drivers/saul/init_devs/auto_init_sen5x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Braunschweig Institut für Betriebssysteme und Rechnerverbund
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Braunschweig Institut für Betriebssysteme und Rechnerverbund
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_servo.c
+++ b/drivers/saul/init_devs/auto_init_servo.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_sgp30.c
+++ b/drivers/saul/init_devs/auto_init_sgp30.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_sht1x.c
+++ b/drivers/saul/init_devs/auto_init_sht1x.c
@@ -1,10 +1,6 @@
 /*
- * Copyright 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_sht2x.c
+++ b/drivers/saul/init_devs/auto_init_sht2x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Kees Bakker, SODAQ
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Kees Bakker, SODAQ
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_sht3x.c
+++ b/drivers/saul/init_devs/auto_init_sht3x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_shtcx.c
+++ b/drivers/saul/init_devs/auto_init_shtcx.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_si1133.c
+++ b/drivers/saul/init_devs/auto_init_si1133.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_si114x.c
+++ b/drivers/saul/init_devs/auto_init_si114x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017-2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017-2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_si70xx.c
+++ b/drivers/saul/init_devs/auto_init_si70xx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_sm_pwm_01c.c
+++ b/drivers/saul/init_devs/auto_init_sm_pwm_01c.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_sps30.c
+++ b/drivers/saul/init_devs/auto_init_sps30.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_tcs37727.c
+++ b/drivers/saul/init_devs/auto_init_tcs37727.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_tmp00x.c
+++ b/drivers/saul/init_devs/auto_init_tmp00x.c
@@ -1,11 +1,6 @@
 /*
- * Copyright (C) 2017 HAW Hamburg
- *               2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017,2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_tsl2561.c
+++ b/drivers/saul/init_devs/auto_init_tsl2561.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_tsl4531x.c
+++ b/drivers/saul/init_devs/auto_init_tsl4531x.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Inria
- * Copyright (C) 2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_vcnl40x0.c
+++ b/drivers/saul/init_devs/auto_init_vcnl40x0.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_veml6070.c
+++ b/drivers/saul/init_devs/auto_init_veml6070.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/init_devs/auto_init_vl6180x.c
+++ b/drivers/saul/init_devs/auto_init_vl6180x.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/drivers/saul/init_devs/auto_init_ws281x.c
+++ b/drivers/saul/init_devs/auto_init_ws281x.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2024 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2024 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/pwm_saul.c
+++ b/drivers/saul/pwm_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/saul.c
+++ b/drivers/saul/saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/saul/saul_str.c
+++ b/drivers/saul/saul_str.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *               2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/scd30/include/scd30_internal.h
+++ b/drivers/scd30/include/scd30_internal.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2020 Puhang Ding
- *               2020 Jan Schlichter
- *               2020 Nishchay Agrawal
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Puhang Ding
+ * SPDX-FileCopyrightText: 2020 Jan Schlichter
+ * SPDX-FileCopyrightText: 2020 Nishchay Agrawal
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/scd30/include/scd30_params.h
+++ b/drivers/scd30/include/scd30_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2020 Puhang Ding
- *               2020 Nishchay Agrawal
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Puhang Ding
+ * SPDX-FileCopyrightText: 2020 Nishchay Agrawal
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/scd30/scd30.c
+++ b/drivers/scd30/scd30.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2020 Puhang Ding
- *               2020 Jan Schlichter
- *               2020 Nishchay Agrawal
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Puhang Ding
+ * SPDX-FileCopyrightText: 2020 Jan Schlichter
+ * SPDX-FileCopyrightText: 2020 Nishchay Agrawal
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/scd30/scd30_saul.c
+++ b/drivers/scd30/scd30_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Technische Universität Braunschweig
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Technische Universität Braunschweig
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sdcard_spi/include/sdcard_spi_internal.h
+++ b/drivers/sdcard_spi/include/sdcard_spi_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sdcard_spi/include/sdcard_spi_params.h
+++ b/drivers/sdcard_spi/include/sdcard_spi_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sdcard_spi/sdcard_spi.c
+++ b/drivers/sdcard_spi/sdcard_spi.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sdmmc/sdmmc.c
+++ b/drivers/sdmmc/sdmmc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sdmmc/sdmmc_sdhc.c
+++ b/drivers/sdmmc/sdmmc_sdhc.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *               2023 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-FileCopyrightText: 2023 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sdp3x/include/sdp3x_params.h
+++ b/drivers/sdp3x/include/sdp3x_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2019 Dirk Ehmen
- *               2020 Nishchay Agrawal
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Dirk Ehmen
+ * SPDX-FileCopyrightText: 2020 Nishchay Agrawal
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sdp3x/sdp3x.c
+++ b/drivers/sdp3x/sdp3x.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2019 Dirk Ehmen
- *               2020 Jan Schlichter
- *               2020 Nishchay Agrawal
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Dirk Ehmen
+ * SPDX-FileCopyrightText: 2020 Jan Schlichter
+ * SPDX-FileCopyrightText: 2020 Nishchay Agrawal
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sdp3x/sdp3x_saul.c
+++ b/drivers/sdp3x/sdp3x_saul.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2019 Jan Schlichter
- *               2020 Nishchay Agrawal
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Jan Schlichter
+ * SPDX-FileCopyrightText: 2020 Nishchay Agrawal
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sds011/include/sds011_internal.h
+++ b/drivers/sds011/include/sds011_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 HAW-Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sds011/include/sds011_params.h
+++ b/drivers/sds011/include/sds011_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 HAW-Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sds011/sds011.c
+++ b/drivers/sds011/sds011.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 HAW-Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sds011/sds011_saul.c
+++ b/drivers/sds011/sds011_saul.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2018 HAW-Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/seesaw_soil/Kconfig
+++ b/drivers/seesaw_soil/Kconfig
@@ -1,10 +1,6 @@
-# Copyright (c) 2020 Viktor Gal
-#               2021 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Viktor Gal
+# SPDX-FileCopyrightText: 2021 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "SEESAW_SOIL driver"
     depends on USEMODULE_SEESAW_SOIL

--- a/drivers/seesaw_soil/include/seesaw_soil_params.h
+++ b/drivers/seesaw_soil/include/seesaw_soil_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Viktor Gal
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Viktor Gal
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/seesaw_soil/include/seesaw_soil_regs.h
+++ b/drivers/seesaw_soil/include/seesaw_soil_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Viktor Gal
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Viktor Gal
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/seesaw_soil/seesaw_soil.c
+++ b/drivers/seesaw_soil/seesaw_soil.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2020 Viktor Gal
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2020 Viktor Gal
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/seesaw_soil/seesaw_soil_saul.c
+++ b/drivers/seesaw_soil/seesaw_soil_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Viktor Gal
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Viktor Gal
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sen5x/include/sen5x_constants.h
+++ b/drivers/sen5x/include/sen5x_constants.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Braunschweig Institut für Betriebssysteme und Rechnerverbund
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Braunschweig Institut für Betriebssysteme und Rechnerverbund
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sen5x/include/sen5x_params.h
+++ b/drivers/sen5x/include/sen5x_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Braunschweig Institut für Betriebssysteme und Rechnerverbund
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Braunschweig Institut für Betriebssysteme und Rechnerverbund
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sen5x/sen5x.c
+++ b/drivers/sen5x/sen5x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Braunschweig Institut für Betriebssysteme und Rechnerverbund
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Braunschweig Institut für Betriebssysteme und Rechnerverbund
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sen5x/sen5x_saul.c
+++ b/drivers/sen5x/sen5x_saul.c
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2023 TU Braunschweig Institut für Betriebssysteme und Rechnerverbund
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Braunschweig Institut für Betriebssysteme und Rechnerverbund
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup     drivers_sen5x
  * @{

--- a/drivers/servo/include/servo_params.h
+++ b/drivers/servo/include/servo_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/servo/pwm.c
+++ b/drivers/servo/pwm.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- * Copyright (C) 2015 Eistec AB
- * Copyright (C) 2022 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Eistec AB
+ * SPDX-FileCopyrightText: 2022 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/servo/saul.c
+++ b/drivers/servo/saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/servo/timer.c
+++ b/drivers/servo/timer.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2022 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sgp30/include/sgp30_constants.h
+++ b/drivers/sgp30/include/sgp30_constants.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sgp30/include/sgp30_params.h
+++ b/drivers/sgp30/include/sgp30_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sgp30/sgp30.c
+++ b/drivers/sgp30/sgp30.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sgp30/sgp30_saul.c
+++ b/drivers/sgp30/sgp30_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sht1x/include/sht1x_defines.h
+++ b/drivers/sht1x/include/sht1x_defines.h
@@ -1,10 +1,7 @@
 /*
- * Copyright 2009 Freie Universitaet Berlin (FUB)
- *           2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2009 Freie Universität Berlin (FUB)
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sht1x/include/sht1x_params.h
+++ b/drivers/sht1x/include/sht1x_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sht1x/sht1x.c
+++ b/drivers/sht1x/sht1x.c
@@ -1,10 +1,7 @@
 /*
- * Copyright 2009 Freie Universitaet Berlin (FUB)
- *           2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2009 Freie Universität Berlin (FUB)
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sht1x/sht1x_saul.c
+++ b/drivers/sht1x/sht1x_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sht2x/Kconfig
+++ b/drivers/sht2x/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_SHT2X
 

--- a/drivers/sht2x/include/sht2x_params.h
+++ b/drivers/sht2x/include/sht2x_params.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2016,2017,2018 Kees Bakker, SODAQ
- * Copyright (C) 2017 George Psimenos
- * Copyright (C) 2018 Steffen Robertz
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2018 Kees Bakker, SODAQ
+ * SPDX-FileCopyrightText: 2017 George Psimenos
+ * SPDX-FileCopyrightText: 2018 Steffen Robertz
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sht2x/sht2x.c
+++ b/drivers/sht2x/sht2x.c
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2016,2017,2018 Kees Bakker, SODAQ
- *               2017 George Psimenos
- *               2018 Steffen Robertz
- *               2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2018 Kees Bakker, SODAQ
+ * SPDX-FileCopyrightText: 2017 George Psimenos
+ * SPDX-FileCopyrightText: 2018 Steffen Robertz
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sht2x/sht2x_saul.c
+++ b/drivers/sht2x/sht2x_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Kees Bakker, SODAQ
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Kees Bakker, SODAQ
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sht3x/include/sht3x_params.h
+++ b/drivers/sht3x/include/sht3x_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sht3x/sht3x.c
+++ b/drivers/sht3x/sht3x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sht3x/sht3x_saul.c
+++ b/drivers/sht3x/sht3x_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/shtcx/shtcx.c
+++ b/drivers/shtcx/shtcx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 RWTH-Aachen
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 RWTH Aachen
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/shtcx/shtcx_saul.c
+++ b/drivers/shtcx/shtcx_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/si1133/include/si1133_internals.h
+++ b/drivers/si1133/include/si1133_internals.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/si1133/include/si1133_params.h
+++ b/drivers/si1133/include/si1133_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/si1133/si1133.c
+++ b/drivers/si1133/si1133.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/si1133/si1133_saul.c
+++ b/drivers/si1133/si1133_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 iosabi
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 iosabi
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/si114x/include/si114x_internals.h
+++ b/drivers/si114x/include/si114x_internals.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/si114x/include/si114x_params.h
+++ b/drivers/si114x/include/si114x_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/si114x/si114x.c
+++ b/drivers/si114x/si114x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/si114x/si114x_saul.c
+++ b/drivers/si114x/si114x_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/si70xx/include/si70xx_internals.h
+++ b/drivers/si70xx/include/si70xx_internals.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/si70xx/include/si70xx_params.h
+++ b/drivers/si70xx/include/si70xx_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Inria
- *               2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/si70xx/si70xx.c
+++ b/drivers/si70xx/si70xx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/si70xx/si70xx_saul.c
+++ b/drivers/si70xx/si70xx_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/slipdev/Kconfig
+++ b/drivers/slipdev/Kconfig
@@ -1,10 +1,6 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#               2021 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+# SPDX-FileCopyrightText: 2021 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "SLIPDEV driver"
     depends on USEMODULE_SLIPDEV

--- a/drivers/slipdev/include/slipdev_internal.h
+++ b/drivers/slipdev/include/slipdev_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/slipdev/include/slipdev_params.h
+++ b/drivers/slipdev/include/slipdev_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018-2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/slipdev/stdio.c
+++ b/drivers/slipdev/stdio.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sm_pwm_01c/include/sm_pwm_01c_params.h
+++ b/drivers/sm_pwm_01c/include/sm_pwm_01c_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sm_pwm_01c/sm_pwm_01c.c
+++ b/drivers/sm_pwm_01c/sm_pwm_01c.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sm_pwm_01c/sm_pwm_01c_saul.c
+++ b/drivers/sm_pwm_01c/sm_pwm_01c_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/soft_spi/include/soft_spi_params.h
+++ b/drivers/soft_spi/include/soft_spi_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Hamburg University of Applied Sciences
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Hamburg University of Applied Sciences
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/soft_spi/soft_spi.c
+++ b/drivers/soft_spi/soft_spi.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Hamburg University of Applied Sciences
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Hamburg University of Applied Sciences
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/soft_uart/include/soft_uart_params.h
+++ b/drivers/soft_uart/include/soft_uart_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/soft_uart/soft_uart.c
+++ b/drivers/soft_uart/soft_uart.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sps30/Kconfig
+++ b/drivers/sps30/Kconfig
@@ -1,10 +1,6 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#               2021 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+# SPDX-FileCopyrightText: 2021 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "SPS30 driver"
     depends on USEMODULE_SPS30

--- a/drivers/sps30/include/sps30_params.h
+++ b/drivers/sps30/include/sps30_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sps30/sps30.c
+++ b/drivers/sps30/sps30.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Michel Rottleuthner
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Michel Rottleuthner
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sps30/sps30_saul.c
+++ b/drivers/sps30/sps30_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/srf02/srf02.c
+++ b/drivers/srf02/srf02.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2013 Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
- *               2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2013 Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/srf04/include/srf04_params.h
+++ b/drivers/srf04/include/srf04_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/srf04/srf04.c
+++ b/drivers/srf04/srf04.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/srf08/include/srf08_params.h
+++ b/drivers/srf08/include/srf08_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/srf08/srf08.c
+++ b/drivers/srf08/srf08.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2013 Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/st77xx/Kconfig
+++ b/drivers/st77xx/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource "Kconfig.st7735"
 rsource "Kconfig.st7789"

--- a/drivers/st77xx/Kconfig.st7735
+++ b/drivers/st77xx/Kconfig.st7735
@@ -1,9 +1,5 @@
-# Copyright (c) 2023 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2023 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_ST77XX
 

--- a/drivers/st77xx/Kconfig.st7789
+++ b/drivers/st77xx/Kconfig.st7789
@@ -1,9 +1,5 @@
-# Copyright (c) 2023 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2023 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_ST77XX
 

--- a/drivers/st77xx/Kconfig.st7796
+++ b/drivers/st77xx/Kconfig.st7796
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_ST77XX
 

--- a/drivers/st77xx/include/st7735.h
+++ b/drivers/st77xx/include/st7735.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2018 Koen Zandberg
- *               2021 Francisco Molina
- *               2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-FileCopyrightText: 2021 Francisco Molina
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/st77xx/include/st7735_internal.h
+++ b/drivers/st77xx/include/st7735_internal.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Koen Zandberg
- *               2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/st77xx/include/st7735_params.h
+++ b/drivers/st77xx/include/st7735_params.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2018 Koen Zandberg <koen@bergzand.net>
- *               2021 Francisco Molina
- *               2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg <koen@bergzand.net>
+ * SPDX-FileCopyrightText: 2021 Francisco Molina
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/st77xx/include/st7789_internal.h
+++ b/drivers/st77xx/include/st7789_internal.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Koen Zandberg
- *               2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/st77xx/include/st7796_internal.h
+++ b/drivers/st77xx/include/st7796_internal.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Koen Zandberg
- *               2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/st77xx/include/st77xx_internal.h
+++ b/drivers/st77xx/include/st77xx_internal.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Koen Zandberg
- *               2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/st77xx/include/st77xx_params.h
+++ b/drivers/st77xx/include/st77xx_params.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2018 Koen Zandberg <koen@bergzand.net>
- *               2021 Francisco Molina
- *               2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg <koen@bergzand.net>
+ * SPDX-FileCopyrightText: 2021 Francisco Molina
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/st77xx/st7735_init.c
+++ b/drivers/st77xx/st7735_init.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/st77xx/st7789_init.c
+++ b/drivers/st77xx/st7789_init.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/st77xx/st7796_init.c
+++ b/drivers/st77xx/st7796_init.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/st77xx/st77xx.c
+++ b/drivers/st77xx/st77xx.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2018 Koen Zandberg
- *               2021 Francisco Molina
- *               2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-FileCopyrightText: 2021 Francisco Molina
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/stmpe811/include/stmpe811_constants.h
+++ b/drivers/stmpe811/include/stmpe811_constants.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/stmpe811/include/stmpe811_params.h
+++ b/drivers/stmpe811/include/stmpe811_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/stmpe811/include/stmpe811_touch_dev.h
+++ b/drivers/stmpe811/include/stmpe811_touch_dev.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/stmpe811/stmpe811.c
+++ b/drivers/stmpe811/stmpe811.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/stmpe811/stmpe811_touch_dev.c
+++ b/drivers/stmpe811/stmpe811_touch_dev.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sx126x/include/sx126x_internal.h
+++ b/drivers/sx126x/include/sx126x_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sx126x/include/sx126x_netdev.h
+++ b/drivers/sx126x/include/sx126x_netdev.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sx126x/include/sx126x_params.h
+++ b/drivers/sx126x/include/sx126x_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sx126x/sx126x.c
+++ b/drivers/sx126x/sx126x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sx126x/sx126x_netdev.c
+++ b/drivers/sx126x/sx126x_netdev.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sx127x/include/sx127x_internal.h
+++ b/drivers/sx127x/include/sx127x_internal.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2016 Unwired Devices <info@unwds.com>
- *               2017 Inria Chile
- *               2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Unwired Devices <info@unwds.com>
+ * SPDX-FileCopyrightText: 2017 Inria Chile
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sx127x/include/sx127x_netdev.h
+++ b/drivers/sx127x/include/sx127x_netdev.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Inria
- *               2017 Inria Chile
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2017 Inria Chile
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sx127x/include/sx127x_params.h
+++ b/drivers/sx127x/include/sx127x_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Inria
- *               2017 Inria Chile
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2017 Inria Chile
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sx127x/include/sx127x_registers.h
+++ b/drivers/sx127x/include/sx127x_registers.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2016 Unwired Devices <info@unwds.com>
- *               2016 Inria Chile
- *               2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Unwired Devices <info@unwds.com>
+ * SPDX-FileCopyrightText: 2016 Inria Chile
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2016 Unwired Devices <info@unwds.com>
- *               2017 Inria Chile
- *               2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Unwired Devices <info@unwds.com>
+ * SPDX-FileCopyrightText: 2017 Inria Chile
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2016 Unwired Devices <info@unwds.com>
- *               2017 Inria Chile
- *               2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Unwired Devices <info@unwds.com>
+ * SPDX-FileCopyrightText: 2017 Inria Chile
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sx127x/sx127x_internal.c
+++ b/drivers/sx127x/sx127x_internal.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (c) 2016 Unwired Devices <info@unwds.com>
- *               2017 Inria Chile
- *               2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Unwired Devices <info@unwds.com>
+ * SPDX-FileCopyrightText: 2017 Inria Chile
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Fundación Inria Chile
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Fundación Inria Chile
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sx1280/include/sx1280_constants.h
+++ b/drivers/sx1280/include/sx1280_constants.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2022 Inria
- * Copyright (C) 2020-2022 Université Grenoble Alpes
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Inria
+ * SPDX-FileCopyrightText: 2020-2022 Université Grenoble Alpes
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sx1280/include/sx1280_netdev.h
+++ b/drivers/sx1280/include/sx1280_netdev.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2022 Inria
- * Copyright (C) 2020-2022 Université Grenoble Alpes
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Inria
+ * SPDX-FileCopyrightText: 2020-2022 Université Grenoble Alpes
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sx1280/include/sx1280_params.h
+++ b/drivers/sx1280/include/sx1280_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2022 Inria
- * Copyright (C) 2020-2022 Université Grenoble Alpes
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Inria
+ * SPDX-FileCopyrightText: 2020-2022 Université Grenoble Alpes
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/sx1280/sx1280.c
+++ b/drivers/sx1280/sx1280.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2022 Inria
- * Copyright (C) 2020-2022 Université Grenoble Alpes
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Inria
+ * SPDX-FileCopyrightText: 2020-2022 Université Grenoble Alpes
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/sx1280/sx1280_netdev.c
+++ b/drivers/sx1280/sx1280_netdev.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2022 Inria
- * Copyright (C) 2020-2022 Université Grenoble Alpes
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Inria
+ * SPDX-FileCopyrightText: 2020-2022 Université Grenoble Alpes
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/tcs37727/Kconfig
+++ b/drivers/tcs37727/Kconfig
@@ -1,10 +1,6 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#               2021 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+# SPDX-FileCopyrightText: 2021 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "TCS37727 driver"
     depends on USEMODULE_TCS37727

--- a/drivers/tcs37727/include/tcs37727-internal.h
+++ b/drivers/tcs37727/include/tcs37727-internal.h
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2015 PHYTEC Messtechnik GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2015 PHYTEC Messtechnik GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/tcs37727/include/tcs37727_params.h
+++ b/drivers/tcs37727/include/tcs37727_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/tcs37727/tcs37727.c
+++ b/drivers/tcs37727/tcs37727.c
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2015 PHYTEC Messtechnik GmbH
- *               2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2015 PHYTEC Messtechnik GmbH
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/tcs37727/tcs37727_saul.c
+++ b/drivers/tcs37727/tcs37727_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/tja1042/tja1042.c
+++ b/drivers/tja1042/tja1042.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2018  OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2018 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/tm1637/include/tm1637_params.h
+++ b/drivers/tm1637/include/tm1637_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 Nico Behrens <nifrabe@outlook.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 Nico Behrens <nifrabe@outlook.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/tm1637/tm1637.c
+++ b/drivers/tm1637/tm1637.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 Nico Behrens <nifrabe@outlook.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 Nico Behrens <nifrabe@outlook.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/tmp00x/Kconfig
+++ b/drivers/tmp00x/Kconfig
@@ -1,10 +1,6 @@
-# Copyright (c) 2020 Freie Universitaet Berlin
-#               2021 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+# SPDX-FileCopyrightText: 2021 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "TMP00X driver"
     depends on USEMODULE_TMP00X

--- a/drivers/tmp00x/include/tmp00x_params.h
+++ b/drivers/tmp00x/include/tmp00x_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 - 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017-2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/tmp00x/include/tmp00x_regs.h
+++ b/drivers/tmp00x/include/tmp00x_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 - 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017-2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/tmp00x/tmp00x.c
+++ b/drivers/tmp00x/tmp00x.c
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2014 PHYTEC Messtechnik GmbH
- *               2017 - 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2014 PHYTEC Messtechnik GmbH
+ * SPDX-FileCopyrightText: 2017-2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/tmp00x/tmp00x_saul.c
+++ b/drivers/tmp00x/tmp00x_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 - 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017-2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/touch_dev/touch_dev.c
+++ b/drivers/touch_dev/touch_dev.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/touch_dev_gestures/Kconfig
+++ b/drivers/touch_dev_gestures/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2023 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2023 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_TOUCH_DEV_GESTURES
 

--- a/drivers/touch_dev_gestures/touch_dev_gestures.c
+++ b/drivers/touch_dev_gestures/touch_dev_gestures.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/tps6274x/include/tps6274x_params.h
+++ b/drivers/tps6274x/include/tps6274x_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/tps6274x/tps6274x.c
+++ b/drivers/tps6274x/tps6274x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 RWTH Aachen
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 RWTH Aachen
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/tsl2561/include/tsl2561_internals.h
+++ b/drivers/tsl2561/include/tsl2561_internals.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/tsl2561/include/tsl2561_params.h
+++ b/drivers/tsl2561/include/tsl2561_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/tsl2561/tsl2561.c
+++ b/drivers/tsl2561/tsl2561.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/tsl2561/tsl2561_saul.c
+++ b/drivers/tsl2561/tsl2561_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/tsl4531x/include/tsl4531x_internals.h
+++ b/drivers/tsl4531x/include/tsl4531x_internals.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Inria
- * Copyright (C) 2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/tsl4531x/include/tsl4531x_params.h
+++ b/drivers/tsl4531x/include/tsl4531x_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 Inria
- * Copyright (C) 2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/tsl4531x/tsl4531x.c
+++ b/drivers/tsl4531x/tsl4531x.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Inria
- * Copyright (C) 2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/tsl4531x/tsl4531x_saul.c
+++ b/drivers/tsl4531x/tsl4531x_saul.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Inria
- * Copyright (C) 2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Inria
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/uart_half_duplex/include/uart_half_duplex.h
+++ b/drivers/uart_half_duplex/include/uart_half_duplex.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/uart_half_duplex/uart_half_duplex.c
+++ b/drivers/uart_half_duplex/uart_half_duplex.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/usbdev_mock/usbdev_mock.c
+++ b/drivers/usbdev_mock/usbdev_mock.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
+++ b/drivers/usbdev_synopsys_dwc2/usbdev_synopsys_dwc2.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *               2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/vcnl40x0/include/vcnl40x0_internals.h
+++ b/drivers/vcnl40x0/include/vcnl40x0_internals.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/vcnl40x0/include/vcnl40x0_params.h
+++ b/drivers/vcnl40x0/include/vcnl40x0_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/vcnl40x0/vcnl40x0.c
+++ b/drivers/vcnl40x0/vcnl40x0.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/vcnl40x0/vcnl40x0_saul.c
+++ b/drivers/vcnl40x0/vcnl40x0_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/veml6070/include/veml6070_params.h
+++ b/drivers/veml6070/include/veml6070_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/veml6070/veml6070.c
+++ b/drivers/veml6070/veml6070.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/veml6070/veml6070_saul.c
+++ b/drivers/veml6070/veml6070_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/vl6180x/Kconfig
+++ b/drivers/vl6180x/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Gunar Schorcht
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Gunar Schorcht
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_VL6180X
 

--- a/drivers/vl6180x/include/vl6180x_params.h
+++ b/drivers/vl6180x/include/vl6180x_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/vl6180x/include/vl6180x_regs.h
+++ b/drivers/vl6180x/include/vl6180x_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/vl6180x/vl6180x.c
+++ b/drivers/vl6180x/vl6180x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/vl6180x/vl6180x_saul.c
+++ b/drivers/vl6180x/vl6180x_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/w5100/include/w5100_params.h
+++ b/drivers/w5100/include/w5100_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/w5100/include/w5100_regs.h
+++ b/drivers/w5100/include/w5100_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/w5100/w5100.c
+++ b/drivers/w5100/w5100.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/w5500/include/w5500_params.h
+++ b/drivers/w5500/include/w5500_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Stefan Schmidt
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Stefan Schmidt
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/w5500/include/w5500_regs.h
+++ b/drivers/w5500/include/w5500_regs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Stefan Schmidt
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Stefan Schmidt
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/w5500/w5500.c
+++ b/drivers/w5500/w5500.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Stefan Schmidt
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Stefan Schmidt
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ws281x/atmega.c
+++ b/drivers/ws281x/atmega.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2019 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ws281x/esp32.c
+++ b/drivers/ws281x/esp32.c
@@ -1,10 +1,7 @@
 /*
- * Copyright 2020 Christian Friedrich Coors
- *           2023 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Christian Friedrich Coors
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ws281x/include/ws281x_backend.h
+++ b/drivers/ws281x/include/ws281x_backend.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ws281x/include/ws281x_constants.h
+++ b/drivers/ws281x/include/ws281x_constants.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ws281x/include/ws281x_params.h
+++ b/drivers/ws281x/include/ws281x_params.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/ws281x/timer_gpio_ll.c
+++ b/drivers/ws281x/timer_gpio_ll.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2023 Christian Amsüss
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Christian Amsüss
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ws281x/vt100.c
+++ b/drivers/ws281x/vt100.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2019 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ws281x/ws281x.c
+++ b/drivers/ws281x/ws281x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2019 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/ws281x/ws281x_saul.c
+++ b/drivers/ws281x/ws281x_saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/xbee/gnrc_xbee.c
+++ b/drivers/xbee/gnrc_xbee.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-17 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/drivers/xbee/include/gnrc_netif_xbee.h
+++ b/drivers/xbee/include/gnrc_netif_xbee.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/xbee/include/xbee_params.h
+++ b/drivers/xbee/include/xbee_params.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- *               2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 INRIA
- * Copyright (C) 2015-2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 INRIA
+ * SPDX-FileCopyrightText: 2015-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR attempts to convert all license headers for all folders inside the `drivers/` directory starting with the letters S to Z. Vendor specific files are left untouched as well as some files missing some copyright or license information.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
To check for correct license/copyright information in all c and h files that are not vendor provided, use this command:

`reuse lint -l | grep "^drivers/" | grep -E '\.(c|h):' | grep -v "/vendor/"`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
This PR splits up #21516 and therefore closes it 
Tracking #21515 
