### PR TITLE
core/init: don't call vfs_bind_stdio() in early init

### DIFF
--- a/core/lib/init.c
+++ b/core/lib/init.c
@@ -49,6 +49,10 @@ static void *main_trampoline(void *arg)
 {
     (void)arg;
 
+#if MODULE_VFS
+    vfs_bind_stdio();
+#endif
+
     if (IS_USED(MODULE_AUTO_INIT)) {
         auto_init();
     }
@@ -133,8 +137,4 @@ void early_init(void)
     }
 
     stdio_init();
-
-#if MODULE_VFS
-    vfs_bind_stdio();
-#endif
 }

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -109,7 +109,7 @@ bool mutex_lock_internal(mutex_t *mutex, bool block)
 #if IS_USED(MODULE_CORE_MUTEX_PRIORITY_INHERITANCE) \
         || IS_USED(MODULE_CORE_MUTEX_DEBUG)
         thread_t *me = thread_get_active();
-        mutex->owner = me->pid;
+        mutex->owner = me ? me->pid : KERNEL_PID_UNDEF;
 #endif
 #if IS_USED(MODULE_CORE_MUTEX_DEBUG)
         mutex->owner_calling_pc = pc;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

When `core_mutex_debug` is enabled, `mutex_lock_internal()` will store the PID of the locking thread. This causes `vfs_bind_stdio()` to fail as it now dereferences a NULL pointer in early init.

But we don't need to bind VFS in early init at all, we can do it later when threads are enabled.

Still `mutex_lock()` works outside thread mode (e.g. in interrupts) without `core_mutex_debug`, so enabling that module should not change the behavior.

So set the mutex owner to `KERNEL_PID_UNDEF` when no thread is active. 


### Testing procedure

`examples/basic/filesystem` still works with `core_mutex_debug` or `core_mutex_priority_inheritance`.


### Issues/PRs references

reported in the forum

https://forum.riot-os.org/t/solve-problem-with-mutex-debug-in-early-init/4831
