### PR TITLE
boards/nucleo-h753zi: add pinout to documentation

### DIFF
--- a/boards/nucleo-h753zi/doc.md
+++ b/boards/nucleo-h753zi/doc.md
@@ -9,7 +9,7 @@ STM32H753ZI microcontroller with 1 MiB of RAM and 2 MiB of Flash.
 
 ## Pinout
 
-"Pinout for the Nucleo-H753ZI (from STM user manual, UM2607, https://www.st.com/resource/en/user_manual/um2407-stm32h7-nucleo144-boards-mb1364-stmicroelectronics.pdf, page 38)"
+@image html pinouts/nucleo-h753zi.svg "Pinout for the Nucleo-H753ZI (from STM user manual UM2407, https://www.st.com/resource/en/user_manual/um2407-stm32h7-nucleo144-boards-mb1364-stmicroelectronics.pdf, page 38)" width=50%
 
 ### MCU
 

--- a/doc/doxygen/src/pinouts/nucleo-h753zi.svg
+++ b/doc/doxygen/src/pinouts/nucleo-h753zi.svg
@@ -1,0 +1,7128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   width="402.89999"
+   height="396.849"
+   viewBox="0 0 402.89999 396.849"
+   sodipodi:docname="nucleo-h753zi.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path1" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath2">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path2" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path3" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path4" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path6" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path7" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path8" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path9" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath10">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path10" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath11">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path11" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath12">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path12" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath13">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path13" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath14">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path14" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath15">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path15" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath16">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path16" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath17">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path17" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path18" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath19">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path19" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath20">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path20" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath21">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path21" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath22">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path22" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath23">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path23" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath24">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path24" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath25">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path25" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath26">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path26" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath27">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path27" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath28">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path28" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath29">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path29" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath30">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path30" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath31">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path31" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath32">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path32" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath33">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path33" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath34">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path34" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath35">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path35" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath36">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path36" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath37">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path37" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath38">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path38" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath39">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path39" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath40">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path40" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath41">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path41" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath42">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path42" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath43">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path43" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath44">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path44" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath45">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path45" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath46">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path46" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath47">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path47" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath48">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path48" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath49">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path49" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath50">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path50" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath51">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path51" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath52">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path52" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath53">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path53" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath54">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path54" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath55">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path55" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath56">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path56" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath57">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path57" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath58">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path58" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath59">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path59" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath60">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path60" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath61">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path61" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath62">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path62" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath63">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path63" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath64">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path64" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath65">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path65" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath66">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path66" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath67">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path67" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath68">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path68" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath69">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path69" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath70">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path70" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath71">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path71" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath72">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path72" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath73">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path73" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath74">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path74" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath75">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path75" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath76">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path76" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath77">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path77" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath78">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path78" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath79">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path79" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath80">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path80" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath81">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path81" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath82">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path82" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath83">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path83" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath84">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path84" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath85">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path85" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath86">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path86" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath87">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path87" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath88">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path88" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath89">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path89" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath90">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path90" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath91">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path91" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath92">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path92" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath93">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path93" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath94">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path94" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath95">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path95" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath96">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path96" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath97">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path97" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath98">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path98" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath99">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path99" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath100">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path100" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath101">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path101" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath102">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path102" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath103">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path103" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath104">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path104" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath105">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path105" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath106">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path106" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath107">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path107" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath108">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path108" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath109">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path109" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath110">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path110" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath111">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path111" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath112">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path112" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath113">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path113" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath114">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path114" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath115">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path115" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath116">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path116" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath117">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path117" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath118">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path118" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath119">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path119" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath120">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path120" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath121">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path121" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath122">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path122" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath123">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path123" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath124">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path124" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath125">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path125" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath126">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path126" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath127">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path127" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath128">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path128" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath129">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path129" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath130">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path130" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath131">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path131" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath132">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path132" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath133">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path133" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath134">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path134" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath135">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path135" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath136">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path136" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath137">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path137" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath138">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path138" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath139">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path139" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath140">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path140" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath141">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path141" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath142">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path142" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath143">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path143" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath144">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path144" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath145">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path145" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath146">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path146" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath147">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path147" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath148">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path148" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath149">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path149" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath150">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path150" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath151">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path151" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath152">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path152" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath153">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path153" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath154">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path154" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath155">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path155" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath156">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path156" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath157">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path157" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath158">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path158" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath159">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path159" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath160">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path160" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath161">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path161" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath162">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path162" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath163">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path163" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath164">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path164" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath165">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path165" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath166">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path166" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath167">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path167" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath168">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path168" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath169">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path169" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath170">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path170" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath171">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path171" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath172">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path172" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath173">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path173" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath174">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path174" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath175">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path175" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath176">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path176" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath177">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path177" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath178">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path178" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath179">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path179" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath180">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path180" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath181">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path181" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath182">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path182" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath183">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path183" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath184">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path184" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath185">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path185" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath186">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path186" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath187">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path187" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath188">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path188" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath189">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path189" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath190">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path190" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath191">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path191" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath192">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path192" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath193">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path193" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath194">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path194" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath195">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path195" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath196">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path196" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath197">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path197" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath198">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path198" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath199">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path199" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath200">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path200" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath201">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path201" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath202">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path202" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath203">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path203" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath204">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path204" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath205">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path205" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath206">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path206" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath207">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path207" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath208">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path208" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath209">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path209" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath210">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path210" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath211">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path211" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath212">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path212" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath213">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path213" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath214">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path214" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath215">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path215" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath216">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path216" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath217">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path217" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath218">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path218" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath219">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path219" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath220">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path220" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath221">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path221" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath222">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path222" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath223">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path223" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath224">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path224" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath225">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path225" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath226">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path226" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath227">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path227" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath228">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path228" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath229">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path229" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath230">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path230" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath231">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path231" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath232">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path232" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath233">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path233" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath234">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path234" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath235">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path235" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath236">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path236" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath237">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path237" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath238">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path238" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath239">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path239" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath240">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path240" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath241">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path241" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath242">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path242" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath243">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path243" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath244">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path244" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath245">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path245" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath246">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path246" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath247">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path247" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath248">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path248" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath249">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path249" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath250">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path250" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath251">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path251" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath252">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path252" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath253">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path253" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath254">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path254" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath255">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path255" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath256">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path256" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath257">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path257" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath258">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path258" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath259">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path259" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath260">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path260" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath261">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path261" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath262">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path262" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath263">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path263" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath264">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path264" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath265">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path265" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath266">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path266" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath267">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path267" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath268">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path268" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath269">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path269" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath270">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path270" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath271">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path271" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath272">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path272" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath273">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path273" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath274">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path274" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath275">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path275" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath276">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path276" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath277">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path277" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath278">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path278" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath279">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path279" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath280">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path280" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath281">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path281" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath282">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path282" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath283">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path283" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath284">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path284" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath285">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path285" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath286">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path286" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath287">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path287" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath288">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path288" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath289">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path289" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath290">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path290" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath291">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path291" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath292">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path292" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath293">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path293" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath294">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path294" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath295">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path295" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath296">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path296" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath297">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path297" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath298">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path298" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath299">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path299" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath300">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path300" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath301">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path301" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath302">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path302" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath303">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path303" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath304">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path304" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath305">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path305" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath306">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path306" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath307">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path307" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath308">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path308" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath309">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path309" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath310">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path310" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath311">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path311" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath312">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path312" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath313">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path313" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath314">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path314" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath315">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path315" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath316">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path316" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath317">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path317" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath318">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path318" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath319">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path319" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath320">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path320" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath321">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path321" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath322">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path322" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath323">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path323" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath324">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path324" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath325">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path325" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath326">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path326" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath327">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path327" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath328">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path328" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath329">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path329" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath330">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path330" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath331">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path331" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath332">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path332" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath333">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path333" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath334">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path334" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath335">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path335" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath336">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path336" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath337">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path337" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath338">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path338" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath339">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path339" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath340">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path340" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath341">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path341" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath342">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path342" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath343">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path343" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath344">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path344" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath345">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path345" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath346">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path346" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath347">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path347" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath348">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path348" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath349">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path349" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath350">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path350" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath351">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path351" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath352">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path352" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath353">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path353" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath354">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path354" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath355">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path355" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath356">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path356" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath357">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path357" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath358">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path358" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath359">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path359" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath360">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path360" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath361">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path361" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath362">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path362" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath363">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path363" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath364">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path364" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath365">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path365" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath366">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path366" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath367">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path367" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath368">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path368" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath369">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path369" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath370">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path370" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath371">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path371" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath372">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path372" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath373">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path373" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath374">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path374" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath375">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path375" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath376">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path376" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath377">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path377" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath378">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path378" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath379">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path379" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath380">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path380" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath381">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path381" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath382">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path382" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath383">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path383" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath384">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path384" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath385">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path385" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath386">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path386" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath387">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path387" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath388">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path388" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath389">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path389" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath390">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path390" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath391">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path391" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath392">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path392" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath393">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path393" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath394">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path394" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath395">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path395" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath396">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path396" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath397">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path397" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath398">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path398" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath399">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path399" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath400">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path400" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath401">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path401" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath402">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path402" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath403">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path403" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath404">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path404" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath405">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path405" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath406">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path406" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath407">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path407" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath408">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path408" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath409">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path409" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath410">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path410" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath411">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path411" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath412">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path412" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath413">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path413" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath414">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path414" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath415">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path415" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath416">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path416" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath417">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path417" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath418">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path418" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath419">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path419" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath420">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path420" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath421">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path421" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath422">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path422" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath423">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path423" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath424">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path424" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath425">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path425" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath426">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path426" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath427">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path427" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath428">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path428" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath429">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path429" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath430">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path430" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath431">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path431" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath432">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path432" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath433">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path433" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath434">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path434" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath435">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path435" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath436">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path436" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath437">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path437" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath438">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path438" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath439">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path439" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath440">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path440" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath441">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path441" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath442">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path442" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath443">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path443" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath444">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path444" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath445">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path445" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath446">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path446" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath447">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path447" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath448">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path448" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath449">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path449" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath450">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path450" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath451">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path451" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath452">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path452" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath453">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path453" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath454">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path454" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath455">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path455" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath456">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path456" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath457">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path457" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath458">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path458" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath459">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path459" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath460">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path460" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath461">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path461" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath462">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path462" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath463">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path463" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath464">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path464" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath465">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path465" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath466">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path466" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath467">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path467" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath468">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path468" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath469">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path469" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath470">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path470" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath471">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path471" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath472">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path472" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath473">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path473" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath474">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path474" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath475">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path475" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath476">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path476" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath477">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path477" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath478">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path478" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath479">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path479" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath480">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path480" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath481">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path481" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath482">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path482" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath483">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path483" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath484">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path484" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath485">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path485" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath486">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path486" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath487">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path487" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath488">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path488" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath489">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path489" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath490">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path490" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath491">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path491" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath492">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path492" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath493">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path493" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath494">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path494" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath495">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path495" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath496">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path496" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath497">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path497" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath498">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path498" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath499">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path499" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath500">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path500" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath501">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path501" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath502">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path502" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath503">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path503" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath504">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path504" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath505">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path505" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath506">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path506" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath507">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path507" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath508">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path508" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath509">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path509" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath510">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path510" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath511">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path511" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath512">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path512" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath513">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path513" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath514">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path514" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath515">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path515" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath516">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path516" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath517">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path517" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath518">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path518" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath519">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path519" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath520">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path520" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath521">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path521" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath522">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path522" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath523">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path523" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath524">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path524" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath525">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path525" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath526">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path526" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath527">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path527" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath528">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path528" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath529">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1,-1)"
+         id="path529" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath530">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1.3333333)"
+         id="path530" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath531">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         transform="scale(1.3333333)"
+         id="path531" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1062">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path1062" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1064">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path1064" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1066">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path1066" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1068">
+      <path
+         d="M 0,0 H 303 V 298 H 0 Z"
+         id="path1068" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="2.5878861"
+     inkscape:cx="201.51583"
+     inkscape:cy="198.4245"
+     inkscape:window-width="1792"
+     inkscape:window-height="1275"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g1">
+    <inkscape:page
+       x="0"
+       y="0"
+       inkscape:label="1"
+       id="page1"
+       width="402.89999"
+       height="396.849"
+       margin="0"
+       bleed="0" />
+  </sodipodi:namedview>
+  <g
+     id="g1"
+     inkscape:groupmode="layer"
+     inkscape:label="1">
+    <g
+       id="g1062">
+      <g
+         clip-path="url(#clipPath531)"
+         id="g1061">
+        <g
+           clip-path="url(#clipPath530)"
+           id="g1060">
+          <path
+             d="m 273.891,291.238 h 0.66 l 0.84,2.231 0.839,-2.231 h 0.661 v 3.278 h -0.434 v -2.879 l -0.844,2.25 h -0.445 l -0.848,-2.25 v 2.879 h -0.429 z m 5.714,0.106 v 0.433 c -0.167,-0.078 -0.328,-0.14 -0.476,-0.179 -0.149,-0.039 -0.293,-0.059 -0.434,-0.059 -0.242,0 -0.429,0.047 -0.558,0.141 -0.133,0.093 -0.196,0.226 -0.196,0.398 0,0.145 0.043,0.258 0.129,0.332 0.086,0.07 0.254,0.133 0.496,0.176 l 0.266,0.055 c 0.332,0.062 0.578,0.175 0.734,0.336 0.157,0.156 0.235,0.371 0.235,0.636 0,0.317 -0.106,0.559 -0.321,0.723 -0.21,0.164 -0.523,0.246 -0.933,0.246 -0.156,0 -0.32,-0.02 -0.496,-0.055 -0.176,-0.035 -0.356,-0.086 -0.543,-0.156 v -0.457 c 0.18,0.102 0.355,0.18 0.527,0.231 0.176,0.05 0.344,0.078 0.512,0.078 0.254,0 0.449,-0.051 0.586,-0.153 0.137,-0.097 0.207,-0.242 0.207,-0.425 0,-0.161 -0.051,-0.286 -0.149,-0.379 -0.101,-0.09 -0.261,-0.157 -0.488,-0.204 l -0.269,-0.05 c -0.332,-0.067 -0.571,-0.172 -0.719,-0.313 -0.149,-0.14 -0.223,-0.336 -0.223,-0.586 0,-0.289 0.102,-0.515 0.309,-0.683 0.203,-0.168 0.484,-0.25 0.844,-0.25 0.152,0 0.312,0.011 0.468,0.039 0.16,0.031 0.325,0.07 0.492,0.125 z m 0.727,0.715 h 0.43 l 0.769,2.062 0.766,-2.062 h 0.43 l -0.922,2.457 h -0.551 z m 3.602,0.64 c -0.2,0 -0.36,0.071 -0.477,0.207 -0.113,0.137 -0.172,0.321 -0.172,0.559 0,0.234 0.059,0.422 0.172,0.558 0.117,0.137 0.277,0.207 0.477,0.207 0.199,0 0.355,-0.07 0.472,-0.207 0.117,-0.136 0.176,-0.324 0.176,-0.558 0,-0.238 -0.059,-0.422 -0.176,-0.559 -0.117,-0.136 -0.273,-0.207 -0.472,-0.207 z m 0.878,-1.39 v 0.406 c -0.109,-0.055 -0.222,-0.094 -0.335,-0.121 -0.114,-0.028 -0.227,-0.043 -0.336,-0.043 -0.293,0 -0.52,0.101 -0.672,0.297 -0.157,0.199 -0.242,0.496 -0.266,0.898 0.086,-0.129 0.195,-0.226 0.324,-0.293 0.133,-0.07 0.274,-0.105 0.434,-0.105 0.328,0 0.59,0.101 0.777,0.3 0.192,0.2 0.289,0.473 0.289,0.817 0,0.336 -0.101,0.605 -0.3,0.812 -0.2,0.203 -0.461,0.305 -0.793,0.305 -0.379,0 -0.668,-0.144 -0.872,-0.437 -0.199,-0.29 -0.3,-0.711 -0.3,-1.262 0,-0.52 0.125,-0.934 0.371,-1.242 0.246,-0.309 0.574,-0.461 0.988,-0.461 0.113,0 0.223,0.011 0.336,0.031 0.117,0.023 0.234,0.055 0.355,0.098 z m 1,2.836 h 1.551 v 0.371 h -2.086 v -0.371 c 0.172,-0.176 0.399,-0.411 0.688,-0.704 0.293,-0.293 0.476,-0.48 0.551,-0.566 0.14,-0.16 0.242,-0.297 0.296,-0.406 0.059,-0.11 0.086,-0.219 0.086,-0.324 0,-0.176 -0.062,-0.317 -0.183,-0.426 -0.121,-0.114 -0.281,-0.168 -0.477,-0.168 -0.14,0 -0.289,0.027 -0.441,0.074 -0.156,0.047 -0.32,0.121 -0.496,0.219 v -0.449 c 0.179,-0.071 0.347,-0.125 0.5,-0.161 0.156,-0.039 0.297,-0.054 0.426,-0.054 0.339,0 0.613,0.082 0.816,0.254 0.199,0.168 0.301,0.398 0.301,0.679 0,0.137 -0.024,0.266 -0.078,0.387 -0.047,0.117 -0.141,0.262 -0.274,0.426 -0.035,0.043 -0.152,0.164 -0.347,0.367 -0.2,0.203 -0.473,0.488 -0.833,0.852 z m 2.196,0 h 0.726 v -2.504 l -0.789,0.16 v -0.406 l 0.785,-0.157 h 0.442 v 2.907 h 0.726 v 0.371 h -1.89 z m 2.437,0.304 v -0.402 c 0.114,0.051 0.227,0.09 0.34,0.117 0.113,0.031 0.227,0.043 0.336,0.043 0.293,0 0.516,-0.098 0.672,-0.293 0.152,-0.199 0.242,-0.496 0.266,-0.898 -0.086,0.125 -0.196,0.222 -0.325,0.289 -0.129,0.066 -0.273,0.101 -0.433,0.101 -0.328,0 -0.586,-0.097 -0.778,-0.297 -0.191,-0.199 -0.289,-0.472 -0.289,-0.816 0,-0.336 0.102,-0.605 0.301,-0.809 0.199,-0.203 0.465,-0.304 0.797,-0.304 0.379,0 0.668,0.144 0.867,0.437 0.199,0.289 0.301,0.711 0.301,1.266 0,0.515 -0.125,0.929 -0.371,1.238 -0.242,0.305 -0.574,0.461 -0.988,0.461 -0.11,0 -0.223,-0.012 -0.336,-0.035 -0.117,-0.02 -0.235,-0.055 -0.36,-0.098 z m 0.887,-1.39 c 0.199,0 0.356,-0.067 0.469,-0.204 0.117,-0.136 0.176,-0.324 0.176,-0.562 0,-0.234 -0.059,-0.422 -0.176,-0.555 -0.113,-0.14 -0.27,-0.207 -0.469,-0.207 -0.199,0 -0.359,0.067 -0.477,0.207 -0.117,0.133 -0.171,0.321 -0.171,0.555 0,0.238 0.054,0.426 0.171,0.562 0.118,0.137 0.278,0.204 0.477,0.204 z m 2.609,-0.36 c -0.199,0 -0.359,0.071 -0.476,0.207 -0.117,0.137 -0.172,0.321 -0.172,0.559 0,0.234 0.055,0.422 0.172,0.558 0.117,0.137 0.277,0.207 0.476,0.207 0.2,0 0.356,-0.07 0.469,-0.207 0.117,-0.136 0.176,-0.324 0.176,-0.558 0,-0.238 -0.059,-0.422 -0.176,-0.559 -0.113,-0.136 -0.269,-0.207 -0.469,-0.207 z m 0.879,-1.39 v 0.406 c -0.109,-0.055 -0.222,-0.094 -0.34,-0.121 -0.109,-0.028 -0.222,-0.043 -0.335,-0.043 -0.293,0 -0.516,0.101 -0.672,0.297 -0.153,0.199 -0.243,0.496 -0.262,0.898 0.086,-0.129 0.195,-0.226 0.324,-0.293 0.129,-0.07 0.274,-0.105 0.43,-0.105 0.332,0 0.59,0.101 0.781,0.3 0.192,0.2 0.289,0.473 0.289,0.817 0,0.336 -0.101,0.605 -0.301,0.812 -0.199,0.203 -0.464,0.305 -0.793,0.305 -0.382,0 -0.671,-0.144 -0.871,-0.437 -0.203,-0.29 -0.3,-0.711 -0.3,-1.262 0,-0.52 0.121,-0.934 0.367,-1.242 0.246,-0.309 0.578,-0.461 0.992,-0.461 0.109,0 0.223,0.011 0.336,0.031 0.113,0.023 0.234,0.055 0.355,0.098 z m 1.422,3.207 -1.25,-3.278 h 0.461 l 1.039,2.762 1.043,-2.762 h 0.461 l -1.25,3.278 z m 2.578,-0.371 h 1.551 v 0.371 h -2.086 v -0.371 c 0.172,-0.176 0.399,-0.411 0.688,-0.704 0.293,-0.293 0.476,-0.48 0.55,-0.566 0.141,-0.16 0.243,-0.297 0.297,-0.406 0.059,-0.11 0.086,-0.219 0.086,-0.324 0,-0.176 -0.062,-0.317 -0.183,-0.426 -0.121,-0.114 -0.282,-0.168 -0.477,-0.168 -0.141,0 -0.289,0.027 -0.441,0.074 -0.157,0.047 -0.321,0.121 -0.496,0.219 v -0.449 c 0.179,-0.071 0.347,-0.125 0.5,-0.161 0.156,-0.039 0.296,-0.054 0.425,-0.054 0.34,0 0.614,0.082 0.817,0.254 0.199,0.168 0.301,0.398 0.301,0.679 0,0.137 -0.024,0.266 -0.079,0.387 -0.046,0.117 -0.14,0.262 -0.273,0.426 -0.035,0.043 -0.152,0.164 -0.348,0.367 -0.199,0.203 -0.472,0.488 -0.832,0.852 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath1)"
+             id="path532" />
+          <path
+             d="M -0.398,-0.094 H 302.524 V -297.633 H -0.398 Z"
+             style="fill:none;stroke:#ffffff;stroke-width:0.1875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath2)"
+             id="path533" />
+          <path
+             d="m 60.879,8.281 h 178.562 c 3.52,0 6.375,2.856 6.375,6.375 v 247.399 c 0,3.519 -2.855,6.375 -6.375,6.375 H 60.879 c -3.524,0 -6.379,-2.856 -6.379,-6.375 V 14.656 c 0,-3.519 2.855,-6.375 6.379,-6.375"
+             style="fill:#dddddd;fill-opacity:1;fill-rule:evenodd;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath3)"
+             id="path534" />
+          <path
+             d="m 120.348,24.562 h 1.574 l 1.988,3.747 v -3.747 h 1.336 v 5.465 h -1.574 l -1.988,-3.75 v 3.75 h -1.336 z m 4.941,0 h 1.41 v 3.274 c 0,0.453 0.074,0.777 0.219,0.973 0.148,0.191 0.391,0.289 0.727,0.289 0.335,0 0.578,-0.098 0.722,-0.289 0.149,-0.196 0.223,-0.52 0.223,-0.973 V 24.562 H 130 v 3.274 c 0,0.773 -0.191,1.352 -0.582,1.73 -0.387,0.379 -0.98,0.567 -1.773,0.567 -0.793,0 -1.387,-0.188 -1.774,-0.567 -0.387,-0.378 -0.582,-0.957 -0.582,-1.73 z m 9.231,5.165 c -0.258,0.132 -0.528,0.234 -0.809,0.304 -0.281,0.067 -0.574,0.102 -0.879,0.102 -0.91,0 -1.633,-0.254 -2.164,-0.762 -0.531,-0.512 -0.797,-1.199 -0.797,-2.07 0,-0.875 0.266,-1.567 0.797,-2.074 0.531,-0.508 1.254,-0.766 2.164,-0.766 0.305,0 0.598,0.035 0.879,0.105 0.281,0.067 0.551,0.168 0.809,0.301 V 26 c -0.262,-0.18 -0.516,-0.309 -0.77,-0.391 -0.254,-0.086 -0.523,-0.125 -0.805,-0.125 -0.5,0 -0.898,0.161 -1.183,0.481 -0.289,0.324 -0.434,0.769 -0.434,1.336 0,0.562 0.145,1.004 0.434,1.328 0.285,0.32 0.683,0.484 1.183,0.484 0.282,0 0.551,-0.043 0.805,-0.125 0.254,-0.086 0.508,-0.215 0.77,-0.394 z m -0.368,-5.165 h 1.41 v 4.399 h 2.477 v 1.066 h -3.887 z m 3.172,0 h 3.805 v 1.063 h -2.395 v 1.02 h 2.25 v 1.066 h -2.25 v 1.25 h 2.477 v 1.066 h -3.887 z m 6.028,0.922 c -0.43,0 -0.762,0.157 -1,0.477 -0.235,0.316 -0.356,0.762 -0.356,1.34 0,0.57 0.121,1.015 0.356,1.336 0.238,0.316 0.57,0.476 1,0.476 0.433,0 0.765,-0.16 1.003,-0.476 0.239,-0.321 0.356,-0.766 0.356,-1.336 0,-0.578 -0.117,-1.024 -0.356,-1.34 -0.238,-0.32 -0.57,-0.477 -1.003,-0.477 z m 0,-1.023 c 0.878,0 1.566,0.254 2.066,0.754 0.496,0.504 0.746,1.199 0.746,2.086 0,0.883 -0.25,1.574 -0.746,2.078 -0.5,0.504 -1.188,0.754 -2.066,0.754 -0.875,0 -1.567,-0.25 -2.067,-0.754 -0.496,-0.504 -0.746,-1.195 -0.746,-2.078 0,-0.887 0.25,-1.582 0.746,-2.086 0.5,-0.5 1.192,-0.754 2.067,-0.754 z m 2.289,2.875 h 2.3 v 1.066 h -2.3 z m 2.578,-2.774 h 1.41 v 2.083 h 2.078 v -2.083 h 1.41 v 5.465 h -1.41 v -2.316 h -2.078 v 2.316 h -1.41 z m 4.547,0 h 4.117 v 0.793 l -2.129,4.672 h -1.375 l 2.019,-4.429 h -2.632 z m 5.457,4.43 h 2.406 v 1.035 h -3.973 v -1.035 l 1.996,-1.762 c 0.18,-0.16 0.313,-0.32 0.395,-0.472 0.086,-0.153 0.129,-0.313 0.129,-0.481 0,-0.254 -0.086,-0.461 -0.258,-0.617 -0.172,-0.156 -0.402,-0.234 -0.688,-0.234 -0.218,0 -0.457,0.047 -0.718,0.14 -0.262,0.094 -0.543,0.235 -0.84,0.418 v -1.199 c 0.316,-0.105 0.633,-0.183 0.941,-0.238 0.309,-0.059 0.614,-0.086 0.91,-0.086 0.657,0 1.165,0.144 1.524,0.434 0.363,0.289 0.547,0.687 0.547,1.203 0,0.297 -0.078,0.578 -0.231,0.836 -0.152,0.254 -0.476,0.601 -0.968,1.031 z m 5.136,-1.914 c 0.368,0.098 0.649,0.262 0.84,0.5 0.192,0.234 0.289,0.531 0.289,0.895 0,0.543 -0.207,0.957 -0.625,1.238 -0.414,0.281 -1.019,0.422 -1.816,0.422 -0.277,0 -0.563,-0.024 -0.844,-0.071 -0.281,-0.042 -0.558,-0.109 -0.836,-0.199 v -1.09 c 0.266,0.133 0.528,0.235 0.785,0.301 0.262,0.067 0.516,0.098 0.77,0.098 0.371,0 0.656,-0.063 0.855,-0.192 0.2,-0.128 0.301,-0.316 0.301,-0.558 0,-0.246 -0.101,-0.438 -0.308,-0.563 -0.204,-0.129 -0.504,-0.195 -0.899,-0.195 h -0.566 v -0.906 h 0.593 c 0.356,0 0.618,-0.055 0.79,-0.164 0.175,-0.114 0.261,-0.282 0.261,-0.512 0,-0.207 -0.086,-0.371 -0.254,-0.484 -0.168,-0.118 -0.406,-0.172 -0.711,-0.172 -0.23,0 -0.457,0.023 -0.691,0.074 -0.231,0.055 -0.461,0.129 -0.691,0.23 v -1.035 c 0.277,-0.078 0.554,-0.136 0.828,-0.175 0.273,-0.04 0.543,-0.059 0.804,-0.059 0.711,0 1.243,0.117 1.594,0.351 0.356,0.235 0.531,0.583 0.531,1.051 0,0.321 -0.086,0.582 -0.254,0.789 -0.167,0.203 -0.417,0.344 -0.746,0.426 z m 0.731,-2.516 h 4.594 v 0.852 l -2.934,3.547 h 3.02 v 1.066 h -4.766 v -0.855 l 2.934,-3.547 h -2.848 z m 8.656,5.059 c -0.351,0.172 -0.719,0.297 -1.098,0.383 -0.375,0.086 -0.765,0.129 -1.171,0.129 -0.911,0 -1.629,-0.254 -2.165,-0.762 -0.531,-0.512 -0.796,-1.199 -0.796,-2.07 0,-0.883 0.269,-1.574 0.812,-2.082 0.543,-0.504 1.285,-0.758 2.227,-0.758 0.363,0 0.711,0.035 1.043,0.105 0.336,0.067 0.652,0.168 0.945,0.301 V 26 c -0.305,-0.172 -0.609,-0.305 -0.91,-0.387 -0.301,-0.086 -0.602,-0.129 -0.906,-0.129 -0.563,0 -0.993,0.157 -1.301,0.473 -0.301,0.313 -0.453,0.758 -0.453,1.344 0,0.578 0.148,1.023 0.441,1.34 0.293,0.312 0.707,0.472 1.246,0.472 0.149,0 0.285,-0.011 0.406,-0.027 0.129,-0.02 0.243,-0.051 0.344,-0.09 v -1.058 h -0.863 v -0.946 h 2.199 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath4)"
+             id="path535" />
+          <path
+             d="m 119.836,33.559 h 1.574 l 1.988,3.746 v -3.746 h 1.336 v 5.464 h -1.574 l -1.988,-3.75 v 3.75 h -1.336 z m 4.941,0 h 1.411 v 3.277 c 0,0.449 0.074,0.773 0.218,0.969 0.153,0.191 0.391,0.289 0.727,0.289 0.336,0 0.578,-0.098 0.726,-0.289 0.149,-0.196 0.223,-0.52 0.223,-0.969 v -3.277 h 1.41 v 3.277 c 0,0.773 -0.195,1.348 -0.582,1.726 -0.39,0.379 -0.98,0.567 -1.777,0.567 -0.793,0 -1.383,-0.188 -1.774,-0.567 -0.386,-0.378 -0.582,-0.953 -0.582,-1.726 z m 9.235,5.164 c -0.258,0.136 -0.528,0.234 -0.809,0.304 -0.281,0.067 -0.574,0.102 -0.879,0.102 -0.91,0 -1.633,-0.254 -2.164,-0.762 -0.535,-0.508 -0.801,-1.199 -0.801,-2.07 0,-0.875 0.266,-1.567 0.801,-2.074 0.531,-0.508 1.254,-0.766 2.164,-0.766 0.305,0 0.598,0.035 0.879,0.105 0.281,0.067 0.551,0.168 0.809,0.305 v 1.129 c -0.262,-0.176 -0.52,-0.308 -0.774,-0.391 -0.254,-0.082 -0.519,-0.125 -0.8,-0.125 -0.504,0 -0.899,0.161 -1.188,0.485 -0.289,0.32 -0.434,0.765 -0.434,1.332 0,0.562 0.145,1.008 0.434,1.328 0.289,0.32 0.684,0.484 1.188,0.484 0.281,0 0.546,-0.043 0.8,-0.125 0.254,-0.082 0.512,-0.214 0.774,-0.39 z m -0.371,-5.164 h 1.41 v 4.398 h 2.476 v 1.066 h -3.886 z m 3.175,0 h 3.805 v 1.066 h -2.398 v 1.016 h 2.254 v 1.066 h -2.254 v 1.25 h 2.476 v 1.066 h -3.883 z m 6.024,0.921 c -0.426,0 -0.762,0.161 -0.996,0.477 -0.239,0.316 -0.356,0.762 -0.356,1.34 0,0.574 0.117,1.019 0.356,1.336 0.234,0.316 0.57,0.476 0.996,0.476 0.433,0 0.769,-0.16 1.004,-0.476 0.238,-0.317 0.355,-0.762 0.355,-1.336 0,-0.578 -0.117,-1.024 -0.355,-1.34 -0.235,-0.316 -0.571,-0.477 -1.004,-0.477 z m 0,-1.023 c 0.879,0 1.57,0.254 2.066,0.758 0.5,0.5 0.746,1.195 0.746,2.082 0,0.883 -0.246,1.574 -0.746,2.078 -0.496,0.504 -1.187,0.754 -2.066,0.754 -0.875,0 -1.563,-0.25 -2.063,-0.754 -0.5,-0.504 -0.746,-1.195 -0.746,-2.078 0,-0.887 0.246,-1.582 0.746,-2.082 0.5,-0.504 1.188,-0.758 2.063,-0.758 z m 2.293,2.875 h 2.297 v 1.066 h -2.297 z m 2.574,-2.773 h 1.41 v 2.082 h 2.082 v -2.082 h 1.41 v 5.464 h -1.41 v -2.316 h -2.082 v 2.316 h -1.41 z m 4.547,0 h 4.121 v 0.793 l -2.133,4.671 h -1.375 l 2.02,-4.429 h -2.633 z m 6.062,1.16 -1.546,2.289 h 1.546 z m -0.234,-1.16 h 1.566 v 3.449 h 0.782 v 1.019 h -0.782 v 0.996 h -1.332 v -0.996 h -2.425 V 36.82 Z m 4.766,2.519 c 0.371,0.094 0.648,0.258 0.84,0.496 0.195,0.235 0.289,0.535 0.289,0.899 0,0.539 -0.207,0.953 -0.622,1.234 -0.414,0.281 -1.019,0.422 -1.816,0.422 -0.281,0 -0.562,-0.024 -0.848,-0.07 -0.281,-0.043 -0.558,-0.11 -0.832,-0.2 V 37.77 c 0.262,0.132 0.524,0.234 0.782,0.3 0.261,0.067 0.519,0.102 0.769,0.102 0.375,0 0.66,-0.067 0.856,-0.195 0.203,-0.129 0.3,-0.317 0.3,-0.555 0,-0.25 -0.101,-0.438 -0.304,-0.567 -0.203,-0.128 -0.504,-0.191 -0.903,-0.191 h -0.562 v -0.91 h 0.59 c 0.355,0 0.621,-0.055 0.793,-0.164 0.172,-0.113 0.258,-0.281 0.258,-0.508 0,-0.211 -0.083,-0.375 -0.25,-0.488 -0.168,-0.114 -0.407,-0.172 -0.715,-0.172 -0.227,0 -0.457,0.027 -0.688,0.078 -0.234,0.051 -0.465,0.125 -0.691,0.227 v -1.036 c 0.277,-0.078 0.551,-0.136 0.824,-0.175 0.273,-0.039 0.543,-0.059 0.809,-0.059 0.711,0 1.238,0.117 1.589,0.352 0.356,0.234 0.532,0.582 0.532,1.05 0,0.321 -0.082,0.582 -0.25,0.789 -0.168,0.204 -0.418,0.344 -0.75,0.43 z m 0.73,-2.519 h 4.598 v 0.851 l -2.934,3.547 h 3.016 v 1.066 h -4.762 v -0.851 l 2.934,-3.547 h -2.852 z m 3.852,0 h 1.41 v 5.464 h -1.41 z m 3.476,4.429 h 2.406 v 1.035 h -3.972 v -1.035 l 1.992,-1.761 c 0.18,-0.161 0.313,-0.321 0.398,-0.473 0.086,-0.152 0.129,-0.313 0.129,-0.481 0,-0.253 -0.089,-0.461 -0.261,-0.617 -0.172,-0.156 -0.399,-0.234 -0.684,-0.234 -0.223,0 -0.461,0.047 -0.723,0.144 -0.261,0.09 -0.539,0.231 -0.839,0.414 v -1.199 c 0.32,-0.105 0.632,-0.183 0.941,-0.238 0.312,-0.055 0.613,-0.086 0.914,-0.086 0.652,0 1.16,0.145 1.523,0.434 0.364,0.289 0.543,0.691 0.543,1.203 0,0.301 -0.074,0.578 -0.23,0.836 -0.152,0.258 -0.477,0.601 -0.969,1.031 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath5)"
+             id="path536" />
+          <path
+             d="m 121.734,42.555 h 1.575 l 1.988,3.75 v -3.75 h 1.336 v 5.465 h -1.574 l -1.989,-3.747 v 3.747 h -1.336 z m 4.942,0 h 1.41 v 3.277 c 0,0.449 0.074,0.773 0.219,0.969 0.148,0.191 0.39,0.289 0.726,0.289 0.336,0 0.578,-0.098 0.723,-0.289 0.148,-0.196 0.226,-0.52 0.226,-0.969 v -3.277 h 1.407 v 3.277 c 0,0.773 -0.192,1.348 -0.582,1.727 -0.387,0.379 -0.981,0.566 -1.774,0.566 -0.793,0 -1.386,-0.187 -1.773,-0.566 -0.387,-0.379 -0.582,-0.954 -0.582,-1.727 z m 9.234,5.164 c -0.262,0.136 -0.531,0.238 -0.812,0.304 -0.282,0.071 -0.575,0.102 -0.879,0.102 -0.91,0 -1.629,-0.254 -2.164,-0.762 -0.532,-0.508 -0.797,-1.199 -0.797,-2.07 0,-0.875 0.265,-1.563 0.797,-2.07 0.535,-0.512 1.254,-0.766 2.164,-0.766 0.304,0 0.597,0.031 0.879,0.102 0.281,0.066 0.55,0.168 0.812,0.304 v 1.129 c -0.262,-0.176 -0.519,-0.308 -0.773,-0.39 -0.254,-0.082 -0.524,-0.125 -0.805,-0.125 -0.5,0 -0.898,0.16 -1.184,0.484 -0.289,0.32 -0.433,0.766 -0.433,1.332 0,0.562 0.144,1.008 0.433,1.328 0.286,0.324 0.684,0.484 1.184,0.484 0.281,0 0.551,-0.043 0.805,-0.125 0.254,-0.082 0.511,-0.214 0.773,-0.39 z m -0.371,-5.164 h 1.41 v 4.402 h 2.477 v 1.063 h -3.887 z m 3.172,0 h 3.805 v 1.066 h -2.395 v 1.016 h 2.254 v 1.066 h -2.254 v 1.254 h 2.477 v 1.063 h -3.887 z m 6.027,0.922 c -0.429,0 -0.761,0.16 -1,0.476 -0.234,0.317 -0.355,0.766 -0.355,1.34 0,0.574 0.121,1.019 0.355,1.336 0.239,0.316 0.571,0.476 1,0.476 0.434,0 0.766,-0.16 1.004,-0.476 0.238,-0.317 0.356,-0.762 0.356,-1.336 0,-0.574 -0.118,-1.023 -0.356,-1.34 -0.238,-0.316 -0.57,-0.476 -1.004,-0.476 z m 0,-1.02 c 0.879,0 1.567,0.25 2.067,0.754 0.496,0.5 0.746,1.195 0.746,2.082 0,0.883 -0.25,1.578 -0.746,2.078 -0.5,0.504 -1.188,0.754 -2.067,0.754 -0.875,0 -1.562,-0.25 -2.062,-0.754 -0.5,-0.5 -0.75,-1.195 -0.75,-2.078 0,-0.887 0.25,-1.582 0.75,-2.082 0.5,-0.504 1.187,-0.754 2.062,-0.754 z m 2.289,2.871 h 2.301 v 1.067 h -2.301 z m 2.578,-2.773 h 1.411 v 2.082 h 2.078 v -2.082 h 1.41 v 5.465 h -1.41 v -2.317 h -2.078 v 2.317 h -1.411 z m 4.547,0 h 4.118 v 0.793 l -2.129,4.672 h -1.375 l 2.019,-4.43 h -2.633 z m 4.094,0 h 3.504 v 1.035 h -2.379 v 0.848 c 0.106,-0.032 0.215,-0.051 0.32,-0.067 0.11,-0.019 0.223,-0.027 0.34,-0.027 0.668,0 1.188,0.168 1.559,0.504 0.371,0.332 0.555,0.793 0.555,1.39 0,0.59 -0.204,1.051 -0.606,1.387 -0.402,0.336 -0.965,0.5 -1.684,0.5 -0.308,0 -0.617,-0.027 -0.921,-0.09 -0.301,-0.058 -0.602,-0.148 -0.903,-0.269 v -1.11 c 0.297,0.168 0.578,0.297 0.844,0.383 0.27,0.086 0.523,0.129 0.758,0.129 0.344,0 0.609,-0.082 0.805,-0.25 0.199,-0.168 0.296,-0.395 0.296,-0.68 0,-0.289 -0.097,-0.515 -0.296,-0.683 -0.196,-0.164 -0.461,-0.246 -0.805,-0.246 -0.203,0 -0.418,0.027 -0.649,0.078 -0.226,0.051 -0.476,0.133 -0.738,0.242 z m 6.5,2.519 c 0.371,0.094 0.649,0.262 0.84,0.496 0.191,0.235 0.289,0.535 0.289,0.899 0,0.543 -0.207,0.953 -0.621,1.238 -0.418,0.277 -1.024,0.418 -1.816,0.418 -0.282,0 -0.563,-0.023 -0.848,-0.066 -0.281,-0.047 -0.559,-0.114 -0.836,-0.204 V 46.77 c 0.266,0.128 0.527,0.23 0.785,0.3 0.262,0.063 0.516,0.098 0.77,0.098 0.371,0 0.66,-0.066 0.855,-0.195 0.199,-0.129 0.301,-0.313 0.301,-0.555 0,-0.25 -0.102,-0.438 -0.309,-0.566 -0.203,-0.129 -0.5,-0.192 -0.898,-0.192 h -0.567 v -0.91 h 0.594 c 0.356,0 0.617,-0.055 0.793,-0.164 0.172,-0.113 0.258,-0.281 0.258,-0.508 0,-0.211 -0.082,-0.371 -0.25,-0.488 -0.172,-0.113 -0.41,-0.172 -0.715,-0.172 -0.226,0 -0.457,0.027 -0.691,0.078 -0.231,0.051 -0.461,0.125 -0.692,0.227 v -1.032 c 0.282,-0.078 0.555,-0.136 0.828,-0.175 0.274,-0.039 0.543,-0.059 0.805,-0.059 0.711,0 1.242,0.117 1.594,0.352 0.355,0.23 0.531,0.582 0.531,1.05 0,0.321 -0.082,0.582 -0.254,0.786 -0.168,0.203 -0.414,0.347 -0.746,0.429 z m 0.731,-2.519 h 4.593 v 0.851 l -2.929,3.551 h 3.015 v 1.063 h -4.765 v -0.852 l 2.933,-3.547 h -2.847 z m 3.851,0 h 1.41 v 5.465 h -1.41 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath6)"
+             id="path537" />
+          <path
+             d="M 245.816,-60.152 H 54.5"
+             style="fill:none;stroke:#ffffff;stroke-width:1.62;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:63.1658, 14.577, 24.2948, 14.577, 24.2948, 14.577;stroke-dashoffset:0;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath7)"
+             id="path538" />
+          <path
+             d="m 200.031,81.105 c -0.129,0.067 -0.265,0.118 -0.406,0.153 -0.137,0.031 -0.285,0.051 -0.437,0.051 -0.458,0 -0.817,-0.129 -1.083,-0.383 -0.265,-0.254 -0.398,-0.598 -0.398,-1.035 0,-0.438 0.133,-0.782 0.398,-1.036 0.266,-0.253 0.625,-0.382 1.083,-0.382 0.152,0 0.3,0.015 0.437,0.05 0.141,0.036 0.277,0.086 0.406,0.153 v 0.566 c -0.129,-0.09 -0.258,-0.156 -0.386,-0.195 -0.125,-0.043 -0.262,-0.063 -0.399,-0.063 -0.254,0 -0.449,0.078 -0.594,0.243 -0.144,0.16 -0.218,0.382 -0.218,0.664 0,0.281 0.074,0.504 0.218,0.664 0.145,0.16 0.34,0.242 0.594,0.242 0.137,0 0.274,-0.02 0.399,-0.063 0.128,-0.043 0.257,-0.105 0.386,-0.195 z m -0.183,-2.582 h 0.785 l 0.996,1.872 v -1.872 h 0.668 v 2.731 h -0.789 l -0.992,-1.875 v 1.875 h -0.668 z m 2.379,0 h 2.058 v 0.395 l -1.066,2.336 h -0.688 l 1.012,-2.215 h -1.316 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath8)"
+             id="path539" />
+          <path
+             d="m 199.078,205.645 c -0.129,0.066 -0.262,0.117 -0.402,0.152 -0.141,0.035 -0.289,0.051 -0.442,0.051 -0.453,0 -0.816,-0.125 -1.082,-0.379 -0.265,-0.254 -0.398,-0.602 -0.398,-1.035 0,-0.438 0.133,-0.786 0.398,-1.039 0.266,-0.254 0.629,-0.383 1.082,-0.383 0.153,0 0.301,0.019 0.442,0.054 0.14,0.032 0.273,0.082 0.402,0.149 v 0.566 c -0.129,-0.09 -0.258,-0.152 -0.387,-0.195 -0.125,-0.039 -0.257,-0.063 -0.398,-0.063 -0.254,0 -0.449,0.082 -0.594,0.243 -0.144,0.16 -0.215,0.382 -0.215,0.668 0,0.281 0.071,0.5 0.215,0.664 0.145,0.16 0.34,0.242 0.594,0.242 0.141,0 0.273,-0.024 0.398,-0.063 0.129,-0.043 0.258,-0.109 0.387,-0.199 z m -0.183,-2.583 h 0.789 l 0.992,1.876 v -1.876 h 0.668 v 2.735 h -0.785 l -0.997,-1.875 v 1.875 h -0.667 z m 2.566,2.247 h 0.621 v -1.766 l -0.637,0.133 v -0.481 l 0.633,-0.133 h 0.672 v 2.247 h 0.621 v 0.488 h -1.91 z m 3.187,-0.883 c 0,-0.34 -0.035,-0.582 -0.097,-0.719 -0.063,-0.141 -0.172,-0.211 -0.324,-0.211 -0.149,0 -0.258,0.07 -0.325,0.211 -0.062,0.137 -0.093,0.379 -0.093,0.719 0,0.347 0.031,0.59 0.093,0.73 0.067,0.141 0.176,0.215 0.325,0.215 0.152,0 0.257,-0.074 0.324,-0.215 0.062,-0.14 0.097,-0.383 0.097,-0.73 z m 0.704,0.008 c 0,0.449 -0.098,0.8 -0.293,1.046 -0.196,0.247 -0.473,0.368 -0.832,0.368 -0.36,0 -0.637,-0.121 -0.832,-0.368 -0.196,-0.246 -0.293,-0.597 -0.293,-1.046 0,-0.457 0.097,-0.805 0.293,-1.051 0.195,-0.246 0.472,-0.371 0.832,-0.371 0.359,0 0.636,0.125 0.832,0.371 0.195,0.246 0.293,0.594 0.293,1.051 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath9)"
+             id="path540" />
+          <path
+             d="m 99.059,95.344 c -0.129,0.07 -0.266,0.121 -0.407,0.152 -0.14,0.035 -0.285,0.051 -0.437,0.051 -0.457,0 -0.817,-0.125 -1.082,-0.379 -0.266,-0.254 -0.399,-0.602 -0.399,-1.035 0,-0.438 0.133,-0.781 0.399,-1.035 0.265,-0.258 0.625,-0.383 1.082,-0.383 0.152,0 0.297,0.015 0.437,0.051 0.141,0.031 0.278,0.082 0.407,0.152 V 93.48 C 98.93,93.395 98.801,93.328 98.672,93.285 98.547,93.246 98.41,93.223 98.27,93.223 c -0.25,0 -0.45,0.082 -0.59,0.242 -0.145,0.16 -0.219,0.383 -0.219,0.668 0,0.281 0.074,0.504 0.219,0.664 0.14,0.16 0.34,0.242 0.59,0.242 0.14,0 0.277,-0.023 0.402,-0.062 0.129,-0.043 0.258,-0.11 0.387,-0.196 z m -0.184,-2.582 h 0.785 l 0.996,1.875 v -1.875 h 0.668 v 2.734 h -0.789 l -0.992,-1.875 v 1.875 h -0.668 z m 3.43,1.511 c -0.129,0 -0.231,0.036 -0.301,0.106 -0.07,0.074 -0.109,0.176 -0.109,0.312 0,0.133 0.039,0.235 0.109,0.309 0.07,0.07 0.172,0.105 0.301,0.105 0.133,0 0.23,-0.035 0.3,-0.105 0.071,-0.074 0.106,-0.176 0.106,-0.309 0,-0.136 -0.035,-0.238 -0.106,-0.312 -0.07,-0.07 -0.167,-0.106 -0.3,-0.106 z m -0.512,-0.234 c -0.168,-0.047 -0.293,-0.125 -0.375,-0.23 -0.086,-0.102 -0.129,-0.231 -0.129,-0.387 0,-0.231 0.086,-0.406 0.258,-0.527 0.172,-0.122 0.426,-0.18 0.758,-0.18 0.332,0 0.582,0.058 0.757,0.18 0.172,0.121 0.258,0.296 0.258,0.527 0,0.156 -0.043,0.285 -0.129,0.387 -0.086,0.105 -0.211,0.183 -0.375,0.23 0.184,0.051 0.325,0.137 0.418,0.254 0.094,0.113 0.145,0.258 0.145,0.434 0,0.269 -0.094,0.476 -0.274,0.613 -0.179,0.14 -0.445,0.207 -0.8,0.207 -0.352,0 -0.621,-0.067 -0.805,-0.207 -0.18,-0.137 -0.27,-0.344 -0.27,-0.613 0,-0.176 0.047,-0.321 0.141,-0.434 0.094,-0.117 0.234,-0.203 0.422,-0.254 z m 0.164,-0.547 c 0,0.11 0.031,0.192 0.09,0.25 0.058,0.059 0.148,0.09 0.258,0.09 0.113,0 0.195,-0.031 0.257,-0.09 0.059,-0.058 0.09,-0.14 0.09,-0.25 0,-0.109 -0.031,-0.191 -0.09,-0.25 -0.062,-0.058 -0.144,-0.086 -0.257,-0.086 -0.11,0 -0.2,0.028 -0.258,0.086 -0.059,0.059 -0.09,0.145 -0.09,0.25 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath10)"
+             id="path541" />
+          <path
+             d="m 99.059,205.645 c -0.129,0.066 -0.266,0.117 -0.407,0.152 -0.14,0.035 -0.285,0.051 -0.437,0.051 -0.457,0 -0.817,-0.125 -1.082,-0.379 -0.266,-0.254 -0.399,-0.602 -0.399,-1.035 0,-0.438 0.133,-0.786 0.399,-1.039 0.265,-0.254 0.625,-0.383 1.082,-0.383 0.152,0 0.297,0.019 0.437,0.054 0.141,0.032 0.278,0.082 0.407,0.149 v 0.566 c -0.129,-0.09 -0.258,-0.152 -0.387,-0.195 -0.125,-0.039 -0.262,-0.063 -0.402,-0.063 -0.25,0 -0.45,0.082 -0.59,0.243 -0.145,0.16 -0.219,0.382 -0.219,0.668 0,0.281 0.074,0.5 0.219,0.664 0.14,0.16 0.34,0.242 0.59,0.242 0.14,0 0.277,-0.024 0.402,-0.063 0.129,-0.043 0.258,-0.109 0.387,-0.199 z m -0.184,-2.583 h 0.785 l 0.996,1.876 v -1.876 h 0.668 v 2.735 h -0.789 l -0.992,-1.875 v 1.875 h -0.668 z m 2.5,2.672 v -0.504 c 0.113,0.051 0.223,0.09 0.324,0.118 0.102,0.027 0.203,0.039 0.305,0.039 0.207,0 0.371,-0.059 0.488,-0.172 0.117,-0.117 0.188,-0.293 0.207,-0.52 -0.082,0.059 -0.172,0.106 -0.265,0.137 -0.094,0.031 -0.196,0.043 -0.305,0.043 -0.281,0 -0.504,-0.078 -0.676,-0.242 -0.172,-0.164 -0.258,-0.379 -0.258,-0.645 0,-0.293 0.094,-0.527 0.285,-0.707 0.192,-0.176 0.45,-0.265 0.77,-0.265 0.355,0 0.633,0.121 0.828,0.363 0.195,0.238 0.293,0.578 0.293,1.019 0,0.45 -0.113,0.805 -0.344,1.063 -0.226,0.258 -0.539,0.387 -0.937,0.387 -0.129,0 -0.254,-0.008 -0.371,-0.028 -0.117,-0.019 -0.231,-0.047 -0.344,-0.086 z m 0.871,-1.316 c 0.125,0 0.215,-0.039 0.277,-0.117 0.063,-0.082 0.094,-0.203 0.094,-0.36 0,-0.16 -0.031,-0.281 -0.094,-0.359 -0.062,-0.082 -0.152,-0.121 -0.277,-0.121 -0.125,0 -0.215,0.039 -0.277,0.121 -0.063,0.078 -0.094,0.199 -0.094,0.359 0,0.157 0.031,0.278 0.094,0.36 0.062,0.078 0.152,0.117 0.277,0.117 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath11)"
+             id="path542" />
+          <path
+             d="m 196.395,121.789 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath12)"
+             id="path543" />
+          <path
+             d="m 196.395,-121.785 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath13)"
+             id="path544" />
+          <path
+             d="m 196.395,117.535 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath14)"
+             id="path545" />
+          <path
+             d="m 196.395,-117.535 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath15)"
+             id="path546" />
+          <path
+             d="m 196.395,113.285 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath16)"
+             id="path547" />
+          <path
+             d="m 196.395,-113.285 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath17)"
+             id="path548" />
+          <path
+             d="m 196.395,109.035 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath18)"
+             id="path549" />
+          <path
+             d="m 196.395,-109.035 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath19)"
+             id="path550" />
+          <path
+             d="m 196.395,104.785 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath20)"
+             id="path551" />
+          <path
+             d="m 196.395,-104.785 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath21)"
+             id="path552" />
+          <path
+             d="m 196.395,100.535 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath22)"
+             id="path553" />
+          <path
+             d="m 196.395,-100.535 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath23)"
+             id="path554" />
+          <path
+             d="m 196.395,96.285 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath24)"
+             id="path555" />
+          <path
+             d="m 196.395,-96.285 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath25)"
+             id="path556" />
+          <path
+             d="m 196.395,92.031 h 4.25 v 4.254 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath26)"
+             id="path557" />
+          <path
+             d="m 196.395,-92.035 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath27)"
+             id="path558" />
+          <path
+             d="m 196.395,87.781 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath28)"
+             id="path559" />
+          <path
+             d="m 196.395,-87.781 h 4.25 v -4.254 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath29)"
+             id="path560" />
+          <path
+             d="m 196.395,83.531 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath30)"
+             id="path561" />
+          <path
+             d="m 196.395,-83.531 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath31)"
+             id="path562" />
+          <path
+             d="m 200.645,121.789 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath32)"
+             id="path563" />
+          <path
+             d="m 200.645,-121.785 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath33)"
+             id="path564" />
+          <path
+             d="m 200.645,117.535 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath34)"
+             id="path565" />
+          <path
+             d="m 200.645,-117.535 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath35)"
+             id="path566" />
+          <path
+             d="m 200.645,113.285 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath36)"
+             id="path567" />
+          <path
+             d="m 200.645,-113.285 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath37)"
+             id="path568" />
+          <path
+             d="m 200.645,109.035 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath38)"
+             id="path569" />
+          <path
+             d="m 200.645,-109.035 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath39)"
+             id="path570" />
+          <path
+             d="m 200.645,104.785 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath40)"
+             id="path571" />
+          <path
+             d="m 200.645,-104.785 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath41)"
+             id="path572" />
+          <path
+             d="m 200.645,100.535 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath42)"
+             id="path573" />
+          <path
+             d="m 200.645,-100.535 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath43)"
+             id="path574" />
+          <path
+             d="m 200.645,96.285 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath44)"
+             id="path575" />
+          <path
+             d="m 200.645,-96.285 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath45)"
+             id="path576" />
+          <path
+             d="m 200.645,92.031 h 4.254 v 4.254 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath46)"
+             id="path577" />
+          <path
+             d="m 200.645,-92.035 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath47)"
+             id="path578" />
+          <path
+             d="m 200.645,87.781 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath48)"
+             id="path579" />
+          <path
+             d="m 200.645,-87.781 h 4.254 v -4.254 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath49)"
+             id="path580" />
+          <path
+             d="m 200.645,83.531 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath50)"
+             id="path581" />
+          <path
+             d="m 200.645,-83.531 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath51)"
+             id="path582" />
+          <path
+             d="m 198.105,86.379 h 0.5 v -1.414 l -0.511,0.105 v -0.382 l 0.508,-0.106 h 0.535 v 1.797 h 0.5 v 0.387 h -1.532 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath52)"
+             id="path583" />
+          <path
+             d="m 199.152,89.836 c 0.149,0.039 0.262,0.105 0.336,0.199 0.078,0.094 0.117,0.215 0.117,0.36 0,0.218 -0.085,0.382 -0.25,0.496 -0.167,0.113 -0.41,0.168 -0.726,0.168 -0.113,0 -0.227,-0.008 -0.34,-0.028 -0.109,-0.015 -0.223,-0.043 -0.332,-0.082 v -0.433 c 0.105,0.054 0.211,0.093 0.313,0.121 0.105,0.027 0.207,0.039 0.308,0.039 0.149,0 0.262,-0.028 0.344,-0.078 0.078,-0.051 0.117,-0.125 0.117,-0.223 0,-0.098 -0.039,-0.176 -0.121,-0.227 -0.082,-0.05 -0.203,-0.078 -0.359,-0.078 h -0.227 v -0.363 h 0.238 c 0.141,0 0.246,-0.019 0.317,-0.062 0.066,-0.047 0.101,-0.114 0.101,-0.207 0,-0.083 -0.031,-0.149 -0.101,-0.192 -0.067,-0.047 -0.16,-0.07 -0.285,-0.07 -0.09,0 -0.184,0.012 -0.274,0.031 -0.094,0.02 -0.187,0.051 -0.277,0.09 v -0.414 c 0.109,-0.031 0.222,-0.055 0.332,-0.071 0.109,-0.015 0.215,-0.023 0.32,-0.023 0.285,0 0.496,0.047 0.637,0.141 0.14,0.093 0.215,0.234 0.215,0.422 0,0.128 -0.035,0.234 -0.102,0.316 -0.07,0.078 -0.168,0.137 -0.301,0.168 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath53)"
+             id="path584" />
+          <path
+             d="m 198.074,93.082 h 1.403 v 0.414 h -0.954 v 0.336 c 0.043,-0.012 0.086,-0.02 0.129,-0.023 0.043,-0.008 0.09,-0.012 0.137,-0.012 0.266,0 0.473,0.066 0.621,0.199 0.149,0.133 0.223,0.32 0.223,0.559 0,0.234 -0.082,0.422 -0.242,0.554 -0.161,0.133 -0.387,0.2 -0.672,0.2 -0.125,0 -0.246,-0.012 -0.371,-0.036 -0.121,-0.023 -0.243,-0.058 -0.36,-0.109 v -0.441 c 0.117,0.066 0.231,0.117 0.336,0.152 0.11,0.035 0.211,0.051 0.305,0.051 0.137,0 0.242,-0.035 0.32,-0.102 0.082,-0.066 0.121,-0.156 0.121,-0.269 0,-0.117 -0.039,-0.207 -0.121,-0.274 -0.078,-0.066 -0.183,-0.097 -0.32,-0.097 -0.082,0 -0.168,0.007 -0.258,0.031 -0.094,0.019 -0.191,0.051 -0.297,0.097 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath54)"
+             id="path585" />
+          <path
+             d="m 197.957,97.332 h 1.648 v 0.316 l -0.855,1.868 h -0.547 l 0.805,-1.77 h -1.051 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath55)"
+             id="path586" />
+          <path
+             d="m 198.055,103.719 v -0.407 c 0.09,0.043 0.175,0.075 0.257,0.098 0.083,0.02 0.165,0.031 0.247,0.031 0.168,0 0.296,-0.046 0.39,-0.14 0.094,-0.094 0.149,-0.231 0.164,-0.414 -0.066,0.047 -0.136,0.082 -0.211,0.109 -0.074,0.024 -0.156,0.035 -0.246,0.035 -0.222,0 -0.402,-0.066 -0.539,-0.195 -0.137,-0.129 -0.207,-0.301 -0.207,-0.516 0,-0.234 0.078,-0.422 0.231,-0.566 0.152,-0.141 0.355,-0.211 0.613,-0.211 0.285,0 0.508,0.098 0.664,0.289 0.156,0.191 0.234,0.465 0.234,0.816 0,0.36 -0.093,0.645 -0.273,0.852 -0.184,0.207 -0.434,0.309 -0.754,0.309 -0.102,0 -0.199,-0.008 -0.293,-0.024 -0.094,-0.015 -0.187,-0.035 -0.277,-0.066 z m 0.695,-1.055 c 0.102,0 0.176,-0.031 0.223,-0.094 0.05,-0.066 0.078,-0.16 0.078,-0.289 0,-0.125 -0.028,-0.222 -0.078,-0.285 -0.047,-0.066 -0.121,-0.098 -0.223,-0.098 -0.098,0 -0.172,0.032 -0.223,0.098 -0.047,0.063 -0.074,0.16 -0.074,0.285 0,0.129 0.027,0.223 0.074,0.289 0.051,0.063 0.125,0.094 0.223,0.094 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath56)"
+             id="path587" />
+          <path
+             d="m 197.352,107.625 h 0.496 v -1.41 l -0.508,0.105 v -0.386 l 0.508,-0.106 h 0.535 v 1.797 h 0.496 v 0.391 h -1.527 z m 1.519,0 h 0.5 v -1.41 l -0.512,0.105 v -0.386 l 0.508,-0.106 h 0.535 v 1.797 h 0.5 v 0.391 h -1.531 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath57)"
+             id="path588" />
+          <path
+             d="m 197.352,111.875 h 0.496 v -1.41 l -0.508,0.105 v -0.386 l 0.508,-0.106 h 0.535 v 1.797 h 0.496 v 0.391 h -1.527 z m 2.566,-0.789 c 0.148,0.039 0.258,0.105 0.336,0.199 0.078,0.094 0.117,0.215 0.117,0.36 0,0.218 -0.086,0.382 -0.25,0.496 -0.168,0.113 -0.41,0.168 -0.726,0.168 -0.114,0 -0.227,-0.008 -0.34,-0.028 -0.114,-0.019 -0.223,-0.047 -0.332,-0.082 v -0.433 c 0.105,0.05 0.207,0.093 0.312,0.121 0.106,0.023 0.207,0.039 0.309,0.039 0.148,0 0.261,-0.028 0.34,-0.078 0.082,-0.051 0.121,-0.125 0.121,-0.223 0,-0.102 -0.039,-0.176 -0.121,-0.227 -0.082,-0.05 -0.204,-0.078 -0.364,-0.078 h -0.222 v -0.363 h 0.234 c 0.145,0 0.25,-0.019 0.316,-0.066 0.071,-0.043 0.106,-0.11 0.106,-0.203 0,-0.083 -0.035,-0.149 -0.102,-0.196 -0.066,-0.043 -0.16,-0.066 -0.285,-0.066 -0.09,0 -0.183,0.008 -0.273,0.031 -0.094,0.02 -0.188,0.051 -0.278,0.09 v -0.414 c 0.11,-0.031 0.219,-0.055 0.329,-0.071 0.109,-0.015 0.218,-0.023 0.324,-0.023 0.285,0 0.496,0.047 0.636,0.141 0.141,0.093 0.211,0.234 0.211,0.422 0,0.128 -0.031,0.23 -0.097,0.312 -0.071,0.082 -0.168,0.141 -0.301,0.172 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath58)"
+             id="path589" />
+          <path
+             d="m 197.352,116.125 h 0.496 v -1.414 l -0.508,0.105 v -0.382 l 0.508,-0.106 h 0.535 v 1.797 h 0.496 v 0.391 h -1.527 z m 1.488,-1.797 h 1.402 v 0.414 h -0.953 v 0.34 c 0.043,-0.012 0.086,-0.02 0.129,-0.027 0.043,-0.008 0.09,-0.008 0.137,-0.008 0.265,0 0.472,0.066 0.621,0.199 0.148,0.133 0.222,0.316 0.222,0.555 0,0.238 -0.082,0.422 -0.242,0.554 -0.16,0.137 -0.386,0.204 -0.672,0.204 -0.125,0 -0.25,-0.012 -0.371,-0.039 -0.121,-0.024 -0.242,-0.059 -0.359,-0.106 v -0.445 c 0.117,0.07 0.23,0.121 0.336,0.152 0.109,0.035 0.211,0.055 0.305,0.055 0.136,0 0.242,-0.035 0.32,-0.102 0.082,-0.066 0.121,-0.156 0.121,-0.273 0,-0.113 -0.039,-0.203 -0.121,-0.27 -0.078,-0.066 -0.184,-0.101 -0.32,-0.101 -0.083,0 -0.168,0.011 -0.262,0.031 -0.09,0.023 -0.188,0.055 -0.293,0.098 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath59)"
+             id="path590" />
+          <path
+             d="m 197.352,120.375 h 0.496 v -1.414 l -0.508,0.105 v -0.382 l 0.508,-0.106 h 0.535 v 1.797 h 0.496 v 0.391 h -1.527 z m 1.371,-1.797 h 1.648 v 0.32 l -0.855,1.868 h -0.547 l 0.804,-1.774 h -1.05 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath60)"
+             id="path591" />
+          <path
+             d="m 197.352,124.625 h 0.496 v -1.41 l -0.508,0.101 v -0.382 l 0.508,-0.106 h 0.535 v 1.797 h 0.496 v 0.391 h -1.527 z m 1.468,0.344 v -0.407 c 0.09,0.043 0.176,0.075 0.258,0.098 0.082,0.02 0.164,0.028 0.242,0.028 0.168,0 0.301,-0.043 0.395,-0.137 0.094,-0.094 0.148,-0.235 0.164,-0.418 -0.067,0.051 -0.137,0.086 -0.211,0.109 -0.074,0.028 -0.156,0.039 -0.246,0.039 -0.223,0 -0.402,-0.066 -0.539,-0.195 -0.137,-0.133 -0.207,-0.305 -0.207,-0.516 0,-0.234 0.078,-0.422 0.23,-0.566 0.153,-0.141 0.356,-0.211 0.614,-0.211 0.285,0 0.507,0.098 0.664,0.289 0.156,0.191 0.234,0.465 0.234,0.816 0,0.36 -0.094,0.645 -0.277,0.852 -0.18,0.203 -0.43,0.309 -0.75,0.309 -0.102,0 -0.2,-0.008 -0.293,-0.024 -0.094,-0.015 -0.188,-0.039 -0.278,-0.066 z m 0.696,-1.055 c 0.101,0 0.175,-0.031 0.222,-0.094 0.051,-0.066 0.074,-0.16 0.074,-0.289 0,-0.129 -0.023,-0.222 -0.074,-0.289 -0.047,-0.062 -0.121,-0.094 -0.222,-0.094 -0.098,0 -0.172,0.032 -0.223,0.094 -0.047,0.067 -0.074,0.16 -0.074,0.289 0,0.129 0.027,0.223 0.074,0.289 0.051,0.063 0.125,0.094 0.223,0.094 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath61)"
+             id="path592" />
+          <path
+             d="m 202.977,86.344 h 0.964 v 0.414 h -1.589 v -0.414 l 0.796,-0.703 c 0.075,-0.067 0.125,-0.129 0.161,-0.192 0.035,-0.058 0.05,-0.125 0.05,-0.191 0,-0.102 -0.035,-0.184 -0.105,-0.246 -0.066,-0.063 -0.16,-0.094 -0.274,-0.094 -0.085,0 -0.183,0.02 -0.289,0.059 -0.101,0.035 -0.214,0.089 -0.336,0.164 V 84.66 c 0.129,-0.039 0.254,-0.074 0.379,-0.094 0.125,-0.023 0.246,-0.035 0.364,-0.035 0.261,0 0.464,0.059 0.609,0.176 0.145,0.113 0.219,0.273 0.219,0.481 0,0.117 -0.031,0.23 -0.094,0.332 -0.059,0.105 -0.187,0.242 -0.387,0.414 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath62)"
+             id="path593" />
+          <path
+             d="m 203.219,89.285 -0.617,0.918 h 0.617 z m -0.094,-0.465 h 0.625 v 1.383 h 0.312 v 0.406 h -0.312 v 0.399 h -0.531 v -0.399 h -0.969 v -0.484 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath63)"
+             id="path594" />
+          <path
+             d="m 203.199,94.18 c -0.097,0 -0.172,0.031 -0.222,0.097 -0.047,0.063 -0.075,0.157 -0.075,0.285 0,0.129 0.028,0.223 0.075,0.29 0.05,0.062 0.125,0.093 0.222,0.093 0.102,0 0.176,-0.031 0.223,-0.093 0.051,-0.067 0.074,-0.161 0.074,-0.29 0,-0.128 -0.023,-0.222 -0.074,-0.285 -0.047,-0.066 -0.121,-0.097 -0.223,-0.097 z m 0.699,-1.051 v 0.406 c -0.093,-0.047 -0.183,-0.078 -0.265,-0.097 -0.082,-0.024 -0.16,-0.032 -0.238,-0.032 -0.168,0 -0.301,0.047 -0.395,0.141 -0.094,0.09 -0.148,0.23 -0.164,0.414 0.066,-0.051 0.137,-0.086 0.211,-0.109 0.074,-0.024 0.156,-0.036 0.246,-0.036 0.223,0 0.402,0.067 0.539,0.196 0.141,0.133 0.207,0.304 0.207,0.515 0,0.235 -0.074,0.422 -0.23,0.563 -0.153,0.14 -0.356,0.211 -0.614,0.211 -0.285,0 -0.507,-0.094 -0.664,-0.285 -0.152,-0.196 -0.23,-0.465 -0.23,-0.821 0,-0.359 0.09,-0.644 0.273,-0.847 0.18,-0.207 0.43,-0.313 0.75,-0.313 0.098,0 0.196,0.008 0.293,0.024 0.094,0.015 0.188,0.039 0.281,0.07 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath64)"
+             id="path595" />
+          <path
+             d="m 203.16,98.531 c -0.105,0 -0.187,0.028 -0.246,0.086 -0.055,0.059 -0.082,0.141 -0.082,0.246 0,0.11 0.027,0.192 0.082,0.25 0.059,0.055 0.141,0.082 0.246,0.082 0.102,0 0.184,-0.027 0.238,-0.082 0.055,-0.058 0.082,-0.14 0.082,-0.25 0,-0.109 -0.027,-0.191 -0.082,-0.246 -0.054,-0.058 -0.136,-0.086 -0.238,-0.086 z m -0.414,-0.187 c -0.133,-0.039 -0.23,-0.102 -0.301,-0.184 -0.066,-0.082 -0.101,-0.187 -0.101,-0.312 0,-0.184 0.07,-0.325 0.207,-0.422 0.14,-0.094 0.34,-0.145 0.609,-0.145 0.262,0 0.465,0.051 0.602,0.145 0.136,0.097 0.207,0.238 0.207,0.422 0,0.125 -0.035,0.23 -0.102,0.312 -0.07,0.082 -0.168,0.145 -0.301,0.184 0.149,0.043 0.258,0.109 0.336,0.199 0.075,0.094 0.114,0.211 0.114,0.352 0,0.214 -0.075,0.378 -0.219,0.492 -0.141,0.109 -0.356,0.164 -0.637,0.164 -0.285,0 -0.5,-0.055 -0.644,-0.164 -0.145,-0.114 -0.219,-0.278 -0.219,-0.492 0,-0.141 0.039,-0.258 0.113,-0.352 0.074,-0.09 0.188,-0.156 0.336,-0.199 z m 0.133,-0.438 c 0,0.086 0.023,0.153 0.07,0.199 0.051,0.047 0.121,0.071 0.211,0.071 0.086,0 0.152,-0.024 0.203,-0.071 0.047,-0.046 0.071,-0.113 0.071,-0.199 0,-0.086 -0.024,-0.152 -0.071,-0.199 -0.051,-0.047 -0.117,-0.07 -0.203,-0.07 -0.09,0 -0.16,0.023 -0.211,0.07 -0.047,0.047 -0.07,0.113 -0.07,0.199 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath65)"
+             id="path596" />
+          <path
+             d="m 201.711,103.367 h 0.496 v -1.41 l -0.512,0.105 v -0.386 l 0.508,-0.106 h 0.539 v 1.797 h 0.496 v 0.391 h -1.527 z m 2.547,-0.703 c 0,-0.273 -0.024,-0.469 -0.078,-0.578 -0.051,-0.113 -0.137,-0.168 -0.258,-0.168 -0.121,0 -0.207,0.055 -0.258,0.168 -0.051,0.109 -0.078,0.305 -0.078,0.578 0,0.274 0.027,0.469 0.078,0.582 0.051,0.113 0.137,0.172 0.258,0.172 0.121,0 0.207,-0.059 0.258,-0.172 0.054,-0.113 0.078,-0.308 0.078,-0.582 z m 0.566,0.004 c 0,0.359 -0.078,0.641 -0.234,0.84 -0.156,0.195 -0.379,0.293 -0.668,0.293 -0.285,0 -0.508,-0.098 -0.664,-0.293 -0.156,-0.199 -0.235,-0.481 -0.235,-0.84 0,-0.363 0.079,-0.645 0.235,-0.84 0.156,-0.199 0.379,-0.297 0.664,-0.297 0.289,0 0.512,0.098 0.668,0.297 0.156,0.195 0.234,0.477 0.234,0.84 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath66)"
+             id="path597" />
+          <path
+             d="m 201.711,107.617 h 0.496 v -1.414 l -0.512,0.106 v -0.383 l 0.508,-0.106 h 0.539 v 1.797 h 0.496 v 0.391 h -1.527 z m 2.031,-0.023 h 0.965 v 0.414 h -1.59 v -0.414 l 0.797,-0.703 c 0.07,-0.067 0.125,-0.129 0.16,-0.192 0.031,-0.062 0.051,-0.125 0.051,-0.191 0,-0.102 -0.035,-0.184 -0.105,-0.246 -0.067,-0.063 -0.161,-0.094 -0.274,-0.094 -0.09,0 -0.184,0.02 -0.289,0.055 -0.105,0.039 -0.215,0.093 -0.336,0.168 v -0.481 c 0.129,-0.043 0.254,-0.074 0.379,-0.094 0.121,-0.023 0.242,-0.035 0.363,-0.035 0.262,0 0.465,0.059 0.61,0.172 0.144,0.117 0.218,0.277 0.218,0.485 0,0.117 -0.031,0.23 -0.093,0.332 -0.063,0.101 -0.192,0.242 -0.387,0.414 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath67)"
+             id="path598" />
+          <path
+             d="m 201.711,111.867 h 0.496 v -1.414 l -0.512,0.106 v -0.383 l 0.508,-0.106 h 0.539 v 1.797 h 0.496 v 0.391 h -1.527 z m 2.273,-1.332 -0.617,0.914 h 0.617 z m -0.093,-0.465 h 0.625 v 1.379 h 0.312 v 0.41 h -0.312 v 0.399 h -0.532 v -0.399 h -0.968 v -0.484 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath68)"
+             id="path599" />
+          <path
+             d="m 201.711,116.117 h 0.496 v -1.414 l -0.512,0.106 v -0.383 l 0.508,-0.106 h 0.539 v 1.797 h 0.496 v 0.391 h -1.527 z m 2.254,-0.687 c -0.098,0 -0.172,0.031 -0.223,0.093 -0.051,0.067 -0.074,0.161 -0.074,0.289 0,0.126 0.023,0.223 0.074,0.29 0.051,0.062 0.125,0.093 0.223,0.093 0.097,0 0.172,-0.031 0.223,-0.093 0.05,-0.067 0.074,-0.164 0.074,-0.29 0,-0.128 -0.024,-0.222 -0.074,-0.289 -0.051,-0.062 -0.126,-0.093 -0.223,-0.093 z m 0.695,-1.051 v 0.402 c -0.09,-0.043 -0.18,-0.074 -0.262,-0.097 -0.082,-0.02 -0.16,-0.032 -0.238,-0.032 -0.168,0 -0.301,0.047 -0.394,0.141 -0.094,0.094 -0.149,0.23 -0.164,0.414 0.066,-0.047 0.136,-0.082 0.21,-0.105 0.075,-0.024 0.157,-0.036 0.247,-0.036 0.222,0 0.402,0.063 0.539,0.196 0.136,0.129 0.207,0.3 0.207,0.511 0,0.235 -0.078,0.422 -0.231,0.567 -0.152,0.14 -0.359,0.211 -0.617,0.211 -0.281,0 -0.504,-0.098 -0.66,-0.289 -0.152,-0.192 -0.231,-0.465 -0.231,-0.817 0,-0.359 0.09,-0.644 0.27,-0.851 0.184,-0.207 0.434,-0.309 0.75,-0.309 0.102,0 0.199,0.008 0.293,0.024 0.098,0.015 0.191,0.039 0.281,0.07 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath69)"
+             id="path600" />
+          <path
+             d="m 201.711,120.367 h 0.496 v -1.414 l -0.512,0.106 v -0.383 l 0.508,-0.106 h 0.539 v 1.797 h 0.496 v 0.391 h -1.527 z m 2.211,-0.59 c -0.106,0 -0.184,0.032 -0.242,0.086 -0.055,0.059 -0.086,0.141 -0.086,0.25 0,0.106 0.031,0.188 0.086,0.246 0.058,0.059 0.136,0.086 0.242,0.086 0.105,0 0.187,-0.027 0.242,-0.086 0.055,-0.058 0.082,-0.14 0.082,-0.246 0,-0.109 -0.027,-0.191 -0.082,-0.25 -0.055,-0.054 -0.137,-0.086 -0.242,-0.086 z m -0.41,-0.183 c -0.133,-0.043 -0.235,-0.102 -0.301,-0.188 -0.066,-0.082 -0.102,-0.183 -0.102,-0.308 0,-0.184 0.071,-0.325 0.207,-0.422 0.137,-0.098 0.34,-0.145 0.606,-0.145 0.266,0 0.469,0.047 0.605,0.145 0.137,0.097 0.207,0.238 0.207,0.422 0,0.125 -0.035,0.226 -0.105,0.308 -0.067,0.086 -0.164,0.145 -0.297,0.188 0.148,0.039 0.258,0.105 0.332,0.199 0.078,0.094 0.117,0.207 0.117,0.348 0,0.218 -0.074,0.382 -0.219,0.492 -0.144,0.113 -0.355,0.168 -0.64,0.168 -0.281,0 -0.496,-0.055 -0.645,-0.168 -0.144,-0.11 -0.215,-0.274 -0.215,-0.492 0,-0.141 0.04,-0.254 0.114,-0.348 0.074,-0.094 0.187,-0.16 0.336,-0.199 z m 0.133,-0.438 c 0,0.086 0.023,0.153 0.07,0.199 0.051,0.047 0.117,0.071 0.207,0.071 0.09,0 0.156,-0.024 0.203,-0.071 0.051,-0.046 0.074,-0.113 0.074,-0.199 0,-0.09 -0.023,-0.156 -0.074,-0.199 -0.047,-0.047 -0.113,-0.07 -0.203,-0.07 -0.09,0 -0.156,0.023 -0.207,0.07 -0.047,0.047 -0.07,0.113 -0.07,0.199 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath70)"
+             id="path601" />
+          <path
+             d="m 202.223,124.594 h 0.961 v 0.414 h -1.59 v -0.414 l 0.801,-0.707 c 0.07,-0.063 0.125,-0.125 0.156,-0.188 0.035,-0.062 0.051,-0.125 0.051,-0.191 0,-0.102 -0.032,-0.184 -0.102,-0.246 -0.07,-0.063 -0.16,-0.094 -0.273,-0.094 -0.09,0 -0.184,0.016 -0.289,0.055 -0.106,0.039 -0.219,0.093 -0.336,0.168 v -0.481 c 0.125,-0.043 0.253,-0.074 0.375,-0.094 0.125,-0.023 0.246,-0.035 0.367,-0.035 0.261,0 0.465,0.059 0.609,0.172 0.145,0.117 0.219,0.277 0.219,0.485 0,0.117 -0.031,0.23 -0.094,0.332 -0.062,0.101 -0.191,0.242 -0.387,0.414 z m 2.035,-0.684 c 0,-0.273 -0.024,-0.465 -0.078,-0.574 -0.051,-0.113 -0.137,-0.168 -0.258,-0.168 -0.121,0 -0.207,0.055 -0.258,0.168 -0.051,0.109 -0.078,0.301 -0.078,0.574 0,0.278 0.027,0.473 0.078,0.586 0.051,0.113 0.137,0.168 0.258,0.168 0.121,0 0.207,-0.055 0.258,-0.168 0.054,-0.113 0.078,-0.308 0.078,-0.586 z m 0.566,0.008 c 0,0.359 -0.078,0.641 -0.234,0.836 -0.156,0.199 -0.379,0.297 -0.668,0.297 -0.285,0 -0.508,-0.098 -0.664,-0.297 -0.156,-0.195 -0.235,-0.477 -0.235,-0.836 0,-0.363 0.079,-0.645 0.235,-0.84 0.156,-0.199 0.379,-0.297 0.664,-0.297 0.289,0 0.512,0.098 0.668,0.297 0.156,0.195 0.234,0.477 0.234,0.84 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath71)"
+             id="path602" />
+          <path
+             d="m 95.262,128.164 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath72)"
+             id="path603" />
+          <path
+             d="m 95.262,-128.164 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath73)"
+             id="path604" />
+          <path
+             d="m 95.262,123.914 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath74)"
+             id="path605" />
+          <path
+             d="m 95.262,-123.91 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath75)"
+             id="path606" />
+          <path
+             d="m 95.262,119.66 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath76)"
+             id="path607" />
+          <path
+             d="m 95.262,-119.66 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath77)"
+             id="path608" />
+          <path
+             d="m 95.262,115.41 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath78)"
+             id="path609" />
+          <path
+             d="m 95.262,-115.41 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath79)"
+             id="path610" />
+          <path
+             d="m 95.262,111.16 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath80)"
+             id="path611" />
+          <path
+             d="m 95.262,-111.16 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath81)"
+             id="path612" />
+          <path
+             d="m 95.262,106.91 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath82)"
+             id="path613" />
+          <path
+             d="m 95.262,-106.91 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath83)"
+             id="path614" />
+          <path
+             d="m 95.262,102.66 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath84)"
+             id="path615" />
+          <path
+             d="m 95.262,-102.66 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath85)"
+             id="path616" />
+          <path
+             d="m 95.262,98.41 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath86)"
+             id="path617" />
+          <path
+             d="m 95.262,-98.41 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath87)"
+             id="path618" />
+          <path
+             d="m 99.512,128.164 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath88)"
+             id="path619" />
+          <path
+             d="m 99.512,-128.164 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath89)"
+             id="path620" />
+          <path
+             d="m 99.512,123.914 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath90)"
+             id="path621" />
+          <path
+             d="m 99.512,-123.91 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath91)"
+             id="path622" />
+          <path
+             d="m 99.512,119.66 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath92)"
+             id="path623" />
+          <path
+             d="m 99.512,-119.66 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath93)"
+             id="path624" />
+          <path
+             d="m 99.512,115.41 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath94)"
+             id="path625" />
+          <path
+             d="m 99.512,-115.41 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath95)"
+             id="path626" />
+          <path
+             d="m 99.512,111.16 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath96)"
+             id="path627" />
+          <path
+             d="m 99.512,-111.16 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath97)"
+             id="path628" />
+          <path
+             d="m 99.512,106.91 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath98)"
+             id="path629" />
+          <path
+             d="m 99.512,-106.91 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath99)"
+             id="path630" />
+          <path
+             d="m 99.512,102.66 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath100)"
+             id="path631" />
+          <path
+             d="m 99.512,-102.66 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath101)"
+             id="path632" />
+          <path
+             d="m 99.512,98.41 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath102)"
+             id="path633" />
+          <path
+             d="m 99.512,-98.41 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath103)"
+             id="path634" />
+          <path
+             d="m 96.977,101.254 h 0.496 V 99.84 l -0.512,0.105 v -0.383 l 0.508,-0.105 h 0.539 v 1.797 h 0.496 v 0.391 h -1.527 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath104)"
+             id="path635" />
+          <path
+             d="m 98.02,104.715 c 0.148,0.039 0.261,0.105 0.335,0.199 0.079,0.094 0.118,0.215 0.118,0.359 0,0.215 -0.082,0.383 -0.25,0.497 -0.164,0.109 -0.407,0.168 -0.727,0.168 -0.113,0 -0.223,-0.012 -0.336,-0.028 -0.113,-0.019 -0.226,-0.047 -0.336,-0.082 v -0.433 c 0.106,0.05 0.211,0.089 0.313,0.117 0.105,0.027 0.207,0.039 0.308,0.039 0.149,0 0.266,-0.024 0.344,-0.074 0.078,-0.055 0.121,-0.129 0.121,-0.223 0,-0.102 -0.043,-0.176 -0.125,-0.227 -0.082,-0.05 -0.199,-0.078 -0.359,-0.078 h -0.227 v -0.363 h 0.239 c 0.14,0 0.246,-0.024 0.316,-0.066 0.07,-0.043 0.101,-0.114 0.101,-0.204 0,-0.082 -0.031,-0.148 -0.097,-0.195 -0.07,-0.047 -0.164,-0.066 -0.289,-0.066 -0.09,0 -0.18,0.007 -0.274,0.027 -0.093,0.023 -0.183,0.051 -0.277,0.094 v -0.414 c 0.113,-0.032 0.223,-0.055 0.332,-0.071 0.109,-0.015 0.215,-0.023 0.32,-0.023 0.285,0 0.496,0.047 0.637,0.141 0.145,0.093 0.215,0.234 0.215,0.421 0,0.125 -0.035,0.231 -0.102,0.313 -0.066,0.082 -0.168,0.141 -0.3,0.172 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath105)"
+             id="path636" />
+          <path
+             d="m 96.941,107.957 h 1.403 v 0.414 h -0.953 v 0.34 c 0.043,-0.012 0.086,-0.023 0.129,-0.027 0.042,-0.008 0.089,-0.012 0.136,-0.012 0.266,0 0.473,0.066 0.621,0.203 0.149,0.133 0.223,0.316 0.223,0.555 0,0.238 -0.078,0.422 -0.242,0.554 -0.16,0.133 -0.383,0.204 -0.672,0.204 -0.125,0 -0.246,-0.016 -0.367,-0.04 -0.121,-0.023 -0.242,-0.058 -0.364,-0.109 v -0.441 c 0.118,0.066 0.231,0.121 0.34,0.152 0.106,0.035 0.207,0.051 0.301,0.051 0.137,0 0.246,-0.031 0.324,-0.098 0.078,-0.066 0.118,-0.16 0.118,-0.273 0,-0.114 -0.04,-0.207 -0.118,-0.274 -0.078,-0.066 -0.187,-0.097 -0.324,-0.097 -0.082,0 -0.168,0.011 -0.258,0.031 -0.093,0.019 -0.191,0.055 -0.297,0.098 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath106)"
+             id="path637" />
+          <path
+             d="m 96.824,112.207 h 1.649 v 0.316 l -0.852,1.872 H 97.07 l 0.809,-1.774 h -1.055 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath107)"
+             id="path638" />
+          <path
+             d="m 96.926,118.594 v -0.403 c 0.09,0.043 0.176,0.075 0.258,0.094 0.082,0.02 0.16,0.031 0.242,0.031 0.168,0 0.297,-0.046 0.39,-0.14 0.094,-0.094 0.149,-0.231 0.168,-0.414 -0.066,0.047 -0.136,0.086 -0.214,0.109 -0.075,0.024 -0.157,0.035 -0.243,0.035 -0.226,0 -0.406,-0.062 -0.543,-0.191 -0.136,-0.133 -0.207,-0.305 -0.207,-0.516 0,-0.238 0.078,-0.426 0.231,-0.566 0.152,-0.141 0.359,-0.211 0.613,-0.211 0.285,0 0.508,0.094 0.664,0.285 0.156,0.195 0.235,0.465 0.235,0.816 0,0.364 -0.09,0.645 -0.274,0.852 -0.184,0.207 -0.434,0.309 -0.754,0.309 -0.101,0 -0.199,-0.008 -0.293,-0.024 -0.094,-0.012 -0.183,-0.035 -0.273,-0.066 z m 0.695,-1.051 c 0.098,0 0.172,-0.031 0.223,-0.098 0.047,-0.062 0.074,-0.16 0.074,-0.289 0,-0.125 -0.027,-0.222 -0.074,-0.285 -0.051,-0.066 -0.125,-0.098 -0.223,-0.098 -0.101,0 -0.176,0.032 -0.223,0.098 -0.05,0.063 -0.074,0.16 -0.074,0.285 0,0.129 0.024,0.227 0.074,0.289 0.047,0.067 0.122,0.098 0.223,0.098 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath108)"
+             id="path639" />
+          <path
+             d="m 96.219,122.504 h 0.5 v -1.414 l -0.512,0.105 v -0.383 l 0.508,-0.105 h 0.535 v 1.797 h 0.5 v 0.391 h -1.531 z m 1.523,0 h 0.496 v -1.414 l -0.511,0.105 v -0.383 l 0.507,-0.105 h 0.539 v 1.797 h 0.497 v 0.391 h -1.528 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath109)"
+             id="path640" />
+          <path
+             d="m 96.219,126.754 h 0.5 v -1.414 l -0.512,0.105 v -0.383 l 0.508,-0.105 h 0.535 v 1.797 h 0.5 v 0.391 h -1.531 z m 2.566,-0.789 c 0.149,0.039 0.262,0.105 0.336,0.199 0.078,0.094 0.117,0.211 0.117,0.359 0,0.215 -0.086,0.379 -0.25,0.493 -0.164,0.113 -0.406,0.168 -0.726,0.168 -0.114,0 -0.227,-0.008 -0.34,-0.028 -0.11,-0.015 -0.223,-0.043 -0.332,-0.078 v -0.437 c 0.105,0.054 0.211,0.093 0.312,0.121 0.106,0.027 0.207,0.039 0.309,0.039 0.148,0 0.262,-0.024 0.344,-0.078 0.078,-0.051 0.117,-0.125 0.117,-0.223 0,-0.098 -0.039,-0.172 -0.121,-0.223 -0.082,-0.054 -0.203,-0.078 -0.36,-0.078 h -0.226 v -0.363 h 0.238 c 0.141,0 0.246,-0.024 0.317,-0.066 0.066,-0.047 0.101,-0.114 0.101,-0.204 0,-0.086 -0.031,-0.148 -0.101,-0.195 -0.067,-0.047 -0.161,-0.07 -0.286,-0.07 -0.089,0 -0.179,0.011 -0.273,0.031 -0.094,0.02 -0.188,0.051 -0.277,0.09 v -0.41 c 0.109,-0.032 0.222,-0.055 0.332,-0.071 0.109,-0.015 0.214,-0.023 0.32,-0.023 0.285,0 0.496,0.047 0.637,0.141 0.14,0.093 0.215,0.23 0.215,0.418 0,0.128 -0.036,0.234 -0.102,0.316 -0.066,0.082 -0.168,0.137 -0.301,0.172 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath110)"
+             id="path641" />
+          <path
+             d="m 96.219,131.004 h 0.5 v -1.414 l -0.512,0.105 v -0.383 l 0.508,-0.105 h 0.535 v 1.797 h 0.5 v 0.391 h -1.531 z m 1.488,-1.797 h 1.402 v 0.414 h -0.953 v 0.34 c 0.043,-0.012 0.086,-0.023 0.129,-0.027 0.043,-0.008 0.09,-0.012 0.137,-0.012 0.266,0 0.473,0.066 0.621,0.203 0.148,0.133 0.223,0.316 0.223,0.555 0,0.234 -0.082,0.422 -0.243,0.554 -0.16,0.133 -0.386,0.2 -0.671,0.2 -0.125,0 -0.247,-0.012 -0.372,-0.036 -0.121,-0.023 -0.238,-0.058 -0.359,-0.109 v -0.441 c 0.117,0.066 0.231,0.117 0.336,0.152 0.109,0.035 0.211,0.051 0.305,0.051 0.136,0 0.246,-0.031 0.324,-0.098 0.078,-0.07 0.117,-0.16 0.117,-0.273 0,-0.118 -0.039,-0.207 -0.117,-0.274 -0.078,-0.066 -0.188,-0.097 -0.324,-0.097 -0.082,0 -0.168,0.011 -0.258,0.031 -0.094,0.019 -0.192,0.055 -0.297,0.098 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath111)"
+             id="path642" />
+          <path
+             d="m 101.848,101.223 h 0.961 v 0.418 h -1.59 v -0.418 l 0.801,-0.703 c 0.07,-0.063 0.121,-0.129 0.156,-0.188 0.035,-0.062 0.051,-0.125 0.051,-0.191 0,-0.106 -0.036,-0.188 -0.102,-0.25 -0.07,-0.063 -0.16,-0.094 -0.277,-0.094 -0.086,0 -0.184,0.019 -0.286,0.058 -0.105,0.036 -0.218,0.094 -0.335,0.168 v -0.48 c 0.125,-0.043 0.25,-0.074 0.375,-0.098 0.125,-0.019 0.246,-0.031 0.363,-0.031 0.262,0 0.465,0.055 0.609,0.172 0.149,0.113 0.219,0.277 0.219,0.48 0,0.122 -0.031,0.231 -0.09,0.336 -0.062,0.102 -0.191,0.239 -0.391,0.41 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath112)"
+             id="path643" />
+          <path
+             d="m 102.086,104.168 -0.617,0.914 h 0.617 z m -0.094,-0.465 h 0.629 v 1.379 h 0.313 v 0.406 h -0.313 v 0.399 h -0.535 v -0.399 h -0.969 v -0.48 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath113)"
+             id="path644" />
+          <path
+             d="m 102.066,109.059 c -0.097,0 -0.171,0.031 -0.222,0.097 -0.047,0.063 -0.071,0.16 -0.071,0.285 0,0.129 0.024,0.227 0.071,0.289 0.051,0.063 0.125,0.098 0.222,0.098 0.102,0 0.176,-0.035 0.223,-0.098 0.051,-0.062 0.074,-0.16 0.074,-0.289 0,-0.125 -0.023,-0.222 -0.074,-0.285 -0.047,-0.066 -0.121,-0.097 -0.223,-0.097 z m 0.7,-1.051 v 0.406 c -0.094,-0.047 -0.18,-0.078 -0.262,-0.098 -0.082,-0.023 -0.164,-0.031 -0.242,-0.031 -0.168,0 -0.297,0.047 -0.391,0.141 -0.094,0.09 -0.148,0.23 -0.164,0.414 0.063,-0.047 0.133,-0.086 0.207,-0.11 0.078,-0.023 0.16,-0.035 0.246,-0.035 0.227,0 0.406,0.067 0.543,0.196 0.137,0.132 0.207,0.304 0.207,0.515 0,0.235 -0.078,0.422 -0.23,0.563 -0.157,0.14 -0.36,0.211 -0.618,0.211 -0.285,0 -0.503,-0.094 -0.66,-0.285 -0.156,-0.192 -0.234,-0.465 -0.234,-0.817 0,-0.363 0.09,-0.648 0.273,-0.851 0.184,-0.207 0.434,-0.313 0.75,-0.313 0.102,0 0.2,0.008 0.293,0.024 0.094,0.015 0.188,0.039 0.282,0.07 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath114)"
+             id="path645" />
+          <path
+             d="m 102.027,113.41 c -0.105,0 -0.187,0.028 -0.242,0.086 -0.058,0.059 -0.086,0.141 -0.086,0.246 0,0.11 0.028,0.192 0.086,0.25 0.055,0.055 0.137,0.082 0.242,0.082 0.106,0 0.184,-0.027 0.239,-0.082 0.058,-0.058 0.086,-0.14 0.086,-0.25 0,-0.105 -0.028,-0.191 -0.086,-0.246 -0.055,-0.058 -0.133,-0.086 -0.239,-0.086 z m -0.414,-0.187 c -0.129,-0.039 -0.23,-0.102 -0.297,-0.184 -0.07,-0.082 -0.101,-0.187 -0.101,-0.309 0,-0.187 0.066,-0.328 0.207,-0.421 0.137,-0.098 0.34,-0.149 0.605,-0.149 0.266,0 0.465,0.051 0.602,0.149 0.141,0.093 0.207,0.234 0.207,0.421 0,0.122 -0.035,0.227 -0.102,0.309 -0.066,0.082 -0.168,0.145 -0.3,0.184 0.148,0.043 0.261,0.109 0.336,0.203 0.074,0.09 0.113,0.207 0.113,0.347 0,0.215 -0.071,0.379 -0.215,0.493 -0.145,0.109 -0.359,0.164 -0.641,0.164 -0.285,0 -0.5,-0.055 -0.644,-0.164 -0.145,-0.114 -0.219,-0.278 -0.219,-0.493 0,-0.14 0.039,-0.257 0.113,-0.347 0.078,-0.094 0.192,-0.16 0.336,-0.203 z m 0.133,-0.438 c 0,0.086 0.024,0.156 0.074,0.203 0.047,0.047 0.118,0.071 0.207,0.071 0.086,0 0.157,-0.024 0.203,-0.071 0.047,-0.047 0.071,-0.117 0.071,-0.203 0,-0.086 -0.024,-0.152 -0.071,-0.199 -0.046,-0.047 -0.117,-0.07 -0.203,-0.07 -0.089,0 -0.16,0.023 -0.207,0.07 -0.05,0.047 -0.074,0.113 -0.074,0.199 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath115)"
+             id="path646" />
+          <path
+             d="m 100.578,118.246 h 0.496 v -1.41 l -0.508,0.105 v -0.382 l 0.508,-0.106 h 0.535 v 1.793 h 0.496 v 0.391 h -1.527 z m 2.551,-0.703 c 0,-0.273 -0.027,-0.465 -0.078,-0.578 -0.051,-0.113 -0.137,-0.168 -0.258,-0.168 -0.121,0 -0.207,0.055 -0.262,0.168 -0.051,0.113 -0.078,0.305 -0.078,0.578 0,0.277 0.027,0.469 0.078,0.582 0.055,0.113 0.141,0.172 0.262,0.172 0.117,0 0.203,-0.059 0.258,-0.172 0.051,-0.113 0.078,-0.305 0.078,-0.582 z m 0.562,0.004 c 0,0.363 -0.078,0.641 -0.234,0.84 -0.156,0.195 -0.379,0.293 -0.664,0.293 -0.289,0 -0.512,-0.098 -0.668,-0.293 -0.156,-0.199 -0.234,-0.477 -0.234,-0.84 0,-0.363 0.078,-0.645 0.234,-0.84 0.156,-0.195 0.379,-0.297 0.668,-0.297 0.285,0 0.508,0.102 0.664,0.297 0.156,0.195 0.234,0.477 0.234,0.84 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath116)"
+             id="path647" />
+          <path
+             d="m 100.578,122.5 h 0.496 v -1.414 l -0.508,0.105 v -0.382 l 0.508,-0.106 h 0.535 v 1.797 h 0.496 v 0.387 h -1.527 z m 2.035,-0.027 h 0.961 v 0.414 h -1.59 v -0.414 l 0.797,-0.703 c 0.074,-0.067 0.125,-0.129 0.16,-0.188 0.036,-0.062 0.051,-0.129 0.051,-0.195 0,-0.102 -0.035,-0.184 -0.105,-0.246 -0.067,-0.063 -0.157,-0.094 -0.274,-0.094 -0.086,0 -0.183,0.019 -0.289,0.058 -0.101,0.036 -0.215,0.09 -0.332,0.165 v -0.481 c 0.125,-0.039 0.25,-0.07 0.375,-0.094 0.125,-0.023 0.246,-0.035 0.363,-0.035 0.262,0 0.465,0.059 0.61,0.176 0.148,0.113 0.219,0.273 0.219,0.48 0,0.122 -0.032,0.231 -0.09,0.336 -0.063,0.102 -0.192,0.239 -0.391,0.41 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath117)"
+             id="path648" />
+          <path
+             d="m 100.578,126.75 h 0.496 v -1.414 l -0.508,0.105 v -0.382 l 0.508,-0.106 h 0.535 v 1.797 h 0.496 v 0.387 h -1.527 z m 2.274,-1.336 -0.618,0.918 h 0.618 z m -0.094,-0.461 h 0.629 v 1.379 h 0.308 v 0.406 h -0.308 v 0.399 h -0.535 v -0.399 h -0.969 v -0.48 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath118)"
+             id="path649" />
+          <path
+             d="m 100.578,130.996 h 0.496 v -1.41 l -0.508,0.105 v -0.386 l 0.508,-0.106 h 0.535 v 1.797 h 0.496 v 0.391 h -1.527 z m 2.254,-0.687 c -0.098,0 -0.172,0.031 -0.223,0.097 -0.047,0.063 -0.074,0.156 -0.074,0.285 0,0.129 0.027,0.223 0.074,0.289 0.051,0.063 0.125,0.094 0.223,0.094 0.102,0 0.176,-0.031 0.223,-0.094 0.05,-0.066 0.074,-0.16 0.074,-0.289 0,-0.129 -0.024,-0.222 -0.074,-0.285 -0.047,-0.066 -0.121,-0.097 -0.223,-0.097 z m 0.699,-1.051 v 0.406 c -0.093,-0.047 -0.179,-0.078 -0.261,-0.098 -0.082,-0.023 -0.165,-0.031 -0.243,-0.031 -0.168,0 -0.297,0.047 -0.39,0.141 -0.094,0.09 -0.149,0.23 -0.164,0.414 0.062,-0.051 0.132,-0.086 0.207,-0.11 0.074,-0.023 0.156,-0.035 0.246,-0.035 0.222,0 0.406,0.067 0.543,0.196 0.136,0.132 0.203,0.3 0.203,0.515 0,0.235 -0.074,0.422 -0.227,0.563 -0.156,0.14 -0.359,0.211 -0.617,0.211 -0.285,0 -0.504,-0.094 -0.66,-0.285 -0.156,-0.196 -0.234,-0.465 -0.234,-0.821 0,-0.359 0.089,-0.644 0.273,-0.847 0.18,-0.207 0.43,-0.313 0.75,-0.313 0.098,0 0.195,0.008 0.293,0.024 0.094,0.015 0.188,0.039 0.281,0.07 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath119)"
+             id="path650" />
+          <path
+             d="m 95.262,196.172 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath120)"
+             id="path651" />
+          <path
+             d="m 95.262,-196.172 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath121)"
+             id="path652" />
+          <path
+             d="m 95.262,191.922 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath122)"
+             id="path653" />
+          <path
+             d="m 95.262,-191.922 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath123)"
+             id="path654" />
+          <path
+             d="m 95.262,187.668 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath124)"
+             id="path655" />
+          <path
+             d="m 95.262,-187.668 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath125)"
+             id="path656" />
+          <path
+             d="m 95.262,183.418 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath126)"
+             id="path657" />
+          <path
+             d="m 95.262,-183.418 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath127)"
+             id="path658" />
+          <path
+             d="m 95.262,179.168 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath128)"
+             id="path659" />
+          <path
+             d="m 95.262,-179.168 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath129)"
+             id="path660" />
+          <path
+             d="m 95.262,174.918 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath130)"
+             id="path661" />
+          <path
+             d="m 95.262,-174.918 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath131)"
+             id="path662" />
+          <path
+             d="m 95.262,170.668 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath132)"
+             id="path663" />
+          <path
+             d="m 95.262,-170.668 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath133)"
+             id="path664" />
+          <path
+             d="m 95.262,166.418 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath134)"
+             id="path665" />
+          <path
+             d="m 95.262,-166.418 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath135)"
+             id="path666" />
+          <path
+             d="m 95.262,162.168 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath136)"
+             id="path667" />
+          <path
+             d="m 95.262,-162.168 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath137)"
+             id="path668" />
+          <path
+             d="m 95.262,157.914 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath138)"
+             id="path669" />
+          <path
+             d="m 95.262,-157.914 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath139)"
+             id="path670" />
+          <path
+             d="m 95.262,153.664 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath140)"
+             id="path671" />
+          <path
+             d="m 95.262,-153.664 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath141)"
+             id="path672" />
+          <path
+             d="m 95.262,149.414 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath142)"
+             id="path673" />
+          <path
+             d="m 95.262,-149.414 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath143)"
+             id="path674" />
+          <path
+             d="m 95.262,145.164 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath144)"
+             id="path675" />
+          <path
+             d="m 95.262,-145.164 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath145)"
+             id="path676" />
+          <path
+             d="m 95.262,140.914 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath146)"
+             id="path677" />
+          <path
+             d="m 95.262,-140.914 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath147)"
+             id="path678" />
+          <path
+             d="m 95.262,136.664 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath148)"
+             id="path679" />
+          <path
+             d="m 95.262,-136.664 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath149)"
+             id="path680" />
+          <path
+             d="m 99.512,196.172 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath150)"
+             id="path681" />
+          <path
+             d="m 99.512,-196.172 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath151)"
+             id="path682" />
+          <path
+             d="m 99.512,191.922 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath152)"
+             id="path683" />
+          <path
+             d="m 99.512,-191.922 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath153)"
+             id="path684" />
+          <path
+             d="m 99.512,187.668 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath154)"
+             id="path685" />
+          <path
+             d="m 99.512,-187.668 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath155)"
+             id="path686" />
+          <path
+             d="m 99.512,183.418 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath156)"
+             id="path687" />
+          <path
+             d="m 99.512,-183.418 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath157)"
+             id="path688" />
+          <path
+             d="m 99.512,179.168 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath158)"
+             id="path689" />
+          <path
+             d="m 99.512,-179.168 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath159)"
+             id="path690" />
+          <path
+             d="m 99.512,174.918 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath160)"
+             id="path691" />
+          <path
+             d="m 99.512,-174.918 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath161)"
+             id="path692" />
+          <path
+             d="m 99.512,170.668 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath162)"
+             id="path693" />
+          <path
+             d="m 99.512,-170.668 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath163)"
+             id="path694" />
+          <path
+             d="m 99.512,166.418 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath164)"
+             id="path695" />
+          <path
+             d="m 99.512,-166.418 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath165)"
+             id="path696" />
+          <path
+             d="m 99.512,162.168 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath166)"
+             id="path697" />
+          <path
+             d="m 99.512,-162.168 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath167)"
+             id="path698" />
+          <path
+             d="m 99.512,157.914 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath168)"
+             id="path699" />
+          <path
+             d="m 99.512,-157.914 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath169)"
+             id="path700" />
+          <path
+             d="m 99.512,153.664 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath170)"
+             id="path701" />
+          <path
+             d="m 99.512,-153.664 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath171)"
+             id="path702" />
+          <path
+             d="m 99.512,149.414 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath172)"
+             id="path703" />
+          <path
+             d="m 99.512,-149.414 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath173)"
+             id="path704" />
+          <path
+             d="m 99.512,145.164 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath174)"
+             id="path705" />
+          <path
+             d="m 99.512,-145.164 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath175)"
+             id="path706" />
+          <path
+             d="m 99.512,140.914 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath176)"
+             id="path707" />
+          <path
+             d="m 99.512,-140.914 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath177)"
+             id="path708" />
+          <path
+             d="m 99.512,136.664 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath178)"
+             id="path709" />
+          <path
+             d="m 99.512,-136.664 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath179)"
+             id="path710" />
+          <path
+             d="m 96.977,139.508 h 0.496 v -1.41 l -0.512,0.105 v -0.387 l 0.508,-0.105 h 0.539 v 1.797 h 0.496 v 0.39 h -1.527 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath180)"
+             id="path711" />
+          <path
+             d="m 98.02,142.969 c 0.148,0.039 0.261,0.105 0.335,0.199 0.079,0.094 0.118,0.215 0.118,0.359 0,0.215 -0.082,0.383 -0.25,0.496 -0.164,0.11 -0.407,0.168 -0.727,0.168 -0.113,0 -0.223,-0.011 -0.336,-0.027 -0.113,-0.019 -0.226,-0.047 -0.336,-0.082 v -0.434 c 0.106,0.051 0.211,0.09 0.313,0.118 0.105,0.027 0.207,0.043 0.308,0.043 0.149,0 0.266,-0.028 0.344,-0.079 0.078,-0.054 0.121,-0.128 0.121,-0.222 0,-0.102 -0.043,-0.176 -0.125,-0.227 -0.082,-0.051 -0.199,-0.078 -0.359,-0.078 h -0.227 v -0.363 h 0.239 c 0.14,0 0.246,-0.02 0.316,-0.067 0.07,-0.043 0.101,-0.113 0.101,-0.203 0,-0.082 -0.031,-0.148 -0.097,-0.195 -0.07,-0.043 -0.164,-0.066 -0.289,-0.066 -0.09,0 -0.18,0.007 -0.274,0.031 -0.093,0.019 -0.183,0.051 -0.277,0.09 v -0.414 c 0.113,-0.032 0.223,-0.055 0.332,-0.071 0.109,-0.015 0.215,-0.023 0.32,-0.023 0.285,0 0.496,0.047 0.637,0.14 0.145,0.094 0.215,0.235 0.215,0.422 0,0.125 -0.035,0.231 -0.102,0.313 -0.066,0.082 -0.168,0.141 -0.3,0.172 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath181)"
+             id="path712" />
+          <path
+             d="m 96.941,146.211 h 1.403 v 0.414 h -0.953 v 0.34 c 0.043,-0.012 0.086,-0.02 0.129,-0.027 0.042,-0.008 0.089,-0.012 0.136,-0.012 0.266,0 0.473,0.07 0.621,0.203 0.149,0.133 0.223,0.316 0.223,0.555 0,0.238 -0.078,0.421 -0.242,0.554 -0.16,0.137 -0.383,0.203 -0.672,0.203 -0.125,0 -0.246,-0.011 -0.367,-0.039 -0.121,-0.023 -0.242,-0.058 -0.364,-0.105 v -0.445 c 0.118,0.07 0.231,0.121 0.34,0.152 0.106,0.035 0.207,0.051 0.301,0.051 0.137,0 0.246,-0.032 0.324,-0.098 0.078,-0.066 0.118,-0.156 0.118,-0.273 0,-0.114 -0.04,-0.204 -0.118,-0.27 -0.078,-0.066 -0.187,-0.102 -0.324,-0.102 -0.082,0 -0.168,0.012 -0.258,0.032 -0.093,0.023 -0.191,0.054 -0.297,0.097 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath182)"
+             id="path713" />
+          <path
+             d="m 96.824,150.461 h 1.649 v 0.316 l -0.852,1.871 H 97.07 l 0.809,-1.773 h -1.055 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath183)"
+             id="path714" />
+          <path
+             d="m 96.926,156.848 v -0.403 c 0.09,0.043 0.176,0.075 0.258,0.094 0.082,0.02 0.16,0.031 0.242,0.031 0.168,0 0.297,-0.047 0.39,-0.136 0.094,-0.094 0.149,-0.235 0.168,-0.418 -0.066,0.05 -0.136,0.086 -0.214,0.109 -0.075,0.023 -0.157,0.039 -0.243,0.039 -0.226,0 -0.406,-0.066 -0.543,-0.195 -0.136,-0.133 -0.207,-0.305 -0.207,-0.516 0,-0.238 0.078,-0.426 0.231,-0.566 0.152,-0.141 0.359,-0.211 0.613,-0.211 0.285,0 0.508,0.094 0.664,0.285 0.156,0.195 0.235,0.465 0.235,0.816 0,0.364 -0.09,0.645 -0.274,0.852 -0.184,0.207 -0.434,0.312 -0.754,0.312 -0.101,0 -0.199,-0.007 -0.293,-0.023 -0.094,-0.016 -0.183,-0.039 -0.273,-0.07 z m 0.695,-1.051 c 0.098,0 0.172,-0.031 0.223,-0.098 0.047,-0.062 0.074,-0.16 0.074,-0.285 0,-0.129 -0.027,-0.223 -0.074,-0.289 -0.051,-0.063 -0.125,-0.098 -0.223,-0.098 -0.101,0 -0.176,0.035 -0.223,0.098 -0.05,0.066 -0.074,0.16 -0.074,0.289 0,0.125 0.024,0.223 0.074,0.285 0.047,0.067 0.122,0.098 0.223,0.098 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath184)"
+             id="path715" />
+          <path
+             d="m 96.219,160.758 h 0.5 v -1.414 l -0.512,0.105 v -0.383 l 0.508,-0.105 h 0.535 v 1.797 h 0.5 v 0.39 h -1.531 z m 1.523,0 h 0.496 v -1.414 l -0.511,0.105 v -0.383 l 0.507,-0.105 h 0.539 v 1.797 h 0.497 v 0.39 h -1.528 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath185)"
+             id="path716" />
+          <path
+             d="m 96.219,165.008 h 0.5 v -1.414 l -0.512,0.105 v -0.383 l 0.508,-0.105 h 0.535 v 1.797 h 0.5 v 0.39 h -1.531 z m 2.566,-0.789 c 0.149,0.039 0.262,0.105 0.336,0.199 0.078,0.094 0.117,0.215 0.117,0.359 0,0.215 -0.086,0.383 -0.25,0.493 -0.164,0.113 -0.406,0.171 -0.726,0.171 -0.114,0 -0.227,-0.011 -0.34,-0.031 -0.11,-0.015 -0.223,-0.043 -0.332,-0.078 v -0.434 c 0.105,0.051 0.211,0.09 0.312,0.118 0.106,0.027 0.207,0.039 0.309,0.039 0.148,0 0.262,-0.024 0.344,-0.075 0.078,-0.054 0.117,-0.128 0.117,-0.222 0,-0.102 -0.039,-0.176 -0.121,-0.227 -0.082,-0.051 -0.203,-0.078 -0.36,-0.078 h -0.226 v -0.363 h 0.238 c 0.141,0 0.246,-0.024 0.317,-0.067 0.066,-0.043 0.101,-0.113 0.101,-0.203 0,-0.086 -0.031,-0.148 -0.101,-0.195 -0.067,-0.047 -0.161,-0.07 -0.286,-0.07 -0.089,0 -0.179,0.011 -0.273,0.031 -0.094,0.023 -0.188,0.051 -0.277,0.094 v -0.414 c 0.109,-0.032 0.222,-0.055 0.332,-0.071 0.109,-0.015 0.214,-0.023 0.32,-0.023 0.285,0 0.496,0.047 0.637,0.14 0.14,0.094 0.215,0.231 0.215,0.418 0,0.129 -0.036,0.235 -0.102,0.317 -0.066,0.082 -0.168,0.137 -0.301,0.172 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath186)"
+             id="path717" />
+          <path
+             d="m 96.219,169.258 h 0.5 v -1.414 l -0.512,0.105 v -0.383 l 0.508,-0.105 h 0.535 v 1.797 h 0.5 v 0.39 h -1.531 z m 1.488,-1.797 h 1.402 v 0.414 h -0.953 v 0.34 c 0.043,-0.012 0.086,-0.024 0.129,-0.027 0.043,-0.008 0.09,-0.012 0.137,-0.012 0.266,0 0.473,0.066 0.621,0.203 0.148,0.133 0.223,0.316 0.223,0.555 0,0.238 -0.082,0.421 -0.243,0.554 -0.16,0.133 -0.386,0.203 -0.671,0.203 -0.125,0 -0.247,-0.015 -0.372,-0.039 -0.121,-0.023 -0.238,-0.058 -0.359,-0.109 v -0.441 c 0.117,0.066 0.231,0.117 0.336,0.152 0.109,0.035 0.211,0.051 0.305,0.051 0.136,0 0.246,-0.032 0.324,-0.098 0.078,-0.066 0.117,-0.16 0.117,-0.273 0,-0.114 -0.039,-0.207 -0.117,-0.274 -0.078,-0.066 -0.188,-0.098 -0.324,-0.098 -0.082,0 -0.168,0.012 -0.258,0.032 -0.094,0.019 -0.192,0.054 -0.297,0.097 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath187)"
+             id="path718" />
+          <path
+             d="m 96.219,173.508 h 0.5 v -1.414 l -0.512,0.105 v -0.383 l 0.508,-0.105 h 0.535 v 1.797 h 0.5 v 0.39 h -1.531 z m 1.371,-1.797 h 1.648 v 0.316 l -0.851,1.871 h -0.551 l 0.809,-1.773 H 97.59 Z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath188)"
+             id="path719" />
+          <path
+             d="m 96.219,177.758 h 0.5 v -1.414 l -0.512,0.105 v -0.383 l 0.508,-0.105 h 0.535 v 1.797 h 0.5 v 0.39 h -1.531 z m 1.469,0.34 v -0.403 c 0.089,0.039 0.175,0.075 0.257,0.094 0.082,0.02 0.164,0.031 0.246,0.031 0.168,0 0.297,-0.047 0.391,-0.14 0.094,-0.094 0.148,-0.231 0.168,-0.414 -0.066,0.046 -0.141,0.086 -0.215,0.109 -0.074,0.023 -0.156,0.035 -0.242,0.035 -0.227,0 -0.406,-0.062 -0.543,-0.195 -0.137,-0.129 -0.207,-0.301 -0.207,-0.516 0,-0.234 0.078,-0.422 0.23,-0.562 0.153,-0.141 0.36,-0.215 0.614,-0.215 0.285,0 0.508,0.098 0.664,0.289 0.156,0.195 0.234,0.465 0.234,0.816 0,0.364 -0.094,0.645 -0.273,0.852 -0.184,0.207 -0.434,0.309 -0.754,0.309 -0.102,0 -0.199,-0.008 -0.293,-0.024 -0.094,-0.012 -0.188,-0.035 -0.277,-0.066 z m 0.699,-1.051 c 0.097,0 0.172,-0.035 0.222,-0.098 0.047,-0.062 0.075,-0.16 0.075,-0.289 0,-0.125 -0.028,-0.222 -0.075,-0.285 -0.05,-0.066 -0.125,-0.098 -0.222,-0.098 -0.102,0 -0.176,0.032 -0.223,0.098 -0.051,0.063 -0.078,0.16 -0.078,0.285 0,0.129 0.027,0.227 0.078,0.289 0.047,0.063 0.121,0.098 0.223,0.098 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath189)"
+             id="path720" />
+          <path
+             d="m 96.73,181.98 h 0.965 v 0.415 h -1.59 v -0.415 l 0.797,-0.703 c 0.075,-0.062 0.125,-0.129 0.16,-0.187 0.036,-0.063 0.051,-0.125 0.051,-0.192 0,-0.105 -0.035,-0.187 -0.105,-0.25 -0.067,-0.062 -0.16,-0.093 -0.274,-0.093 -0.086,0 -0.183,0.019 -0.289,0.058 -0.101,0.035 -0.215,0.094 -0.336,0.168 v -0.48 c 0.129,-0.043 0.254,-0.074 0.379,-0.098 0.125,-0.023 0.246,-0.031 0.364,-0.031 0.261,0 0.464,0.055 0.609,0.172 0.144,0.113 0.219,0.273 0.219,0.48 0,0.121 -0.032,0.231 -0.094,0.336 -0.059,0.102 -0.188,0.238 -0.387,0.41 z m 1.012,0.028 h 0.496 v -1.414 l -0.511,0.105 v -0.383 l 0.507,-0.105 h 0.539 v 1.797 h 0.497 v 0.387 h -1.528 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath190)"
+             id="path721" />
+          <path
+             d="m 96.73,186.23 h 0.965 v 0.415 h -1.59 v -0.415 l 0.797,-0.703 c 0.075,-0.066 0.125,-0.129 0.16,-0.187 0.036,-0.063 0.051,-0.129 0.051,-0.195 0,-0.102 -0.035,-0.184 -0.105,-0.247 -0.067,-0.062 -0.16,-0.093 -0.274,-0.093 -0.086,0 -0.183,0.019 -0.289,0.058 -0.101,0.035 -0.215,0.094 -0.336,0.168 v -0.48 c 0.129,-0.043 0.254,-0.074 0.379,-0.098 0.125,-0.023 0.246,-0.031 0.364,-0.031 0.261,0 0.464,0.055 0.609,0.172 0.144,0.113 0.219,0.273 0.219,0.48 0,0.121 -0.032,0.231 -0.094,0.336 -0.059,0.102 -0.188,0.238 -0.387,0.41 z m 2.055,-0.761 c 0.149,0.035 0.262,0.101 0.336,0.199 0.078,0.094 0.117,0.211 0.117,0.355 0,0.219 -0.086,0.383 -0.25,0.497 -0.164,0.113 -0.406,0.168 -0.726,0.168 -0.114,0 -0.227,-0.008 -0.34,-0.028 -0.11,-0.015 -0.223,-0.043 -0.332,-0.078 v -0.437 c 0.105,0.054 0.211,0.093 0.312,0.121 0.106,0.027 0.207,0.039 0.309,0.039 0.148,0 0.262,-0.028 0.344,-0.078 0.078,-0.051 0.117,-0.125 0.117,-0.223 0,-0.098 -0.039,-0.176 -0.121,-0.227 -0.082,-0.05 -0.203,-0.074 -0.36,-0.074 h -0.226 v -0.363 h 0.238 c 0.141,0 0.246,-0.024 0.317,-0.067 0.066,-0.046 0.101,-0.113 0.101,-0.203 0,-0.086 -0.031,-0.152 -0.101,-0.195 -0.067,-0.047 -0.161,-0.07 -0.286,-0.07 -0.089,0 -0.179,0.011 -0.273,0.031 -0.094,0.019 -0.188,0.051 -0.277,0.09 v -0.41 c 0.109,-0.032 0.222,-0.055 0.332,-0.071 0.109,-0.015 0.214,-0.023 0.32,-0.023 0.285,0 0.496,0.047 0.637,0.14 0.14,0.09 0.215,0.231 0.215,0.418 0,0.129 -0.036,0.235 -0.102,0.317 -0.066,0.078 -0.168,0.137 -0.301,0.172 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath191)"
+             id="path722" />
+          <path
+             d="m 96.73,190.48 h 0.965 v 0.415 h -1.59 v -0.415 l 0.797,-0.703 c 0.075,-0.062 0.125,-0.129 0.16,-0.187 0.036,-0.063 0.051,-0.125 0.051,-0.192 0,-0.105 -0.035,-0.187 -0.105,-0.25 -0.067,-0.062 -0.16,-0.093 -0.274,-0.093 -0.086,0 -0.183,0.019 -0.289,0.058 -0.101,0.035 -0.215,0.094 -0.336,0.168 v -0.48 c 0.129,-0.043 0.254,-0.074 0.379,-0.098 0.125,-0.019 0.246,-0.031 0.364,-0.031 0.261,0 0.464,0.055 0.609,0.172 0.144,0.113 0.219,0.273 0.219,0.48 0,0.121 -0.032,0.231 -0.094,0.336 -0.059,0.102 -0.188,0.238 -0.387,0.41 z m 0.977,-1.769 h 1.402 v 0.414 h -0.953 v 0.336 c 0.043,-0.012 0.086,-0.02 0.129,-0.023 0.043,-0.008 0.09,-0.012 0.137,-0.012 0.266,0 0.473,0.066 0.621,0.199 0.148,0.133 0.223,0.32 0.223,0.559 0,0.234 -0.082,0.421 -0.243,0.554 -0.16,0.133 -0.386,0.2 -0.671,0.2 -0.125,0 -0.247,-0.012 -0.372,-0.036 -0.121,-0.023 -0.238,-0.058 -0.359,-0.109 v -0.441 c 0.117,0.066 0.231,0.117 0.336,0.152 0.109,0.035 0.211,0.051 0.305,0.051 0.136,0 0.246,-0.032 0.324,-0.098 0.078,-0.07 0.117,-0.16 0.117,-0.273 0,-0.118 -0.039,-0.207 -0.117,-0.274 -0.078,-0.066 -0.188,-0.098 -0.324,-0.098 -0.082,0 -0.168,0.008 -0.258,0.032 -0.094,0.019 -0.192,0.051 -0.297,0.097 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath192)"
+             id="path723" />
+          <path
+             d="m 96.73,194.73 h 0.965 v 0.415 h -1.59 v -0.415 l 0.797,-0.703 c 0.075,-0.066 0.125,-0.129 0.16,-0.187 0.036,-0.063 0.051,-0.129 0.051,-0.195 0,-0.102 -0.035,-0.184 -0.105,-0.247 -0.067,-0.062 -0.16,-0.093 -0.274,-0.093 -0.086,0 -0.183,0.019 -0.289,0.058 -0.101,0.035 -0.215,0.09 -0.336,0.164 v -0.48 c 0.129,-0.039 0.254,-0.07 0.379,-0.094 0.125,-0.023 0.246,-0.035 0.364,-0.035 0.261,0 0.464,0.059 0.609,0.176 0.144,0.113 0.219,0.273 0.219,0.48 0,0.121 -0.032,0.231 -0.094,0.336 -0.059,0.102 -0.188,0.238 -0.387,0.41 z m 0.86,-1.769 h 1.648 v 0.316 l -0.851,1.868 h -0.551 l 0.809,-1.77 H 97.59 Z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath193)"
+             id="path724" />
+          <path
+             d="m 96.73,198.98 h 0.965 v 0.415 h -1.59 v -0.415 l 0.797,-0.703 c 0.075,-0.066 0.125,-0.129 0.16,-0.191 0.036,-0.059 0.051,-0.125 0.051,-0.191 0,-0.102 -0.035,-0.184 -0.105,-0.247 -0.067,-0.062 -0.16,-0.093 -0.274,-0.093 -0.086,0 -0.183,0.019 -0.289,0.058 -0.101,0.035 -0.215,0.09 -0.336,0.164 v -0.48 c 0.129,-0.039 0.254,-0.074 0.379,-0.094 0.125,-0.023 0.246,-0.035 0.364,-0.035 0.261,0 0.464,0.059 0.609,0.176 0.144,0.113 0.219,0.273 0.219,0.48 0,0.117 -0.032,0.231 -0.094,0.332 -0.059,0.106 -0.188,0.242 -0.387,0.414 z m 0.958,0.368 v -0.407 c 0.089,0.043 0.175,0.075 0.257,0.098 0.082,0.02 0.164,0.031 0.246,0.031 0.168,0 0.297,-0.047 0.391,-0.14 0.094,-0.094 0.148,-0.235 0.168,-0.418 -0.066,0.05 -0.141,0.086 -0.215,0.113 -0.074,0.023 -0.156,0.035 -0.242,0.035 -0.227,0 -0.406,-0.066 -0.543,-0.195 -0.137,-0.129 -0.207,-0.301 -0.207,-0.516 0,-0.234 0.078,-0.422 0.23,-0.566 0.153,-0.141 0.36,-0.211 0.614,-0.211 0.285,0 0.508,0.098 0.664,0.289 0.156,0.191 0.234,0.465 0.234,0.816 0,0.36 -0.094,0.645 -0.273,0.852 -0.184,0.207 -0.434,0.309 -0.754,0.309 -0.102,0 -0.199,-0.008 -0.293,-0.024 -0.094,-0.016 -0.188,-0.035 -0.277,-0.066 z m 0.699,-1.055 c 0.097,0 0.172,-0.031 0.222,-0.094 0.047,-0.066 0.075,-0.16 0.075,-0.289 0,-0.125 -0.028,-0.222 -0.075,-0.285 -0.05,-0.066 -0.125,-0.098 -0.222,-0.098 -0.102,0 -0.176,0.032 -0.223,0.098 -0.051,0.063 -0.078,0.16 -0.078,0.285 0,0.129 0.027,0.223 0.078,0.289 0.047,0.063 0.121,0.094 0.223,0.094 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath194)"
+             id="path725" />
+          <path
+             d="m 101.848,139.473 h 0.961 v 0.414 h -1.59 v -0.414 l 0.801,-0.703 c 0.07,-0.067 0.121,-0.129 0.156,-0.192 0.035,-0.058 0.051,-0.125 0.051,-0.191 0,-0.102 -0.036,-0.184 -0.102,-0.246 -0.07,-0.063 -0.16,-0.094 -0.277,-0.094 -0.086,0 -0.184,0.019 -0.286,0.055 -0.105,0.039 -0.218,0.093 -0.335,0.168 v -0.481 c 0.125,-0.043 0.25,-0.074 0.375,-0.094 0.125,-0.023 0.246,-0.035 0.363,-0.035 0.262,0 0.465,0.059 0.609,0.172 0.149,0.117 0.219,0.277 0.219,0.484 0,0.118 -0.031,0.231 -0.09,0.332 -0.062,0.106 -0.191,0.243 -0.391,0.414 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath195)"
+             id="path726" />
+          <path
+             d="m 102.086,142.414 -0.617,0.914 h 0.617 z m -0.094,-0.465 h 0.629 v 1.379 h 0.313 v 0.41 h -0.313 v 0.399 h -0.535 v -0.399 h -0.969 v -0.484 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath196)"
+             id="path727" />
+          <path
+             d="m 102.066,147.309 c -0.097,0 -0.171,0.031 -0.222,0.093 -0.047,0.067 -0.071,0.16 -0.071,0.289 0,0.129 0.024,0.223 0.071,0.289 0.051,0.063 0.125,0.094 0.222,0.094 0.102,0 0.176,-0.031 0.223,-0.094 0.051,-0.066 0.074,-0.16 0.074,-0.289 0,-0.129 -0.023,-0.222 -0.074,-0.289 -0.047,-0.062 -0.121,-0.093 -0.223,-0.093 z m 0.7,-1.051 v 0.402 c -0.094,-0.043 -0.18,-0.074 -0.262,-0.094 -0.082,-0.023 -0.164,-0.035 -0.242,-0.035 -0.168,0 -0.297,0.047 -0.391,0.141 -0.094,0.094 -0.148,0.23 -0.164,0.414 0.063,-0.047 0.133,-0.082 0.207,-0.106 0.078,-0.023 0.16,-0.035 0.246,-0.035 0.227,0 0.406,0.063 0.543,0.196 0.137,0.129 0.207,0.3 0.207,0.511 0,0.235 -0.078,0.426 -0.23,0.567 -0.157,0.14 -0.36,0.211 -0.618,0.211 -0.285,0 -0.503,-0.098 -0.66,-0.289 -0.156,-0.192 -0.234,-0.465 -0.234,-0.817 0,-0.359 0.09,-0.644 0.273,-0.851 0.184,-0.207 0.434,-0.309 0.75,-0.309 0.102,0 0.2,0.008 0.293,0.024 0.094,0.015 0.188,0.039 0.282,0.07 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath197)"
+             id="path728" />
+          <path
+             d="m 102.027,151.656 c -0.105,0 -0.187,0.032 -0.242,0.09 -0.058,0.055 -0.086,0.137 -0.086,0.246 0,0.106 0.028,0.192 0.086,0.246 0.055,0.059 0.137,0.086 0.242,0.086 0.106,0 0.184,-0.027 0.239,-0.086 0.058,-0.054 0.086,-0.14 0.086,-0.246 0,-0.109 -0.028,-0.191 -0.086,-0.246 -0.055,-0.058 -0.133,-0.09 -0.239,-0.09 z m -0.414,-0.183 c -0.129,-0.039 -0.23,-0.102 -0.297,-0.184 -0.07,-0.086 -0.101,-0.187 -0.101,-0.312 0,-0.184 0.066,-0.325 0.207,-0.422 0.137,-0.098 0.34,-0.145 0.605,-0.145 0.266,0 0.465,0.047 0.602,0.145 0.141,0.097 0.207,0.238 0.207,0.422 0,0.125 -0.035,0.226 -0.102,0.312 -0.066,0.082 -0.168,0.145 -0.3,0.184 0.148,0.039 0.261,0.105 0.336,0.199 0.074,0.094 0.113,0.207 0.113,0.348 0,0.218 -0.071,0.382 -0.215,0.492 -0.145,0.113 -0.359,0.168 -0.641,0.168 -0.285,0 -0.5,-0.055 -0.644,-0.168 -0.145,-0.11 -0.219,-0.274 -0.219,-0.492 0,-0.141 0.039,-0.254 0.113,-0.348 0.078,-0.094 0.192,-0.16 0.336,-0.199 z m 0.133,-0.438 c 0,0.086 0.024,0.153 0.074,0.199 0.047,0.047 0.118,0.071 0.207,0.071 0.086,0 0.157,-0.024 0.203,-0.071 0.047,-0.046 0.071,-0.113 0.071,-0.199 0,-0.09 -0.024,-0.156 -0.071,-0.199 -0.046,-0.047 -0.117,-0.07 -0.203,-0.07 -0.089,0 -0.16,0.023 -0.207,0.07 -0.05,0.047 -0.074,0.113 -0.074,0.199 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath198)"
+             id="path729" />
+          <path
+             d="m 100.578,156.496 h 0.496 v -1.414 l -0.508,0.106 v -0.383 l 0.508,-0.106 h 0.535 v 1.797 h 0.496 v 0.391 h -1.527 z m 2.551,-0.707 c 0,-0.273 -0.027,-0.465 -0.078,-0.574 -0.051,-0.113 -0.137,-0.168 -0.258,-0.168 -0.121,0 -0.207,0.055 -0.262,0.168 -0.051,0.109 -0.078,0.301 -0.078,0.574 0,0.277 0.027,0.473 0.078,0.586 0.055,0.113 0.141,0.168 0.262,0.168 0.117,0 0.203,-0.055 0.258,-0.168 0.051,-0.113 0.078,-0.309 0.078,-0.586 z m 0.562,0.008 c 0,0.359 -0.078,0.641 -0.234,0.836 -0.156,0.199 -0.379,0.297 -0.664,0.297 -0.289,0 -0.512,-0.098 -0.668,-0.297 -0.156,-0.195 -0.234,-0.477 -0.234,-0.836 0,-0.363 0.078,-0.645 0.234,-0.84 0.156,-0.199 0.379,-0.297 0.668,-0.297 0.285,0 0.508,0.098 0.664,0.297 0.156,0.195 0.234,0.477 0.234,0.84 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath199)"
+             id="path730" />
+          <path
+             d="m 100.578,160.746 h 0.496 v -1.414 l -0.508,0.106 v -0.383 l 0.508,-0.106 h 0.535 v 1.797 h 0.496 v 0.391 h -1.527 z m 2.035,-0.023 h 0.961 v 0.414 h -1.59 v -0.414 l 0.797,-0.707 c 0.074,-0.063 0.125,-0.125 0.16,-0.188 0.036,-0.062 0.051,-0.125 0.051,-0.191 0,-0.102 -0.035,-0.184 -0.105,-0.246 -0.067,-0.063 -0.157,-0.094 -0.274,-0.094 -0.086,0 -0.183,0.019 -0.289,0.055 -0.101,0.039 -0.215,0.093 -0.332,0.168 v -0.481 c 0.125,-0.043 0.25,-0.074 0.375,-0.094 0.125,-0.023 0.246,-0.035 0.363,-0.035 0.262,0 0.465,0.059 0.61,0.172 0.148,0.117 0.219,0.277 0.219,0.484 0,0.118 -0.032,0.231 -0.09,0.332 -0.063,0.102 -0.192,0.243 -0.391,0.414 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath200)"
+             id="path731" />
+          <path
+             d="m 100.578,164.996 h 0.496 v -1.414 l -0.508,0.106 v -0.383 l 0.508,-0.106 h 0.535 v 1.797 h 0.496 v 0.391 h -1.527 z m 2.274,-1.332 -0.618,0.914 h 0.618 z m -0.094,-0.465 h 0.629 v 1.379 h 0.308 v 0.41 h -0.308 v 0.399 h -0.535 v -0.399 h -0.969 v -0.484 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath201)"
+             id="path732" />
+          <path
+             d="m 100.578,169.246 h 0.496 v -1.414 l -0.508,0.106 v -0.383 l 0.508,-0.106 h 0.535 v 1.797 h 0.496 v 0.391 h -1.527 z m 2.254,-0.691 c -0.098,0 -0.172,0.035 -0.223,0.097 -0.047,0.063 -0.074,0.16 -0.074,0.289 0,0.125 0.027,0.223 0.074,0.289 0.051,0.063 0.125,0.094 0.223,0.094 0.102,0 0.176,-0.031 0.223,-0.094 0.05,-0.066 0.074,-0.164 0.074,-0.289 0,-0.129 -0.024,-0.226 -0.074,-0.289 -0.047,-0.062 -0.121,-0.097 -0.223,-0.097 z m 0.699,-1.047 v 0.402 c -0.093,-0.043 -0.179,-0.074 -0.261,-0.098 -0.082,-0.019 -0.165,-0.031 -0.243,-0.031 -0.168,0 -0.297,0.047 -0.39,0.141 -0.094,0.094 -0.149,0.23 -0.164,0.414 0.062,-0.047 0.132,-0.082 0.207,-0.106 0.074,-0.023 0.156,-0.039 0.246,-0.039 0.222,0 0.406,0.067 0.543,0.2 0.136,0.129 0.203,0.3 0.203,0.511 0,0.235 -0.074,0.422 -0.227,0.567 -0.156,0.14 -0.359,0.211 -0.617,0.211 -0.285,0 -0.504,-0.098 -0.66,-0.289 -0.156,-0.192 -0.234,-0.465 -0.234,-0.817 0,-0.363 0.089,-0.644 0.273,-0.851 0.18,-0.207 0.43,-0.309 0.75,-0.309 0.098,0 0.195,0.008 0.293,0.024 0.094,0.015 0.188,0.039 0.281,0.07 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath202)"
+             id="path733" />
+          <path
+             d="m 100.578,173.496 h 0.496 v -1.414 l -0.508,0.106 v -0.383 l 0.508,-0.106 h 0.535 v 1.797 h 0.496 v 0.391 h -1.527 z m 2.215,-0.59 c -0.105,0 -0.188,0.032 -0.246,0.086 -0.055,0.059 -0.082,0.141 -0.082,0.25 0,0.106 0.027,0.188 0.082,0.246 0.058,0.059 0.141,0.086 0.246,0.086 0.102,0 0.184,-0.027 0.238,-0.086 0.055,-0.058 0.086,-0.14 0.086,-0.246 0,-0.109 -0.031,-0.191 -0.086,-0.25 -0.054,-0.054 -0.136,-0.086 -0.238,-0.086 z m -0.414,-0.183 c -0.133,-0.043 -0.231,-0.102 -0.301,-0.188 -0.066,-0.082 -0.098,-0.183 -0.098,-0.308 0,-0.184 0.067,-0.325 0.204,-0.422 0.14,-0.098 0.339,-0.145 0.609,-0.145 0.262,0 0.465,0.047 0.602,0.145 0.136,0.093 0.207,0.234 0.207,0.422 0,0.125 -0.036,0.226 -0.102,0.308 -0.066,0.086 -0.168,0.145 -0.301,0.188 0.149,0.039 0.262,0.105 0.336,0.199 0.074,0.09 0.113,0.207 0.113,0.348 0,0.218 -0.07,0.382 -0.214,0.492 -0.145,0.109 -0.36,0.168 -0.641,0.168 -0.285,0 -0.5,-0.059 -0.645,-0.168 -0.144,-0.11 -0.218,-0.274 -0.218,-0.492 0,-0.141 0.039,-0.258 0.113,-0.348 0.078,-0.094 0.187,-0.16 0.336,-0.199 z m 0.133,-0.438 c 0,0.086 0.023,0.153 0.07,0.199 0.051,0.047 0.121,0.071 0.211,0.071 0.086,0 0.156,-0.024 0.203,-0.071 0.047,-0.046 0.07,-0.113 0.07,-0.199 0,-0.09 -0.023,-0.156 -0.07,-0.199 -0.047,-0.047 -0.117,-0.07 -0.203,-0.07 -0.09,0 -0.16,0.023 -0.211,0.07 -0.047,0.047 -0.07,0.113 -0.07,0.199 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath203)"
+             id="path734" />
+          <path
+             d="m 101.09,177.719 h 0.965 v 0.418 h -1.59 v -0.418 l 0.797,-0.703 c 0.07,-0.063 0.125,-0.125 0.16,-0.188 0.031,-0.062 0.051,-0.125 0.051,-0.191 0,-0.106 -0.035,-0.188 -0.106,-0.25 -0.066,-0.063 -0.16,-0.094 -0.273,-0.094 -0.09,0 -0.184,0.019 -0.289,0.059 -0.106,0.035 -0.215,0.093 -0.336,0.168 v -0.481 c 0.129,-0.043 0.254,-0.074 0.379,-0.098 0.121,-0.019 0.242,-0.031 0.363,-0.031 0.262,0 0.465,0.055 0.609,0.172 0.145,0.113 0.219,0.277 0.219,0.48 0,0.122 -0.031,0.231 -0.094,0.336 -0.062,0.102 -0.191,0.239 -0.386,0.414 z m 2.039,-0.68 c 0,-0.273 -0.027,-0.465 -0.078,-0.578 -0.051,-0.109 -0.137,-0.168 -0.258,-0.168 -0.121,0 -0.207,0.059 -0.262,0.168 -0.051,0.113 -0.078,0.305 -0.078,0.578 0,0.277 0.027,0.473 0.078,0.586 0.055,0.113 0.141,0.168 0.262,0.168 0.117,0 0.203,-0.055 0.258,-0.168 0.051,-0.113 0.078,-0.309 0.078,-0.586 z m 0.562,0.004 c 0,0.363 -0.078,0.645 -0.234,0.84 -0.156,0.195 -0.379,0.293 -0.664,0.293 -0.289,0 -0.512,-0.098 -0.668,-0.293 -0.156,-0.195 -0.234,-0.477 -0.234,-0.84 0,-0.363 0.078,-0.641 0.234,-0.836 0.156,-0.199 0.379,-0.297 0.668,-0.297 0.285,0 0.508,0.098 0.664,0.297 0.156,0.195 0.234,0.473 0.234,0.836 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath204)"
+             id="path735" />
+          <path
+             d="m 101.09,181.969 h 0.965 v 0.418 h -1.59 v -0.418 l 0.797,-0.703 c 0.07,-0.063 0.125,-0.129 0.16,-0.188 0.031,-0.062 0.051,-0.125 0.051,-0.191 0,-0.106 -0.035,-0.188 -0.106,-0.25 -0.066,-0.063 -0.16,-0.094 -0.273,-0.094 -0.09,0 -0.184,0.019 -0.289,0.059 -0.106,0.035 -0.215,0.093 -0.336,0.168 v -0.481 c 0.129,-0.043 0.254,-0.074 0.379,-0.098 0.121,-0.019 0.242,-0.031 0.363,-0.031 0.262,0 0.465,0.055 0.609,0.172 0.145,0.113 0.219,0.277 0.219,0.48 0,0.122 -0.031,0.231 -0.094,0.336 -0.062,0.102 -0.191,0.239 -0.386,0.411 z m 1.523,0 h 0.961 v 0.418 h -1.59 v -0.418 l 0.797,-0.703 c 0.074,-0.063 0.125,-0.129 0.16,-0.188 0.036,-0.062 0.051,-0.125 0.051,-0.191 0,-0.106 -0.035,-0.188 -0.105,-0.25 -0.067,-0.063 -0.157,-0.094 -0.274,-0.094 -0.086,0 -0.183,0.019 -0.289,0.059 -0.101,0.035 -0.215,0.093 -0.332,0.168 v -0.481 c 0.125,-0.043 0.25,-0.074 0.375,-0.098 0.125,-0.019 0.246,-0.031 0.363,-0.031 0.262,0 0.465,0.055 0.61,0.172 0.148,0.113 0.219,0.277 0.219,0.48 0,0.122 -0.032,0.231 -0.09,0.336 -0.063,0.102 -0.192,0.239 -0.391,0.411 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath205)"
+             id="path736" />
+          <path
+             d="m 101.09,186.219 h 0.965 v 0.414 h -1.59 v -0.414 l 0.797,-0.703 c 0.07,-0.063 0.125,-0.129 0.16,-0.188 0.031,-0.062 0.051,-0.125 0.051,-0.191 0,-0.106 -0.035,-0.188 -0.106,-0.25 -0.066,-0.063 -0.16,-0.094 -0.273,-0.094 -0.09,0 -0.184,0.019 -0.289,0.059 -0.106,0.035 -0.215,0.093 -0.336,0.168 v -0.481 c 0.129,-0.043 0.254,-0.074 0.379,-0.098 0.121,-0.023 0.242,-0.031 0.363,-0.031 0.262,0 0.465,0.055 0.609,0.172 0.145,0.113 0.219,0.273 0.219,0.48 0,0.122 -0.031,0.231 -0.094,0.336 -0.062,0.102 -0.191,0.239 -0.386,0.411 z m 1.762,-1.305 -0.618,0.914 h 0.618 z m -0.094,-0.465 h 0.629 v 1.379 h 0.308 v 0.406 h -0.308 v 0.399 h -0.535 v -0.399 h -0.969 v -0.48 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath206)"
+             id="path737" />
+          <path
+             d="m 101.09,190.469 h 0.965 v 0.414 h -1.59 v -0.414 l 0.797,-0.703 c 0.07,-0.067 0.125,-0.129 0.16,-0.188 0.031,-0.062 0.051,-0.129 0.051,-0.195 0,-0.102 -0.035,-0.184 -0.106,-0.246 -0.066,-0.063 -0.16,-0.094 -0.273,-0.094 -0.09,0 -0.184,0.019 -0.289,0.059 -0.106,0.035 -0.215,0.093 -0.336,0.168 v -0.481 c 0.129,-0.043 0.254,-0.074 0.379,-0.098 0.121,-0.023 0.242,-0.031 0.363,-0.031 0.262,0 0.465,0.055 0.609,0.172 0.145,0.113 0.219,0.273 0.219,0.48 0,0.122 -0.031,0.231 -0.094,0.336 -0.062,0.102 -0.191,0.239 -0.386,0.411 z m 1.742,-0.664 c -0.098,0 -0.172,0.031 -0.223,0.097 -0.047,0.063 -0.074,0.16 -0.074,0.286 0,0.128 0.027,0.226 0.074,0.289 0.051,0.062 0.125,0.097 0.223,0.097 0.102,0 0.176,-0.035 0.223,-0.097 0.05,-0.063 0.074,-0.161 0.074,-0.289 0,-0.126 -0.024,-0.223 -0.074,-0.286 -0.047,-0.066 -0.121,-0.097 -0.223,-0.097 z m 0.699,-1.051 v 0.406 c -0.093,-0.047 -0.179,-0.078 -0.261,-0.098 -0.082,-0.019 -0.165,-0.031 -0.243,-0.031 -0.168,0 -0.297,0.047 -0.39,0.141 -0.094,0.09 -0.149,0.23 -0.164,0.414 0.062,-0.047 0.132,-0.086 0.207,-0.109 0.074,-0.024 0.156,-0.036 0.246,-0.036 0.222,0 0.406,0.067 0.543,0.196 0.136,0.133 0.203,0.304 0.203,0.515 0,0.235 -0.074,0.422 -0.227,0.563 -0.156,0.14 -0.359,0.211 -0.617,0.211 -0.285,0 -0.504,-0.094 -0.66,-0.285 -0.156,-0.192 -0.234,-0.465 -0.234,-0.817 0,-0.363 0.089,-0.648 0.273,-0.851 0.18,-0.207 0.43,-0.313 0.75,-0.313 0.098,0 0.195,0.008 0.293,0.024 0.094,0.015 0.188,0.039 0.281,0.07 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath207)"
+             id="path738" />
+          <path
+             d="m 101.09,194.719 h 0.965 v 0.414 h -1.59 v -0.414 l 0.797,-0.703 c 0.07,-0.063 0.125,-0.129 0.16,-0.188 0.031,-0.062 0.051,-0.125 0.051,-0.191 0,-0.106 -0.035,-0.188 -0.106,-0.25 -0.066,-0.063 -0.16,-0.094 -0.273,-0.094 -0.09,0 -0.184,0.019 -0.289,0.059 -0.106,0.035 -0.215,0.093 -0.336,0.168 v -0.481 c 0.129,-0.043 0.254,-0.074 0.379,-0.098 0.121,-0.019 0.242,-0.031 0.363,-0.031 0.262,0 0.465,0.055 0.609,0.172 0.145,0.113 0.219,0.273 0.219,0.48 0,0.122 -0.031,0.231 -0.094,0.336 -0.062,0.102 -0.191,0.239 -0.386,0.411 z m 1.703,-0.563 c -0.105,0 -0.188,0.028 -0.246,0.086 -0.055,0.059 -0.082,0.141 -0.082,0.25 0,0.106 0.027,0.188 0.082,0.246 0.058,0.055 0.141,0.086 0.246,0.086 0.102,0 0.184,-0.031 0.238,-0.086 0.055,-0.058 0.086,-0.14 0.086,-0.246 0,-0.109 -0.031,-0.191 -0.086,-0.25 -0.054,-0.058 -0.136,-0.086 -0.238,-0.086 z m -0.414,-0.187 c -0.133,-0.039 -0.231,-0.102 -0.301,-0.184 -0.066,-0.082 -0.098,-0.187 -0.098,-0.308 0,-0.188 0.067,-0.329 0.204,-0.422 0.14,-0.098 0.339,-0.145 0.609,-0.145 0.262,0 0.465,0.047 0.602,0.145 0.136,0.093 0.207,0.234 0.207,0.422 0,0.121 -0.036,0.226 -0.102,0.308 -0.066,0.082 -0.168,0.145 -0.301,0.184 0.149,0.043 0.262,0.109 0.336,0.203 0.074,0.09 0.113,0.207 0.113,0.348 0,0.214 -0.07,0.378 -0.214,0.492 -0.145,0.109 -0.36,0.164 -0.641,0.164 -0.285,0 -0.5,-0.055 -0.645,-0.164 -0.144,-0.114 -0.218,-0.278 -0.218,-0.492 0,-0.141 0.039,-0.258 0.113,-0.348 0.078,-0.094 0.187,-0.16 0.336,-0.203 z m 0.133,-0.438 c 0,0.09 0.023,0.157 0.07,0.203 0.051,0.047 0.121,0.071 0.211,0.071 0.086,0 0.156,-0.024 0.203,-0.071 0.047,-0.046 0.07,-0.113 0.07,-0.203 0,-0.086 -0.023,-0.152 -0.07,-0.199 -0.047,-0.047 -0.117,-0.07 -0.203,-0.07 -0.09,0 -0.16,0.023 -0.211,0.07 -0.047,0.047 -0.07,0.113 -0.07,0.199 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath208)"
+             id="path739" />
+          <path
+             d="m 101.625,198.207 c 0.145,0.035 0.258,0.102 0.336,0.199 0.074,0.094 0.113,0.211 0.113,0.356 0,0.218 -0.082,0.383 -0.25,0.496 -0.164,0.113 -0.406,0.168 -0.726,0.168 -0.11,0 -0.223,-0.008 -0.336,-0.028 -0.114,-0.015 -0.223,-0.043 -0.336,-0.078 v -0.437 c 0.105,0.055 0.211,0.094 0.316,0.121 0.102,0.027 0.207,0.039 0.305,0.039 0.152,0 0.265,-0.027 0.344,-0.078 0.082,-0.051 0.121,-0.125 0.121,-0.223 0,-0.097 -0.043,-0.176 -0.125,-0.226 -0.078,-0.051 -0.199,-0.075 -0.36,-0.075 h -0.226 v -0.363 h 0.238 c 0.141,0 0.246,-0.023 0.316,-0.066 0.071,-0.047 0.106,-0.114 0.106,-0.203 0,-0.086 -0.035,-0.149 -0.102,-0.196 -0.066,-0.047 -0.164,-0.07 -0.285,-0.07 -0.094,0 -0.183,0.012 -0.277,0.031 -0.094,0.02 -0.184,0.051 -0.277,0.09 v -0.41 c 0.113,-0.031 0.222,-0.055 0.332,-0.07 0.109,-0.016 0.218,-0.024 0.324,-0.024 0.281,0 0.496,0.047 0.636,0.141 0.141,0.09 0.211,0.23 0.211,0.418 0,0.129 -0.035,0.234 -0.101,0.316 -0.067,0.078 -0.168,0.137 -0.297,0.172 z m 1.504,0.082 c 0,-0.273 -0.027,-0.465 -0.078,-0.578 -0.051,-0.109 -0.137,-0.168 -0.258,-0.168 -0.121,0 -0.207,0.059 -0.262,0.168 -0.051,0.113 -0.078,0.305 -0.078,0.578 0,0.277 0.027,0.473 0.078,0.586 0.055,0.113 0.141,0.168 0.262,0.168 0.117,0 0.203,-0.055 0.258,-0.168 0.051,-0.113 0.078,-0.309 0.078,-0.586 z m 0.562,0.004 c 0,0.363 -0.078,0.641 -0.234,0.84 -0.156,0.195 -0.379,0.293 -0.664,0.293 -0.289,0 -0.512,-0.098 -0.668,-0.293 -0.156,-0.199 -0.234,-0.477 -0.234,-0.84 0,-0.363 0.078,-0.641 0.234,-0.84 0.156,-0.195 0.379,-0.293 0.668,-0.293 0.285,0 0.508,0.098 0.664,0.293 0.156,0.199 0.234,0.477 0.234,0.84 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath209)"
+             id="path740" />
+          <path
+             d="m 196.395,196.172 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath210)"
+             id="path741" />
+          <path
+             d="m 196.395,-196.172 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath211)"
+             id="path742" />
+          <path
+             d="m 196.395,191.922 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath212)"
+             id="path743" />
+          <path
+             d="m 196.395,-191.922 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath213)"
+             id="path744" />
+          <path
+             d="m 196.395,187.668 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath214)"
+             id="path745" />
+          <path
+             d="m 196.395,-187.668 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath215)"
+             id="path746" />
+          <path
+             d="m 196.395,183.418 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath216)"
+             id="path747" />
+          <path
+             d="m 196.395,-183.418 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath217)"
+             id="path748" />
+          <path
+             d="m 196.395,179.168 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath218)"
+             id="path749" />
+          <path
+             d="m 196.395,-179.168 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath219)"
+             id="path750" />
+          <path
+             d="m 196.395,174.918 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath220)"
+             id="path751" />
+          <path
+             d="m 196.395,-174.918 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath221)"
+             id="path752" />
+          <path
+             d="m 196.395,170.668 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath222)"
+             id="path753" />
+          <path
+             d="m 196.395,-170.668 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath223)"
+             id="path754" />
+          <path
+             d="m 196.395,166.418 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath224)"
+             id="path755" />
+          <path
+             d="m 196.395,-166.418 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath225)"
+             id="path756" />
+          <path
+             d="m 196.395,162.168 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath226)"
+             id="path757" />
+          <path
+             d="m 196.395,-162.168 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath227)"
+             id="path758" />
+          <path
+             d="m 196.395,157.914 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath228)"
+             id="path759" />
+          <path
+             d="m 196.395,-157.914 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath229)"
+             id="path760" />
+          <path
+             d="m 196.395,153.664 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath230)"
+             id="path761" />
+          <path
+             d="m 196.395,-153.664 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath231)"
+             id="path762" />
+          <path
+             d="m 196.395,149.414 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath232)"
+             id="path763" />
+          <path
+             d="m 196.395,-149.414 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath233)"
+             id="path764" />
+          <path
+             d="m 196.395,145.164 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath234)"
+             id="path765" />
+          <path
+             d="m 196.395,-145.164 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath235)"
+             id="path766" />
+          <path
+             d="m 196.395,140.914 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath236)"
+             id="path767" />
+          <path
+             d="m 196.395,-140.914 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath237)"
+             id="path768" />
+          <path
+             d="m 196.395,136.664 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath238)"
+             id="path769" />
+          <path
+             d="m 196.395,-136.664 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath239)"
+             id="path770" />
+          <path
+             d="m 196.395,132.414 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath240)"
+             id="path771" />
+          <path
+             d="m 196.395,-132.414 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath241)"
+             id="path772" />
+          <path
+             d="m 196.395,128.164 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath242)"
+             id="path773" />
+          <path
+             d="m 196.395,-128.164 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath243)"
+             id="path774" />
+          <path
+             d="m 200.645,196.172 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath244)"
+             id="path775" />
+          <path
+             d="m 200.645,-196.172 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath245)"
+             id="path776" />
+          <path
+             d="m 200.645,191.922 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath246)"
+             id="path777" />
+          <path
+             d="m 200.645,-191.922 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath247)"
+             id="path778" />
+          <path
+             d="m 200.645,187.668 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath248)"
+             id="path779" />
+          <path
+             d="m 200.645,-187.668 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath249)"
+             id="path780" />
+          <path
+             d="m 200.645,183.418 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath250)"
+             id="path781" />
+          <path
+             d="m 200.645,-183.418 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath251)"
+             id="path782" />
+          <path
+             d="m 200.645,179.168 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath252)"
+             id="path783" />
+          <path
+             d="m 200.645,-179.168 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath253)"
+             id="path784" />
+          <path
+             d="m 200.645,174.918 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath254)"
+             id="path785" />
+          <path
+             d="m 200.645,-174.918 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath255)"
+             id="path786" />
+          <path
+             d="m 200.645,170.668 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath256)"
+             id="path787" />
+          <path
+             d="m 200.645,-170.668 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath257)"
+             id="path788" />
+          <path
+             d="m 200.645,166.418 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath258)"
+             id="path789" />
+          <path
+             d="m 200.645,-166.418 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath259)"
+             id="path790" />
+          <path
+             d="m 200.645,162.168 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath260)"
+             id="path791" />
+          <path
+             d="m 200.645,-162.168 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath261)"
+             id="path792" />
+          <path
+             d="m 200.645,157.914 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath262)"
+             id="path793" />
+          <path
+             d="m 200.645,-157.914 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath263)"
+             id="path794" />
+          <path
+             d="m 200.645,153.664 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath264)"
+             id="path795" />
+          <path
+             d="m 200.645,-153.664 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath265)"
+             id="path796" />
+          <path
+             d="m 200.645,149.414 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath266)"
+             id="path797" />
+          <path
+             d="m 200.645,-149.414 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath267)"
+             id="path798" />
+          <path
+             d="m 200.645,145.164 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath268)"
+             id="path799" />
+          <path
+             d="m 200.645,-145.164 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath269)"
+             id="path800" />
+          <path
+             d="m 200.645,140.914 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath270)"
+             id="path801" />
+          <path
+             d="m 200.645,-140.914 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath271)"
+             id="path802" />
+          <path
+             d="m 200.645,136.664 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath272)"
+             id="path803" />
+          <path
+             d="m 200.645,-136.664 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath273)"
+             id="path804" />
+          <path
+             d="m 200.645,132.414 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath274)"
+             id="path805" />
+          <path
+             d="m 200.645,-132.414 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath275)"
+             id="path806" />
+          <path
+             d="m 200.645,128.164 h 4.254 v 4.25 h -4.254 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath276)"
+             id="path807" />
+          <path
+             d="m 200.645,-128.164 h 4.254 v -4.25 h -4.254 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath277)"
+             id="path808" />
+          <path
+             d="m 198.105,131.008 h 0.5 v -1.414 l -0.511,0.105 v -0.383 l 0.508,-0.105 h 0.535 v 1.797 h 0.5 v 0.39 h -1.532 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath278)"
+             id="path809" />
+          <path
+             d="m 199.152,134.469 c 0.149,0.039 0.262,0.105 0.336,0.199 0.078,0.094 0.117,0.211 0.117,0.359 0,0.215 -0.085,0.379 -0.25,0.493 -0.167,0.113 -0.41,0.168 -0.726,0.168 -0.113,0 -0.227,-0.008 -0.34,-0.028 -0.109,-0.015 -0.223,-0.043 -0.332,-0.078 v -0.437 c 0.105,0.054 0.211,0.093 0.313,0.121 0.105,0.027 0.207,0.039 0.308,0.039 0.149,0 0.262,-0.024 0.344,-0.078 0.078,-0.051 0.117,-0.125 0.117,-0.223 0,-0.098 -0.039,-0.172 -0.121,-0.223 -0.082,-0.054 -0.203,-0.078 -0.359,-0.078 h -0.227 v -0.363 h 0.238 c 0.141,0 0.246,-0.024 0.317,-0.067 0.066,-0.046 0.101,-0.113 0.101,-0.203 0,-0.086 -0.031,-0.148 -0.101,-0.195 -0.067,-0.047 -0.16,-0.07 -0.285,-0.07 -0.09,0 -0.184,0.011 -0.274,0.031 -0.094,0.019 -0.187,0.051 -0.277,0.09 v -0.41 c 0.109,-0.032 0.222,-0.055 0.332,-0.071 0.109,-0.015 0.215,-0.023 0.32,-0.023 0.285,0 0.496,0.047 0.637,0.14 0.14,0.09 0.215,0.231 0.215,0.418 0,0.129 -0.035,0.235 -0.102,0.317 -0.07,0.082 -0.168,0.137 -0.301,0.172 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath279)"
+             id="path810" />
+          <path
+             d="m 198.074,137.711 h 1.403 v 0.414 h -0.954 v 0.34 c 0.043,-0.012 0.086,-0.024 0.129,-0.027 0.043,-0.008 0.09,-0.012 0.137,-0.012 0.266,0 0.473,0.066 0.621,0.203 0.149,0.133 0.223,0.316 0.223,0.555 0,0.238 -0.082,0.421 -0.242,0.554 -0.161,0.133 -0.387,0.203 -0.672,0.203 -0.125,0 -0.246,-0.015 -0.371,-0.039 -0.121,-0.023 -0.243,-0.058 -0.36,-0.109 v -0.441 c 0.117,0.066 0.231,0.117 0.336,0.152 0.11,0.035 0.211,0.051 0.305,0.051 0.137,0 0.242,-0.032 0.32,-0.098 0.082,-0.066 0.121,-0.16 0.121,-0.273 0,-0.114 -0.039,-0.207 -0.121,-0.274 -0.078,-0.066 -0.183,-0.098 -0.32,-0.098 -0.082,0 -0.168,0.012 -0.258,0.032 -0.094,0.019 -0.191,0.054 -0.297,0.097 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath280)"
+             id="path811" />
+          <path
+             d="m 197.957,141.961 h 1.648 v 0.316 l -0.855,1.871 h -0.547 l 0.805,-1.773 h -1.051 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath281)"
+             id="path812" />
+          <path
+             d="m 198.055,148.348 v -0.403 c 0.09,0.039 0.175,0.075 0.257,0.094 0.083,0.02 0.165,0.031 0.247,0.031 0.168,0 0.296,-0.047 0.39,-0.14 0.094,-0.094 0.149,-0.231 0.164,-0.414 -0.066,0.046 -0.136,0.086 -0.211,0.109 -0.074,0.023 -0.156,0.035 -0.246,0.035 -0.222,0 -0.402,-0.062 -0.539,-0.195 -0.137,-0.129 -0.207,-0.301 -0.207,-0.512 0,-0.238 0.078,-0.426 0.231,-0.566 0.152,-0.141 0.355,-0.215 0.613,-0.215 0.285,0 0.508,0.098 0.664,0.289 0.156,0.195 0.234,0.465 0.234,0.816 0,0.364 -0.093,0.645 -0.273,0.852 -0.184,0.207 -0.434,0.309 -0.754,0.309 -0.102,0 -0.199,-0.008 -0.293,-0.024 -0.094,-0.012 -0.187,-0.035 -0.277,-0.066 z m 0.695,-1.051 c 0.102,0 0.176,-0.035 0.223,-0.098 0.05,-0.062 0.078,-0.16 0.078,-0.289 0,-0.125 -0.028,-0.222 -0.078,-0.285 -0.047,-0.066 -0.121,-0.098 -0.223,-0.098 -0.098,0 -0.172,0.032 -0.223,0.098 -0.047,0.063 -0.074,0.16 -0.074,0.285 0,0.129 0.027,0.227 0.074,0.289 0.051,0.063 0.125,0.098 0.223,0.098 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath282)"
+             id="path813" />
+          <path
+             d="m 197.352,152.258 h 0.496 v -1.414 l -0.508,0.105 v -0.383 l 0.508,-0.105 h 0.535 v 1.797 h 0.496 v 0.387 h -1.527 z m 1.519,0 h 0.5 v -1.414 l -0.512,0.105 v -0.383 l 0.508,-0.105 h 0.535 v 1.797 h 0.5 v 0.387 h -1.531 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath283)"
+             id="path814" />
+          <path
+             d="m 197.352,156.508 h 0.496 v -1.414 l -0.508,0.105 v -0.383 l 0.508,-0.105 h 0.535 v 1.797 h 0.496 v 0.387 h -1.527 z m 2.566,-0.789 c 0.148,0.035 0.258,0.101 0.336,0.199 0.078,0.094 0.117,0.211 0.117,0.355 0,0.219 -0.086,0.383 -0.25,0.497 -0.168,0.113 -0.41,0.168 -0.726,0.168 -0.114,0 -0.227,-0.008 -0.34,-0.028 -0.114,-0.015 -0.223,-0.043 -0.332,-0.078 v -0.437 c 0.105,0.054 0.207,0.093 0.312,0.121 0.106,0.027 0.207,0.039 0.309,0.039 0.148,0 0.261,-0.028 0.34,-0.078 0.082,-0.051 0.121,-0.125 0.121,-0.223 0,-0.098 -0.039,-0.176 -0.121,-0.227 -0.082,-0.05 -0.204,-0.074 -0.364,-0.074 h -0.222 v -0.363 h 0.234 c 0.145,0 0.25,-0.024 0.316,-0.067 0.071,-0.046 0.106,-0.113 0.106,-0.203 0,-0.086 -0.035,-0.148 -0.102,-0.195 -0.066,-0.047 -0.16,-0.07 -0.285,-0.07 -0.09,0 -0.183,0.011 -0.273,0.031 -0.094,0.019 -0.188,0.051 -0.278,0.09 v -0.41 c 0.11,-0.032 0.219,-0.055 0.329,-0.071 0.109,-0.015 0.218,-0.023 0.324,-0.023 0.285,0 0.496,0.047 0.636,0.14 0.141,0.09 0.211,0.231 0.211,0.418 0,0.129 -0.031,0.235 -0.097,0.317 -0.071,0.078 -0.168,0.137 -0.301,0.172 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath284)"
+             id="path815" />
+          <path
+             d="m 197.352,160.758 h 0.496 v -1.414 l -0.508,0.105 v -0.383 l 0.508,-0.105 h 0.535 v 1.797 h 0.496 v 0.387 h -1.527 z m 1.488,-1.797 h 1.402 v 0.414 h -0.953 v 0.336 c 0.043,-0.012 0.086,-0.02 0.129,-0.023 0.043,-0.008 0.09,-0.012 0.137,-0.012 0.265,0 0.472,0.066 0.621,0.199 0.148,0.133 0.222,0.32 0.222,0.559 0,0.234 -0.082,0.421 -0.242,0.554 -0.16,0.133 -0.386,0.2 -0.672,0.2 -0.125,0 -0.25,-0.012 -0.371,-0.036 -0.121,-0.023 -0.242,-0.058 -0.359,-0.109 v -0.445 c 0.117,0.07 0.23,0.121 0.336,0.156 0.109,0.035 0.211,0.051 0.305,0.051 0.136,0 0.242,-0.035 0.32,-0.102 0.082,-0.066 0.121,-0.156 0.121,-0.269 0,-0.118 -0.039,-0.207 -0.121,-0.274 -0.078,-0.066 -0.184,-0.098 -0.32,-0.098 -0.083,0 -0.168,0.008 -0.262,0.032 -0.09,0.019 -0.188,0.051 -0.293,0.097 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath285)"
+             id="path816" />
+          <path
+             d="m 197.352,165.008 h 0.496 v -1.414 l -0.508,0.105 v -0.383 l 0.508,-0.105 h 0.535 v 1.797 h 0.496 v 0.387 h -1.527 z m 1.371,-1.797 h 1.648 v 0.316 l -0.855,1.868 h -0.547 l 0.804,-1.77 h -1.05 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath286)"
+             id="path817" />
+          <path
+             d="m 197.352,169.258 h 0.496 v -1.414 l -0.508,0.105 v -0.383 l 0.508,-0.105 h 0.535 v 1.797 h 0.496 v 0.387 h -1.527 z m 1.468,0.34 v -0.407 c 0.09,0.043 0.176,0.075 0.258,0.098 0.082,0.02 0.164,0.031 0.242,0.031 0.168,0 0.301,-0.047 0.395,-0.14 0.094,-0.094 0.148,-0.231 0.164,-0.414 -0.067,0.046 -0.137,0.082 -0.211,0.109 -0.074,0.023 -0.156,0.035 -0.246,0.035 -0.223,0 -0.402,-0.066 -0.539,-0.195 -0.137,-0.129 -0.207,-0.301 -0.207,-0.516 0,-0.234 0.078,-0.422 0.23,-0.562 0.153,-0.145 0.356,-0.215 0.614,-0.215 0.285,0 0.507,0.098 0.664,0.289 0.156,0.191 0.234,0.465 0.234,0.816 0,0.36 -0.094,0.645 -0.277,0.852 -0.18,0.207 -0.43,0.309 -0.75,0.309 -0.102,0 -0.2,-0.008 -0.293,-0.024 -0.094,-0.016 -0.188,-0.035 -0.278,-0.066 z m 0.696,-1.055 c 0.101,0 0.175,-0.031 0.222,-0.094 0.051,-0.062 0.074,-0.16 0.074,-0.289 0,-0.125 -0.023,-0.222 -0.074,-0.285 -0.047,-0.066 -0.121,-0.098 -0.222,-0.098 -0.098,0 -0.172,0.032 -0.223,0.098 -0.047,0.063 -0.074,0.16 -0.074,0.285 0,0.129 0.027,0.227 0.074,0.289 0.051,0.063 0.125,0.094 0.223,0.094 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath287)"
+             id="path818" />
+          <path
+             d="m 197.863,173.48 h 0.965 v 0.415 h -1.59 v -0.415 l 0.797,-0.703 c 0.07,-0.066 0.125,-0.129 0.16,-0.191 0.032,-0.059 0.051,-0.125 0.051,-0.191 0,-0.102 -0.035,-0.184 -0.105,-0.247 -0.067,-0.062 -0.161,-0.093 -0.274,-0.093 -0.09,0 -0.183,0.019 -0.289,0.058 -0.105,0.035 -0.215,0.09 -0.336,0.164 v -0.48 c 0.129,-0.039 0.254,-0.07 0.379,-0.094 0.121,-0.023 0.242,-0.035 0.363,-0.035 0.262,0 0.465,0.059 0.61,0.176 0.144,0.113 0.218,0.273 0.218,0.48 0,0.117 -0.031,0.231 -0.093,0.332 -0.063,0.106 -0.192,0.242 -0.387,0.414 z m 1.008,0.028 h 0.5 v -1.414 l -0.512,0.105 v -0.383 l 0.508,-0.105 h 0.535 v 1.797 h 0.5 v 0.387 h -1.531 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath288)"
+             id="path819" />
+          <path
+             d="m 197.863,177.73 h 0.965 v 0.415 h -1.59 v -0.415 l 0.797,-0.703 c 0.07,-0.066 0.125,-0.129 0.16,-0.191 0.032,-0.059 0.051,-0.125 0.051,-0.191 0,-0.102 -0.035,-0.184 -0.105,-0.247 -0.067,-0.062 -0.161,-0.093 -0.274,-0.093 -0.09,0 -0.183,0.019 -0.289,0.058 -0.105,0.035 -0.215,0.09 -0.336,0.164 v -0.48 c 0.129,-0.039 0.254,-0.074 0.379,-0.094 0.121,-0.023 0.242,-0.035 0.363,-0.035 0.262,0 0.465,0.059 0.61,0.176 0.144,0.113 0.218,0.273 0.218,0.48 0,0.117 -0.031,0.231 -0.093,0.332 -0.063,0.106 -0.192,0.242 -0.387,0.414 z m 2.055,-0.765 c 0.148,0.039 0.258,0.105 0.336,0.199 0.078,0.094 0.117,0.215 0.117,0.359 0,0.219 -0.086,0.383 -0.25,0.497 -0.168,0.113 -0.41,0.168 -0.726,0.168 -0.114,0 -0.227,-0.008 -0.34,-0.028 -0.114,-0.019 -0.223,-0.043 -0.332,-0.082 v -0.433 c 0.105,0.05 0.207,0.093 0.312,0.121 0.106,0.023 0.207,0.039 0.309,0.039 0.148,0 0.261,-0.028 0.34,-0.078 0.082,-0.051 0.121,-0.125 0.121,-0.223 0,-0.102 -0.039,-0.176 -0.121,-0.227 -0.082,-0.05 -0.204,-0.078 -0.364,-0.078 h -0.222 v -0.363 h 0.234 c 0.145,0 0.25,-0.02 0.316,-0.063 0.071,-0.046 0.106,-0.113 0.106,-0.207 0,-0.082 -0.035,-0.148 -0.102,-0.191 -0.066,-0.047 -0.16,-0.07 -0.285,-0.07 -0.09,0 -0.183,0.011 -0.273,0.031 -0.094,0.019 -0.188,0.051 -0.278,0.09 v -0.414 c 0.11,-0.032 0.219,-0.055 0.329,-0.071 0.109,-0.015 0.218,-0.023 0.324,-0.023 0.285,0 0.496,0.047 0.636,0.141 0.141,0.093 0.211,0.234 0.211,0.421 0,0.129 -0.031,0.235 -0.097,0.317 -0.071,0.078 -0.168,0.137 -0.301,0.168 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath289)"
+             id="path820" />
+          <path
+             d="m 197.863,181.98 h 0.965 v 0.415 h -1.59 v -0.415 l 0.797,-0.703 c 0.07,-0.066 0.125,-0.129 0.16,-0.191 0.032,-0.059 0.051,-0.125 0.051,-0.191 0,-0.102 -0.035,-0.184 -0.105,-0.247 -0.067,-0.062 -0.161,-0.093 -0.274,-0.093 -0.09,0 -0.183,0.019 -0.289,0.054 -0.105,0.039 -0.215,0.094 -0.336,0.168 v -0.48 c 0.129,-0.039 0.254,-0.074 0.379,-0.094 0.121,-0.023 0.242,-0.035 0.363,-0.035 0.262,0 0.465,0.059 0.61,0.176 0.144,0.113 0.218,0.273 0.218,0.48 0,0.117 -0.031,0.231 -0.093,0.332 -0.063,0.106 -0.192,0.242 -0.387,0.414 z m 0.977,-1.773 h 1.402 v 0.414 h -0.953 v 0.34 c 0.043,-0.012 0.086,-0.02 0.129,-0.027 0.043,-0.004 0.09,-0.008 0.137,-0.008 0.265,0 0.472,0.066 0.621,0.199 0.148,0.133 0.222,0.32 0.222,0.559 0,0.234 -0.082,0.418 -0.242,0.554 -0.16,0.133 -0.386,0.2 -0.672,0.2 -0.125,0 -0.25,-0.012 -0.371,-0.036 -0.121,-0.023 -0.242,-0.062 -0.359,-0.109 v -0.445 c 0.117,0.07 0.23,0.121 0.336,0.156 0.109,0.031 0.211,0.051 0.305,0.051 0.136,0 0.242,-0.035 0.32,-0.102 0.082,-0.066 0.121,-0.156 0.121,-0.269 0,-0.118 -0.039,-0.207 -0.121,-0.274 -0.078,-0.066 -0.184,-0.101 -0.32,-0.101 -0.083,0 -0.168,0.011 -0.262,0.035 -0.09,0.019 -0.188,0.051 -0.293,0.094 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath290)"
+             id="path821" />
+          <path
+             d="m 197.863,186.23 h 0.965 v 0.415 h -1.59 v -0.415 l 0.797,-0.703 c 0.07,-0.066 0.125,-0.129 0.16,-0.191 0.032,-0.059 0.051,-0.125 0.051,-0.191 0,-0.102 -0.035,-0.184 -0.105,-0.247 -0.067,-0.062 -0.161,-0.093 -0.274,-0.093 -0.09,0 -0.183,0.019 -0.289,0.054 -0.105,0.039 -0.215,0.094 -0.336,0.168 v -0.48 c 0.129,-0.043 0.254,-0.074 0.379,-0.094 0.121,-0.023 0.242,-0.035 0.363,-0.035 0.262,0 0.465,0.059 0.61,0.172 0.144,0.117 0.218,0.277 0.218,0.484 0,0.117 -0.031,0.231 -0.093,0.332 -0.063,0.106 -0.192,0.242 -0.387,0.414 z m 0.86,-1.773 h 1.648 v 0.32 l -0.855,1.868 h -0.547 l 0.804,-1.774 h -1.05 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath291)"
+             id="path822" />
+          <path
+             d="m 197.863,190.48 h 0.965 v 0.415 h -1.59 v -0.415 l 0.797,-0.703 c 0.07,-0.066 0.125,-0.129 0.16,-0.191 0.032,-0.063 0.051,-0.125 0.051,-0.191 0,-0.102 -0.035,-0.184 -0.105,-0.247 -0.067,-0.062 -0.161,-0.093 -0.274,-0.093 -0.09,0 -0.183,0.019 -0.289,0.054 -0.105,0.039 -0.215,0.094 -0.336,0.168 v -0.48 c 0.129,-0.043 0.254,-0.074 0.379,-0.094 0.121,-0.023 0.242,-0.035 0.363,-0.035 0.262,0 0.465,0.059 0.61,0.172 0.144,0.117 0.218,0.277 0.218,0.484 0,0.117 -0.031,0.231 -0.093,0.332 -0.063,0.102 -0.192,0.242 -0.387,0.414 z m 0.957,0.368 v -0.407 c 0.09,0.043 0.176,0.075 0.258,0.094 0.082,0.024 0.164,0.031 0.242,0.031 0.168,0 0.301,-0.046 0.395,-0.136 0.094,-0.094 0.148,-0.235 0.164,-0.418 -0.067,0.05 -0.137,0.086 -0.211,0.109 -0.074,0.027 -0.156,0.039 -0.246,0.039 -0.223,0 -0.402,-0.066 -0.539,-0.195 -0.137,-0.133 -0.207,-0.305 -0.207,-0.516 0,-0.234 0.078,-0.426 0.23,-0.566 0.153,-0.141 0.356,-0.211 0.614,-0.211 0.285,0 0.507,0.094 0.664,0.289 0.156,0.191 0.234,0.465 0.234,0.816 0,0.36 -0.094,0.645 -0.277,0.852 -0.18,0.203 -0.43,0.309 -0.75,0.309 -0.102,0 -0.2,-0.008 -0.293,-0.024 -0.094,-0.016 -0.188,-0.039 -0.278,-0.066 z m 0.696,-1.055 c 0.101,0 0.175,-0.031 0.222,-0.094 0.051,-0.066 0.074,-0.16 0.074,-0.289 0,-0.129 -0.023,-0.222 -0.074,-0.289 -0.047,-0.062 -0.121,-0.094 -0.222,-0.094 -0.098,0 -0.172,0.032 -0.223,0.094 -0.047,0.067 -0.074,0.16 -0.074,0.289 0,0.129 0.027,0.223 0.074,0.289 0.051,0.063 0.125,0.094 0.223,0.094 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath292)"
+             id="path823" />
+          <path
+             d="m 198.398,193.965 c 0.145,0.039 0.258,0.105 0.336,0.199 0.075,0.094 0.114,0.215 0.114,0.359 0,0.215 -0.082,0.383 -0.25,0.497 -0.164,0.109 -0.407,0.168 -0.727,0.168 -0.109,0 -0.223,-0.012 -0.336,-0.028 -0.113,-0.019 -0.223,-0.047 -0.336,-0.082 v -0.433 c 0.106,0.05 0.211,0.089 0.317,0.117 0.101,0.027 0.207,0.043 0.304,0.043 0.153,0 0.266,-0.028 0.344,-0.078 0.082,-0.055 0.121,-0.129 0.121,-0.223 0,-0.102 -0.043,-0.176 -0.125,-0.227 -0.078,-0.05 -0.199,-0.078 -0.359,-0.078 h -0.227 v -0.363 h 0.238 c 0.141,0 0.247,-0.024 0.317,-0.066 0.07,-0.043 0.105,-0.114 0.105,-0.204 0,-0.082 -0.035,-0.148 -0.101,-0.195 -0.067,-0.043 -0.164,-0.066 -0.285,-0.066 -0.094,0 -0.184,0.007 -0.278,0.031 -0.093,0.019 -0.183,0.051 -0.277,0.09 v -0.414 c 0.113,-0.032 0.223,-0.055 0.332,-0.071 0.109,-0.015 0.219,-0.023 0.324,-0.023 0.281,0 0.496,0.047 0.637,0.141 0.141,0.093 0.211,0.234 0.211,0.421 0,0.125 -0.035,0.231 -0.102,0.313 -0.066,0.082 -0.168,0.141 -0.297,0.172 z m 0.473,0.789 h 0.5 v -1.414 l -0.512,0.105 v -0.383 l 0.508,-0.105 h 0.535 v 1.797 h 0.5 v 0.391 h -1.531 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath293)"
+             id="path824" />
+          <path
+             d="m 198.398,198.215 c 0.145,0.039 0.258,0.105 0.336,0.199 0.075,0.094 0.114,0.215 0.114,0.359 0,0.215 -0.082,0.383 -0.25,0.497 -0.164,0.109 -0.407,0.168 -0.727,0.168 -0.109,0 -0.223,-0.012 -0.336,-0.028 -0.113,-0.019 -0.223,-0.047 -0.336,-0.082 v -0.433 c 0.106,0.05 0.211,0.089 0.317,0.117 0.101,0.027 0.207,0.039 0.304,0.039 0.153,0 0.266,-0.024 0.344,-0.074 0.082,-0.055 0.121,-0.129 0.121,-0.223 0,-0.102 -0.043,-0.176 -0.125,-0.227 -0.078,-0.05 -0.199,-0.078 -0.359,-0.078 h -0.227 v -0.363 h 0.238 c 0.141,0 0.247,-0.024 0.317,-0.066 0.07,-0.043 0.105,-0.114 0.105,-0.204 0,-0.082 -0.035,-0.148 -0.101,-0.195 -0.067,-0.047 -0.164,-0.066 -0.285,-0.066 -0.094,0 -0.184,0.007 -0.278,0.027 -0.093,0.023 -0.183,0.051 -0.277,0.094 v -0.414 c 0.113,-0.032 0.223,-0.055 0.332,-0.071 0.109,-0.015 0.219,-0.023 0.324,-0.023 0.281,0 0.496,0.047 0.637,0.141 0.141,0.093 0.211,0.234 0.211,0.421 0,0.125 -0.035,0.231 -0.102,0.313 -0.066,0.082 -0.168,0.141 -0.297,0.172 z m 1.52,0 c 0.148,0.039 0.258,0.105 0.336,0.199 0.078,0.094 0.117,0.215 0.117,0.359 0,0.215 -0.086,0.383 -0.25,0.497 -0.168,0.109 -0.41,0.168 -0.726,0.168 -0.114,0 -0.227,-0.012 -0.34,-0.028 -0.114,-0.019 -0.223,-0.047 -0.332,-0.082 v -0.433 c 0.105,0.05 0.207,0.089 0.312,0.117 0.106,0.027 0.207,0.039 0.309,0.039 0.148,0 0.261,-0.024 0.34,-0.074 0.082,-0.055 0.121,-0.129 0.121,-0.223 0,-0.102 -0.039,-0.176 -0.121,-0.227 -0.082,-0.05 -0.204,-0.078 -0.364,-0.078 h -0.222 v -0.363 h 0.234 c 0.145,0 0.25,-0.024 0.316,-0.066 0.071,-0.043 0.106,-0.114 0.106,-0.204 0,-0.082 -0.035,-0.148 -0.102,-0.195 -0.066,-0.047 -0.16,-0.066 -0.285,-0.066 -0.09,0 -0.183,0.007 -0.273,0.027 -0.094,0.023 -0.188,0.051 -0.278,0.094 v -0.414 c 0.11,-0.032 0.219,-0.055 0.329,-0.071 0.109,-0.015 0.218,-0.023 0.324,-0.023 0.285,0 0.496,0.047 0.636,0.141 0.141,0.093 0.211,0.234 0.211,0.421 0,0.125 -0.031,0.231 -0.097,0.313 -0.071,0.082 -0.168,0.141 -0.301,0.172 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath294)"
+             id="path825" />
+          <path
+             d="m 202.977,130.973 h 0.964 v 0.414 h -1.589 v -0.414 l 0.796,-0.703 c 0.075,-0.067 0.125,-0.129 0.161,-0.192 0.035,-0.062 0.05,-0.125 0.05,-0.191 0,-0.102 -0.035,-0.184 -0.105,-0.246 -0.066,-0.063 -0.16,-0.094 -0.274,-0.094 -0.085,0 -0.183,0.019 -0.289,0.055 -0.101,0.039 -0.214,0.093 -0.336,0.168 v -0.481 c 0.129,-0.043 0.254,-0.074 0.379,-0.094 0.125,-0.023 0.246,-0.035 0.364,-0.035 0.261,0 0.464,0.059 0.609,0.172 0.145,0.117 0.219,0.277 0.219,0.484 0,0.118 -0.031,0.231 -0.094,0.332 -0.059,0.102 -0.187,0.243 -0.387,0.414 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath295)"
+             id="path826" />
+          <path
+             d="m 203.219,133.914 -0.617,0.914 h 0.617 z m -0.094,-0.465 h 0.625 v 1.379 h 0.312 v 0.41 h -0.312 v 0.399 h -0.531 v -0.399 h -0.969 v -0.484 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath296)"
+             id="path827" />
+          <path
+             d="m 203.199,138.809 c -0.097,0 -0.172,0.031 -0.222,0.093 -0.047,0.063 -0.075,0.16 -0.075,0.289 0,0.125 0.028,0.223 0.075,0.289 0.05,0.063 0.125,0.094 0.222,0.094 0.102,0 0.176,-0.031 0.223,-0.094 0.051,-0.066 0.074,-0.164 0.074,-0.289 0,-0.129 -0.023,-0.226 -0.074,-0.289 -0.047,-0.062 -0.121,-0.093 -0.223,-0.093 z m 0.699,-1.051 v 0.402 c -0.093,-0.043 -0.183,-0.074 -0.265,-0.098 -0.082,-0.019 -0.16,-0.031 -0.238,-0.031 -0.168,0 -0.301,0.047 -0.395,0.141 -0.094,0.094 -0.148,0.23 -0.164,0.414 0.066,-0.047 0.137,-0.082 0.211,-0.106 0.074,-0.023 0.156,-0.035 0.246,-0.035 0.223,0 0.402,0.063 0.539,0.196 0.141,0.129 0.207,0.3 0.207,0.511 0,0.235 -0.074,0.422 -0.23,0.567 -0.153,0.14 -0.356,0.211 -0.614,0.211 -0.285,0 -0.507,-0.098 -0.664,-0.289 -0.152,-0.192 -0.23,-0.465 -0.23,-0.817 0,-0.359 0.09,-0.644 0.273,-0.851 0.18,-0.207 0.43,-0.309 0.75,-0.309 0.098,0 0.196,0.008 0.293,0.024 0.094,0.015 0.188,0.039 0.281,0.07 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath297)"
+             id="path828" />
+          <path
+             d="m 203.16,143.156 c -0.105,0 -0.187,0.032 -0.246,0.09 -0.055,0.055 -0.082,0.137 -0.082,0.246 0,0.106 0.027,0.192 0.082,0.246 0.059,0.059 0.141,0.086 0.246,0.086 0.102,0 0.184,-0.027 0.238,-0.086 0.055,-0.054 0.082,-0.14 0.082,-0.246 0,-0.109 -0.027,-0.191 -0.082,-0.246 -0.054,-0.058 -0.136,-0.09 -0.238,-0.09 z m -0.414,-0.183 c -0.133,-0.039 -0.23,-0.102 -0.301,-0.184 -0.066,-0.086 -0.101,-0.187 -0.101,-0.312 0,-0.184 0.07,-0.325 0.207,-0.422 0.14,-0.098 0.34,-0.145 0.609,-0.145 0.262,0 0.465,0.047 0.602,0.145 0.136,0.097 0.207,0.238 0.207,0.422 0,0.125 -0.035,0.226 -0.102,0.312 -0.07,0.082 -0.168,0.145 -0.301,0.184 0.149,0.039 0.258,0.105 0.336,0.199 0.075,0.094 0.114,0.207 0.114,0.348 0,0.218 -0.075,0.382 -0.219,0.492 -0.141,0.113 -0.356,0.168 -0.637,0.168 -0.285,0 -0.5,-0.055 -0.644,-0.168 -0.145,-0.11 -0.219,-0.274 -0.219,-0.492 0,-0.141 0.039,-0.254 0.113,-0.348 0.074,-0.094 0.188,-0.16 0.336,-0.199 z m 0.133,-0.438 c 0,0.086 0.023,0.153 0.07,0.199 0.051,0.047 0.121,0.071 0.211,0.071 0.086,0 0.152,-0.024 0.203,-0.071 0.047,-0.046 0.071,-0.113 0.071,-0.199 0,-0.086 -0.024,-0.152 -0.071,-0.199 -0.051,-0.047 -0.117,-0.07 -0.203,-0.07 -0.09,0 -0.16,0.023 -0.211,0.07 -0.047,0.047 -0.07,0.113 -0.07,0.199 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath298)"
+             id="path829" />
+          <path
+             d="m 201.711,147.996 h 0.496 v -1.414 l -0.512,0.106 v -0.383 l 0.508,-0.106 h 0.539 v 1.797 h 0.496 v 0.391 h -1.527 z m 2.547,-0.707 c 0,-0.273 -0.024,-0.465 -0.078,-0.574 -0.051,-0.113 -0.137,-0.168 -0.258,-0.168 -0.121,0 -0.207,0.055 -0.258,0.168 -0.051,0.109 -0.078,0.301 -0.078,0.574 0,0.277 0.027,0.473 0.078,0.586 0.051,0.113 0.137,0.168 0.258,0.168 0.121,0 0.207,-0.055 0.258,-0.168 0.054,-0.113 0.078,-0.309 0.078,-0.586 z m 0.566,0.008 c 0,0.359 -0.078,0.641 -0.234,0.836 -0.156,0.199 -0.379,0.297 -0.668,0.297 -0.285,0 -0.508,-0.098 -0.664,-0.297 -0.156,-0.195 -0.235,-0.477 -0.235,-0.836 0,-0.363 0.079,-0.645 0.235,-0.84 0.156,-0.199 0.379,-0.297 0.664,-0.297 0.289,0 0.512,0.098 0.668,0.297 0.156,0.195 0.234,0.477 0.234,0.84 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath299)"
+             id="path830" />
+          <path
+             d="m 201.711,152.246 h 0.496 v -1.414 l -0.512,0.106 v -0.383 l 0.508,-0.106 h 0.539 v 1.797 h 0.496 v 0.391 h -1.527 z m 2.031,-0.023 h 0.965 v 0.414 h -1.59 v -0.414 l 0.797,-0.707 c 0.07,-0.063 0.125,-0.125 0.16,-0.188 0.031,-0.062 0.051,-0.125 0.051,-0.191 0,-0.102 -0.035,-0.188 -0.105,-0.246 -0.067,-0.063 -0.161,-0.094 -0.274,-0.094 -0.09,0 -0.184,0.015 -0.289,0.055 -0.105,0.039 -0.215,0.093 -0.336,0.168 v -0.481 c 0.129,-0.043 0.254,-0.074 0.379,-0.094 0.121,-0.023 0.242,-0.035 0.363,-0.035 0.262,0 0.465,0.059 0.61,0.172 0.144,0.117 0.218,0.277 0.218,0.48 0,0.122 -0.031,0.231 -0.093,0.336 -0.063,0.102 -0.192,0.239 -0.387,0.414 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath300)"
+             id="path831" />
+          <path
+             d="m 201.711,156.496 h 0.496 v -1.414 l -0.512,0.106 v -0.383 l 0.508,-0.106 h 0.539 v 1.797 h 0.496 v 0.391 h -1.527 z m 2.273,-1.332 -0.617,0.914 h 0.617 z m -0.093,-0.465 h 0.625 v 1.379 h 0.312 v 0.41 h -0.312 v 0.399 h -0.532 v -0.399 h -0.968 v -0.484 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath301)"
+             id="path832" />
+          <path
+             d="m 201.711,160.746 h 0.496 v -1.414 l -0.512,0.106 v -0.383 l 0.508,-0.106 h 0.539 v 1.797 h 0.496 v 0.391 h -1.527 z m 2.254,-0.691 c -0.098,0 -0.172,0.035 -0.223,0.097 -0.051,0.063 -0.074,0.16 -0.074,0.289 0,0.125 0.023,0.223 0.074,0.286 0.051,0.066 0.125,0.097 0.223,0.097 0.097,0 0.172,-0.031 0.223,-0.097 0.05,-0.063 0.074,-0.161 0.074,-0.286 0,-0.129 -0.024,-0.226 -0.074,-0.289 -0.051,-0.062 -0.126,-0.097 -0.223,-0.097 z m 0.695,-1.047 v 0.402 c -0.09,-0.043 -0.18,-0.078 -0.262,-0.098 -0.082,-0.019 -0.16,-0.031 -0.238,-0.031 -0.168,0 -0.301,0.047 -0.394,0.141 -0.094,0.094 -0.149,0.23 -0.164,0.414 0.066,-0.047 0.136,-0.082 0.21,-0.106 0.075,-0.027 0.157,-0.039 0.247,-0.039 0.222,0 0.402,0.067 0.539,0.2 0.136,0.129 0.207,0.3 0.207,0.511 0,0.235 -0.078,0.422 -0.231,0.563 -0.152,0.14 -0.359,0.211 -0.617,0.211 -0.281,0 -0.504,-0.094 -0.66,-0.285 -0.152,-0.192 -0.231,-0.465 -0.231,-0.817 0,-0.363 0.09,-0.644 0.27,-0.851 0.184,-0.207 0.434,-0.309 0.75,-0.309 0.102,0 0.199,0.008 0.293,0.024 0.098,0.011 0.191,0.035 0.281,0.066 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath302)"
+             id="path833" />
+          <path
+             d="m 201.711,164.996 h 0.496 v -1.414 l -0.512,0.106 v -0.383 l 0.508,-0.106 h 0.539 v 1.797 h 0.496 v 0.391 h -1.527 z m 2.211,-0.59 c -0.106,0 -0.184,0.028 -0.242,0.086 -0.055,0.059 -0.086,0.141 -0.086,0.25 0,0.106 0.031,0.188 0.086,0.246 0.058,0.055 0.136,0.086 0.242,0.086 0.105,0 0.187,-0.031 0.242,-0.086 0.055,-0.058 0.082,-0.14 0.082,-0.246 0,-0.109 -0.027,-0.191 -0.082,-0.25 -0.055,-0.058 -0.137,-0.086 -0.242,-0.086 z m -0.41,-0.187 c -0.133,-0.039 -0.235,-0.102 -0.301,-0.184 -0.066,-0.082 -0.102,-0.183 -0.102,-0.308 0,-0.184 0.071,-0.325 0.207,-0.422 0.137,-0.098 0.34,-0.145 0.606,-0.145 0.266,0 0.469,0.047 0.605,0.145 0.137,0.093 0.207,0.234 0.207,0.422 0,0.125 -0.035,0.226 -0.105,0.308 -0.067,0.082 -0.164,0.145 -0.297,0.184 0.148,0.043 0.258,0.109 0.332,0.203 0.078,0.09 0.117,0.207 0.117,0.348 0,0.218 -0.074,0.382 -0.219,0.492 -0.144,0.109 -0.355,0.164 -0.64,0.164 -0.281,0 -0.496,-0.055 -0.645,-0.164 -0.144,-0.11 -0.215,-0.274 -0.215,-0.492 0,-0.141 0.04,-0.258 0.114,-0.348 0.074,-0.094 0.187,-0.16 0.336,-0.203 z m 0.133,-0.438 c 0,0.09 0.023,0.157 0.07,0.203 0.051,0.047 0.117,0.071 0.207,0.071 0.09,0 0.156,-0.024 0.203,-0.071 0.051,-0.046 0.074,-0.113 0.074,-0.203 0,-0.086 -0.023,-0.152 -0.074,-0.199 -0.047,-0.047 -0.113,-0.07 -0.203,-0.07 -0.09,0 -0.156,0.023 -0.207,0.07 -0.047,0.047 -0.07,0.113 -0.07,0.199 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath303)"
+             id="path834" />
+          <path
+             d="m 202.223,169.219 h 0.961 v 0.414 h -1.59 v -0.414 l 0.801,-0.703 c 0.07,-0.063 0.125,-0.129 0.156,-0.188 0.035,-0.062 0.051,-0.125 0.051,-0.191 0,-0.106 -0.032,-0.188 -0.102,-0.25 -0.07,-0.063 -0.16,-0.094 -0.273,-0.094 -0.09,0 -0.184,0.019 -0.289,0.059 -0.106,0.035 -0.219,0.093 -0.336,0.168 v -0.481 c 0.125,-0.043 0.253,-0.074 0.375,-0.098 0.125,-0.019 0.246,-0.031 0.367,-0.031 0.261,0 0.465,0.055 0.609,0.172 0.145,0.113 0.219,0.273 0.219,0.48 0,0.122 -0.031,0.231 -0.094,0.336 -0.062,0.102 -0.191,0.239 -0.387,0.411 z m 2.035,-0.68 c 0,-0.273 -0.024,-0.465 -0.078,-0.578 -0.051,-0.109 -0.137,-0.168 -0.258,-0.168 -0.121,0 -0.207,0.059 -0.258,0.168 -0.051,0.113 -0.078,0.305 -0.078,0.578 0,0.277 0.027,0.473 0.078,0.586 0.051,0.113 0.137,0.168 0.258,0.168 0.121,0 0.207,-0.055 0.258,-0.168 0.054,-0.113 0.078,-0.309 0.078,-0.586 z m 0.566,0.004 c 0,0.363 -0.078,0.645 -0.234,0.84 -0.156,0.195 -0.379,0.293 -0.668,0.293 -0.285,0 -0.508,-0.098 -0.664,-0.293 -0.156,-0.195 -0.235,-0.477 -0.235,-0.84 0,-0.363 0.079,-0.641 0.235,-0.84 0.156,-0.195 0.379,-0.293 0.664,-0.293 0.289,0 0.512,0.098 0.668,0.293 0.156,0.199 0.234,0.477 0.234,0.84 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath304)"
+             id="path835" />
+          <path
+             d="m 202.223,173.469 h 0.961 v 0.418 h -1.59 v -0.418 l 0.801,-0.703 c 0.07,-0.063 0.125,-0.125 0.156,-0.188 0.035,-0.062 0.051,-0.125 0.051,-0.191 0,-0.106 -0.032,-0.188 -0.102,-0.25 -0.07,-0.063 -0.16,-0.094 -0.273,-0.094 -0.09,0 -0.184,0.019 -0.289,0.059 -0.106,0.035 -0.219,0.093 -0.336,0.168 v -0.481 c 0.125,-0.043 0.253,-0.074 0.375,-0.098 0.125,-0.019 0.246,-0.031 0.367,-0.031 0.261,0 0.465,0.055 0.609,0.172 0.145,0.113 0.219,0.277 0.219,0.48 0,0.122 -0.031,0.231 -0.094,0.336 -0.062,0.102 -0.191,0.239 -0.387,0.411 z m 1.519,0 h 0.965 v 0.418 h -1.59 v -0.418 l 0.797,-0.703 c 0.07,-0.063 0.125,-0.125 0.16,-0.188 0.031,-0.062 0.051,-0.125 0.051,-0.191 0,-0.106 -0.035,-0.188 -0.105,-0.25 -0.067,-0.063 -0.161,-0.094 -0.274,-0.094 -0.09,0 -0.184,0.019 -0.289,0.059 -0.105,0.035 -0.215,0.093 -0.336,0.168 v -0.481 c 0.129,-0.043 0.254,-0.074 0.379,-0.098 0.121,-0.019 0.242,-0.031 0.363,-0.031 0.262,0 0.465,0.055 0.61,0.172 0.144,0.113 0.218,0.277 0.218,0.48 0,0.122 -0.031,0.231 -0.093,0.336 -0.063,0.102 -0.192,0.239 -0.387,0.411 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath305)"
+             id="path836" />
+          <path
+             d="m 202.223,177.719 h 0.961 v 0.414 h -1.59 v -0.414 l 0.801,-0.703 c 0.07,-0.063 0.125,-0.129 0.156,-0.188 0.035,-0.062 0.051,-0.125 0.051,-0.191 0,-0.106 -0.032,-0.188 -0.102,-0.25 -0.07,-0.063 -0.16,-0.094 -0.273,-0.094 -0.09,0 -0.184,0.019 -0.289,0.059 -0.106,0.035 -0.219,0.093 -0.336,0.168 v -0.481 c 0.125,-0.043 0.253,-0.074 0.375,-0.098 0.125,-0.019 0.246,-0.031 0.367,-0.031 0.261,0 0.465,0.055 0.609,0.172 0.145,0.113 0.219,0.273 0.219,0.48 0,0.122 -0.031,0.231 -0.094,0.336 -0.062,0.102 -0.191,0.239 -0.387,0.411 z m 1.761,-1.305 -0.617,0.914 h 0.617 z m -0.093,-0.465 h 0.625 v 1.379 h 0.312 v 0.41 h -0.312 v 0.395 h -0.532 v -0.395 h -0.968 v -0.484 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath306)"
+             id="path837" />
+          <path
+             d="m 202.223,181.969 h 0.961 v 0.414 h -1.59 v -0.414 l 0.801,-0.703 c 0.07,-0.067 0.125,-0.129 0.156,-0.188 0.035,-0.062 0.051,-0.125 0.051,-0.191 0,-0.106 -0.032,-0.188 -0.102,-0.25 -0.07,-0.063 -0.16,-0.094 -0.273,-0.094 -0.09,0 -0.184,0.019 -0.289,0.059 -0.106,0.035 -0.219,0.093 -0.336,0.168 v -0.481 c 0.125,-0.043 0.253,-0.074 0.375,-0.098 0.125,-0.023 0.246,-0.031 0.367,-0.031 0.261,0 0.465,0.055 0.609,0.172 0.145,0.113 0.219,0.273 0.219,0.48 0,0.122 -0.031,0.231 -0.094,0.336 -0.062,0.102 -0.191,0.239 -0.387,0.411 z m 1.742,-0.664 c -0.098,0 -0.172,0.031 -0.223,0.097 -0.051,0.063 -0.074,0.16 -0.074,0.286 0,0.128 0.023,0.226 0.074,0.289 0.051,0.062 0.125,0.097 0.223,0.097 0.097,0 0.172,-0.035 0.223,-0.097 0.05,-0.063 0.074,-0.161 0.074,-0.289 0,-0.126 -0.024,-0.223 -0.074,-0.286 -0.051,-0.066 -0.126,-0.097 -0.223,-0.097 z m 0.695,-1.051 v 0.406 c -0.09,-0.043 -0.18,-0.078 -0.262,-0.098 -0.082,-0.019 -0.16,-0.031 -0.238,-0.031 -0.168,0 -0.301,0.047 -0.394,0.141 -0.094,0.094 -0.149,0.23 -0.164,0.414 0.066,-0.047 0.136,-0.086 0.21,-0.109 0.075,-0.024 0.157,-0.036 0.247,-0.036 0.222,0 0.402,0.067 0.539,0.196 0.136,0.133 0.207,0.304 0.207,0.515 0,0.235 -0.078,0.422 -0.231,0.563 -0.152,0.14 -0.359,0.211 -0.617,0.211 -0.281,0 -0.504,-0.094 -0.66,-0.285 -0.152,-0.192 -0.231,-0.465 -0.231,-0.817 0,-0.363 0.09,-0.644 0.27,-0.851 0.184,-0.207 0.434,-0.313 0.75,-0.313 0.102,0 0.199,0.008 0.293,0.024 0.098,0.015 0.191,0.039 0.281,0.07 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath307)"
+             id="path838" />
+          <path
+             d="m 202.223,186.219 h 0.961 v 0.414 h -1.59 v -0.414 l 0.801,-0.703 c 0.07,-0.067 0.125,-0.129 0.156,-0.188 0.035,-0.062 0.051,-0.129 0.051,-0.195 0,-0.102 -0.032,-0.184 -0.102,-0.246 -0.07,-0.063 -0.16,-0.094 -0.273,-0.094 -0.09,0 -0.184,0.019 -0.289,0.059 -0.106,0.035 -0.219,0.089 -0.336,0.164 v -0.481 c 0.125,-0.039 0.253,-0.07 0.375,-0.094 0.125,-0.023 0.246,-0.035 0.367,-0.035 0.261,0 0.465,0.059 0.609,0.176 0.145,0.113 0.219,0.273 0.219,0.48 0,0.122 -0.031,0.231 -0.094,0.336 -0.062,0.102 -0.191,0.239 -0.387,0.411 z m 1.699,-0.563 c -0.106,0 -0.184,0.028 -0.242,0.086 -0.055,0.059 -0.086,0.141 -0.086,0.246 0,0.11 0.031,0.192 0.086,0.25 0.058,0.055 0.136,0.082 0.242,0.082 0.105,0 0.187,-0.027 0.242,-0.082 0.055,-0.058 0.082,-0.14 0.082,-0.25 0,-0.105 -0.027,-0.187 -0.082,-0.246 -0.055,-0.058 -0.137,-0.086 -0.242,-0.086 z m -0.41,-0.187 c -0.133,-0.039 -0.235,-0.102 -0.301,-0.184 -0.066,-0.082 -0.102,-0.187 -0.102,-0.308 0,-0.188 0.071,-0.329 0.207,-0.422 0.137,-0.098 0.34,-0.149 0.606,-0.149 0.266,0 0.469,0.051 0.605,0.149 0.137,0.093 0.207,0.234 0.207,0.422 0,0.121 -0.035,0.226 -0.105,0.308 -0.067,0.082 -0.164,0.145 -0.297,0.184 0.148,0.043 0.258,0.109 0.332,0.203 0.078,0.09 0.117,0.207 0.117,0.348 0,0.214 -0.074,0.378 -0.219,0.492 -0.144,0.109 -0.355,0.164 -0.64,0.164 -0.281,0 -0.496,-0.055 -0.645,-0.164 -0.144,-0.114 -0.215,-0.278 -0.215,-0.492 0,-0.141 0.04,-0.258 0.114,-0.348 0.074,-0.094 0.187,-0.16 0.336,-0.203 z m 0.133,-0.438 c 0,0.086 0.023,0.157 0.07,0.203 0.051,0.047 0.117,0.071 0.207,0.071 0.09,0 0.156,-0.024 0.203,-0.071 0.051,-0.046 0.074,-0.117 0.074,-0.203 0,-0.086 -0.023,-0.152 -0.074,-0.199 -0.047,-0.047 -0.113,-0.07 -0.203,-0.07 -0.09,0 -0.156,0.023 -0.207,0.07 -0.047,0.047 -0.07,0.113 -0.07,0.199 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath308)"
+             id="path839" />
+          <path
+             d="m 202.754,189.703 c 0.148,0.039 0.262,0.106 0.336,0.199 0.078,0.094 0.117,0.215 0.117,0.36 0,0.218 -0.082,0.383 -0.25,0.496 -0.164,0.113 -0.406,0.168 -0.727,0.168 -0.113,0 -0.222,-0.008 -0.335,-0.028 -0.114,-0.015 -0.227,-0.043 -0.336,-0.082 v -0.433 c 0.105,0.055 0.211,0.094 0.312,0.121 0.106,0.027 0.207,0.039 0.309,0.039 0.148,0 0.265,-0.027 0.343,-0.078 0.079,-0.051 0.122,-0.125 0.122,-0.223 0,-0.097 -0.043,-0.176 -0.125,-0.226 -0.082,-0.051 -0.2,-0.078 -0.36,-0.078 h -0.226 v -0.364 h 0.238 c 0.14,0 0.246,-0.019 0.316,-0.062 0.071,-0.047 0.102,-0.114 0.102,-0.207 0,-0.082 -0.031,-0.149 -0.098,-0.192 -0.07,-0.047 -0.164,-0.07 -0.289,-0.07 -0.09,0 -0.18,0.012 -0.273,0.031 -0.094,0.02 -0.184,0.051 -0.278,0.09 v -0.414 c 0.114,-0.031 0.223,-0.055 0.332,-0.07 0.11,-0.016 0.215,-0.024 0.321,-0.024 0.285,0 0.496,0.047 0.636,0.141 0.145,0.094 0.215,0.234 0.215,0.422 0,0.129 -0.035,0.234 -0.101,0.316 -0.067,0.078 -0.168,0.137 -0.301,0.168 z m 1.504,0.086 c 0,-0.273 -0.024,-0.465 -0.078,-0.578 -0.051,-0.113 -0.137,-0.168 -0.258,-0.168 -0.121,0 -0.207,0.055 -0.258,0.168 -0.051,0.113 -0.078,0.305 -0.078,0.578 0,0.277 0.027,0.469 0.078,0.582 0.051,0.113 0.137,0.172 0.258,0.172 0.121,0 0.207,-0.059 0.258,-0.172 0.054,-0.113 0.078,-0.305 0.078,-0.582 z m 0.566,0.004 c 0,0.363 -0.078,0.641 -0.234,0.84 -0.156,0.195 -0.379,0.293 -0.668,0.293 -0.285,0 -0.508,-0.098 -0.664,-0.293 -0.156,-0.199 -0.235,-0.477 -0.235,-0.84 0,-0.363 0.079,-0.645 0.235,-0.84 0.156,-0.195 0.379,-0.297 0.664,-0.297 0.289,0 0.512,0.102 0.668,0.297 0.156,0.195 0.234,0.477 0.234,0.84 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath309)"
+             id="path840" />
+          <path
+             d="m 202.754,193.953 c 0.148,0.039 0.262,0.106 0.336,0.199 0.078,0.094 0.117,0.215 0.117,0.36 0,0.218 -0.082,0.383 -0.25,0.496 -0.164,0.113 -0.406,0.168 -0.727,0.168 -0.113,0 -0.222,-0.008 -0.335,-0.028 -0.114,-0.019 -0.227,-0.043 -0.336,-0.082 v -0.433 c 0.105,0.051 0.211,0.094 0.312,0.121 0.106,0.023 0.207,0.039 0.309,0.039 0.148,0 0.265,-0.027 0.343,-0.078 0.079,-0.051 0.122,-0.125 0.122,-0.223 0,-0.101 -0.043,-0.176 -0.125,-0.226 -0.082,-0.051 -0.2,-0.078 -0.36,-0.078 h -0.226 v -0.364 h 0.238 c 0.14,0 0.246,-0.019 0.316,-0.062 0.071,-0.047 0.102,-0.114 0.102,-0.207 0,-0.082 -0.031,-0.149 -0.098,-0.192 -0.07,-0.047 -0.164,-0.07 -0.289,-0.07 -0.09,0 -0.18,0.012 -0.273,0.031 -0.094,0.02 -0.184,0.051 -0.278,0.09 V 193 c 0.114,-0.031 0.223,-0.055 0.332,-0.07 0.11,-0.016 0.215,-0.024 0.321,-0.024 0.285,0 0.496,0.047 0.636,0.141 0.145,0.094 0.215,0.234 0.215,0.422 0,0.129 -0.035,0.234 -0.101,0.316 -0.067,0.078 -0.168,0.137 -0.301,0.168 z m 0.988,0.766 h 0.965 v 0.414 h -1.59 v -0.414 l 0.797,-0.703 c 0.07,-0.067 0.125,-0.129 0.16,-0.192 0.031,-0.058 0.051,-0.125 0.051,-0.191 0,-0.102 -0.035,-0.184 -0.105,-0.246 -0.067,-0.063 -0.161,-0.094 -0.274,-0.094 -0.09,0 -0.184,0.019 -0.289,0.059 -0.105,0.035 -0.215,0.089 -0.336,0.164 v -0.481 c 0.129,-0.039 0.254,-0.074 0.379,-0.094 0.121,-0.023 0.242,-0.035 0.363,-0.035 0.262,0 0.465,0.059 0.61,0.176 0.144,0.113 0.218,0.273 0.218,0.48 0,0.118 -0.031,0.231 -0.093,0.333 -0.063,0.105 -0.192,0.242 -0.387,0.414 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath310)"
+             id="path841" />
+          <path
+             d="m 202.754,198.203 c 0.148,0.039 0.262,0.106 0.336,0.199 0.078,0.094 0.117,0.215 0.117,0.36 0,0.218 -0.082,0.383 -0.25,0.496 -0.164,0.113 -0.406,0.168 -0.727,0.168 -0.113,0 -0.222,-0.008 -0.335,-0.028 -0.114,-0.019 -0.227,-0.046 -0.336,-0.082 v -0.433 c 0.105,0.051 0.211,0.094 0.312,0.121 0.106,0.023 0.207,0.039 0.309,0.039 0.148,0 0.265,-0.027 0.343,-0.078 0.079,-0.051 0.122,-0.125 0.122,-0.223 0,-0.101 -0.043,-0.176 -0.125,-0.226 -0.082,-0.051 -0.2,-0.078 -0.36,-0.078 h -0.226 v -0.364 h 0.238 c 0.14,0 0.246,-0.019 0.316,-0.066 0.071,-0.043 0.102,-0.11 0.102,-0.203 0,-0.082 -0.031,-0.149 -0.098,-0.196 -0.07,-0.043 -0.164,-0.066 -0.289,-0.066 -0.09,0 -0.18,0.008 -0.273,0.031 -0.094,0.02 -0.184,0.051 -0.278,0.09 v -0.414 c 0.114,-0.031 0.223,-0.055 0.332,-0.07 0.11,-0.016 0.215,-0.024 0.321,-0.024 0.285,0 0.496,0.047 0.636,0.141 0.145,0.094 0.215,0.234 0.215,0.422 0,0.129 -0.035,0.23 -0.101,0.312 -0.067,0.082 -0.168,0.141 -0.301,0.172 z m 1.23,-0.543 -0.617,0.918 h 0.617 z m -0.093,-0.465 h 0.625 v 1.383 h 0.312 v 0.406 h -0.312 v 0.399 h -0.532 v -0.399 h -0.968 V 198.5 Z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath311)"
+             id="path842" />
+          <path
+             d="m 84.871,197.203 v 2.125 h 0.445 c 0.379,0 0.657,-0.086 0.829,-0.258 0.175,-0.168 0.265,-0.437 0.265,-0.808 0,-0.364 -0.09,-0.633 -0.265,-0.801 -0.172,-0.172 -0.45,-0.258 -0.829,-0.258 z M 84.5,196.898 h 0.762 c 0.527,0 0.918,0.114 1.164,0.332 0.25,0.219 0.375,0.563 0.375,1.032 0,0.472 -0.125,0.82 -0.375,1.039 -0.25,0.222 -0.637,0.332 -1.164,0.332 H 84.5 Z m 3.176,1.219 c -0.164,0 -0.297,0.059 -0.395,0.172 -0.097,0.113 -0.144,0.27 -0.144,0.465 0,0.199 0.047,0.355 0.144,0.469 0.098,0.113 0.231,0.168 0.395,0.168 0.168,0 0.297,-0.055 0.394,-0.168 0.098,-0.114 0.149,-0.27 0.149,-0.469 0,-0.195 -0.051,-0.352 -0.149,-0.465 -0.097,-0.113 -0.226,-0.172 -0.394,-0.172 z m 0.734,-1.156 v 0.336 c -0.094,-0.043 -0.187,-0.078 -0.281,-0.102 -0.094,-0.023 -0.188,-0.035 -0.281,-0.035 -0.243,0 -0.43,0.082 -0.559,0.25 -0.129,0.164 -0.203,0.41 -0.219,0.746 0.071,-0.105 0.16,-0.187 0.27,-0.246 0.109,-0.055 0.226,-0.086 0.359,-0.086 0.274,0 0.492,0.086 0.649,0.254 0.16,0.164 0.242,0.391 0.242,0.676 0,0.281 -0.086,0.508 -0.25,0.676 -0.168,0.172 -0.387,0.254 -0.664,0.254 -0.317,0 -0.559,-0.118 -0.723,-0.36 -0.168,-0.242 -0.254,-0.594 -0.254,-1.054 0,-0.434 0.106,-0.778 0.309,-1.036 0.207,-0.254 0.48,-0.382 0.828,-0.382 0.09,0 0.184,0.007 0.277,0.027 0.098,0.016 0.196,0.043 0.297,0.082 z m 0.336,-0.063 h 1.449 v 0.313 h -1.113 v 0.668 c 0.055,-0.016 0.109,-0.031 0.164,-0.039 0.051,-0.008 0.106,-0.016 0.16,-0.016 0.305,0 0.547,0.086 0.723,0.254 0.18,0.164 0.269,0.391 0.269,0.676 0,0.297 -0.093,0.523 -0.273,0.687 -0.184,0.164 -0.441,0.243 -0.777,0.243 -0.114,0 -0.231,-0.008 -0.352,-0.028 -0.117,-0.019 -0.238,-0.051 -0.367,-0.09 v -0.371 c 0.109,0.063 0.223,0.106 0.34,0.137 0.117,0.027 0.242,0.043 0.371,0.043 0.215,0 0.379,-0.055 0.504,-0.168 0.121,-0.109 0.183,-0.262 0.183,-0.453 0,-0.188 -0.062,-0.34 -0.183,-0.449 -0.125,-0.114 -0.289,-0.168 -0.504,-0.168 -0.098,0 -0.195,0.011 -0.293,0.031 -0.098,0.023 -0.199,0.059 -0.301,0.105 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath312)"
+             id="path843" />
+          <path
+             d="m 84.922,192.953 v 2.125 h 0.449 c 0.375,0 0.652,-0.086 0.828,-0.258 0.176,-0.172 0.262,-0.441 0.262,-0.808 0,-0.367 -0.086,-0.633 -0.262,-0.805 -0.176,-0.168 -0.453,-0.254 -0.828,-0.254 z m -0.367,-0.305 h 0.757 c 0.532,0 0.918,0.11 1.168,0.332 0.247,0.219 0.372,0.563 0.372,1.032 0,0.472 -0.125,0.816 -0.375,1.039 -0.247,0.219 -0.637,0.332 -1.165,0.332 h -0.757 z m 3.175,1.219 c -0.168,0 -0.3,0.059 -0.398,0.172 -0.094,0.113 -0.144,0.27 -0.144,0.465 0,0.195 0.05,0.351 0.144,0.469 0.098,0.113 0.23,0.168 0.398,0.168 0.165,0 0.297,-0.055 0.391,-0.168 0.098,-0.118 0.149,-0.274 0.149,-0.469 0,-0.195 -0.051,-0.352 -0.149,-0.465 -0.094,-0.113 -0.226,-0.172 -0.391,-0.172 z m 0.735,-1.16 v 0.34 c -0.094,-0.047 -0.188,-0.078 -0.285,-0.102 -0.094,-0.023 -0.184,-0.035 -0.278,-0.035 -0.246,0 -0.433,0.082 -0.562,0.246 -0.125,0.164 -0.199,0.414 -0.219,0.746 0.074,-0.105 0.164,-0.183 0.27,-0.242 0.109,-0.058 0.23,-0.086 0.359,-0.086 0.277,0 0.492,0.086 0.652,0.25 0.16,0.168 0.239,0.395 0.239,0.68 0,0.281 -0.082,0.508 -0.25,0.676 -0.164,0.168 -0.387,0.254 -0.661,0.254 -0.316,0 -0.558,-0.122 -0.726,-0.364 -0.168,-0.242 -0.25,-0.593 -0.25,-1.05 0,-0.434 0.101,-0.778 0.308,-1.036 0.204,-0.257 0.481,-0.386 0.825,-0.386 0.093,0 0.187,0.011 0.281,0.027 0.094,0.02 0.191,0.047 0.297,0.082 z m 1.164,1.16 c -0.164,0 -0.297,0.059 -0.395,0.172 -0.097,0.113 -0.144,0.27 -0.144,0.465 0,0.195 0.047,0.351 0.144,0.469 0.098,0.113 0.231,0.168 0.395,0.168 0.168,0 0.297,-0.055 0.394,-0.168 0.098,-0.118 0.149,-0.274 0.149,-0.469 0,-0.195 -0.051,-0.352 -0.149,-0.465 -0.097,-0.113 -0.226,-0.172 -0.394,-0.172 z m 0.734,-1.16 v 0.34 c -0.09,-0.047 -0.183,-0.078 -0.281,-0.102 -0.094,-0.023 -0.187,-0.035 -0.281,-0.035 -0.242,0 -0.43,0.082 -0.559,0.246 -0.129,0.164 -0.203,0.414 -0.219,0.746 0.071,-0.105 0.161,-0.183 0.27,-0.242 0.109,-0.058 0.23,-0.086 0.359,-0.086 0.274,0 0.493,0.086 0.649,0.25 0.16,0.168 0.242,0.395 0.242,0.68 0,0.281 -0.082,0.508 -0.25,0.676 -0.164,0.168 -0.387,0.254 -0.664,0.254 -0.317,0 -0.555,-0.122 -0.723,-0.364 -0.168,-0.242 -0.25,-0.593 -0.25,-1.05 0,-0.434 0.102,-0.778 0.305,-1.036 0.207,-0.257 0.48,-0.386 0.828,-0.386 0.09,0 0.184,0.011 0.277,0.027 0.098,0.02 0.196,0.047 0.297,0.082 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath313)"
+             id="path844" />
+          <path
+             d="m 84.871,188.703 v 2.125 h 0.445 c 0.379,0 0.657,-0.086 0.829,-0.258 0.175,-0.172 0.265,-0.441 0.265,-0.808 0,-0.367 -0.09,-0.633 -0.265,-0.805 -0.172,-0.172 -0.45,-0.254 -0.829,-0.254 z M 84.5,188.398 h 0.762 c 0.527,0 0.918,0.11 1.164,0.332 0.25,0.219 0.375,0.563 0.375,1.032 0,0.468 -0.125,0.816 -0.375,1.039 -0.25,0.219 -0.637,0.328 -1.164,0.328 H 84.5 Z m 3.176,1.219 c -0.164,0 -0.297,0.055 -0.395,0.168 -0.097,0.113 -0.144,0.27 -0.144,0.469 0,0.195 0.047,0.351 0.144,0.465 0.098,0.113 0.231,0.172 0.395,0.172 0.168,0 0.297,-0.059 0.394,-0.172 0.098,-0.114 0.149,-0.27 0.149,-0.465 0,-0.199 -0.051,-0.356 -0.149,-0.469 -0.097,-0.113 -0.226,-0.168 -0.394,-0.168 z m 0.734,-1.16 v 0.336 c -0.094,-0.043 -0.187,-0.074 -0.281,-0.098 -0.094,-0.023 -0.188,-0.035 -0.281,-0.035 -0.243,0 -0.43,0.082 -0.559,0.246 -0.129,0.164 -0.203,0.414 -0.219,0.746 0.071,-0.105 0.16,-0.187 0.27,-0.242 0.109,-0.058 0.226,-0.086 0.359,-0.086 0.274,0 0.492,0.082 0.649,0.25 0.16,0.168 0.242,0.395 0.242,0.68 0,0.281 -0.086,0.504 -0.25,0.676 -0.168,0.168 -0.387,0.254 -0.664,0.254 -0.317,0 -0.559,-0.122 -0.723,-0.364 -0.168,-0.242 -0.254,-0.593 -0.254,-1.054 0,-0.43 0.106,-0.774 0.309,-1.032 0.207,-0.257 0.48,-0.386 0.828,-0.386 0.09,0 0.184,0.007 0.277,0.027 0.098,0.02 0.196,0.047 0.297,0.082 z m 0.238,-0.059 h 1.758 v 0.157 l -0.992,2.574 h -0.387 l 0.934,-2.422 h -1.313 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath314)"
+             id="path845" />
+          <path
+             d="m 85.383,186.488 v -0.734 h -0.606 v -0.301 h 0.973 v 1.172 c -0.145,0.102 -0.301,0.18 -0.473,0.23 -0.172,0.051 -0.355,0.079 -0.55,0.079 -0.43,0 -0.762,-0.125 -1.004,-0.375 -0.243,-0.25 -0.36,-0.598 -0.36,-1.043 0,-0.446 0.117,-0.793 0.36,-1.043 0.242,-0.25 0.574,-0.375 1.004,-0.375 0.175,0 0.347,0.019 0.507,0.066 0.161,0.043 0.309,0.109 0.442,0.191 v 0.395 c -0.137,-0.117 -0.281,-0.203 -0.434,-0.262 -0.152,-0.058 -0.316,-0.086 -0.484,-0.086 -0.336,0 -0.586,0.094 -0.754,0.278 -0.168,0.187 -0.254,0.465 -0.254,0.836 0,0.367 0.086,0.644 0.254,0.832 0.168,0.187 0.418,0.281 0.754,0.281 0.129,0 0.246,-0.012 0.347,-0.031 0.102,-0.024 0.196,-0.059 0.278,-0.11 z m 0.5,-2.34 h 0.5 l 1.211,2.286 v -2.286 h 0.359 v 2.731 h -0.5 l -1.211,-2.285 v 2.285 h -0.359 z m 2.793,0.301 v 2.125 h 0.445 c 0.379,0 0.652,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.441 0.262,-0.808 0,-0.367 -0.086,-0.637 -0.262,-0.805 -0.176,-0.172 -0.449,-0.258 -0.828,-0.258 z m -0.371,-0.301 h 0.761 c 0.528,0 0.918,0.11 1.164,0.329 0.25,0.222 0.372,0.566 0.372,1.035 0,0.468 -0.125,0.816 -0.372,1.035 -0.25,0.223 -0.636,0.332 -1.164,0.332 h -0.761 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath315)"
+             id="path846" />
+          <path
+             d="m 84.871,180.199 v 2.125 h 0.445 c 0.379,0 0.657,-0.086 0.829,-0.258 0.175,-0.168 0.265,-0.437 0.265,-0.808 0,-0.363 -0.09,-0.633 -0.265,-0.801 -0.172,-0.172 -0.45,-0.258 -0.829,-0.258 z M 84.5,179.895 h 0.762 c 0.527,0 0.918,0.113 1.164,0.332 0.25,0.218 0.375,0.562 0.375,1.031 0,0.472 -0.125,0.82 -0.375,1.039 -0.25,0.223 -0.637,0.332 -1.164,0.332 H 84.5 Z m 3.176,1.218 c -0.164,0 -0.297,0.059 -0.395,0.172 -0.097,0.113 -0.144,0.27 -0.144,0.465 0,0.199 0.047,0.355 0.144,0.469 0.098,0.113 0.231,0.168 0.395,0.168 0.168,0 0.297,-0.055 0.394,-0.168 0.098,-0.114 0.149,-0.27 0.149,-0.469 0,-0.195 -0.051,-0.352 -0.149,-0.465 -0.097,-0.113 -0.226,-0.172 -0.394,-0.172 z m 0.734,-1.156 v 0.336 c -0.094,-0.043 -0.187,-0.078 -0.281,-0.102 -0.094,-0.023 -0.188,-0.035 -0.281,-0.035 -0.243,0 -0.43,0.082 -0.559,0.25 -0.129,0.164 -0.203,0.41 -0.219,0.746 0.071,-0.105 0.16,-0.187 0.27,-0.246 0.109,-0.054 0.226,-0.086 0.359,-0.086 0.274,0 0.492,0.086 0.649,0.254 0.16,0.164 0.242,0.391 0.242,0.676 0,0.281 -0.086,0.508 -0.25,0.676 -0.168,0.172 -0.387,0.254 -0.664,0.254 -0.317,0 -0.559,-0.118 -0.723,-0.36 -0.168,-0.242 -0.254,-0.593 -0.254,-1.054 0,-0.434 0.106,-0.778 0.309,-1.036 0.207,-0.253 0.48,-0.382 0.828,-0.382 0.09,0 0.184,0.007 0.277,0.027 0.098,0.016 0.196,0.043 0.297,0.082 z m 1.121,1.375 c -0.176,0 -0.312,0.047 -0.414,0.141 -0.101,0.093 -0.152,0.222 -0.152,0.386 0,0.164 0.051,0.293 0.152,0.387 0.102,0.094 0.238,0.141 0.414,0.141 0.176,0 0.317,-0.047 0.418,-0.141 0.102,-0.094 0.153,-0.223 0.153,-0.387 0,-0.164 -0.051,-0.293 -0.153,-0.386 -0.101,-0.094 -0.238,-0.141 -0.418,-0.141 z m -0.367,-0.16 c -0.16,-0.039 -0.285,-0.113 -0.375,-0.219 -0.086,-0.109 -0.129,-0.242 -0.129,-0.398 0,-0.219 0.074,-0.391 0.231,-0.52 0.156,-0.125 0.371,-0.187 0.64,-0.187 0.274,0 0.489,0.062 0.641,0.187 0.156,0.129 0.234,0.301 0.234,0.52 0,0.156 -0.047,0.289 -0.133,0.398 -0.089,0.106 -0.211,0.18 -0.371,0.219 0.18,0.043 0.317,0.125 0.418,0.246 0.098,0.121 0.149,0.266 0.149,0.441 0,0.266 -0.082,0.469 -0.242,0.61 -0.161,0.14 -0.395,0.211 -0.696,0.211 -0.301,0 -0.531,-0.071 -0.695,-0.211 -0.16,-0.141 -0.242,-0.344 -0.242,-0.61 0,-0.175 0.051,-0.32 0.152,-0.441 0.098,-0.121 0.238,-0.203 0.418,-0.246 z m -0.137,-0.582 c 0,0.14 0.043,0.25 0.133,0.332 0.086,0.078 0.211,0.117 0.371,0.117 0.16,0 0.285,-0.039 0.371,-0.117 0.09,-0.082 0.137,-0.192 0.137,-0.332 0,-0.141 -0.047,-0.254 -0.137,-0.332 -0.086,-0.078 -0.211,-0.117 -0.371,-0.117 -0.16,0 -0.285,0.039 -0.371,0.117 -0.09,0.078 -0.133,0.191 -0.133,0.332 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath316)"
+             id="path847" />
+          <path
+             d="m 84.922,175.949 v 2.125 h 0.449 c 0.375,0 0.652,-0.086 0.828,-0.258 0.176,-0.171 0.262,-0.441 0.262,-0.808 0,-0.367 -0.086,-0.633 -0.262,-0.805 -0.176,-0.168 -0.453,-0.254 -0.828,-0.254 z m -0.367,-0.304 h 0.757 c 0.532,0 0.918,0.109 1.168,0.332 0.247,0.218 0.372,0.562 0.372,1.031 0,0.472 -0.125,0.816 -0.375,1.039 -0.247,0.219 -0.637,0.332 -1.165,0.332 h -0.757 z m 3.175,1.218 c -0.168,0 -0.3,0.059 -0.398,0.172 -0.094,0.113 -0.144,0.27 -0.144,0.465 0,0.195 0.05,0.352 0.144,0.469 0.098,0.113 0.23,0.168 0.398,0.168 0.165,0 0.297,-0.055 0.391,-0.168 0.098,-0.117 0.149,-0.274 0.149,-0.469 0,-0.195 -0.051,-0.352 -0.149,-0.465 -0.094,-0.113 -0.226,-0.172 -0.391,-0.172 z m 0.735,-1.16 v 0.34 c -0.094,-0.047 -0.188,-0.078 -0.285,-0.102 -0.094,-0.023 -0.184,-0.035 -0.278,-0.035 -0.246,0 -0.433,0.082 -0.562,0.246 -0.125,0.164 -0.199,0.414 -0.219,0.746 0.074,-0.105 0.164,-0.183 0.27,-0.242 0.109,-0.058 0.23,-0.086 0.359,-0.086 0.277,0 0.492,0.086 0.652,0.25 0.16,0.168 0.239,0.395 0.239,0.68 0,0.281 -0.082,0.508 -0.25,0.676 -0.164,0.168 -0.387,0.254 -0.661,0.254 -0.316,0 -0.558,-0.121 -0.726,-0.364 -0.168,-0.242 -0.25,-0.593 -0.25,-1.05 0,-0.434 0.101,-0.778 0.308,-1.036 0.204,-0.257 0.481,-0.386 0.825,-0.386 0.093,0 0.187,0.011 0.281,0.027 0.094,0.02 0.191,0.047 0.297,0.082 z m 0.34,2.617 v -0.336 c 0.093,0.043 0.187,0.078 0.281,0.102 0.098,0.023 0.187,0.035 0.281,0.035 0.242,0 0.43,-0.082 0.559,-0.246 0.129,-0.164 0.203,-0.414 0.222,-0.75 -0.074,0.105 -0.164,0.187 -0.269,0.242 -0.109,0.055 -0.231,0.086 -0.363,0.086 -0.274,0 -0.489,-0.086 -0.649,-0.25 -0.16,-0.164 -0.238,-0.391 -0.238,-0.68 0,-0.277 0.082,-0.503 0.25,-0.671 0.164,-0.172 0.387,-0.258 0.66,-0.258 0.316,0 0.559,0.121 0.727,0.367 0.164,0.238 0.25,0.59 0.25,1.055 0,0.429 -0.102,0.773 -0.309,1.031 -0.203,0.254 -0.477,0.383 -0.824,0.383 -0.094,0 -0.188,-0.008 -0.281,-0.028 -0.094,-0.019 -0.196,-0.047 -0.297,-0.082 z m 0.734,-1.16 c 0.168,0 0.297,-0.055 0.395,-0.168 0.097,-0.113 0.148,-0.269 0.148,-0.469 0,-0.195 -0.051,-0.351 -0.148,-0.464 -0.098,-0.114 -0.227,-0.172 -0.395,-0.172 -0.164,0 -0.297,0.058 -0.394,0.172 -0.098,0.113 -0.145,0.269 -0.145,0.464 0,0.2 0.047,0.356 0.145,0.469 0.097,0.113 0.23,0.168 0.394,0.168 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath317)"
+             id="path848" />
+          <path
+             d="m 84.922,171.699 v 2.125 h 0.449 c 0.375,0 0.652,-0.086 0.828,-0.258 0.176,-0.171 0.262,-0.441 0.262,-0.808 0,-0.367 -0.086,-0.633 -0.262,-0.805 -0.176,-0.168 -0.453,-0.254 -0.828,-0.254 z m -0.367,-0.304 h 0.757 c 0.532,0 0.918,0.109 1.168,0.332 0.247,0.218 0.372,0.562 0.372,1.031 0,0.472 -0.125,0.816 -0.375,1.039 -0.247,0.219 -0.637,0.332 -1.165,0.332 h -0.757 z m 2.246,0 h 1.758 v 0.156 l -0.993,2.578 H 87.18 l 0.933,-2.422 h -1.312 z m 2.785,0.242 c -0.191,0 -0.336,0.093 -0.43,0.281 -0.097,0.187 -0.144,0.469 -0.144,0.844 0,0.375 0.047,0.656 0.144,0.843 0.094,0.188 0.239,0.282 0.43,0.282 0.191,0 0.332,-0.094 0.43,-0.282 0.093,-0.187 0.144,-0.468 0.144,-0.843 0,-0.375 -0.051,-0.657 -0.144,-0.844 -0.098,-0.188 -0.239,-0.281 -0.43,-0.281 z m 0,-0.293 c 0.305,0 0.539,0.121 0.699,0.367 0.164,0.238 0.242,0.59 0.242,1.051 0,0.461 -0.078,0.812 -0.242,1.054 -0.16,0.243 -0.394,0.364 -0.699,0.364 -0.309,0 -0.543,-0.121 -0.703,-0.364 -0.164,-0.242 -0.242,-0.593 -0.242,-1.054 0,-0.461 0.078,-0.813 0.242,-1.051 0.16,-0.246 0.394,-0.367 0.703,-0.367 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath318)"
+             id="path849" />
+          <path
+             d="m 84.871,167.449 v 2.125 h 0.445 c 0.379,0 0.657,-0.086 0.829,-0.258 0.175,-0.171 0.265,-0.441 0.265,-0.808 0,-0.367 -0.09,-0.633 -0.265,-0.805 -0.172,-0.172 -0.45,-0.254 -0.829,-0.254 z M 84.5,167.145 h 0.762 c 0.527,0 0.918,0.109 1.164,0.332 0.25,0.218 0.375,0.562 0.375,1.031 0,0.469 -0.125,0.816 -0.375,1.039 -0.25,0.219 -0.637,0.328 -1.164,0.328 H 84.5 Z m 2.246,0 h 1.758 v 0.156 l -0.992,2.574 h -0.387 l 0.934,-2.422 h -1.313 z m 2.059,2.421 h 0.605 v -2.086 l -0.656,0.133 v -0.34 l 0.652,-0.128 h 0.371 v 2.421 h 0.602 v 0.309 h -1.574 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath319)"
+             id="path850" />
+          <path
+             d="m 84.871,163.195 v 2.125 h 0.445 c 0.379,0 0.657,-0.086 0.829,-0.254 0.175,-0.171 0.265,-0.441 0.265,-0.808 0,-0.367 -0.09,-0.637 -0.265,-0.805 -0.172,-0.172 -0.45,-0.258 -0.829,-0.258 z M 84.5,162.891 h 0.762 c 0.527,0 0.918,0.113 1.164,0.332 0.25,0.222 0.375,0.566 0.375,1.035 0,0.469 -0.125,0.816 -0.375,1.035 -0.25,0.223 -0.637,0.332 -1.164,0.332 H 84.5 Z m 2.246,0 h 1.758 v 0.16 l -0.992,2.574 h -0.387 l 0.934,-2.422 h -1.313 z m 2.313,2.421 h 1.293 v 0.313 h -1.739 v -0.313 c 0.141,-0.144 0.332,-0.339 0.575,-0.582 0.242,-0.246 0.394,-0.402 0.457,-0.472 0.121,-0.133 0.203,-0.246 0.25,-0.34 0.046,-0.09 0.07,-0.184 0.07,-0.27 0,-0.148 -0.051,-0.265 -0.156,-0.355 -0.098,-0.094 -0.231,-0.141 -0.395,-0.141 -0.117,0 -0.238,0.024 -0.367,0.063 -0.129,0.039 -0.266,0.101 -0.414,0.183 v -0.375 c 0.148,-0.058 0.289,-0.105 0.418,-0.132 0.129,-0.032 0.246,-0.047 0.355,-0.047 0.282,0 0.508,0.07 0.676,0.211 0.168,0.14 0.254,0.332 0.254,0.566 0,0.113 -0.02,0.223 -0.063,0.32 -0.043,0.102 -0.121,0.219 -0.23,0.356 -0.031,0.035 -0.129,0.141 -0.293,0.308 -0.16,0.168 -0.391,0.407 -0.691,0.707 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath320)"
+             id="path851" />
+          <path
+             d="m 85.82,131.406 -1.043,-2.73 h 0.387 l 0.867,2.301 0.867,-2.301 h 0.383 l -1.039,2.73 z m 1.422,-2.73 h 0.371 v 2.73 h -0.371 z m 0.946,0 h 0.496 l 1.214,2.285 v -2.285 h 0.36 v 2.73 h -0.5 l -1.211,-2.285 v 2.285 h -0.359 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath321)"
+             id="path852" />
+          <path
+             d="m 85.383,126.766 v -0.735 h -0.606 v -0.301 h 0.973 v 1.172 c -0.145,0.102 -0.301,0.18 -0.473,0.231 -0.172,0.051 -0.355,0.078 -0.55,0.078 -0.43,0 -0.762,-0.125 -1.004,-0.375 -0.243,-0.25 -0.36,-0.598 -0.36,-1.043 0,-0.445 0.117,-0.793 0.36,-1.043 0.242,-0.25 0.574,-0.375 1.004,-0.375 0.175,0 0.347,0.02 0.507,0.066 0.161,0.043 0.309,0.11 0.442,0.192 v 0.394 c -0.137,-0.117 -0.281,-0.203 -0.434,-0.261 -0.152,-0.059 -0.316,-0.086 -0.484,-0.086 -0.336,0 -0.586,0.093 -0.754,0.277 -0.168,0.188 -0.254,0.465 -0.254,0.836 0,0.367 0.086,0.645 0.254,0.832 0.168,0.187 0.418,0.281 0.754,0.281 0.129,0 0.246,-0.011 0.347,-0.035 0.102,-0.019 0.196,-0.059 0.278,-0.105 z m 0.5,-2.344 h 0.5 l 1.211,2.289 v -2.289 h 0.359 v 2.734 h -0.5 l -1.211,-2.285 v 2.285 h -0.359 z m 2.793,0.305 v 2.125 h 0.445 c 0.379,0 0.652,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.442 0.262,-0.809 0,-0.367 -0.086,-0.637 -0.262,-0.805 -0.176,-0.172 -0.449,-0.257 -0.828,-0.257 z m -0.371,-0.305 h 0.761 c 0.528,0 0.918,0.113 1.164,0.332 0.25,0.223 0.372,0.566 0.372,1.035 0,0.469 -0.125,0.816 -0.372,1.035 -0.25,0.223 -0.636,0.332 -1.164,0.332 h -0.761 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath322)"
+             id="path853" />
+          <path
+             d="m 85.383,122.516 v -0.735 h -0.606 v -0.304 h 0.973 v 1.175 c -0.145,0.102 -0.301,0.176 -0.473,0.231 -0.172,0.051 -0.355,0.074 -0.55,0.074 -0.43,0 -0.762,-0.121 -1.004,-0.371 -0.243,-0.25 -0.36,-0.598 -0.36,-1.043 0,-0.449 0.117,-0.797 0.36,-1.043 0.242,-0.25 0.574,-0.375 1.004,-0.375 0.175,0 0.347,0.02 0.507,0.063 0.161,0.046 0.309,0.109 0.442,0.195 v 0.394 c -0.137,-0.117 -0.281,-0.203 -0.434,-0.261 -0.152,-0.059 -0.316,-0.09 -0.484,-0.09 -0.336,0 -0.586,0.094 -0.754,0.281 -0.168,0.188 -0.254,0.465 -0.254,0.836 0,0.367 0.086,0.645 0.254,0.832 0.168,0.187 0.418,0.281 0.754,0.281 0.129,0 0.246,-0.011 0.347,-0.035 0.102,-0.023 0.196,-0.059 0.278,-0.105 z m 0.5,-2.344 h 0.5 l 1.211,2.289 v -2.289 h 0.359 v 2.734 h -0.5 l -1.211,-2.285 v 2.285 h -0.359 z m 2.793,0.305 v 2.125 h 0.445 c 0.379,0 0.652,-0.086 0.828,-0.258 0.176,-0.168 0.262,-0.438 0.262,-0.809 0,-0.363 -0.086,-0.633 -0.262,-0.801 -0.176,-0.172 -0.449,-0.257 -0.828,-0.257 z m -0.371,-0.305 h 0.761 c 0.528,0 0.918,0.113 1.164,0.332 0.25,0.219 0.372,0.562 0.372,1.031 0,0.473 -0.125,0.817 -0.372,1.039 -0.25,0.223 -0.636,0.332 -1.164,0.332 h -0.761 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath323)"
+             id="path854" />
+          <path
+             d="m 86.074,116.305 v 1.019 h 1.02 v 0.313 h -1.02 v 1.019 H 85.77 v -1.019 h -1.02 v -0.313 h 1.02 v -1.019 z m 0.547,-0.383 h 1.453 v 0.312 h -1.113 v 0.668 c 0.055,-0.019 0.109,-0.031 0.16,-0.039 0.055,-0.011 0.109,-0.015 0.164,-0.015 0.305,0 0.547,0.082 0.723,0.25 0.18,0.168 0.269,0.394 0.269,0.679 0,0.293 -0.093,0.524 -0.277,0.688 -0.184,0.16 -0.441,0.242 -0.773,0.242 -0.114,0 -0.231,-0.008 -0.352,-0.027 -0.117,-0.02 -0.242,-0.051 -0.367,-0.09 v -0.371 c 0.109,0.058 0.222,0.105 0.34,0.133 0.117,0.031 0.242,0.046 0.371,0.046 0.211,0 0.379,-0.058 0.504,-0.168 0.121,-0.113 0.183,-0.261 0.183,-0.453 0,-0.191 -0.062,-0.339 -0.183,-0.453 -0.125,-0.109 -0.293,-0.164 -0.504,-0.164 -0.098,0 -0.196,0.012 -0.297,0.031 -0.098,0.024 -0.195,0.059 -0.301,0.102 z m 2.57,2.734 -1.043,-2.734 h 0.387 l 0.867,2.301 0.868,-2.301 h 0.382 l -1.043,2.734 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath324)"
+             id="path855" />
+          <path
+             d="m 84.172,112.055 v 1.019 h 1.019 v 0.309 h -1.019 v 1.019 h -0.309 v -1.019 h -1.019 v -0.309 h 1.019 v -1.019 z m 1.664,0.875 c 0.176,0.039 0.312,0.117 0.414,0.238 0.098,0.117 0.148,0.266 0.148,0.441 0,0.27 -0.093,0.477 -0.277,0.625 -0.187,0.149 -0.449,0.223 -0.793,0.223 -0.113,0 -0.23,-0.012 -0.355,-0.035 -0.121,-0.024 -0.246,-0.055 -0.375,-0.102 v -0.355 c 0.105,0.058 0.214,0.105 0.34,0.137 0.121,0.027 0.246,0.043 0.382,0.043 0.231,0 0.407,-0.043 0.528,-0.137 0.121,-0.09 0.183,-0.223 0.183,-0.399 0,-0.16 -0.058,-0.285 -0.172,-0.379 -0.109,-0.089 -0.269,-0.136 -0.468,-0.136 H 85.07 v -0.301 h 0.336 c 0.18,0 0.321,-0.039 0.414,-0.109 0.098,-0.075 0.145,-0.18 0.145,-0.317 0,-0.14 -0.047,-0.246 -0.149,-0.32 -0.097,-0.078 -0.242,-0.113 -0.425,-0.113 -0.102,0 -0.211,0.011 -0.329,0.031 -0.113,0.023 -0.242,0.058 -0.382,0.101 v -0.328 c 0.14,-0.039 0.273,-0.066 0.394,-0.086 0.125,-0.019 0.238,-0.031 0.348,-0.031 0.281,0 0.504,0.063 0.668,0.191 0.164,0.129 0.246,0.301 0.246,0.516 0,0.152 -0.043,0.281 -0.133,0.387 -0.086,0.101 -0.207,0.176 -0.367,0.215 z m 1.453,1.472 -1.047,-2.73 h 0.387 l 0.867,2.301 0.867,-2.301 h 0.387 l -1.043,2.73 z m 2.574,-1.472 c 0.176,0.039 0.313,0.117 0.414,0.238 0.098,0.117 0.149,0.266 0.149,0.441 0,0.27 -0.094,0.477 -0.278,0.625 -0.187,0.149 -0.449,0.223 -0.793,0.223 -0.113,0 -0.23,-0.012 -0.355,-0.035 -0.121,-0.024 -0.246,-0.055 -0.375,-0.102 v -0.355 c 0.102,0.058 0.215,0.105 0.336,0.137 0.125,0.027 0.25,0.043 0.383,0.043 0.234,0 0.41,-0.043 0.531,-0.137 0.121,-0.09 0.184,-0.223 0.184,-0.399 0,-0.16 -0.059,-0.285 -0.172,-0.379 -0.114,-0.089 -0.27,-0.136 -0.469,-0.136 h -0.32 v -0.301 h 0.332 c 0.183,0 0.324,-0.039 0.418,-0.109 0.097,-0.075 0.144,-0.18 0.144,-0.317 0,-0.14 -0.047,-0.246 -0.148,-0.32 -0.098,-0.078 -0.242,-0.113 -0.426,-0.113 -0.102,0 -0.211,0.011 -0.328,0.031 -0.113,0.023 -0.242,0.058 -0.383,0.101 v -0.328 c 0.141,-0.039 0.273,-0.066 0.395,-0.086 0.125,-0.019 0.238,-0.031 0.347,-0.031 0.281,0 0.504,0.063 0.668,0.191 0.164,0.129 0.246,0.301 0.246,0.516 0,0.152 -0.047,0.281 -0.133,0.387 -0.085,0.101 -0.207,0.176 -0.367,0.215 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath325)"
+             id="path856" />
+          <path
+             d="m 82.656,108.871 c 0.078,0.027 0.156,0.086 0.231,0.172 0.074,0.09 0.152,0.211 0.226,0.363 l 0.375,0.746 H 83.09 l -0.348,-0.699 c -0.09,-0.183 -0.18,-0.305 -0.265,-0.367 -0.082,-0.059 -0.2,-0.09 -0.344,-0.09 H 81.73 v 1.156 h -0.371 v -2.734 h 0.836 c 0.313,0 0.543,0.066 0.7,0.199 0.152,0.129 0.23,0.328 0.23,0.59 0,0.172 -0.043,0.316 -0.121,0.43 -0.078,0.113 -0.195,0.191 -0.348,0.234 z m -0.926,-1.148 v 0.972 h 0.465 c 0.176,0 0.313,-0.043 0.403,-0.125 0.09,-0.082 0.136,-0.203 0.136,-0.363 0,-0.16 -0.046,-0.281 -0.136,-0.359 -0.09,-0.082 -0.227,-0.125 -0.403,-0.125 z m 1.665,-0.305 h 1.73 v 0.312 h -1.359 v 0.809 h 1.3 v 0.313 h -1.3 v 0.988 h 1.39 v 0.312 h -1.761 z m 3.433,0.09 v 0.363 c -0.14,-0.066 -0.273,-0.117 -0.398,-0.152 -0.125,-0.031 -0.242,-0.047 -0.36,-0.047 -0.203,0 -0.355,0.039 -0.468,0.117 -0.106,0.078 -0.161,0.188 -0.161,0.332 0,0.121 0.036,0.211 0.106,0.274 0.074,0.062 0.211,0.113 0.414,0.148 l 0.223,0.047 c 0.277,0.051 0.48,0.144 0.613,0.277 0.129,0.133 0.195,0.309 0.195,0.531 0,0.266 -0.09,0.465 -0.265,0.602 -0.18,0.137 -0.438,0.207 -0.782,0.207 -0.129,0 -0.265,-0.016 -0.414,-0.047 -0.144,-0.027 -0.297,-0.07 -0.453,-0.129 v -0.379 c 0.152,0.082 0.297,0.145 0.442,0.188 0.144,0.043 0.285,0.066 0.425,0.066 0.211,0 0.375,-0.043 0.489,-0.125 0.117,-0.082 0.171,-0.203 0.171,-0.355 0,-0.133 -0.039,-0.238 -0.125,-0.317 -0.082,-0.074 -0.214,-0.129 -0.402,-0.168 l -0.226,-0.043 c -0.274,-0.054 -0.477,-0.14 -0.598,-0.257 -0.125,-0.118 -0.184,-0.282 -0.184,-0.493 0,-0.238 0.082,-0.429 0.254,-0.57 0.168,-0.137 0.406,-0.207 0.703,-0.207 0.129,0 0.258,0.012 0.391,0.035 0.133,0.024 0.27,0.059 0.41,0.102 z m 0.082,-0.09 h 1.727 v 0.312 h -1.356 v 0.809 h 1.301 v 0.313 h -1.301 v 0.988 h 1.391 v 0.312 H 86.91 Z m 1.449,0 h 2.313 v 0.312 h -0.969 v 2.422 h -0.371 v -2.422 h -0.973 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath326)"
+             id="path857" />
+          <path
+             d="m 81.59,103.168 h 0.371 v 2.734 H 81.59 Z m 2.055,0.25 c -0.266,0 -0.481,0.102 -0.641,0.301 -0.156,0.203 -0.234,0.472 -0.234,0.82 0,0.344 0.078,0.613 0.234,0.816 0.16,0.2 0.375,0.301 0.641,0.301 0.269,0 0.484,-0.101 0.636,-0.301 0.16,-0.203 0.239,-0.472 0.239,-0.816 0,-0.348 -0.079,-0.617 -0.239,-0.82 -0.152,-0.199 -0.367,-0.301 -0.636,-0.301 z m 0,-0.297 c 0.386,0 0.691,0.129 0.921,0.383 0.227,0.258 0.344,0.601 0.344,1.035 0,0.43 -0.117,0.773 -0.344,1.031 -0.23,0.258 -0.535,0.383 -0.921,0.383 -0.383,0 -0.692,-0.125 -0.922,-0.383 -0.231,-0.258 -0.344,-0.601 -0.344,-1.031 0,-0.434 0.113,-0.777 0.344,-1.035 0.23,-0.254 0.539,-0.383 0.922,-0.383 z m 2.671,1.5 c 0.079,0.027 0.157,0.082 0.231,0.172 0.074,0.086 0.148,0.207 0.226,0.363 l 0.375,0.746 H 86.75 l -0.348,-0.703 c -0.09,-0.179 -0.179,-0.304 -0.265,-0.363 -0.082,-0.059 -0.199,-0.09 -0.344,-0.09 h -0.406 v 1.156 H 85.02 v -2.734 h 0.835 c 0.313,0 0.543,0.066 0.7,0.195 0.152,0.133 0.23,0.328 0.23,0.594 0,0.172 -0.043,0.313 -0.121,0.426 -0.082,0.113 -0.195,0.195 -0.348,0.238 z m -0.929,-1.148 v 0.968 h 0.468 c 0.176,0 0.313,-0.039 0.403,-0.121 0.09,-0.082 0.137,-0.203 0.137,-0.363 0,-0.16 -0.047,-0.281 -0.137,-0.363 -0.09,-0.082 -0.227,-0.121 -0.403,-0.121 z m 1.668,-0.305 h 1.726 v 0.312 h -1.355 v 0.809 h 1.301 v 0.313 h -1.301 v 0.988 h 1.39 v 0.312 h -1.761 z m 1.828,0 h 1.574 v 0.312 h -1.203 v 0.805 h 1.086 v 0.313 h -1.086 v 1.304 h -0.371 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath327)"
+             id="path858" />
+          <path
+             d="m 86.188,98.918 h 0.5 l 1.21,2.285 v -2.285 h 0.36 v 2.734 h -0.5 l -1.211,-2.289 v 2.289 h -0.359 z m 4.468,0.211 v 0.391 c -0.125,-0.118 -0.258,-0.204 -0.398,-0.262 -0.141,-0.059 -0.293,-0.086 -0.449,-0.086 -0.313,0 -0.551,0.098 -0.719,0.289 -0.164,0.187 -0.25,0.465 -0.25,0.824 0,0.363 0.086,0.637 0.25,0.828 0.168,0.192 0.406,0.285 0.719,0.285 0.156,0 0.308,-0.027 0.449,-0.086 0.14,-0.054 0.273,-0.14 0.398,-0.257 v 0.386 c -0.129,0.086 -0.265,0.153 -0.414,0.196 -0.14,0.047 -0.297,0.066 -0.457,0.066 -0.414,0 -0.738,-0.125 -0.976,-0.379 -0.239,-0.254 -0.356,-0.597 -0.356,-1.035 0,-0.441 0.117,-0.789 0.356,-1.039 0.238,-0.254 0.562,-0.383 0.976,-0.383 0.164,0 0.317,0.024 0.461,0.067 0.149,0.043 0.281,0.109 0.41,0.195 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath328)"
+             id="path859" />
+          <path
+             d="m 87.453,158.793 -0.5,1.359 h 1.004 z m -0.207,-0.363 h 0.418 l 1.043,2.73 h -0.383 l -0.25,-0.699 H 86.84 l -0.246,0.699 h -0.391 z m 1.504,0 h 1.449 v 0.308 h -1.113 v 0.672 c 0.055,-0.019 0.109,-0.031 0.164,-0.043 0.051,-0.008 0.105,-0.012 0.16,-0.012 0.305,0 0.547,0.083 0.723,0.25 0.179,0.168 0.269,0.395 0.269,0.68 0,0.293 -0.093,0.524 -0.273,0.684 -0.184,0.164 -0.441,0.246 -0.777,0.246 -0.114,0 -0.231,-0.012 -0.352,-0.031 -0.117,-0.02 -0.238,-0.047 -0.367,-0.086 v -0.371 c 0.109,0.058 0.222,0.101 0.34,0.132 0.117,0.028 0.242,0.043 0.371,0.043 0.211,0 0.379,-0.054 0.504,-0.168 0.121,-0.109 0.183,-0.261 0.183,-0.449 0,-0.191 -0.062,-0.344 -0.183,-0.453 -0.125,-0.109 -0.293,-0.168 -0.504,-0.168 -0.098,0 -0.196,0.012 -0.293,0.035 -0.098,0.02 -0.199,0.055 -0.301,0.102 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath329)"
+             id="path860" />
+          <path
+             d="m 87.453,154.543 -0.5,1.359 h 1.004 z m -0.207,-0.367 h 0.418 l 1.043,2.734 h -0.383 l -0.25,-0.703 H 86.84 l -0.246,0.703 h -0.391 z m 2.516,0.324 -0.934,1.457 h 0.934 z m -0.098,-0.324 h 0.465 v 1.781 h 0.391 v 0.309 h -0.391 v 0.644 h -0.367 v -0.644 h -1.235 v -0.356 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath330)"
+             id="path861" />
+          <path
+             d="m 87.453,150.289 -0.5,1.363 h 1.004 z m -0.207,-0.363 h 0.418 l 1.043,2.734 h -0.383 l -0.25,-0.703 H 86.84 l -0.246,0.703 h -0.391 z m 2.621,1.258 c 0.176,0.039 0.313,0.117 0.41,0.238 0.102,0.121 0.153,0.266 0.153,0.441 0,0.27 -0.094,0.481 -0.278,0.629 -0.187,0.145 -0.449,0.219 -0.793,0.219 -0.113,0 -0.23,-0.012 -0.355,-0.035 -0.121,-0.02 -0.246,-0.055 -0.375,-0.098 v -0.359 c 0.101,0.062 0.215,0.105 0.336,0.136 0.125,0.032 0.25,0.047 0.383,0.047 0.234,0 0.41,-0.047 0.531,-0.14 0.121,-0.09 0.183,-0.223 0.183,-0.399 0,-0.16 -0.058,-0.285 -0.171,-0.375 -0.114,-0.093 -0.27,-0.136 -0.469,-0.136 h -0.32 v -0.305 h 0.332 c 0.183,0 0.324,-0.035 0.418,-0.109 0.097,-0.075 0.144,-0.176 0.144,-0.313 0,-0.141 -0.051,-0.25 -0.148,-0.324 -0.098,-0.074 -0.243,-0.113 -0.426,-0.113 -0.102,0 -0.211,0.011 -0.328,0.035 -0.114,0.019 -0.242,0.054 -0.383,0.101 v -0.332 c 0.141,-0.039 0.273,-0.066 0.394,-0.086 0.125,-0.019 0.239,-0.031 0.348,-0.031 0.281,0 0.504,0.066 0.668,0.195 0.164,0.125 0.242,0.297 0.242,0.516 0,0.152 -0.043,0.277 -0.129,0.383 -0.086,0.105 -0.211,0.176 -0.367,0.215 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath331)"
+             id="path862" />
+          <path
+             d="m 87.453,146.039 -0.5,1.359 h 1.004 z m -0.207,-0.363 h 0.418 l 1.043,2.73 h -0.383 l -0.25,-0.699 H 86.84 l -0.246,0.699 h -0.391 z m 1.816,2.422 h 1.293 v 0.308 h -1.738 v -0.308 c 0.141,-0.145 0.332,-0.34 0.574,-0.586 0.243,-0.242 0.395,-0.403 0.457,-0.473 0.122,-0.133 0.204,-0.246 0.25,-0.336 0.047,-0.094 0.071,-0.183 0.071,-0.273 0,-0.145 -0.051,-0.266 -0.157,-0.356 -0.101,-0.09 -0.23,-0.136 -0.394,-0.136 -0.117,0 -0.238,0.019 -0.367,0.058 -0.129,0.043 -0.266,0.102 -0.414,0.184 v -0.371 c 0.148,-0.063 0.289,-0.106 0.418,-0.137 0.129,-0.031 0.246,-0.047 0.355,-0.047 0.281,0 0.508,0.07 0.676,0.215 0.168,0.14 0.254,0.328 0.254,0.566 0,0.114 -0.024,0.219 -0.063,0.321 -0.043,0.097 -0.121,0.218 -0.23,0.355 -0.031,0.035 -0.129,0.137 -0.293,0.305 -0.16,0.172 -0.391,0.406 -0.692,0.711 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath332)"
+             id="path863" />
+          <path
+             d="m 87.453,141.789 -0.5,1.359 h 1.004 z m -0.207,-0.363 h 0.418 l 1.043,2.73 h -0.383 l -0.25,-0.699 H 86.84 l -0.246,0.699 h -0.391 z m 1.563,2.422 h 0.605 v -2.086 l -0.656,0.133 v -0.34 l 0.652,-0.129 h 0.371 v 2.422 h 0.602 v 0.308 h -1.574 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath333)"
+             id="path864" />
+          <path
+             d="m 87.453,137.539 -0.5,1.359 h 1.004 z m -0.207,-0.367 h 0.418 l 1.043,2.734 h -0.383 l -0.25,-0.703 H 86.84 l -0.246,0.703 h -0.391 z m 2.289,0.246 c -0.191,0 -0.332,0.094 -0.43,0.281 -0.093,0.188 -0.144,0.469 -0.144,0.844 0,0.375 0.051,0.656 0.144,0.844 0.098,0.187 0.239,0.281 0.43,0.281 0.192,0 0.336,-0.094 0.43,-0.281 0.097,-0.188 0.144,-0.469 0.144,-0.844 0,-0.375 -0.047,-0.656 -0.144,-0.844 -0.094,-0.187 -0.238,-0.281 -0.43,-0.281 z m 0,-0.293 c 0.309,0 0.539,0.121 0.703,0.363 0.16,0.242 0.242,0.594 0.242,1.055 0,0.461 -0.082,0.812 -0.242,1.055 -0.164,0.242 -0.394,0.363 -0.703,0.363 -0.305,0 -0.539,-0.121 -0.703,-0.363 -0.16,-0.243 -0.242,-0.594 -0.242,-1.055 0,-0.461 0.082,-0.813 0.242,-1.055 0.164,-0.242 0.398,-0.363 0.703,-0.363 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath334)"
+             id="path865" />
+          <path
+             d="m 109.84,128.977 v 2.125 h 0.445 c 0.379,0 0.653,-0.086 0.828,-0.258 0.176,-0.168 0.262,-0.442 0.262,-0.809 0,-0.367 -0.086,-0.633 -0.262,-0.805 -0.175,-0.168 -0.449,-0.253 -0.828,-0.253 z m -0.371,-0.305 h 0.758 c 0.531,0 0.921,0.109 1.168,0.332 0.246,0.219 0.371,0.562 0.371,1.031 0,0.473 -0.125,0.817 -0.371,1.039 -0.25,0.219 -0.641,0.332 -1.168,0.332 h -0.758 z m 2.343,0 h 1.45 v 0.312 h -1.114 v 0.668 c 0.055,-0.015 0.11,-0.031 0.164,-0.039 0.051,-0.011 0.106,-0.015 0.161,-0.015 0.304,0 0.547,0.086 0.722,0.25 0.18,0.168 0.27,0.394 0.27,0.679 0,0.293 -0.094,0.524 -0.274,0.688 -0.183,0.16 -0.441,0.242 -0.777,0.242 -0.113,0 -0.23,-0.008 -0.352,-0.027 -0.117,-0.02 -0.238,-0.051 -0.367,-0.09 v -0.371 c 0.11,0.058 0.223,0.105 0.34,0.133 0.117,0.031 0.242,0.046 0.371,0.046 0.215,0 0.379,-0.058 0.504,-0.168 0.121,-0.109 0.184,-0.261 0.184,-0.453 0,-0.191 -0.063,-0.339 -0.184,-0.453 -0.125,-0.109 -0.289,-0.164 -0.504,-0.164 -0.097,0 -0.195,0.012 -0.293,0.031 -0.097,0.024 -0.199,0.059 -0.301,0.102 z m 2.688,0.242 c -0.191,0 -0.336,0.094 -0.43,0.285 -0.097,0.184 -0.144,0.465 -0.144,0.844 0,0.371 0.047,0.652 0.144,0.844 0.094,0.183 0.239,0.277 0.43,0.277 0.191,0 0.336,-0.094 0.43,-0.277 0.097,-0.192 0.144,-0.473 0.144,-0.844 0,-0.379 -0.047,-0.66 -0.144,-0.844 -0.094,-0.191 -0.239,-0.285 -0.43,-0.285 z m 0,-0.293 c 0.305,0 0.539,0.121 0.699,0.367 0.164,0.239 0.246,0.59 0.246,1.055 0,0.457 -0.082,0.809 -0.246,1.051 -0.16,0.242 -0.394,0.363 -0.699,0.363 -0.309,0 -0.543,-0.121 -0.703,-0.363 -0.16,-0.242 -0.242,-0.594 -0.242,-1.051 0,-0.465 0.082,-0.816 0.242,-1.055 0.16,-0.246 0.394,-0.367 0.703,-0.367 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath335)"
+             id="path866" />
+          <path
+             d="m 109.84,124.727 v 2.125 h 0.445 c 0.379,0 0.653,-0.086 0.828,-0.258 0.176,-0.172 0.262,-0.442 0.262,-0.809 0,-0.367 -0.086,-0.633 -0.262,-0.805 -0.175,-0.171 -0.449,-0.253 -0.828,-0.253 z m -0.371,-0.305 h 0.758 c 0.531,0 0.921,0.109 1.168,0.332 0.246,0.219 0.371,0.562 0.371,1.031 0,0.469 -0.125,0.817 -0.371,1.039 -0.25,0.219 -0.641,0.328 -1.168,0.328 h -0.758 z m 3.355,0.32 -0.933,1.461 h 0.933 z m -0.097,-0.32 h 0.464 v 1.781 h 0.391 v 0.305 h -0.391 v 0.644 h -0.367 v -0.644 h -1.234 v -0.356 z m 0.992,2.676 v -0.336 c 0.093,0.043 0.187,0.074 0.281,0.097 0.098,0.024 0.191,0.036 0.281,0.036 0.246,0 0.43,-0.083 0.559,-0.243 0.129,-0.168 0.203,-0.418 0.222,-0.75 -0.07,0.106 -0.16,0.184 -0.269,0.243 -0.109,0.054 -0.231,0.082 -0.359,0.082 -0.274,0 -0.493,-0.082 -0.653,-0.247 -0.156,-0.164 -0.238,-0.39 -0.238,-0.679 0,-0.281 0.082,-0.504 0.25,-0.676 0.164,-0.168 0.387,-0.254 0.664,-0.254 0.316,0 0.555,0.121 0.723,0.363 0.168,0.243 0.25,0.594 0.25,1.055 0,0.434 -0.102,0.777 -0.309,1.035 -0.203,0.254 -0.476,0.383 -0.824,0.383 -0.09,0 -0.184,-0.008 -0.281,-0.027 -0.094,-0.02 -0.196,-0.047 -0.297,-0.082 z m 0.738,-1.16 c 0.164,0 0.297,-0.055 0.391,-0.168 0.097,-0.114 0.148,-0.27 0.148,-0.469 0,-0.196 -0.051,-0.352 -0.148,-0.465 -0.094,-0.113 -0.227,-0.172 -0.391,-0.172 -0.168,0 -0.301,0.059 -0.398,0.172 -0.094,0.113 -0.145,0.269 -0.145,0.465 0,0.199 0.051,0.355 0.145,0.469 0.097,0.113 0.23,0.168 0.398,0.168 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath336)"
+             id="path867" />
+          <path
+             d="m 109.84,120.473 v 2.125 h 0.445 c 0.379,0 0.653,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.442 0.262,-0.809 0,-0.367 -0.086,-0.637 -0.262,-0.805 -0.175,-0.171 -0.449,-0.257 -0.828,-0.257 z m -0.371,-0.301 h 0.758 c 0.531,0 0.921,0.109 1.168,0.328 0.246,0.223 0.371,0.566 0.371,1.035 0,0.469 -0.125,0.817 -0.371,1.035 -0.25,0.223 -0.641,0.332 -1.168,0.332 h -0.758 z m 3.355,0.32 -0.933,1.457 h 0.933 z m -0.097,-0.32 h 0.464 v 1.777 h 0.391 v 0.309 h -0.391 v 0.644 h -0.367 v -0.644 h -1.234 v -0.356 z m 1.773,1.433 c -0.176,0 -0.316,0.047 -0.418,0.141 -0.098,0.094 -0.148,0.223 -0.148,0.387 0,0.168 0.05,0.297 0.148,0.39 0.102,0.094 0.242,0.141 0.418,0.141 0.176,0 0.312,-0.047 0.414,-0.141 0.102,-0.097 0.152,-0.226 0.152,-0.39 0,-0.164 -0.05,-0.293 -0.152,-0.387 -0.098,-0.094 -0.238,-0.141 -0.414,-0.141 z m -0.371,-0.156 c -0.156,-0.039 -0.281,-0.113 -0.371,-0.222 -0.086,-0.11 -0.133,-0.243 -0.133,-0.399 0,-0.219 0.078,-0.39 0.234,-0.516 0.157,-0.128 0.368,-0.191 0.641,-0.191 0.273,0 0.484,0.063 0.641,0.191 0.156,0.126 0.23,0.297 0.23,0.516 0,0.156 -0.043,0.289 -0.133,0.399 -0.086,0.109 -0.211,0.183 -0.367,0.222 0.18,0.039 0.317,0.121 0.414,0.242 0.102,0.121 0.153,0.27 0.153,0.442 0,0.265 -0.083,0.469 -0.247,0.609 -0.16,0.145 -0.39,0.215 -0.691,0.215 -0.301,0 -0.535,-0.07 -0.695,-0.215 -0.16,-0.14 -0.243,-0.344 -0.243,-0.609 0,-0.172 0.051,-0.321 0.149,-0.442 0.101,-0.121 0.242,-0.203 0.418,-0.242 z m -0.133,-0.586 c 0,0.141 0.043,0.254 0.129,0.332 0.09,0.078 0.215,0.117 0.375,0.117 0.156,0 0.281,-0.039 0.371,-0.117 0.09,-0.078 0.137,-0.191 0.137,-0.332 0,-0.14 -0.047,-0.25 -0.137,-0.332 -0.09,-0.078 -0.215,-0.117 -0.371,-0.117 -0.16,0 -0.285,0.039 -0.375,0.117 -0.086,0.082 -0.129,0.192 -0.129,0.332 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath337)"
+             id="path868" />
+          <path
+             d="m 109.84,116.223 v 2.125 h 0.445 c 0.379,0 0.653,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.442 0.262,-0.813 0,-0.363 -0.086,-0.633 -0.262,-0.801 -0.175,-0.171 -0.449,-0.257 -0.828,-0.257 z m -0.371,-0.305 h 0.758 c 0.531,0 0.921,0.113 1.168,0.332 0.246,0.219 0.371,0.562 0.371,1.031 0,0.473 -0.125,0.821 -0.371,1.039 -0.25,0.223 -0.641,0.332 -1.168,0.332 h -0.758 z m 3.355,0.324 -0.933,1.457 h 0.933 z m -0.097,-0.324 h 0.464 v 1.781 h 0.391 v 0.309 h -0.391 v 0.644 h -0.367 v -0.644 h -1.234 v -0.356 z m 0.886,0 h 1.758 v 0.16 l -0.992,2.574 h -0.383 l 0.934,-2.422 h -1.317 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath338)"
+             id="path869" />
+          <path
+             d="m 109.84,111.973 v 2.125 h 0.445 c 0.379,0 0.653,-0.086 0.828,-0.258 0.176,-0.168 0.262,-0.442 0.262,-0.809 0,-0.367 -0.086,-0.633 -0.262,-0.804 -0.175,-0.168 -0.449,-0.254 -0.828,-0.254 z m -0.371,-0.305 h 0.758 c 0.531,0 0.921,0.109 1.168,0.332 0.246,0.219 0.371,0.562 0.371,1.031 0,0.473 -0.125,0.817 -0.371,1.039 -0.25,0.219 -0.641,0.332 -1.168,0.332 h -0.758 z m 3.355,0.324 -0.933,1.457 h 0.933 z m -0.097,-0.324 h 0.464 v 1.781 h 0.391 v 0.309 h -0.391 v 0.644 h -0.367 v -0.644 h -1.234 v -0.36 z m 1.82,1.219 c -0.168,0 -0.301,0.058 -0.399,0.172 -0.093,0.113 -0.144,0.269 -0.144,0.464 0,0.196 0.051,0.352 0.144,0.469 0.098,0.113 0.231,0.168 0.399,0.168 0.164,0 0.297,-0.055 0.391,-0.168 0.097,-0.117 0.148,-0.273 0.148,-0.469 0,-0.195 -0.051,-0.351 -0.148,-0.464 -0.094,-0.114 -0.227,-0.172 -0.391,-0.172 z m 0.734,-1.157 v 0.336 c -0.093,-0.046 -0.187,-0.078 -0.285,-0.101 -0.094,-0.024 -0.187,-0.035 -0.277,-0.035 -0.246,0 -0.434,0.082 -0.563,0.246 -0.129,0.164 -0.199,0.414 -0.218,0.746 0.07,-0.106 0.164,-0.184 0.269,-0.242 0.109,-0.059 0.231,-0.086 0.359,-0.086 0.278,0 0.493,0.086 0.653,0.25 0.16,0.168 0.238,0.394 0.238,0.679 0,0.282 -0.082,0.508 -0.25,0.676 -0.164,0.172 -0.387,0.254 -0.66,0.254 -0.317,0 -0.559,-0.121 -0.727,-0.363 -0.168,-0.242 -0.25,-0.594 -0.25,-1.051 0,-0.434 0.102,-0.777 0.309,-1.035 0.203,-0.258 0.476,-0.387 0.824,-0.387 0.094,0 0.188,0.012 0.281,0.028 0.094,0.019 0.192,0.046 0.297,0.085 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath339)"
+             id="path870" />
+          <path
+             d="m 109.84,107.723 v 2.125 h 0.445 c 0.379,0 0.653,-0.086 0.828,-0.258 0.176,-0.172 0.262,-0.442 0.262,-0.809 0,-0.367 -0.086,-0.633 -0.262,-0.804 -0.175,-0.172 -0.449,-0.254 -0.828,-0.254 z m -0.371,-0.305 h 0.758 c 0.531,0 0.921,0.109 1.168,0.332 0.246,0.219 0.371,0.562 0.371,1.031 0,0.469 -0.125,0.817 -0.371,1.039 -0.25,0.219 -0.641,0.328 -1.168,0.328 h -0.758 z m 3.355,0.32 -0.933,1.461 h 0.933 z m -0.097,-0.32 h 0.464 v 1.781 h 0.391 v 0.305 h -0.391 v 0.644 h -0.367 v -0.644 h -1.234 v -0.356 z m 0.984,0 h 1.453 v 0.309 h -1.113 v 0.671 c 0.054,-0.019 0.109,-0.031 0.16,-0.039 0.055,-0.011 0.109,-0.015 0.164,-0.015 0.305,0 0.547,0.082 0.723,0.25 0.179,0.168 0.269,0.394 0.269,0.679 0,0.293 -0.094,0.524 -0.277,0.688 -0.184,0.16 -0.442,0.242 -0.774,0.242 -0.113,0 -0.23,-0.012 -0.351,-0.031 -0.117,-0.02 -0.242,-0.047 -0.367,-0.086 v -0.371 c 0.109,0.058 0.222,0.105 0.34,0.133 0.117,0.031 0.242,0.043 0.371,0.043 0.211,0 0.379,-0.055 0.503,-0.164 0.122,-0.114 0.184,-0.262 0.184,-0.454 0,-0.191 -0.062,-0.339 -0.184,-0.453 -0.124,-0.109 -0.292,-0.164 -0.503,-0.164 -0.098,0 -0.196,0.008 -0.297,0.032 -0.098,0.023 -0.196,0.054 -0.301,0.101 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath340)"
+             id="path871" />
+          <path
+             d="m 109.84,103.469 v 2.125 h 0.445 c 0.379,0 0.653,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.442 0.262,-0.809 0,-0.367 -0.086,-0.636 -0.262,-0.804 -0.175,-0.172 -0.449,-0.258 -0.828,-0.258 z m -0.371,-0.301 h 0.758 c 0.531,0 0.921,0.109 1.168,0.328 0.246,0.223 0.371,0.566 0.371,1.035 0,0.469 -0.125,0.817 -0.371,1.035 -0.25,0.223 -0.641,0.332 -1.168,0.332 h -0.758 z m 3.355,0.32 -0.933,1.457 h 0.933 z m -0.097,-0.32 h 0.464 v 1.777 h 0.391 v 0.309 h -0.391 v 0.644 h -0.367 v -0.644 h -1.234 v -0.356 z m 2,0.32 -0.938,1.457 h 0.938 z m -0.098,-0.32 h 0.465 v 1.777 h 0.39 v 0.309 h -0.39 v 0.644 h -0.367 v -0.644 h -1.235 v -0.356 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath341)"
+             id="path872" />
+          <path
+             d="m 109.84,99.219 v 2.125 h 0.445 c 0.379,0 0.653,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.442 0.262,-0.813 0,-0.363 -0.086,-0.632 -0.262,-0.8 -0.175,-0.172 -0.449,-0.258 -0.828,-0.258 z m -0.371,-0.305 h 0.758 c 0.531,0 0.921,0.113 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.473 -0.125,0.821 -0.371,1.039 -0.25,0.223 -0.641,0.332 -1.168,0.332 h -0.758 z m 3.355,0.324 -0.933,1.457 h 0.933 z m -0.097,-0.324 h 0.464 v 1.781 h 0.391 v 0.309 h -0.391 v 0.644 h -0.367 v -0.644 h -1.234 v -0.356 z m 2.101,1.262 c 0.18,0.035 0.317,0.117 0.414,0.234 0.102,0.121 0.153,0.27 0.153,0.445 0,0.27 -0.094,0.477 -0.282,0.625 -0.183,0.149 -0.449,0.219 -0.789,0.219 -0.117,0 -0.234,-0.008 -0.355,-0.031 -0.121,-0.023 -0.246,-0.059 -0.375,-0.102 v -0.359 c 0.101,0.063 0.215,0.105 0.336,0.137 0.121,0.031 0.25,0.047 0.382,0.047 0.231,0 0.411,-0.047 0.532,-0.137 0.121,-0.094 0.179,-0.227 0.179,-0.399 0,-0.164 -0.054,-0.289 -0.168,-0.378 -0.113,-0.09 -0.269,-0.137 -0.472,-0.137 h -0.317 v -0.305 h 0.332 c 0.184,0 0.321,-0.035 0.418,-0.109 0.098,-0.071 0.145,-0.176 0.145,-0.313 0,-0.14 -0.051,-0.25 -0.149,-0.324 -0.101,-0.074 -0.242,-0.113 -0.429,-0.113 -0.102,0 -0.207,0.012 -0.324,0.035 -0.118,0.019 -0.243,0.055 -0.383,0.101 v -0.328 c 0.14,-0.039 0.269,-0.07 0.394,-0.089 0.121,-0.02 0.239,-0.028 0.348,-0.028 0.281,0 0.504,0.063 0.664,0.192 0.164,0.125 0.246,0.296 0.246,0.515 0,0.153 -0.043,0.278 -0.129,0.383 -0.086,0.105 -0.211,0.176 -0.371,0.219 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath342)"
+             id="path873" />
+          <path
+             d="m 111.281,160.77 v -0.735 h -0.605 v -0.305 h 0.969 v 1.172 c -0.141,0.102 -0.297,0.18 -0.473,0.231 -0.172,0.055 -0.356,0.078 -0.551,0.078 -0.426,0 -0.762,-0.125 -1,-0.375 -0.242,-0.25 -0.363,-0.598 -0.363,-1.043 0,-0.445 0.121,-0.793 0.363,-1.043 0.238,-0.25 0.574,-0.375 1,-0.375 0.18,0 0.348,0.023 0.508,0.066 0.16,0.043 0.309,0.11 0.445,0.196 v 0.394 c -0.136,-0.117 -0.281,-0.203 -0.433,-0.261 -0.157,-0.059 -0.317,-0.09 -0.489,-0.09 -0.332,0 -0.586,0.093 -0.754,0.281 -0.168,0.187 -0.25,0.465 -0.25,0.832 0,0.371 0.082,0.648 0.25,0.836 0.168,0.183 0.422,0.277 0.754,0.277 0.133,0 0.25,-0.008 0.352,-0.031 0.101,-0.023 0.195,-0.059 0.277,-0.105 z m 0.5,-2.344 h 0.496 l 1.215,2.285 v -2.285 h 0.36 v 2.734 h -0.5 l -1.211,-2.289 v 2.289 h -0.36 z m 2.789,0.304 v 2.125 h 0.45 c 0.375,0 0.652,-0.085 0.828,-0.257 0.175,-0.172 0.261,-0.442 0.261,-0.809 0,-0.367 -0.086,-0.633 -0.261,-0.805 -0.176,-0.168 -0.453,-0.254 -0.828,-0.254 z m -0.367,-0.304 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.219 0.371,0.562 0.371,1.031 0,0.473 -0.125,0.816 -0.375,1.039 -0.246,0.219 -0.637,0.332 -1.164,0.332 h -0.758 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath343)"
+             id="path874" />
+          <path
+             d="m 109.785,154.477 v 2.125 h 0.449 c 0.375,0 0.653,-0.082 0.825,-0.254 0.175,-0.172 0.265,-0.442 0.265,-0.809 0,-0.367 -0.09,-0.637 -0.265,-0.805 -0.172,-0.172 -0.45,-0.257 -0.825,-0.257 z m -0.367,-0.301 h 0.758 c 0.531,0 0.918,0.109 1.168,0.328 0.246,0.223 0.371,0.566 0.371,1.035 0,0.469 -0.125,0.816 -0.375,1.035 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.758 z m 2.34,0 h 1.453 v 0.308 h -1.113 v 0.672 c 0.054,-0.019 0.105,-0.031 0.16,-0.039 0.054,-0.012 0.109,-0.015 0.16,-0.015 0.309,0 0.547,0.082 0.727,0.25 0.179,0.168 0.265,0.394 0.265,0.679 0,0.293 -0.09,0.524 -0.273,0.688 -0.184,0.16 -0.442,0.242 -0.774,0.242 -0.113,0 -0.23,-0.012 -0.351,-0.031 -0.117,-0.02 -0.242,-0.047 -0.367,-0.086 v -0.371 c 0.109,0.058 0.222,0.101 0.339,0.132 0.118,0.028 0.243,0.043 0.371,0.043 0.211,0 0.379,-0.054 0.5,-0.164 0.125,-0.113 0.188,-0.261 0.188,-0.453 0,-0.191 -0.063,-0.34 -0.188,-0.453 -0.121,-0.109 -0.289,-0.168 -0.5,-0.168 -0.097,0 -0.199,0.012 -0.296,0.035 -0.098,0.02 -0.2,0.055 -0.301,0.102 z m 1.902,0 h 1.453 v 0.308 H 114 v 0.672 c 0.051,-0.019 0.105,-0.031 0.16,-0.039 0.055,-0.012 0.106,-0.015 0.16,-0.015 0.305,0 0.547,0.082 0.727,0.25 0.176,0.168 0.265,0.394 0.265,0.679 0,0.293 -0.089,0.524 -0.273,0.688 -0.184,0.16 -0.441,0.242 -0.773,0.242 -0.118,0 -0.235,-0.012 -0.352,-0.031 -0.121,-0.02 -0.242,-0.047 -0.371,-0.086 v -0.371 c 0.109,0.058 0.227,0.101 0.344,0.132 0.117,0.028 0.238,0.043 0.371,0.043 0.211,0 0.379,-0.054 0.5,-0.164 0.125,-0.113 0.183,-0.261 0.183,-0.453 0,-0.191 -0.058,-0.34 -0.183,-0.453 -0.121,-0.109 -0.289,-0.168 -0.5,-0.168 -0.102,0 -0.199,0.012 -0.297,0.035 -0.098,0.02 -0.199,0.055 -0.301,0.102 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath344)"
+             id="path875" />
+          <path
+             d="m 109.785,150.227 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.825,-0.254 0.175,-0.172 0.265,-0.442 0.265,-0.809 0,-0.367 -0.09,-0.637 -0.265,-0.805 -0.172,-0.172 -0.45,-0.257 -0.825,-0.257 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.113 1.168,0.332 0.246,0.219 0.371,0.566 0.371,1.035 0,0.469 -0.125,0.816 -0.375,1.035 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.758 z m 2.34,0 h 1.453 v 0.312 h -1.113 v 0.672 c 0.054,-0.019 0.105,-0.035 0.16,-0.043 0.054,-0.008 0.109,-0.011 0.16,-0.011 0.309,0 0.547,0.082 0.727,0.25 0.179,0.168 0.265,0.39 0.265,0.679 0,0.293 -0.09,0.52 -0.273,0.684 -0.184,0.164 -0.442,0.246 -0.774,0.246 -0.113,0 -0.23,-0.012 -0.351,-0.031 -0.117,-0.02 -0.242,-0.047 -0.367,-0.086 v -0.375 c 0.109,0.062 0.222,0.105 0.339,0.136 0.118,0.028 0.243,0.043 0.371,0.043 0.211,0 0.379,-0.054 0.5,-0.168 0.125,-0.109 0.188,-0.261 0.188,-0.449 0,-0.191 -0.063,-0.343 -0.188,-0.453 -0.121,-0.113 -0.289,-0.168 -0.5,-0.168 -0.097,0 -0.199,0.012 -0.296,0.035 -0.098,0.02 -0.2,0.055 -0.301,0.102 z m 2.914,0.324 -0.934,1.457 h 0.934 z m -0.098,-0.324 h 0.465 v 1.781 h 0.391 v 0.309 h -0.391 v 0.644 h -0.367 v -0.644 h -1.234 v -0.356 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath345)"
+             id="path876" />
+          <path
+             d="m 109.785,145.977 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.825,-0.258 0.175,-0.168 0.265,-0.438 0.265,-0.809 0,-0.363 -0.09,-0.633 -0.265,-0.801 -0.172,-0.172 -0.45,-0.257 -0.825,-0.257 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.219 0.371,0.562 0.371,1.031 0,0.473 -0.125,0.817 -0.375,1.039 -0.25,0.219 -0.637,0.332 -1.164,0.332 h -0.758 z m 2.34,0 h 1.453 v 0.312 h -1.113 v 0.668 c 0.054,-0.015 0.105,-0.031 0.16,-0.039 0.054,-0.008 0.109,-0.015 0.16,-0.015 0.309,0 0.547,0.086 0.727,0.25 0.179,0.168 0.265,0.394 0.265,0.679 0,0.297 -0.09,0.524 -0.273,0.688 -0.184,0.164 -0.442,0.242 -0.774,0.242 -0.113,0 -0.23,-0.008 -0.351,-0.027 -0.117,-0.02 -0.242,-0.051 -0.367,-0.09 v -0.371 c 0.109,0.062 0.222,0.105 0.339,0.133 0.118,0.031 0.243,0.046 0.371,0.046 0.211,0 0.379,-0.058 0.5,-0.168 0.125,-0.109 0.188,-0.261 0.188,-0.453 0,-0.187 -0.063,-0.339 -0.188,-0.449 -0.121,-0.113 -0.289,-0.168 -0.5,-0.168 -0.097,0 -0.199,0.012 -0.296,0.031 -0.098,0.024 -0.2,0.059 -0.301,0.106 z m 3.019,1.262 c 0.176,0.035 0.313,0.113 0.414,0.234 0.098,0.121 0.149,0.266 0.149,0.441 0,0.27 -0.094,0.481 -0.278,0.629 -0.187,0.145 -0.449,0.219 -0.792,0.219 -0.114,0 -0.231,-0.012 -0.352,-0.035 -0.121,-0.02 -0.246,-0.055 -0.379,-0.098 v -0.359 c 0.106,0.062 0.215,0.105 0.34,0.137 0.121,0.031 0.25,0.046 0.383,0.046 0.23,0 0.406,-0.046 0.527,-0.136 0.121,-0.094 0.184,-0.227 0.184,-0.403 0,-0.16 -0.059,-0.285 -0.172,-0.375 -0.11,-0.093 -0.27,-0.136 -0.469,-0.136 h -0.32 v -0.305 h 0.336 c 0.179,0 0.32,-0.035 0.418,-0.109 0.093,-0.071 0.144,-0.176 0.144,-0.313 0,-0.141 -0.051,-0.25 -0.152,-0.324 -0.098,-0.074 -0.242,-0.113 -0.426,-0.113 -0.102,0 -0.211,0.011 -0.328,0.035 -0.113,0.019 -0.242,0.054 -0.379,0.101 v -0.332 c 0.137,-0.039 0.27,-0.066 0.391,-0.086 0.125,-0.019 0.242,-0.031 0.347,-0.031 0.282,0 0.504,0.067 0.668,0.195 0.164,0.125 0.246,0.297 0.246,0.516 0,0.152 -0.043,0.277 -0.132,0.383 -0.086,0.105 -0.207,0.176 -0.368,0.219 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath346)"
+             id="path877" />
+          <path
+             d="m 109.785,141.727 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.825,-0.258 0.175,-0.172 0.265,-0.442 0.265,-0.809 0,-0.367 -0.09,-0.633 -0.265,-0.805 -0.172,-0.168 -0.45,-0.253 -0.825,-0.253 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.219 0.371,0.562 0.371,1.031 0,0.473 -0.125,0.817 -0.375,1.039 -0.25,0.219 -0.637,0.328 -1.164,0.328 h -0.758 z m 2.34,0 h 1.453 v 0.312 h -1.113 v 0.668 c 0.054,-0.019 0.105,-0.031 0.16,-0.039 0.054,-0.011 0.109,-0.015 0.16,-0.015 0.309,0 0.547,0.082 0.727,0.25 0.179,0.168 0.265,0.394 0.265,0.679 0,0.293 -0.09,0.524 -0.273,0.688 -0.184,0.16 -0.442,0.242 -0.774,0.242 -0.113,0 -0.23,-0.008 -0.351,-0.027 -0.117,-0.02 -0.242,-0.051 -0.367,-0.09 v -0.371 c 0.109,0.058 0.222,0.105 0.339,0.133 0.118,0.031 0.243,0.043 0.371,0.043 0.211,0 0.379,-0.055 0.5,-0.165 0.125,-0.113 0.188,-0.261 0.188,-0.453 0,-0.191 -0.063,-0.339 -0.188,-0.453 -0.121,-0.109 -0.289,-0.164 -0.5,-0.164 -0.097,0 -0.199,0.008 -0.296,0.031 -0.098,0.024 -0.2,0.055 -0.301,0.102 z m 2.219,2.422 h 1.289 v 0.308 h -1.735 v -0.308 c 0.141,-0.145 0.328,-0.34 0.571,-0.586 0.242,-0.242 0.398,-0.403 0.457,-0.473 0.121,-0.133 0.203,-0.246 0.25,-0.336 0.046,-0.094 0.07,-0.183 0.07,-0.273 0,-0.145 -0.051,-0.266 -0.152,-0.356 -0.102,-0.09 -0.235,-0.136 -0.399,-0.136 -0.117,0 -0.238,0.019 -0.367,0.058 -0.129,0.043 -0.266,0.102 -0.414,0.184 v -0.371 c 0.148,-0.063 0.289,-0.106 0.418,-0.137 0.129,-0.031 0.25,-0.047 0.355,-0.047 0.285,0 0.508,0.07 0.68,0.215 0.168,0.141 0.25,0.328 0.25,0.566 0,0.114 -0.02,0.219 -0.062,0.321 -0.043,0.097 -0.118,0.218 -0.231,0.355 -0.031,0.035 -0.125,0.137 -0.289,0.305 -0.164,0.172 -0.395,0.406 -0.691,0.711 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath347)"
+             id="path878" />
+          <path
+             d="m 109.785,137.473 v 2.125 h 0.449 c 0.375,0 0.653,-0.082 0.825,-0.254 0.175,-0.172 0.265,-0.442 0.265,-0.809 0,-0.367 -0.09,-0.637 -0.265,-0.805 -0.172,-0.171 -0.45,-0.257 -0.825,-0.257 z m -0.367,-0.301 h 0.758 c 0.531,0 0.918,0.109 1.168,0.328 0.246,0.223 0.371,0.566 0.371,1.035 0,0.469 -0.125,0.817 -0.375,1.035 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.758 z m 2.34,0 h 1.453 v 0.308 h -1.113 v 0.672 c 0.054,-0.019 0.105,-0.031 0.16,-0.039 0.054,-0.011 0.109,-0.015 0.16,-0.015 0.309,0 0.547,0.082 0.727,0.25 0.179,0.168 0.265,0.394 0.265,0.679 0,0.293 -0.09,0.524 -0.273,0.688 -0.184,0.16 -0.442,0.242 -0.774,0.242 -0.113,0 -0.23,-0.012 -0.351,-0.031 -0.117,-0.02 -0.242,-0.047 -0.367,-0.086 v -0.371 c 0.109,0.058 0.222,0.101 0.339,0.133 0.118,0.027 0.243,0.043 0.371,0.043 0.211,0 0.379,-0.055 0.5,-0.165 0.125,-0.113 0.188,-0.261 0.188,-0.453 0,-0.191 -0.063,-0.343 -0.188,-0.453 -0.121,-0.109 -0.289,-0.168 -0.5,-0.168 -0.097,0 -0.199,0.012 -0.296,0.035 -0.098,0.02 -0.2,0.055 -0.301,0.102 z m 1.961,2.422 h 0.605 v -2.086 l -0.656,0.133 v -0.34 l 0.652,-0.129 h 0.371 v 2.422 h 0.602 v 0.308 h -1.574 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath348)"
+             id="path879" />
+          <path
+             d="m 109.785,197.195 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.825,-0.258 0.175,-0.171 0.265,-0.441 0.265,-0.808 0,-0.367 -0.09,-0.633 -0.265,-0.805 -0.172,-0.168 -0.45,-0.254 -0.825,-0.254 z m -0.367,-0.304 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.218 0.371,0.562 0.371,1.031 0,0.473 -0.125,0.816 -0.375,1.039 -0.25,0.219 -0.637,0.332 -1.164,0.332 h -0.758 z m 3.172,1.218 c -0.164,0 -0.297,0.059 -0.395,0.172 -0.093,0.114 -0.144,0.27 -0.144,0.465 0,0.195 0.051,0.352 0.144,0.469 0.098,0.113 0.231,0.168 0.395,0.168 0.168,0 0.301,-0.055 0.394,-0.168 0.098,-0.117 0.149,-0.274 0.149,-0.469 0,-0.195 -0.051,-0.351 -0.149,-0.465 -0.093,-0.113 -0.226,-0.172 -0.394,-0.172 z m 0.734,-1.16 v 0.34 c -0.09,-0.047 -0.183,-0.078 -0.281,-0.101 -0.094,-0.024 -0.188,-0.036 -0.277,-0.036 -0.246,0 -0.434,0.082 -0.563,0.246 -0.129,0.164 -0.199,0.414 -0.219,0.747 0.071,-0.106 0.161,-0.184 0.27,-0.243 0.109,-0.058 0.23,-0.086 0.359,-0.086 0.274,0 0.492,0.086 0.653,0.25 0.156,0.168 0.238,0.395 0.238,0.68 0,0.281 -0.082,0.508 -0.25,0.676 -0.164,0.168 -0.387,0.254 -0.664,0.254 -0.313,0 -0.555,-0.121 -0.723,-0.364 -0.168,-0.242 -0.25,-0.593 -0.25,-1.05 0,-0.434 0.102,-0.778 0.305,-1.035 0.207,-0.258 0.48,-0.387 0.828,-0.387 0.094,0 0.184,0.012 0.281,0.027 0.094,0.02 0.192,0.047 0.293,0.082 z m 1.348,0.262 -0.934,1.461 h 0.934 z m -0.098,-0.32 h 0.465 v 1.781 h 0.391 v 0.308 h -0.391 v 0.645 h -0.367 v -0.645 h -1.234 v -0.359 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath349)"
+             id="path880" />
+          <path
+             d="m 109.785,192.945 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.825,-0.258 0.175,-0.171 0.265,-0.441 0.265,-0.808 0,-0.367 -0.09,-0.633 -0.265,-0.805 -0.172,-0.172 -0.45,-0.254 -0.825,-0.254 z m -0.367,-0.304 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.218 0.371,0.562 0.371,1.031 0,0.469 -0.125,0.816 -0.375,1.039 -0.25,0.219 -0.637,0.328 -1.164,0.328 h -0.758 z m 3.172,1.218 c -0.164,0 -0.297,0.055 -0.395,0.168 -0.093,0.114 -0.144,0.27 -0.144,0.469 0,0.195 0.051,0.352 0.144,0.465 0.098,0.113 0.231,0.172 0.395,0.172 0.168,0 0.301,-0.059 0.394,-0.172 0.098,-0.113 0.149,-0.27 0.149,-0.465 0,-0.199 -0.051,-0.355 -0.149,-0.469 -0.093,-0.113 -0.226,-0.168 -0.394,-0.168 z m 0.734,-1.16 v 0.336 c -0.09,-0.043 -0.183,-0.074 -0.281,-0.097 -0.094,-0.024 -0.188,-0.036 -0.277,-0.036 -0.246,0 -0.434,0.082 -0.563,0.246 -0.129,0.164 -0.199,0.414 -0.219,0.747 0.071,-0.106 0.161,-0.188 0.27,-0.243 0.109,-0.058 0.23,-0.086 0.359,-0.086 0.274,0 0.492,0.082 0.653,0.25 0.156,0.168 0.238,0.391 0.238,0.68 0,0.281 -0.082,0.504 -0.25,0.676 -0.164,0.168 -0.387,0.254 -0.664,0.254 -0.313,0 -0.555,-0.121 -0.723,-0.364 -0.168,-0.242 -0.25,-0.593 -0.25,-1.054 0,-0.43 0.102,-0.774 0.305,-1.031 0.207,-0.258 0.48,-0.387 0.828,-0.387 0.094,0 0.184,0.008 0.281,0.027 0.094,0.02 0.192,0.047 0.293,0.082 z m 1.453,1.199 c 0.176,0.04 0.313,0.118 0.414,0.239 0.098,0.117 0.149,0.265 0.149,0.441 0,0.27 -0.094,0.477 -0.278,0.625 -0.187,0.149 -0.449,0.223 -0.792,0.223 -0.114,0 -0.231,-0.012 -0.352,-0.035 -0.121,-0.024 -0.246,-0.055 -0.379,-0.102 v -0.355 c 0.106,0.058 0.215,0.105 0.34,0.136 0.121,0.028 0.25,0.043 0.383,0.043 0.23,0 0.406,-0.043 0.527,-0.136 0.121,-0.09 0.184,-0.223 0.184,-0.399 0,-0.16 -0.059,-0.285 -0.172,-0.379 -0.11,-0.09 -0.27,-0.137 -0.469,-0.137 h -0.32 v -0.3 h 0.336 c 0.179,0 0.32,-0.039 0.418,-0.11 0.093,-0.074 0.144,-0.179 0.144,-0.316 0,-0.141 -0.051,-0.246 -0.152,-0.32 -0.098,-0.078 -0.242,-0.114 -0.426,-0.114 -0.102,0 -0.211,0.012 -0.328,0.032 -0.113,0.023 -0.242,0.058 -0.379,0.101 v -0.328 c 0.137,-0.039 0.27,-0.066 0.391,-0.086 0.125,-0.019 0.242,-0.031 0.347,-0.031 0.282,0 0.504,0.062 0.668,0.191 0.164,0.129 0.246,0.301 0.246,0.516 0,0.152 -0.043,0.281 -0.132,0.387 -0.086,0.101 -0.207,0.175 -0.368,0.214 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath350)"
+             id="path881" />
+          <path
+             d="m 109.785,188.691 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.825,-0.254 0.175,-0.171 0.265,-0.441 0.265,-0.808 0,-0.367 -0.09,-0.637 -0.265,-0.805 -0.172,-0.172 -0.45,-0.258 -0.825,-0.258 z m -0.367,-0.3 h 0.758 c 0.531,0 0.918,0.109 1.168,0.328 0.246,0.222 0.371,0.566 0.371,1.035 0,0.469 -0.125,0.816 -0.375,1.035 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.758 z m 3.172,1.218 c -0.164,0 -0.297,0.055 -0.395,0.168 -0.093,0.114 -0.144,0.27 -0.144,0.469 0,0.195 0.051,0.352 0.144,0.465 0.098,0.113 0.231,0.172 0.395,0.172 0.168,0 0.301,-0.059 0.394,-0.172 0.098,-0.113 0.149,-0.27 0.149,-0.465 0,-0.199 -0.051,-0.355 -0.149,-0.469 -0.093,-0.113 -0.226,-0.168 -0.394,-0.168 z m 0.734,-1.16 v 0.336 c -0.09,-0.043 -0.183,-0.078 -0.281,-0.101 -0.094,-0.024 -0.188,-0.032 -0.277,-0.032 -0.246,0 -0.434,0.082 -0.563,0.246 -0.129,0.164 -0.199,0.414 -0.219,0.747 0.071,-0.106 0.161,-0.188 0.27,-0.243 0.109,-0.058 0.23,-0.086 0.359,-0.086 0.274,0 0.492,0.082 0.653,0.25 0.156,0.164 0.238,0.391 0.238,0.68 0,0.277 -0.082,0.504 -0.25,0.676 -0.164,0.168 -0.387,0.254 -0.664,0.254 -0.313,0 -0.555,-0.121 -0.723,-0.364 -0.168,-0.242 -0.25,-0.593 -0.25,-1.054 0,-0.434 0.102,-0.778 0.305,-1.031 0.207,-0.258 0.48,-0.387 0.828,-0.387 0.094,0 0.184,0.008 0.281,0.027 0.094,0.02 0.192,0.047 0.293,0.082 z m 0.653,2.36 h 1.289 v 0.312 h -1.735 v -0.312 c 0.141,-0.145 0.328,-0.34 0.571,-0.582 0.242,-0.247 0.398,-0.403 0.457,-0.473 0.121,-0.133 0.203,-0.246 0.25,-0.34 0.046,-0.09 0.07,-0.184 0.07,-0.269 0,-0.149 -0.051,-0.266 -0.152,-0.356 -0.102,-0.094 -0.235,-0.137 -0.399,-0.137 -0.117,0 -0.238,0.02 -0.367,0.059 -0.129,0.039 -0.266,0.101 -0.414,0.184 v -0.375 c 0.148,-0.059 0.289,-0.106 0.418,-0.133 0.129,-0.032 0.25,-0.047 0.355,-0.047 0.285,0 0.508,0.07 0.68,0.211 0.168,0.14 0.25,0.332 0.25,0.566 0,0.113 -0.02,0.223 -0.062,0.321 -0.043,0.101 -0.118,0.218 -0.231,0.355 -0.031,0.035 -0.125,0.141 -0.289,0.309 -0.164,0.168 -0.395,0.406 -0.691,0.707 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath351)"
+             id="path882" />
+          <path
+             d="m 109.785,184.441 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.825,-0.257 0.175,-0.168 0.265,-0.438 0.265,-0.809 0,-0.363 -0.09,-0.633 -0.265,-0.801 -0.172,-0.172 -0.45,-0.258 -0.825,-0.258 z m -0.367,-0.304 h 0.758 c 0.531,0 0.918,0.113 1.168,0.332 0.246,0.219 0.371,0.562 0.371,1.031 0,0.473 -0.125,0.816 -0.375,1.039 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.758 z m 3.172,1.218 c -0.164,0 -0.297,0.059 -0.395,0.172 -0.093,0.114 -0.144,0.27 -0.144,0.465 0,0.199 0.051,0.356 0.144,0.469 0.098,0.113 0.231,0.168 0.395,0.168 0.168,0 0.301,-0.055 0.394,-0.168 0.098,-0.113 0.149,-0.27 0.149,-0.469 0,-0.195 -0.051,-0.351 -0.149,-0.465 -0.093,-0.113 -0.226,-0.172 -0.394,-0.172 z m 0.734,-1.156 v 0.336 c -0.09,-0.043 -0.183,-0.078 -0.281,-0.101 -0.094,-0.024 -0.188,-0.036 -0.277,-0.036 -0.246,0 -0.434,0.082 -0.563,0.25 -0.129,0.164 -0.199,0.411 -0.219,0.747 0.071,-0.106 0.161,-0.188 0.27,-0.247 0.109,-0.054 0.23,-0.086 0.359,-0.086 0.274,0 0.492,0.086 0.653,0.254 0.156,0.164 0.238,0.391 0.238,0.676 0,0.281 -0.082,0.508 -0.25,0.676 -0.164,0.172 -0.387,0.254 -0.664,0.254 -0.313,0 -0.555,-0.117 -0.723,-0.36 -0.168,-0.246 -0.25,-0.593 -0.25,-1.054 0,-0.434 0.102,-0.778 0.305,-1.035 0.207,-0.254 0.48,-0.383 0.828,-0.383 0.094,0 0.184,0.008 0.281,0.027 0.094,0.016 0.192,0.043 0.293,0.082 z m 0.395,2.36 h 0.605 v -2.086 l -0.656,0.132 v -0.335 l 0.652,-0.133 h 0.371 v 2.422 h 0.602 v 0.312 h -1.574 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath352)"
+             id="path883" />
+          <path
+             d="m 109.785,180.191 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.825,-0.257 0.175,-0.172 0.265,-0.442 0.265,-0.809 0,-0.367 -0.09,-0.633 -0.265,-0.805 -0.172,-0.168 -0.45,-0.254 -0.825,-0.254 z m -0.367,-0.304 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.219 0.371,0.562 0.371,1.031 0,0.473 -0.125,0.816 -0.375,1.039 -0.25,0.219 -0.637,0.332 -1.164,0.332 h -0.758 z m 3.172,1.218 c -0.164,0 -0.297,0.059 -0.395,0.172 -0.093,0.114 -0.144,0.27 -0.144,0.465 0,0.196 0.051,0.352 0.144,0.469 0.098,0.113 0.231,0.168 0.395,0.168 0.168,0 0.301,-0.055 0.394,-0.168 0.098,-0.117 0.149,-0.273 0.149,-0.469 0,-0.195 -0.051,-0.351 -0.149,-0.465 -0.093,-0.113 -0.226,-0.172 -0.394,-0.172 z m 0.734,-1.16 v 0.34 c -0.09,-0.047 -0.183,-0.078 -0.281,-0.101 -0.094,-0.024 -0.188,-0.036 -0.277,-0.036 -0.246,0 -0.434,0.082 -0.563,0.247 -0.129,0.164 -0.199,0.414 -0.219,0.746 0.071,-0.106 0.161,-0.184 0.27,-0.243 0.109,-0.058 0.23,-0.086 0.359,-0.086 0.274,0 0.492,0.086 0.653,0.25 0.156,0.168 0.238,0.395 0.238,0.68 0,0.281 -0.082,0.508 -0.25,0.676 -0.164,0.168 -0.387,0.254 -0.664,0.254 -0.313,0 -0.555,-0.121 -0.723,-0.363 -0.168,-0.243 -0.25,-0.594 -0.25,-1.051 0,-0.434 0.102,-0.778 0.305,-1.035 0.207,-0.258 0.48,-0.387 0.828,-0.387 0.094,0 0.184,0.012 0.281,0.027 0.094,0.02 0.192,0.047 0.293,0.082 z m 1.121,0.184 c -0.187,0 -0.332,0.094 -0.429,0.281 -0.094,0.188 -0.141,0.469 -0.141,0.848 0,0.371 0.047,0.652 0.141,0.844 0.097,0.183 0.242,0.277 0.429,0.277 0.192,0 0.336,-0.094 0.434,-0.277 0.094,-0.192 0.144,-0.473 0.144,-0.844 0,-0.379 -0.05,-0.66 -0.144,-0.848 -0.098,-0.187 -0.242,-0.281 -0.434,-0.281 z m 0,-0.293 c 0.309,0 0.543,0.121 0.703,0.367 0.161,0.238 0.243,0.59 0.243,1.055 0,0.457 -0.082,0.808 -0.243,1.051 -0.16,0.242 -0.394,0.363 -0.703,0.363 -0.304,0 -0.539,-0.121 -0.703,-0.363 -0.16,-0.243 -0.238,-0.594 -0.238,-1.051 0,-0.465 0.078,-0.817 0.238,-1.055 0.164,-0.246 0.399,-0.367 0.703,-0.367 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath353)"
+             id="path884" />
+          <path
+             d="m 109.785,175.941 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.825,-0.257 0.175,-0.172 0.265,-0.442 0.265,-0.809 0,-0.367 -0.09,-0.633 -0.265,-0.805 -0.172,-0.172 -0.45,-0.254 -0.825,-0.254 z m -0.367,-0.304 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.219 0.371,0.562 0.371,1.031 0,0.469 -0.125,0.816 -0.375,1.039 -0.25,0.219 -0.637,0.328 -1.164,0.328 h -0.758 z m 2.34,0 h 1.453 v 0.308 h -1.113 v 0.672 c 0.054,-0.019 0.105,-0.031 0.16,-0.039 0.054,-0.012 0.109,-0.016 0.16,-0.016 0.309,0 0.547,0.083 0.727,0.25 0.179,0.168 0.265,0.395 0.265,0.68 0,0.293 -0.09,0.524 -0.273,0.688 -0.184,0.16 -0.442,0.242 -0.774,0.242 -0.113,0 -0.23,-0.012 -0.351,-0.031 -0.117,-0.02 -0.242,-0.047 -0.367,-0.086 v -0.371 c 0.109,0.058 0.222,0.105 0.339,0.132 0.118,0.032 0.243,0.043 0.371,0.043 0.211,0 0.379,-0.054 0.5,-0.164 0.125,-0.113 0.188,-0.261 0.188,-0.453 0,-0.191 -0.063,-0.34 -0.188,-0.453 -0.121,-0.109 -0.289,-0.164 -0.5,-0.164 -0.097,0 -0.199,0.008 -0.296,0.031 -0.098,0.024 -0.2,0.055 -0.301,0.102 z m 1.91,2.675 v -0.335 c 0.094,0.043 0.187,0.074 0.281,0.097 0.094,0.024 0.188,0.035 0.281,0.035 0.243,0 0.43,-0.082 0.559,-0.246 0.129,-0.164 0.203,-0.414 0.219,-0.746 -0.07,0.106 -0.16,0.184 -0.27,0.242 -0.105,0.055 -0.226,0.082 -0.359,0.082 -0.274,0 -0.488,-0.082 -0.649,-0.246 -0.16,-0.164 -0.238,-0.39 -0.238,-0.679 0,-0.282 0.082,-0.504 0.25,-0.676 0.164,-0.168 0.387,-0.254 0.66,-0.254 0.317,0 0.559,0.121 0.723,0.363 0.168,0.242 0.254,0.594 0.254,1.055 0,0.434 -0.106,0.777 -0.309,1.035 -0.203,0.254 -0.48,0.383 -0.824,0.383 -0.094,0 -0.187,-0.008 -0.281,-0.027 -0.098,-0.02 -0.195,-0.047 -0.297,-0.083 z m 0.734,-1.16 c 0.168,0 0.297,-0.054 0.395,-0.168 0.098,-0.113 0.144,-0.269 0.144,-0.468 0,-0.196 -0.046,-0.352 -0.144,-0.465 -0.098,-0.113 -0.227,-0.172 -0.395,-0.172 -0.164,0 -0.297,0.059 -0.394,0.172 -0.098,0.113 -0.145,0.269 -0.145,0.465 0,0.199 0.047,0.355 0.145,0.468 0.097,0.114 0.23,0.168 0.394,0.168 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath354)"
+             id="path885" />
+          <path
+             d="m 109.785,171.688 v 2.124 h 0.449 c 0.375,0 0.653,-0.085 0.825,-0.253 0.175,-0.172 0.265,-0.442 0.265,-0.809 0,-0.367 -0.09,-0.637 -0.265,-0.805 -0.172,-0.172 -0.45,-0.257 -0.825,-0.257 z m -0.367,-0.301 h 0.758 c 0.531,0 0.918,0.109 1.168,0.328 0.246,0.223 0.371,0.566 0.371,1.035 0,0.469 -0.125,0.816 -0.375,1.035 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.758 z m 2.34,0 h 1.453 v 0.308 h -1.113 v 0.672 c 0.054,-0.019 0.105,-0.031 0.16,-0.043 0.054,-0.008 0.109,-0.012 0.16,-0.012 0.309,0 0.547,0.083 0.727,0.25 0.179,0.168 0.265,0.395 0.265,0.68 0,0.293 -0.09,0.524 -0.273,0.684 -0.184,0.164 -0.442,0.246 -0.774,0.246 -0.113,0 -0.23,-0.012 -0.351,-0.031 -0.117,-0.02 -0.242,-0.047 -0.367,-0.086 v -0.371 c 0.109,0.058 0.222,0.101 0.339,0.132 0.118,0.028 0.243,0.043 0.371,0.043 0.211,0 0.379,-0.054 0.5,-0.168 0.125,-0.109 0.188,-0.261 0.188,-0.449 0,-0.191 -0.063,-0.344 -0.188,-0.453 -0.121,-0.109 -0.289,-0.168 -0.5,-0.168 -0.097,0 -0.199,0.012 -0.296,0.035 -0.098,0.02 -0.2,0.055 -0.301,0.102 z m 2.687,1.433 c -0.175,0 -0.312,0.047 -0.414,0.141 -0.101,0.094 -0.148,0.223 -0.148,0.387 0,0.164 0.047,0.297 0.148,0.39 0.102,0.094 0.239,0.141 0.414,0.141 0.176,0 0.317,-0.047 0.418,-0.141 0.102,-0.097 0.153,-0.226 0.153,-0.39 0,-0.164 -0.051,-0.293 -0.153,-0.387 -0.101,-0.094 -0.238,-0.141 -0.418,-0.141 z m -0.367,-0.156 c -0.16,-0.039 -0.285,-0.113 -0.371,-0.223 -0.09,-0.109 -0.133,-0.242 -0.133,-0.398 0,-0.219 0.078,-0.391 0.231,-0.516 0.156,-0.129 0.371,-0.191 0.64,-0.191 0.274,0 0.489,0.062 0.641,0.191 0.156,0.125 0.234,0.297 0.234,0.516 0,0.156 -0.043,0.289 -0.132,0.398 -0.09,0.11 -0.211,0.184 -0.368,0.223 0.176,0.039 0.317,0.121 0.414,0.242 0.102,0.121 0.149,0.27 0.149,0.442 0,0.265 -0.078,0.468 -0.242,0.609 -0.161,0.145 -0.391,0.215 -0.696,0.215 -0.3,0 -0.531,-0.07 -0.695,-0.215 -0.16,-0.141 -0.242,-0.344 -0.242,-0.609 0,-0.172 0.051,-0.321 0.152,-0.442 0.102,-0.121 0.238,-0.203 0.418,-0.242 z m -0.137,-0.586 c 0,0.141 0.043,0.254 0.133,0.332 0.09,0.078 0.215,0.117 0.371,0.117 0.16,0 0.285,-0.039 0.375,-0.117 0.09,-0.078 0.133,-0.191 0.133,-0.332 0,-0.14 -0.043,-0.25 -0.133,-0.332 -0.09,-0.078 -0.215,-0.117 -0.375,-0.117 -0.156,0 -0.281,0.039 -0.371,0.117 -0.09,0.082 -0.133,0.192 -0.133,0.332 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath355)"
+             id="path886" />
+          <path
+             d="m 109.734,167.438 v 2.124 h 0.446 c 0.379,0 0.652,-0.085 0.828,-0.253 0.176,-0.172 0.262,-0.442 0.262,-0.809 0,-0.367 -0.086,-0.637 -0.262,-0.805 -0.176,-0.172 -0.449,-0.257 -0.828,-0.257 z m -0.371,-0.305 h 0.762 c 0.527,0 0.918,0.113 1.164,0.332 0.25,0.219 0.371,0.566 0.371,1.035 0,0.469 -0.125,0.816 -0.371,1.035 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.762 z m 2.344,0 h 1.449 v 0.312 h -1.109 v 0.672 c 0.051,-0.019 0.105,-0.035 0.16,-0.043 0.055,-0.008 0.105,-0.012 0.16,-0.012 0.305,0 0.547,0.083 0.727,0.25 0.176,0.168 0.265,0.391 0.265,0.68 0,0.293 -0.089,0.52 -0.273,0.684 -0.184,0.164 -0.441,0.246 -0.777,0.246 -0.114,0 -0.231,-0.012 -0.352,-0.031 -0.117,-0.02 -0.238,-0.047 -0.367,-0.086 v -0.371 c 0.109,0.058 0.222,0.101 0.34,0.132 0.117,0.028 0.242,0.043 0.375,0.043 0.211,0 0.375,-0.054 0.5,-0.168 0.125,-0.109 0.183,-0.261 0.183,-0.449 0,-0.191 -0.058,-0.344 -0.183,-0.453 -0.125,-0.113 -0.289,-0.168 -0.5,-0.168 -0.102,0 -0.2,0.012 -0.297,0.035 -0.098,0.02 -0.199,0.055 -0.301,0.102 z m 1.805,0 h 1.758 v 0.16 l -0.993,2.574 h -0.386 l 0.933,-2.422 h -1.312 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath356)"
+             id="path887" />
+          <path
+             d="m 109.734,163.188 v 2.124 h 0.446 c 0.379,0 0.652,-0.085 0.828,-0.257 0.176,-0.168 0.262,-0.438 0.262,-0.809 0,-0.363 -0.086,-0.633 -0.262,-0.801 -0.176,-0.172 -0.449,-0.257 -0.828,-0.257 z m -0.371,-0.305 h 0.762 c 0.527,0 0.918,0.109 1.164,0.332 0.25,0.219 0.371,0.562 0.371,1.031 0,0.473 -0.125,0.816 -0.371,1.039 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.762 z m 2.344,0 h 1.449 v 0.312 h -1.109 v 0.668 c 0.051,-0.015 0.105,-0.031 0.16,-0.039 0.055,-0.008 0.105,-0.015 0.16,-0.015 0.305,0 0.547,0.086 0.727,0.253 0.176,0.165 0.265,0.391 0.265,0.676 0,0.297 -0.089,0.524 -0.273,0.688 -0.184,0.164 -0.441,0.242 -0.777,0.242 -0.114,0 -0.231,-0.008 -0.352,-0.027 -0.117,-0.02 -0.238,-0.051 -0.367,-0.09 v -0.371 c 0.109,0.062 0.222,0.105 0.34,0.132 0.117,0.032 0.242,0.047 0.375,0.047 0.211,0 0.375,-0.054 0.5,-0.168 0.125,-0.109 0.183,-0.261 0.183,-0.453 0,-0.187 -0.058,-0.34 -0.183,-0.449 -0.125,-0.113 -0.289,-0.168 -0.5,-0.168 -0.102,0 -0.2,0.012 -0.297,0.031 -0.098,0.024 -0.199,0.059 -0.301,0.106 z m 2.734,1.219 c -0.168,0 -0.3,0.058 -0.398,0.171 -0.094,0.114 -0.145,0.27 -0.145,0.465 0,0.2 0.051,0.352 0.145,0.469 0.098,0.113 0.23,0.168 0.398,0.168 0.164,0 0.297,-0.055 0.391,-0.168 0.098,-0.117 0.148,-0.269 0.148,-0.469 0,-0.195 -0.05,-0.351 -0.148,-0.465 -0.094,-0.113 -0.227,-0.171 -0.391,-0.171 z m 0.735,-1.157 v 0.336 c -0.094,-0.043 -0.188,-0.078 -0.285,-0.101 -0.094,-0.024 -0.184,-0.035 -0.278,-0.035 -0.246,0 -0.433,0.082 -0.562,0.246 -0.125,0.168 -0.199,0.414 -0.219,0.75 0.074,-0.11 0.164,-0.188 0.27,-0.246 0.109,-0.055 0.23,-0.086 0.359,-0.086 0.277,0 0.492,0.086 0.652,0.25 0.16,0.168 0.239,0.394 0.239,0.679 0,0.282 -0.082,0.508 -0.25,0.676 -0.164,0.172 -0.387,0.254 -0.661,0.254 -0.316,0 -0.558,-0.121 -0.726,-0.359 -0.168,-0.247 -0.25,-0.598 -0.25,-1.055 0,-0.434 0.101,-0.777 0.308,-1.035 0.204,-0.254 0.481,-0.383 0.825,-0.383 0.093,0 0.187,0.008 0.281,0.027 0.094,0.016 0.191,0.043 0.297,0.082 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath357)"
+             id="path888" />
+          <path
+             d="m 185.949,197.191 v 2.125 h 0.446 c 0.378,0 0.656,-0.086 0.828,-0.257 0.175,-0.168 0.265,-0.438 0.265,-0.809 0,-0.363 -0.09,-0.633 -0.265,-0.801 -0.172,-0.172 -0.45,-0.258 -0.828,-0.258 z m -0.371,-0.304 h 0.762 c 0.527,0 0.918,0.109 1.164,0.332 0.25,0.219 0.375,0.562 0.375,1.031 0,0.473 -0.125,0.816 -0.375,1.039 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.762 z m 3.461,1.261 c 0.176,0.036 0.316,0.114 0.414,0.235 0.098,0.121 0.149,0.265 0.149,0.441 0,0.27 -0.09,0.481 -0.278,0.629 -0.183,0.149 -0.449,0.219 -0.789,0.219 -0.117,0 -0.234,-0.012 -0.355,-0.035 -0.121,-0.02 -0.246,-0.055 -0.375,-0.098 v -0.359 c 0.101,0.062 0.215,0.105 0.336,0.136 0.121,0.032 0.25,0.047 0.382,0.047 0.231,0 0.407,-0.047 0.528,-0.136 0.121,-0.094 0.183,-0.227 0.183,-0.403 0,-0.16 -0.054,-0.285 -0.172,-0.375 -0.109,-0.094 -0.265,-0.137 -0.468,-0.137 h -0.321 v -0.304 h 0.336 c 0.18,0 0.321,-0.035 0.418,-0.11 0.094,-0.07 0.145,-0.175 0.145,-0.312 0,-0.141 -0.051,-0.25 -0.152,-0.324 -0.098,-0.074 -0.243,-0.114 -0.426,-0.114 -0.102,0 -0.211,0.012 -0.324,0.036 -0.118,0.019 -0.247,0.054 -0.383,0.101 v -0.328 c 0.14,-0.039 0.269,-0.07 0.39,-0.09 0.125,-0.019 0.243,-0.027 0.348,-0.027 0.281,0 0.504,0.062 0.668,0.191 0.164,0.125 0.246,0.297 0.246,0.516 0,0.152 -0.043,0.277 -0.129,0.383 -0.09,0.105 -0.211,0.175 -0.371,0.218 z m 1.797,-0.937 -0.934,1.457 h 0.934 z m -0.098,-0.324 h 0.465 v 1.781 h 0.391 v 0.309 h -0.391 v 0.644 h -0.367 v -0.644 h -1.234 v -0.356 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath358)"
+             id="path889" />
+          <path
+             d="m 186,192.941 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.257 0.176,-0.172 0.262,-0.442 0.262,-0.809 0,-0.367 -0.086,-0.633 -0.262,-0.805 -0.175,-0.168 -0.453,-0.254 -0.828,-0.254 z m -0.367,-0.304 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.219 0.371,0.562 0.371,1.031 0,0.473 -0.125,0.816 -0.375,1.039 -0.246,0.219 -0.637,0.332 -1.164,0.332 h -0.758 z m 3.457,1.258 c 0.18,0.039 0.316,0.117 0.414,0.238 0.101,0.117 0.152,0.265 0.152,0.441 0,0.27 -0.094,0.481 -0.281,0.625 -0.184,0.149 -0.449,0.223 -0.789,0.223 -0.113,0 -0.234,-0.012 -0.356,-0.035 -0.121,-0.02 -0.246,-0.055 -0.375,-0.102 v -0.355 c 0.102,0.058 0.215,0.105 0.336,0.136 0.121,0.032 0.25,0.043 0.383,0.043 0.235,0 0.41,-0.043 0.531,-0.136 0.122,-0.09 0.18,-0.223 0.18,-0.399 0,-0.16 -0.055,-0.285 -0.168,-0.375 -0.113,-0.094 -0.269,-0.137 -0.472,-0.137 h -0.317 v -0.304 h 0.332 c 0.184,0 0.32,-0.035 0.418,-0.11 0.098,-0.074 0.145,-0.179 0.145,-0.312 0,-0.141 -0.051,-0.25 -0.149,-0.324 -0.101,-0.074 -0.242,-0.114 -0.429,-0.114 -0.098,0 -0.207,0.012 -0.325,0.032 -0.117,0.023 -0.242,0.058 -0.382,0.105 v -0.332 c 0.14,-0.039 0.273,-0.066 0.394,-0.086 0.121,-0.019 0.238,-0.031 0.348,-0.031 0.281,0 0.504,0.066 0.664,0.195 0.164,0.125 0.246,0.297 0.246,0.516 0,0.148 -0.043,0.277 -0.129,0.383 -0.086,0.105 -0.211,0.175 -0.371,0.215 z m 1.902,0 c 0.176,0.039 0.317,0.117 0.414,0.238 0.102,0.117 0.149,0.265 0.149,0.441 0,0.27 -0.09,0.481 -0.278,0.625 -0.183,0.149 -0.449,0.223 -0.789,0.223 -0.117,0 -0.234,-0.012 -0.355,-0.035 -0.121,-0.02 -0.246,-0.055 -0.375,-0.102 v -0.355 c 0.101,0.058 0.215,0.105 0.336,0.136 0.121,0.032 0.25,0.043 0.383,0.043 0.23,0 0.406,-0.043 0.527,-0.136 0.125,-0.09 0.184,-0.223 0.184,-0.399 0,-0.16 -0.055,-0.285 -0.168,-0.375 -0.114,-0.094 -0.27,-0.137 -0.473,-0.137 h -0.317 v -0.304 h 0.332 c 0.18,0 0.321,-0.035 0.418,-0.11 0.094,-0.074 0.145,-0.179 0.145,-0.312 0,-0.141 -0.051,-0.25 -0.152,-0.324 -0.098,-0.074 -0.239,-0.114 -0.426,-0.114 -0.102,0 -0.211,0.012 -0.324,0.032 -0.118,0.023 -0.246,0.058 -0.383,0.105 v -0.332 c 0.14,-0.039 0.269,-0.066 0.39,-0.086 0.125,-0.019 0.243,-0.031 0.352,-0.031 0.277,0 0.5,0.066 0.664,0.195 0.164,0.125 0.246,0.297 0.246,0.516 0,0.148 -0.043,0.277 -0.129,0.383 -0.09,0.105 -0.211,0.175 -0.371,0.215 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath359)"
+             id="path890" />
+          <path
+             d="m 185.949,188.691 v 2.125 h 0.446 c 0.378,0 0.656,-0.086 0.828,-0.257 0.175,-0.172 0.265,-0.442 0.265,-0.809 0,-0.367 -0.09,-0.633 -0.265,-0.805 -0.172,-0.172 -0.45,-0.254 -0.828,-0.254 z m -0.371,-0.304 h 0.762 c 0.527,0 0.918,0.109 1.164,0.332 0.25,0.219 0.375,0.562 0.375,1.031 0,0.469 -0.125,0.816 -0.375,1.039 -0.25,0.219 -0.637,0.328 -1.164,0.328 h -0.762 z m 3.461,1.258 c 0.176,0.039 0.316,0.117 0.414,0.238 0.098,0.117 0.149,0.265 0.149,0.441 0,0.27 -0.09,0.477 -0.278,0.625 -0.183,0.149 -0.449,0.223 -0.789,0.223 -0.117,0 -0.234,-0.012 -0.355,-0.035 -0.121,-0.024 -0.246,-0.055 -0.375,-0.102 v -0.355 c 0.101,0.058 0.215,0.105 0.336,0.136 0.121,0.028 0.25,0.043 0.382,0.043 0.231,0 0.407,-0.043 0.528,-0.136 0.121,-0.09 0.183,-0.223 0.183,-0.399 0,-0.16 -0.054,-0.285 -0.172,-0.379 -0.109,-0.09 -0.265,-0.136 -0.468,-0.136 h -0.321 v -0.305 h 0.336 c 0.18,0 0.321,-0.035 0.418,-0.106 0.094,-0.074 0.145,-0.179 0.145,-0.316 0,-0.141 -0.051,-0.246 -0.152,-0.32 -0.098,-0.078 -0.243,-0.114 -0.426,-0.114 -0.102,0 -0.211,0.012 -0.324,0.032 -0.118,0.023 -0.247,0.058 -0.383,0.101 v -0.328 c 0.14,-0.039 0.269,-0.066 0.39,-0.086 0.125,-0.019 0.243,-0.031 0.348,-0.031 0.281,0 0.504,0.062 0.668,0.191 0.164,0.129 0.246,0.301 0.246,0.516 0,0.152 -0.043,0.281 -0.129,0.387 -0.09,0.101 -0.211,0.175 -0.371,0.215 z m 1.098,1.164 h 1.293 v 0.308 h -1.739 v -0.308 c 0.141,-0.149 0.332,-0.34 0.575,-0.586 0.242,-0.246 0.394,-0.403 0.457,-0.473 0.121,-0.133 0.203,-0.246 0.25,-0.336 0.047,-0.094 0.07,-0.184 0.07,-0.273 0,-0.145 -0.051,-0.266 -0.156,-0.356 -0.102,-0.094 -0.231,-0.137 -0.395,-0.137 -0.117,0 -0.238,0.02 -0.367,0.059 -0.129,0.043 -0.266,0.102 -0.414,0.184 v -0.375 c 0.148,-0.059 0.289,-0.102 0.418,-0.133 0.129,-0.031 0.246,-0.047 0.355,-0.047 0.282,0 0.508,0.07 0.676,0.211 0.168,0.144 0.254,0.332 0.254,0.57 0,0.11 -0.023,0.219 -0.062,0.321 -0.043,0.097 -0.122,0.218 -0.231,0.355 -0.031,0.035 -0.129,0.137 -0.293,0.305 -0.16,0.168 -0.39,0.406 -0.691,0.711 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath360)"
+             id="path891" />
+          <path
+             d="m 186.461,186.477 v -0.735 h -0.606 v -0.301 h 0.973 v 1.172 c -0.144,0.102 -0.301,0.18 -0.473,0.231 -0.171,0.051 -0.355,0.078 -0.55,0.078 -0.43,0 -0.762,-0.125 -1.004,-0.375 -0.242,-0.25 -0.36,-0.598 -0.36,-1.043 0,-0.445 0.118,-0.793 0.36,-1.043 0.242,-0.25 0.574,-0.375 1.004,-0.375 0.175,0 0.347,0.019 0.507,0.066 0.161,0.043 0.309,0.11 0.442,0.192 v 0.394 c -0.137,-0.117 -0.281,-0.203 -0.434,-0.261 -0.156,-0.059 -0.316,-0.086 -0.484,-0.086 -0.336,0 -0.586,0.093 -0.754,0.277 -0.168,0.187 -0.254,0.465 -0.254,0.836 0,0.367 0.086,0.644 0.254,0.832 0.168,0.187 0.418,0.281 0.754,0.281 0.129,0 0.246,-0.012 0.348,-0.035 0.101,-0.02 0.195,-0.059 0.277,-0.105 z m 0.5,-2.344 h 0.5 l 1.211,2.289 v -2.289 h 0.359 v 2.734 h -0.5 l -1.211,-2.285 v 2.285 h -0.359 z m 2.793,0.305 v 2.124 h 0.445 c 0.379,0 0.653,-0.085 0.828,-0.253 0.176,-0.172 0.262,-0.442 0.262,-0.809 0,-0.367 -0.086,-0.637 -0.262,-0.805 -0.175,-0.172 -0.449,-0.257 -0.828,-0.257 z m -0.371,-0.305 h 0.758 c 0.531,0 0.921,0.113 1.168,0.332 0.246,0.223 0.371,0.566 0.371,1.035 0,0.469 -0.125,0.816 -0.371,1.035 -0.25,0.223 -0.641,0.332 -1.168,0.332 h -0.758 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath361)"
+             id="path892" />
+          <path
+             d="m 185.949,180.188 v 2.124 h 0.446 c 0.378,0 0.656,-0.085 0.828,-0.257 0.175,-0.168 0.265,-0.438 0.265,-0.809 0,-0.363 -0.09,-0.633 -0.265,-0.801 -0.172,-0.172 -0.45,-0.257 -0.828,-0.257 z m -0.371,-0.305 h 0.762 c 0.527,0 0.918,0.113 1.164,0.332 0.25,0.219 0.375,0.562 0.375,1.031 0,0.473 -0.125,0.816 -0.375,1.039 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.762 z m 3.461,1.262 c 0.176,0.035 0.316,0.113 0.414,0.234 0.098,0.121 0.149,0.266 0.149,0.441 0,0.27 -0.09,0.481 -0.278,0.629 -0.183,0.149 -0.449,0.219 -0.789,0.219 -0.117,0 -0.234,-0.012 -0.355,-0.031 -0.121,-0.024 -0.246,-0.059 -0.375,-0.102 v -0.359 c 0.101,0.062 0.215,0.105 0.336,0.136 0.121,0.032 0.25,0.047 0.382,0.047 0.231,0 0.407,-0.047 0.528,-0.136 0.121,-0.094 0.183,-0.227 0.183,-0.403 0,-0.16 -0.054,-0.285 -0.172,-0.375 -0.109,-0.093 -0.265,-0.136 -0.468,-0.136 h -0.321 v -0.305 h 0.336 c 0.18,0 0.321,-0.035 0.418,-0.109 0.094,-0.071 0.145,-0.176 0.145,-0.313 0,-0.141 -0.051,-0.25 -0.152,-0.324 -0.098,-0.074 -0.243,-0.113 -0.426,-0.113 -0.102,0 -0.211,0.011 -0.324,0.035 -0.118,0.019 -0.247,0.054 -0.383,0.101 v -0.328 c 0.14,-0.039 0.269,-0.07 0.39,-0.09 0.125,-0.019 0.243,-0.027 0.348,-0.027 0.281,0 0.504,0.062 0.668,0.191 0.164,0.125 0.246,0.297 0.246,0.516 0,0.152 -0.043,0.277 -0.129,0.383 -0.09,0.105 -0.211,0.176 -0.371,0.219 z m 0.844,1.16 h 0.605 v -2.086 l -0.656,0.133 v -0.336 l 0.652,-0.133 h 0.371 v 2.422 h 0.602 v 0.312 h -1.574 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath362)"
+             id="path893" />
+          <path
+             d="m 186,175.938 v 2.124 h 0.449 c 0.375,0 0.653,-0.085 0.828,-0.257 0.176,-0.172 0.262,-0.442 0.262,-0.809 0,-0.367 -0.086,-0.633 -0.262,-0.805 -0.175,-0.168 -0.453,-0.253 -0.828,-0.253 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.219 0.371,0.562 0.371,1.031 0,0.473 -0.125,0.816 -0.375,1.039 -0.246,0.219 -0.637,0.332 -1.164,0.332 h -0.758 z m 3.457,1.258 c 0.18,0.039 0.316,0.117 0.414,0.238 0.101,0.117 0.152,0.266 0.152,0.441 0,0.27 -0.094,0.481 -0.281,0.625 -0.184,0.149 -0.449,0.223 -0.789,0.223 -0.113,0 -0.234,-0.012 -0.356,-0.035 -0.121,-0.02 -0.246,-0.055 -0.375,-0.102 v -0.355 c 0.102,0.058 0.215,0.105 0.336,0.136 0.121,0.032 0.25,0.043 0.383,0.043 0.235,0 0.41,-0.043 0.531,-0.136 0.122,-0.09 0.18,-0.223 0.18,-0.399 0,-0.16 -0.055,-0.285 -0.168,-0.375 -0.113,-0.093 -0.269,-0.136 -0.472,-0.136 h -0.317 v -0.305 h 0.332 c 0.184,0 0.32,-0.035 0.418,-0.109 0.098,-0.075 0.145,-0.18 0.145,-0.317 0,-0.137 -0.051,-0.246 -0.149,-0.32 -0.101,-0.074 -0.242,-0.113 -0.429,-0.113 -0.098,0 -0.207,0.011 -0.325,0.031 -0.117,0.023 -0.242,0.058 -0.382,0.105 v -0.332 c 0.14,-0.039 0.273,-0.066 0.394,-0.086 0.121,-0.019 0.238,-0.031 0.348,-0.031 0.281,0 0.504,0.066 0.664,0.195 0.164,0.125 0.246,0.297 0.246,0.516 0,0.148 -0.043,0.277 -0.129,0.383 -0.086,0.105 -0.211,0.176 -0.371,0.215 z m 1.574,-1.016 c -0.191,0 -0.336,0.094 -0.434,0.281 -0.093,0.188 -0.14,0.469 -0.14,0.844 0,0.375 0.047,0.656 0.14,0.844 0.098,0.187 0.243,0.281 0.434,0.281 0.191,0 0.332,-0.094 0.43,-0.281 0.094,-0.188 0.144,-0.469 0.144,-0.844 0,-0.375 -0.05,-0.656 -0.144,-0.844 -0.098,-0.187 -0.239,-0.281 -0.43,-0.281 z m 0,-0.293 c 0.305,0 0.539,0.121 0.699,0.367 0.164,0.239 0.242,0.59 0.242,1.051 0,0.461 -0.078,0.812 -0.242,1.055 -0.16,0.242 -0.394,0.363 -0.699,0.363 -0.309,0 -0.543,-0.121 -0.703,-0.363 -0.164,-0.243 -0.242,-0.594 -0.242,-1.055 0,-0.461 0.078,-0.812 0.242,-1.051 0.16,-0.246 0.394,-0.367 0.703,-0.367 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath363)"
+             id="path894" />
+          <path
+             d="m 186,171.688 v 2.124 h 0.449 c 0.375,0 0.653,-0.085 0.828,-0.257 0.176,-0.172 0.262,-0.442 0.262,-0.809 0,-0.367 -0.086,-0.633 -0.262,-0.805 -0.175,-0.171 -0.453,-0.253 -0.828,-0.253 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.219 0.371,0.562 0.371,1.031 0,0.469 -0.125,0.816 -0.375,1.039 -0.246,0.219 -0.637,0.328 -1.164,0.328 h -0.758 z m 2.656,2.422 h 1.289 v 0.308 h -1.734 v -0.308 c 0.14,-0.149 0.332,-0.34 0.574,-0.586 0.242,-0.246 0.394,-0.403 0.457,-0.473 0.117,-0.133 0.199,-0.246 0.246,-0.336 0.047,-0.094 0.074,-0.183 0.074,-0.273 0,-0.145 -0.054,-0.266 -0.156,-0.356 -0.101,-0.093 -0.234,-0.136 -0.398,-0.136 -0.114,0 -0.239,0.019 -0.368,0.058 -0.128,0.043 -0.265,0.102 -0.41,0.184 v -0.375 c 0.149,-0.059 0.289,-0.102 0.418,-0.133 0.129,-0.031 0.246,-0.047 0.356,-0.047 0.281,0 0.508,0.07 0.675,0.211 0.168,0.145 0.254,0.332 0.254,0.57 0,0.11 -0.023,0.219 -0.066,0.321 -0.039,0.097 -0.117,0.218 -0.227,0.355 -0.031,0.035 -0.128,0.137 -0.293,0.305 -0.164,0.168 -0.394,0.406 -0.691,0.711 z m 1.594,0.254 v -0.336 c 0.094,0.043 0.187,0.074 0.281,0.097 0.098,0.024 0.188,0.035 0.281,0.035 0.243,0 0.43,-0.082 0.559,-0.246 0.129,-0.164 0.203,-0.414 0.219,-0.746 -0.071,0.106 -0.161,0.184 -0.266,0.242 -0.109,0.055 -0.23,0.083 -0.363,0.083 -0.274,0 -0.489,-0.083 -0.649,-0.247 -0.16,-0.168 -0.238,-0.39 -0.238,-0.679 0,-0.282 0.082,-0.504 0.25,-0.676 0.164,-0.168 0.387,-0.254 0.66,-0.254 0.317,0 0.559,0.121 0.723,0.363 0.168,0.243 0.254,0.594 0.254,1.055 0,0.434 -0.106,0.777 -0.309,1.035 -0.203,0.254 -0.48,0.383 -0.824,0.383 -0.094,0 -0.188,-0.008 -0.281,-0.027 -0.094,-0.02 -0.196,-0.047 -0.297,-0.082 z m 0.734,-1.161 c 0.168,0 0.297,-0.054 0.395,-0.168 0.097,-0.113 0.148,-0.269 0.148,-0.468 0,-0.196 -0.051,-0.352 -0.148,-0.465 -0.098,-0.113 -0.227,-0.172 -0.395,-0.172 -0.164,0 -0.297,0.059 -0.394,0.172 -0.098,0.113 -0.145,0.269 -0.145,0.465 0,0.199 0.047,0.355 0.145,0.468 0.097,0.114 0.23,0.168 0.394,0.168 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath364)"
+             id="path895" />
+          <path
+             d="m 185.949,167.434 v 2.125 h 0.446 c 0.378,0 0.656,-0.082 0.828,-0.254 0.175,-0.172 0.265,-0.442 0.265,-0.809 0,-0.367 -0.09,-0.637 -0.265,-0.805 -0.172,-0.171 -0.45,-0.257 -0.828,-0.257 z m -0.371,-0.301 h 0.762 c 0.527,0 0.918,0.109 1.164,0.328 0.25,0.223 0.375,0.566 0.375,1.035 0,0.469 -0.125,0.816 -0.375,1.035 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.762 z m 2.66,2.422 h 1.289 v 0.308 h -1.734 v -0.308 c 0.141,-0.149 0.332,-0.34 0.57,-0.586 0.246,-0.246 0.399,-0.403 0.461,-0.473 0.117,-0.133 0.199,-0.246 0.246,-0.336 0.047,-0.094 0.071,-0.183 0.071,-0.273 0,-0.145 -0.051,-0.266 -0.153,-0.356 -0.101,-0.093 -0.234,-0.136 -0.398,-0.136 -0.117,0 -0.238,0.019 -0.367,0.058 -0.129,0.039 -0.266,0.102 -0.414,0.184 v -0.375 c 0.152,-0.059 0.289,-0.102 0.418,-0.133 0.128,-0.031 0.25,-0.047 0.355,-0.047 0.285,0 0.508,0.07 0.68,0.211 0.168,0.145 0.25,0.332 0.25,0.57 0,0.11 -0.02,0.219 -0.063,0.321 -0.043,0.097 -0.117,0.218 -0.23,0.355 -0.031,0.035 -0.125,0.137 -0.289,0.305 -0.164,0.168 -0.395,0.406 -0.692,0.711 z m 2.371,-0.989 c -0.175,0 -0.312,0.047 -0.414,0.141 -0.101,0.094 -0.152,0.223 -0.152,0.387 0,0.168 0.051,0.297 0.152,0.39 0.102,0.094 0.239,0.141 0.414,0.141 0.176,0 0.317,-0.047 0.418,-0.141 0.102,-0.097 0.149,-0.226 0.149,-0.39 0,-0.164 -0.047,-0.293 -0.149,-0.387 -0.101,-0.094 -0.242,-0.141 -0.418,-0.141 z m -0.367,-0.156 c -0.16,-0.039 -0.285,-0.113 -0.375,-0.222 -0.086,-0.11 -0.129,-0.243 -0.129,-0.399 0,-0.219 0.074,-0.391 0.231,-0.516 0.156,-0.128 0.371,-0.191 0.64,-0.191 0.274,0 0.489,0.063 0.641,0.191 0.156,0.125 0.234,0.297 0.234,0.516 0,0.156 -0.046,0.289 -0.132,0.399 -0.09,0.109 -0.211,0.183 -0.372,0.222 0.18,0.039 0.317,0.121 0.418,0.242 0.098,0.121 0.149,0.27 0.149,0.442 0,0.265 -0.082,0.468 -0.242,0.609 -0.16,0.145 -0.395,0.215 -0.696,0.215 -0.3,0 -0.531,-0.07 -0.695,-0.215 -0.16,-0.141 -0.242,-0.344 -0.242,-0.609 0,-0.172 0.051,-0.321 0.152,-0.442 0.098,-0.121 0.238,-0.203 0.418,-0.242 z m -0.137,-0.586 c 0,0.141 0.043,0.254 0.133,0.332 0.086,0.078 0.211,0.121 0.371,0.121 0.161,0 0.286,-0.043 0.371,-0.121 0.09,-0.078 0.137,-0.191 0.137,-0.332 0,-0.14 -0.047,-0.25 -0.137,-0.332 -0.085,-0.078 -0.21,-0.117 -0.371,-0.117 -0.16,0 -0.285,0.039 -0.371,0.117 -0.09,0.082 -0.133,0.192 -0.133,0.332 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath365)"
+             id="path896" />
+          <path
+             d="m 186.461,165.223 v -0.735 h -0.606 v -0.3 h 0.973 v 1.171 c -0.144,0.102 -0.301,0.176 -0.473,0.231 -0.171,0.051 -0.355,0.078 -0.55,0.078 -0.43,0 -0.762,-0.125 -1.004,-0.375 -0.242,-0.25 -0.36,-0.598 -0.36,-1.043 0,-0.445 0.118,-0.793 0.36,-1.043 0.242,-0.25 0.574,-0.375 1.004,-0.375 0.175,0 0.347,0.02 0.507,0.066 0.161,0.043 0.309,0.106 0.442,0.192 v 0.394 c -0.137,-0.117 -0.281,-0.203 -0.434,-0.261 -0.156,-0.059 -0.316,-0.086 -0.484,-0.086 -0.336,0 -0.586,0.09 -0.754,0.277 -0.168,0.188 -0.254,0.465 -0.254,0.836 0,0.367 0.086,0.645 0.254,0.832 0.168,0.188 0.418,0.281 0.754,0.281 0.129,0 0.246,-0.011 0.348,-0.035 0.101,-0.023 0.195,-0.058 0.277,-0.105 z m 0.5,-2.344 h 0.5 l 1.211,2.289 v -2.289 h 0.359 v 2.734 h -0.5 l -1.211,-2.285 v 2.285 h -0.359 z m 2.793,0.305 v 2.125 h 0.445 c 0.379,0 0.653,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.442 0.262,-0.809 0,-0.367 -0.086,-0.637 -0.262,-0.805 -0.175,-0.171 -0.449,-0.257 -0.828,-0.257 z m -0.371,-0.305 h 0.758 c 0.531,0 0.921,0.113 1.168,0.332 0.246,0.219 0.371,0.566 0.371,1.035 0,0.469 -0.125,0.816 -0.371,1.035 -0.25,0.223 -0.641,0.332 -1.168,0.332 h -0.758 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath366)"
+             id="path897" />
+          <path
+             d="m 185.949,122.594 v 2.125 h 0.446 c 0.378,0 0.656,-0.086 0.828,-0.258 0.175,-0.168 0.265,-0.438 0.265,-0.809 0,-0.363 -0.09,-0.632 -0.265,-0.8 -0.172,-0.172 -0.45,-0.258 -0.828,-0.258 z m -0.371,-0.305 h 0.762 c 0.527,0 0.918,0.113 1.164,0.332 0.25,0.219 0.375,0.563 0.375,1.031 0,0.473 -0.125,0.821 -0.375,1.039 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.762 z m 2.66,2.422 h 1.289 v 0.312 h -1.734 v -0.312 c 0.141,-0.145 0.332,-0.34 0.57,-0.582 0.246,-0.246 0.399,-0.406 0.461,-0.477 0.117,-0.132 0.199,-0.242 0.246,-0.336 0.047,-0.093 0.071,-0.183 0.071,-0.273 0,-0.145 -0.051,-0.262 -0.153,-0.355 -0.101,-0.09 -0.234,-0.137 -0.398,-0.137 -0.117,0 -0.238,0.019 -0.367,0.062 -0.129,0.039 -0.266,0.102 -0.414,0.184 v -0.375 c 0.152,-0.059 0.289,-0.106 0.418,-0.137 0.128,-0.027 0.25,-0.043 0.355,-0.043 0.285,0 0.508,0.07 0.68,0.211 0.168,0.141 0.25,0.332 0.25,0.567 0,0.113 -0.02,0.218 -0.063,0.32 -0.043,0.101 -0.117,0.219 -0.23,0.355 -0.031,0.035 -0.125,0.137 -0.289,0.309 -0.164,0.168 -0.395,0.402 -0.692,0.707 z m 1.586,-2.422 h 1.449 v 0.313 h -1.113 v 0.668 c 0.055,-0.016 0.11,-0.032 0.164,-0.04 0.051,-0.007 0.106,-0.015 0.16,-0.015 0.305,0 0.547,0.086 0.723,0.254 0.18,0.164 0.27,0.39 0.27,0.676 0,0.296 -0.094,0.523 -0.274,0.687 -0.183,0.164 -0.441,0.242 -0.777,0.242 -0.114,0 -0.231,-0.008 -0.352,-0.027 -0.117,-0.02 -0.238,-0.051 -0.367,-0.09 v -0.371 c 0.109,0.062 0.223,0.105 0.34,0.137 0.117,0.027 0.242,0.043 0.371,0.043 0.211,0 0.379,-0.055 0.504,-0.168 0.121,-0.11 0.183,-0.262 0.183,-0.453 0,-0.188 -0.062,-0.34 -0.183,-0.45 -0.125,-0.113 -0.293,-0.168 -0.504,-0.168 -0.098,0 -0.195,0.012 -0.293,0.032 -0.098,0.023 -0.199,0.058 -0.301,0.105 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath367)"
+             id="path898" />
+          <path
+             d="m 185.949,118.344 v 2.125 h 0.446 c 0.378,0 0.656,-0.086 0.828,-0.258 0.175,-0.168 0.265,-0.441 0.265,-0.809 0,-0.367 -0.09,-0.632 -0.265,-0.804 -0.172,-0.168 -0.45,-0.254 -0.828,-0.254 z m -0.371,-0.305 h 0.762 c 0.527,0 0.918,0.109 1.164,0.332 0.25,0.219 0.375,0.563 0.375,1.031 0,0.473 -0.125,0.817 -0.375,1.039 -0.25,0.219 -0.637,0.332 -1.164,0.332 h -0.762 z m 2.66,2.422 h 1.289 v 0.312 h -1.734 v -0.312 c 0.141,-0.145 0.332,-0.34 0.57,-0.586 0.246,-0.242 0.399,-0.402 0.461,-0.473 0.117,-0.132 0.199,-0.246 0.246,-0.336 0.047,-0.093 0.071,-0.183 0.071,-0.273 0,-0.145 -0.051,-0.262 -0.153,-0.355 -0.101,-0.09 -0.234,-0.137 -0.398,-0.137 -0.117,0 -0.238,0.019 -0.367,0.058 -0.129,0.043 -0.266,0.102 -0.414,0.184 v -0.371 c 0.152,-0.063 0.289,-0.106 0.418,-0.137 0.128,-0.031 0.25,-0.047 0.355,-0.047 0.285,0 0.508,0.071 0.68,0.215 0.168,0.141 0.25,0.328 0.25,0.567 0,0.113 -0.02,0.218 -0.063,0.32 -0.043,0.101 -0.117,0.219 -0.23,0.355 -0.031,0.035 -0.125,0.137 -0.289,0.309 -0.164,0.168 -0.395,0.402 -0.692,0.707 z m 2.598,-2.098 -0.934,1.457 h 0.934 z m -0.098,-0.324 h 0.465 v 1.781 h 0.391 v 0.309 h -0.391 v 0.644 h -0.367 v -0.644 h -1.234 v -0.359 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath368)"
+             id="path899" />
+          <path
+             d="m 185.949,114.094 v 2.125 h 0.446 c 0.378,0 0.656,-0.086 0.828,-0.258 0.175,-0.172 0.265,-0.441 0.265,-0.809 0,-0.367 -0.09,-0.632 -0.265,-0.804 -0.172,-0.172 -0.45,-0.254 -0.828,-0.254 z m -0.371,-0.305 h 0.762 c 0.527,0 0.918,0.109 1.164,0.332 0.25,0.219 0.375,0.563 0.375,1.031 0,0.469 -0.125,0.817 -0.375,1.039 -0.25,0.219 -0.637,0.329 -1.164,0.329 h -0.762 z m 2.66,2.422 h 1.289 v 0.309 h -1.734 v -0.309 c 0.141,-0.145 0.332,-0.34 0.57,-0.586 0.246,-0.246 0.399,-0.402 0.461,-0.473 0.117,-0.132 0.199,-0.246 0.246,-0.336 0.047,-0.093 0.071,-0.183 0.071,-0.273 0,-0.145 -0.051,-0.266 -0.153,-0.355 -0.101,-0.09 -0.234,-0.137 -0.398,-0.137 -0.117,0 -0.238,0.019 -0.367,0.058 -0.129,0.043 -0.266,0.102 -0.414,0.184 v -0.371 c 0.152,-0.063 0.289,-0.106 0.418,-0.137 0.128,-0.031 0.25,-0.047 0.355,-0.047 0.285,0 0.508,0.071 0.68,0.211 0.168,0.145 0.25,0.332 0.25,0.571 0,0.109 -0.02,0.218 -0.063,0.32 -0.043,0.098 -0.117,0.219 -0.23,0.355 -0.031,0.035 -0.125,0.137 -0.289,0.305 -0.164,0.168 -0.395,0.406 -0.692,0.711 z m 2.703,-1.164 c 0.176,0.039 0.313,0.117 0.411,0.238 0.101,0.117 0.152,0.266 0.152,0.442 0,0.269 -0.094,0.476 -0.277,0.625 -0.188,0.148 -0.45,0.222 -0.793,0.222 -0.114,0 -0.231,-0.012 -0.356,-0.035 -0.121,-0.023 -0.246,-0.055 -0.375,-0.101 v -0.356 c 0.102,0.059 0.215,0.106 0.336,0.137 0.125,0.027 0.25,0.043 0.383,0.043 0.234,0 0.41,-0.043 0.531,-0.137 0.121,-0.09 0.184,-0.223 0.184,-0.398 0,-0.161 -0.059,-0.286 -0.172,-0.379 -0.113,-0.09 -0.27,-0.137 -0.469,-0.137 h -0.32 v -0.301 h 0.332 c 0.183,0 0.324,-0.039 0.418,-0.109 0.097,-0.074 0.144,-0.18 0.144,-0.317 0,-0.14 -0.05,-0.246 -0.148,-0.32 -0.098,-0.078 -0.242,-0.113 -0.426,-0.113 -0.101,0 -0.211,0.011 -0.328,0.031 -0.113,0.023 -0.242,0.059 -0.383,0.102 v -0.329 c 0.141,-0.039 0.274,-0.066 0.395,-0.085 0.125,-0.02 0.238,-0.032 0.347,-0.032 0.282,0 0.504,0.067 0.668,0.192 0.164,0.129 0.243,0.3 0.243,0.515 0,0.153 -0.043,0.282 -0.129,0.387 -0.086,0.102 -0.211,0.176 -0.368,0.215 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath369)"
+             id="path900" />
+          <path
+             d="m 185.949,109.84 v 2.125 h 0.446 c 0.378,0 0.656,-0.086 0.828,-0.254 0.175,-0.172 0.265,-0.441 0.265,-0.809 0,-0.367 -0.09,-0.636 -0.265,-0.804 -0.172,-0.172 -0.45,-0.258 -0.828,-0.258 z m -0.371,-0.301 h 0.762 c 0.527,0 0.918,0.109 1.164,0.328 0.25,0.223 0.375,0.567 0.375,1.035 0,0.469 -0.125,0.817 -0.375,1.036 -0.25,0.222 -0.637,0.332 -1.164,0.332 h -0.762 z m 2.66,2.418 h 1.289 v 0.313 h -1.734 v -0.313 c 0.141,-0.145 0.332,-0.34 0.57,-0.582 0.246,-0.246 0.399,-0.402 0.461,-0.473 0.117,-0.132 0.199,-0.246 0.246,-0.34 0.047,-0.089 0.071,-0.183 0.071,-0.269 0,-0.148 -0.051,-0.266 -0.153,-0.355 -0.101,-0.094 -0.234,-0.137 -0.398,-0.137 -0.117,0 -0.238,0.019 -0.367,0.058 -0.129,0.039 -0.266,0.102 -0.414,0.184 v -0.375 c 0.152,-0.059 0.289,-0.106 0.418,-0.133 0.128,-0.031 0.25,-0.047 0.355,-0.047 0.285,0 0.508,0.071 0.68,0.211 0.168,0.141 0.25,0.332 0.25,0.571 0,0.109 -0.02,0.218 -0.063,0.32 -0.043,0.098 -0.117,0.215 -0.23,0.351 -0.031,0.036 -0.125,0.141 -0.289,0.309 -0.164,0.168 -0.395,0.406 -0.692,0.707 z m 1.899,0 h 1.293 v 0.313 h -1.739 v -0.313 c 0.141,-0.145 0.332,-0.34 0.575,-0.582 0.242,-0.246 0.394,-0.402 0.457,-0.473 0.121,-0.132 0.203,-0.246 0.25,-0.34 0.047,-0.089 0.07,-0.183 0.07,-0.269 0,-0.148 -0.051,-0.266 -0.156,-0.355 -0.102,-0.094 -0.231,-0.137 -0.395,-0.137 -0.117,0 -0.238,0.019 -0.367,0.058 -0.129,0.039 -0.266,0.102 -0.414,0.184 v -0.375 c 0.148,-0.059 0.289,-0.106 0.418,-0.133 0.129,-0.031 0.246,-0.047 0.355,-0.047 0.282,0 0.508,0.071 0.676,0.211 0.168,0.141 0.254,0.332 0.254,0.571 0,0.109 -0.023,0.218 -0.062,0.32 -0.043,0.098 -0.122,0.215 -0.231,0.351 -0.031,0.036 -0.129,0.141 -0.293,0.309 -0.16,0.168 -0.39,0.406 -0.691,0.707 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath370)"
+             id="path901" />
+          <path
+             d="m 185.949,105.59 v 2.125 h 0.446 c 0.378,0 0.656,-0.086 0.828,-0.258 0.175,-0.168 0.265,-0.437 0.265,-0.809 0,-0.363 -0.09,-0.632 -0.265,-0.8 -0.172,-0.172 -0.45,-0.258 -0.828,-0.258 z m -0.371,-0.305 h 0.762 c 0.527,0 0.918,0.113 1.164,0.332 0.25,0.219 0.375,0.563 0.375,1.031 0,0.473 -0.125,0.821 -0.375,1.04 -0.25,0.222 -0.637,0.332 -1.164,0.332 h -0.762 z m 2.66,2.422 h 1.289 v 0.313 h -1.734 v -0.313 c 0.141,-0.145 0.332,-0.34 0.57,-0.582 0.246,-0.246 0.399,-0.406 0.461,-0.477 0.117,-0.132 0.199,-0.242 0.246,-0.336 0.047,-0.093 0.071,-0.183 0.071,-0.273 0,-0.144 -0.051,-0.262 -0.153,-0.355 -0.101,-0.09 -0.234,-0.137 -0.398,-0.137 -0.117,0 -0.238,0.019 -0.367,0.062 -0.129,0.039 -0.266,0.102 -0.414,0.184 v -0.375 c 0.152,-0.059 0.289,-0.106 0.418,-0.137 0.128,-0.027 0.25,-0.043 0.355,-0.043 0.285,0 0.508,0.071 0.68,0.211 0.168,0.141 0.25,0.332 0.25,0.567 0,0.113 -0.02,0.218 -0.063,0.32 -0.043,0.102 -0.117,0.219 -0.23,0.355 -0.031,0.036 -0.125,0.137 -0.289,0.309 -0.164,0.168 -0.395,0.402 -0.692,0.707 z m 1.645,0 h 0.605 v -2.082 l -0.656,0.129 v -0.336 l 0.652,-0.133 h 0.371 v 2.422 h 0.602 v 0.313 h -1.574 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath371)"
+             id="path902" />
+          <path
+             d="m 185.949,101.34 v 2.125 h 0.446 c 0.378,0 0.656,-0.086 0.828,-0.258 0.175,-0.168 0.265,-0.441 0.265,-0.809 0,-0.367 -0.09,-0.632 -0.265,-0.804 -0.172,-0.168 -0.45,-0.254 -0.828,-0.254 z m -0.371,-0.305 h 0.762 c 0.527,0 0.918,0.11 1.164,0.332 0.25,0.219 0.375,0.563 0.375,1.031 0,0.473 -0.125,0.817 -0.375,1.04 -0.25,0.218 -0.637,0.332 -1.164,0.332 h -0.762 z m 2.66,2.422 h 1.289 v 0.313 h -1.734 v -0.313 c 0.141,-0.145 0.332,-0.34 0.57,-0.586 0.246,-0.242 0.399,-0.402 0.461,-0.473 0.117,-0.132 0.199,-0.246 0.246,-0.336 0.047,-0.093 0.071,-0.183 0.071,-0.273 0,-0.144 -0.051,-0.262 -0.153,-0.355 -0.101,-0.09 -0.234,-0.137 -0.398,-0.137 -0.117,0 -0.238,0.019 -0.367,0.062 -0.129,0.039 -0.266,0.098 -0.414,0.18 v -0.371 c 0.152,-0.063 0.289,-0.106 0.418,-0.137 0.128,-0.031 0.25,-0.047 0.355,-0.047 0.285,0 0.508,0.075 0.68,0.215 0.168,0.141 0.25,0.328 0.25,0.567 0,0.113 -0.02,0.218 -0.063,0.32 -0.043,0.102 -0.117,0.219 -0.23,0.355 -0.031,0.036 -0.125,0.137 -0.289,0.309 -0.164,0.168 -0.395,0.402 -0.692,0.707 z m 2.371,-2.18 c -0.191,0 -0.332,0.094 -0.429,0.285 -0.094,0.184 -0.145,0.465 -0.145,0.844 0,0.371 0.051,0.653 0.145,0.844 0.097,0.184 0.238,0.277 0.429,0.277 0.192,0 0.336,-0.093 0.43,-0.277 0.098,-0.191 0.145,-0.473 0.145,-0.844 0,-0.379 -0.047,-0.66 -0.145,-0.844 -0.094,-0.191 -0.238,-0.285 -0.43,-0.285 z m 0,-0.293 c 0.309,0 0.539,0.121 0.703,0.368 0.161,0.238 0.243,0.589 0.243,1.054 0,0.457 -0.082,0.809 -0.243,1.051 -0.164,0.242 -0.394,0.363 -0.703,0.363 -0.304,0 -0.539,-0.121 -0.703,-0.363 -0.16,-0.242 -0.242,-0.594 -0.242,-1.051 0,-0.465 0.082,-0.816 0.242,-1.054 0.164,-0.247 0.399,-0.368 0.703,-0.368 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath372)"
+             id="path903" />
+          <path
+             d="m 185.949,97.09 v 2.125 h 0.446 c 0.378,0 0.656,-0.086 0.828,-0.258 0.175,-0.172 0.265,-0.441 0.265,-0.809 0,-0.367 -0.09,-0.632 -0.265,-0.804 -0.172,-0.172 -0.45,-0.254 -0.828,-0.254 z m -0.371,-0.305 h 0.762 c 0.527,0 0.918,0.11 1.164,0.332 0.25,0.219 0.375,0.563 0.375,1.031 0,0.469 -0.125,0.817 -0.375,1.04 -0.25,0.218 -0.637,0.328 -1.164,0.328 h -0.762 z m 2.402,2.422 h 0.606 v -2.086 l -0.656,0.133 v -0.336 l 0.652,-0.133 h 0.371 v 2.422 h 0.606 v 0.309 h -1.579 z m 1.852,0.254 v -0.336 c 0.09,0.043 0.184,0.074 0.281,0.098 0.094,0.023 0.188,0.035 0.278,0.035 0.246,0 0.433,-0.082 0.558,-0.242 0.129,-0.168 0.203,-0.418 0.223,-0.75 -0.07,0.105 -0.16,0.183 -0.27,0.242 -0.109,0.054 -0.226,0.082 -0.359,0.082 -0.273,0 -0.492,-0.082 -0.652,-0.246 -0.157,-0.164 -0.235,-0.391 -0.235,-0.68 0,-0.281 0.082,-0.504 0.246,-0.676 0.168,-0.168 0.387,-0.254 0.664,-0.254 0.317,0 0.559,0.121 0.723,0.364 0.168,0.242 0.25,0.593 0.25,1.054 0,0.434 -0.101,0.778 -0.305,1.036 -0.207,0.253 -0.48,0.382 -0.824,0.382 -0.094,0 -0.187,-0.008 -0.285,-0.027 -0.094,-0.02 -0.191,-0.047 -0.293,-0.082 z m 0.734,-1.16 c 0.164,0 0.297,-0.055 0.395,-0.168 0.098,-0.113 0.144,-0.27 0.144,-0.469 0,-0.195 -0.046,-0.352 -0.144,-0.465 -0.098,-0.113 -0.231,-0.172 -0.395,-0.172 -0.168,0 -0.296,0.059 -0.394,0.172 -0.098,0.113 -0.145,0.27 -0.145,0.465 0,0.199 0.047,0.356 0.145,0.469 0.098,0.113 0.226,0.168 0.394,0.168 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath373)"
+             id="path904" />
+          <path
+             d="m 185.949,92.836 v 2.125 h 0.446 c 0.378,0 0.656,-0.086 0.828,-0.254 0.175,-0.172 0.265,-0.441 0.265,-0.809 0,-0.367 -0.09,-0.636 -0.265,-0.804 -0.172,-0.172 -0.45,-0.258 -0.828,-0.258 z m -0.371,-0.301 h 0.762 c 0.527,0 0.918,0.11 1.164,0.328 0.25,0.223 0.375,0.567 0.375,1.035 0,0.469 -0.125,0.817 -0.375,1.036 -0.25,0.222 -0.637,0.332 -1.164,0.332 h -0.762 z m 2.402,2.418 h 0.606 V 92.871 L 187.93,93 v -0.336 l 0.652,-0.129 h 0.371 v 2.418 h 0.606 v 0.313 h -1.579 z m 2.629,-0.984 c -0.175,0 -0.312,0.047 -0.414,0.14 -0.101,0.094 -0.152,0.223 -0.152,0.387 0,0.164 0.051,0.297 0.152,0.391 0.102,0.093 0.239,0.14 0.414,0.14 0.176,0 0.317,-0.047 0.418,-0.14 0.102,-0.098 0.149,-0.227 0.149,-0.391 0,-0.164 -0.047,-0.293 -0.149,-0.387 -0.101,-0.093 -0.242,-0.14 -0.418,-0.14 z m -0.367,-0.157 c -0.16,-0.039 -0.285,-0.113 -0.375,-0.222 -0.086,-0.11 -0.129,-0.242 -0.129,-0.399 0,-0.218 0.074,-0.39 0.231,-0.515 0.156,-0.129 0.371,-0.192 0.64,-0.192 0.274,0 0.489,0.063 0.641,0.192 0.156,0.125 0.234,0.297 0.234,0.515 0,0.157 -0.046,0.289 -0.132,0.399 -0.09,0.109 -0.211,0.183 -0.372,0.222 0.18,0.04 0.317,0.122 0.418,0.243 0.098,0.121 0.149,0.269 0.149,0.441 0,0.266 -0.082,0.469 -0.242,0.609 -0.16,0.145 -0.395,0.215 -0.696,0.215 -0.3,0 -0.531,-0.07 -0.695,-0.215 -0.16,-0.14 -0.242,-0.343 -0.242,-0.609 0,-0.172 0.051,-0.32 0.152,-0.441 0.098,-0.121 0.238,-0.203 0.418,-0.243 z m -0.137,-0.585 c 0,0.14 0.043,0.253 0.133,0.332 0.086,0.078 0.211,0.117 0.371,0.117 0.161,0 0.286,-0.039 0.371,-0.117 0.09,-0.079 0.137,-0.192 0.137,-0.332 0,-0.141 -0.047,-0.25 -0.137,-0.332 -0.085,-0.079 -0.21,-0.118 -0.371,-0.118 -0.16,0 -0.285,0.039 -0.371,0.118 -0.09,0.082 -0.133,0.191 -0.133,0.332 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath374)"
+             id="path905" />
+          <path
+             d="m 185.949,88.586 v 2.125 h 0.446 c 0.378,0 0.656,-0.086 0.828,-0.254 0.175,-0.172 0.265,-0.441 0.265,-0.809 0,-0.367 -0.09,-0.636 -0.265,-0.804 -0.172,-0.172 -0.45,-0.258 -0.828,-0.258 z m -0.371,-0.305 h 0.762 c 0.527,0 0.918,0.114 1.164,0.332 0.25,0.223 0.375,0.567 0.375,1.035 0,0.469 -0.125,0.817 -0.375,1.036 -0.25,0.222 -0.637,0.332 -1.164,0.332 h -0.762 z m 2.402,2.422 h 0.606 v -2.082 l -0.656,0.129 v -0.336 l 0.652,-0.133 h 0.371 v 2.422 h 0.606 v 0.313 h -1.579 z m 1.747,-2.422 h 1.757 v 0.16 l -0.992,2.575 h -0.387 l 0.934,-2.422 h -1.312 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath375)"
+             id="path906" />
+          <path
+             d="m 185.949,84.336 v 2.125 h 0.446 c 0.378,0 0.656,-0.086 0.828,-0.258 0.175,-0.168 0.265,-0.437 0.265,-0.808 0,-0.364 -0.09,-0.633 -0.265,-0.801 -0.172,-0.172 -0.45,-0.258 -0.828,-0.258 z m -0.371,-0.305 h 0.762 c 0.527,0 0.918,0.11 1.164,0.332 0.25,0.219 0.375,0.563 0.375,1.032 0,0.472 -0.125,0.816 -0.375,1.039 -0.25,0.222 -0.637,0.332 -1.164,0.332 h -0.762 z m 2.402,2.422 h 0.606 V 84.367 L 187.93,84.5 v -0.336 l 0.652,-0.133 h 0.371 v 2.422 h 0.606 v 0.313 h -1.579 z m 2.676,-1.203 c -0.168,0 -0.297,0.059 -0.394,0.172 -0.098,0.113 -0.145,0.269 -0.145,0.465 0,0.199 0.047,0.351 0.145,0.468 0.097,0.114 0.226,0.168 0.394,0.168 0.164,0 0.297,-0.054 0.395,-0.168 0.097,-0.117 0.144,-0.269 0.144,-0.468 0,-0.196 -0.047,-0.352 -0.144,-0.465 -0.098,-0.113 -0.231,-0.172 -0.395,-0.172 z m 0.735,-1.156 v 0.336 c -0.094,-0.043 -0.188,-0.078 -0.282,-0.102 -0.093,-0.023 -0.187,-0.035 -0.281,-0.035 -0.246,0 -0.43,0.082 -0.558,0.246 -0.129,0.168 -0.204,0.414 -0.223,0.75 0.074,-0.109 0.164,-0.187 0.273,-0.246 0.106,-0.055 0.227,-0.086 0.36,-0.086 0.273,0 0.488,0.086 0.648,0.254 0.16,0.164 0.238,0.391 0.238,0.676 0,0.281 -0.082,0.508 -0.246,0.675 -0.168,0.172 -0.386,0.254 -0.664,0.254 -0.316,0 -0.558,-0.121 -0.726,-0.359 -0.168,-0.246 -0.25,-0.598 -0.25,-1.055 0,-0.433 0.101,-0.777 0.308,-1.035 0.203,-0.254 0.481,-0.383 0.824,-0.383 0.094,0 0.188,0.008 0.282,0.028 0.094,0.015 0.195,0.043 0.297,0.082 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath376)"
+             id="path907" />
+          <path
+             d="m 185.949,158.719 v 2.125 h 0.446 c 0.378,0 0.656,-0.082 0.828,-0.254 0.175,-0.172 0.265,-0.442 0.265,-0.809 0,-0.367 -0.09,-0.636 -0.265,-0.804 -0.172,-0.172 -0.45,-0.258 -0.828,-0.258 z m -0.371,-0.301 h 0.762 c 0.527,0 0.918,0.109 1.164,0.328 0.25,0.223 0.375,0.566 0.375,1.035 0,0.469 -0.125,0.817 -0.375,1.035 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.762 z m 2.66,2.422 h 1.289 v 0.308 h -1.734 v -0.308 c 0.141,-0.149 0.332,-0.34 0.57,-0.586 0.246,-0.246 0.399,-0.402 0.461,-0.473 0.117,-0.133 0.199,-0.246 0.246,-0.336 0.047,-0.093 0.071,-0.183 0.071,-0.273 0,-0.145 -0.051,-0.266 -0.153,-0.356 -0.101,-0.093 -0.234,-0.136 -0.398,-0.136 -0.117,0 -0.238,0.019 -0.367,0.058 -0.129,0.039 -0.266,0.102 -0.414,0.184 v -0.375 c 0.152,-0.059 0.289,-0.102 0.418,-0.133 0.128,-0.031 0.25,-0.047 0.355,-0.047 0.285,0 0.508,0.071 0.68,0.211 0.168,0.145 0.25,0.332 0.25,0.57 0,0.11 -0.02,0.219 -0.063,0.321 -0.043,0.097 -0.117,0.219 -0.23,0.355 -0.031,0.035 -0.125,0.137 -0.289,0.305 -0.164,0.168 -0.395,0.406 -0.692,0.711 z m 1.489,-2.422 h 1.757 v 0.156 l -0.992,2.574 h -0.387 l 0.934,-2.421 h -1.312 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath377)"
+             id="path908" />
+          <path
+             d="m 185.949,154.469 v 2.125 h 0.446 c 0.378,0 0.656,-0.086 0.828,-0.254 0.175,-0.172 0.265,-0.442 0.265,-0.813 0,-0.363 -0.09,-0.632 -0.265,-0.8 -0.172,-0.172 -0.45,-0.258 -0.828,-0.258 z m -0.371,-0.305 h 0.762 c 0.527,0 0.918,0.113 1.164,0.332 0.25,0.219 0.375,0.566 0.375,1.031 0,0.473 -0.125,0.821 -0.375,1.039 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.762 z m 2.66,2.422 h 1.289 v 0.312 h -1.734 v -0.312 c 0.141,-0.145 0.332,-0.34 0.57,-0.582 0.246,-0.246 0.399,-0.402 0.461,-0.477 0.117,-0.132 0.199,-0.242 0.246,-0.336 0.047,-0.089 0.071,-0.183 0.071,-0.273 0,-0.145 -0.051,-0.262 -0.153,-0.352 -0.101,-0.093 -0.234,-0.14 -0.398,-0.14 -0.117,0 -0.238,0.023 -0.367,0.062 -0.129,0.039 -0.266,0.102 -0.414,0.184 v -0.375 c 0.152,-0.059 0.289,-0.106 0.418,-0.137 0.128,-0.027 0.25,-0.043 0.355,-0.043 0.285,0 0.508,0.071 0.68,0.211 0.168,0.141 0.25,0.332 0.25,0.567 0,0.113 -0.02,0.218 -0.063,0.32 -0.043,0.101 -0.117,0.219 -0.23,0.355 -0.031,0.035 -0.125,0.141 -0.289,0.309 -0.164,0.168 -0.395,0.406 -0.692,0.707 z m 2.418,-1.203 c -0.168,0 -0.297,0.058 -0.394,0.172 -0.098,0.113 -0.145,0.269 -0.145,0.468 0,0.196 0.047,0.352 0.145,0.465 0.097,0.114 0.226,0.172 0.394,0.172 0.164,0 0.297,-0.058 0.395,-0.172 0.097,-0.113 0.144,-0.269 0.144,-0.465 0,-0.199 -0.047,-0.355 -0.144,-0.468 -0.098,-0.114 -0.231,-0.172 -0.395,-0.172 z m 0.735,-1.156 v 0.335 c -0.094,-0.042 -0.188,-0.078 -0.282,-0.101 -0.093,-0.023 -0.187,-0.035 -0.281,-0.035 -0.246,0 -0.43,0.082 -0.558,0.25 -0.129,0.164 -0.204,0.414 -0.223,0.746 0.074,-0.106 0.164,-0.188 0.273,-0.242 0.106,-0.059 0.227,-0.086 0.36,-0.086 0.273,0 0.488,0.082 0.648,0.25 0.16,0.164 0.238,0.39 0.238,0.679 0,0.278 -0.082,0.504 -0.246,0.672 -0.168,0.172 -0.386,0.258 -0.664,0.258 -0.316,0 -0.558,-0.121 -0.726,-0.363 -0.168,-0.242 -0.25,-0.594 -0.25,-1.055 0,-0.433 0.101,-0.777 0.308,-1.031 0.203,-0.258 0.481,-0.387 0.824,-0.387 0.094,0 0.188,0.008 0.282,0.028 0.094,0.015 0.195,0.043 0.297,0.082 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath378)"
+             id="path909" />
+          <path
+             d="m 188.531,150.277 -0.5,1.364 h 1.004 z m -0.207,-0.363 h 0.418 l 1.043,2.734 h -0.383 l -0.25,-0.703 h -1.234 l -0.246,0.703 h -0.391 z m 2.289,1.438 c -0.175,0 -0.312,0.046 -0.414,0.14 -0.101,0.094 -0.152,0.223 -0.152,0.387 0,0.164 0.051,0.293 0.152,0.387 0.102,0.093 0.239,0.14 0.414,0.14 0.176,0 0.317,-0.047 0.418,-0.14 0.098,-0.094 0.149,-0.223 0.149,-0.387 0,-0.164 -0.051,-0.293 -0.149,-0.387 -0.101,-0.094 -0.242,-0.14 -0.418,-0.14 z m -0.371,-0.161 c -0.156,-0.039 -0.281,-0.113 -0.371,-0.218 -0.086,-0.11 -0.129,-0.243 -0.129,-0.399 0,-0.219 0.074,-0.39 0.231,-0.519 0.156,-0.125 0.371,-0.188 0.64,-0.188 0.274,0 0.485,0.063 0.641,0.188 0.156,0.129 0.234,0.3 0.234,0.519 0,0.156 -0.047,0.289 -0.136,0.399 -0.086,0.105 -0.207,0.179 -0.368,0.218 0.18,0.043 0.317,0.125 0.418,0.247 0.098,0.117 0.149,0.265 0.149,0.441 0,0.266 -0.082,0.469 -0.242,0.609 -0.161,0.141 -0.395,0.211 -0.696,0.211 -0.301,0 -0.531,-0.07 -0.695,-0.211 -0.16,-0.14 -0.242,-0.343 -0.242,-0.609 0,-0.176 0.051,-0.324 0.152,-0.441 0.098,-0.122 0.238,-0.204 0.414,-0.247 z m -0.133,-0.582 c 0,0.141 0.043,0.25 0.133,0.332 0.086,0.079 0.211,0.118 0.371,0.118 0.16,0 0.282,-0.039 0.371,-0.118 0.09,-0.082 0.137,-0.191 0.137,-0.332 0,-0.14 -0.047,-0.254 -0.137,-0.332 -0.089,-0.078 -0.211,-0.121 -0.371,-0.121 -0.16,0 -0.285,0.043 -0.371,0.121 -0.09,0.078 -0.133,0.192 -0.133,0.332 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath379)"
+             id="path910" />
+          <path
+             d="m 188.531,146.027 -0.5,1.36 h 1.004 z m -0.207,-0.363 h 0.418 l 1.043,2.731 h -0.383 l -0.25,-0.7 h -1.234 l -0.246,0.7 h -0.391 z m 1.406,0 h 1.758 v 0.156 l -0.992,2.575 h -0.387 l 0.934,-2.418 h -1.313 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath380)"
+             id="path911" />
+          <path
+             d="m 188.531,141.777 -0.5,1.36 h 1.004 z m -0.207,-0.363 h 0.418 l 1.043,2.731 h -0.383 l -0.25,-0.7 h -1.234 l -0.246,0.7 h -0.391 z m 2.336,1.219 c -0.168,0 -0.297,0.055 -0.394,0.168 -0.098,0.113 -0.145,0.269 -0.145,0.469 0,0.195 0.047,0.351 0.145,0.464 0.097,0.114 0.226,0.172 0.394,0.172 0.164,0 0.297,-0.058 0.395,-0.172 0.097,-0.113 0.144,-0.269 0.144,-0.464 0,-0.2 -0.047,-0.356 -0.144,-0.469 -0.098,-0.113 -0.231,-0.168 -0.395,-0.168 z m 0.735,-1.16 v 0.336 c -0.094,-0.043 -0.188,-0.079 -0.282,-0.098 -0.093,-0.023 -0.187,-0.035 -0.281,-0.035 -0.246,0 -0.43,0.082 -0.562,0.246 -0.125,0.164 -0.2,0.414 -0.219,0.746 0.074,-0.106 0.164,-0.188 0.273,-0.242 0.106,-0.059 0.227,-0.086 0.356,-0.086 0.277,0 0.492,0.082 0.652,0.25 0.16,0.164 0.238,0.39 0.238,0.68 0,0.281 -0.082,0.503 -0.246,0.675 -0.168,0.168 -0.39,0.254 -0.664,0.254 -0.316,0 -0.558,-0.121 -0.726,-0.363 -0.168,-0.242 -0.25,-0.594 -0.25,-1.055 0,-0.429 0.101,-0.777 0.308,-1.031 0.203,-0.258 0.481,-0.387 0.824,-0.387 0.094,0 0.188,0.008 0.282,0.028 0.093,0.019 0.195,0.047 0.297,0.082 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath381)"
+             id="path912" />
+          <path
+             d="m 186.461,139.504 v -0.734 h -0.606 v -0.301 h 0.973 v 1.172 c -0.144,0.101 -0.301,0.175 -0.473,0.23 -0.171,0.051 -0.355,0.078 -0.55,0.078 -0.43,0 -0.762,-0.125 -1.004,-0.375 -0.242,-0.25 -0.36,-0.597 -0.36,-1.043 0,-0.445 0.118,-0.793 0.36,-1.043 0.242,-0.25 0.574,-0.375 1.004,-0.375 0.175,0 0.347,0.02 0.507,0.067 0.161,0.043 0.309,0.105 0.442,0.191 v 0.395 c -0.137,-0.118 -0.281,-0.204 -0.434,-0.262 -0.156,-0.059 -0.316,-0.086 -0.484,-0.086 -0.336,0 -0.586,0.09 -0.754,0.277 -0.168,0.188 -0.254,0.465 -0.254,0.836 0,0.367 0.086,0.645 0.254,0.832 0.168,0.188 0.418,0.282 0.754,0.282 0.129,0 0.246,-0.012 0.348,-0.036 0.101,-0.023 0.195,-0.058 0.277,-0.105 z m 0.5,-2.344 h 0.5 l 1.211,2.289 v -2.289 h 0.359 v 2.735 h -0.5 l -1.211,-2.286 v 2.286 h -0.359 z m 2.793,0.305 v 2.125 h 0.445 c 0.379,0 0.653,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.441 0.262,-0.813 0,-0.363 -0.086,-0.632 -0.262,-0.8 -0.175,-0.172 -0.449,-0.258 -0.828,-0.258 z m -0.371,-0.305 h 0.758 c 0.531,0 0.921,0.113 1.168,0.332 0.246,0.219 0.371,0.567 0.371,1.031 0,0.473 -0.125,0.821 -0.371,1.039 -0.25,0.223 -0.641,0.333 -1.168,0.333 h -0.758 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath382)"
+             id="path913" />
+          <path
+             d="m 183.344,133.273 -0.504,1.364 h 1.008 z m -0.211,-0.363 h 0.422 l 1.039,2.735 h -0.383 l -0.25,-0.704 h -1.231 l -0.25,0.704 h -0.39 z m 3.305,2.344 v -0.734 h -0.606 v -0.305 h 0.969 v 1.176 c -0.141,0.101 -0.301,0.175 -0.473,0.23 -0.172,0.051 -0.355,0.074 -0.551,0.074 -0.425,0 -0.761,-0.125 -1.004,-0.371 -0.238,-0.25 -0.359,-0.597 -0.359,-1.043 0,-0.449 0.121,-0.797 0.359,-1.043 0.243,-0.25 0.579,-0.375 1.004,-0.375 0.18,0 0.348,0.02 0.508,0.063 0.16,0.047 0.309,0.109 0.445,0.195 v 0.395 c -0.136,-0.118 -0.281,-0.204 -0.437,-0.262 -0.152,-0.059 -0.313,-0.09 -0.484,-0.09 -0.332,0 -0.586,0.094 -0.754,0.281 -0.168,0.188 -0.25,0.465 -0.25,0.836 0,0.367 0.082,0.645 0.25,0.832 0.168,0.188 0.422,0.282 0.754,0.282 0.132,0 0.246,-0.012 0.351,-0.036 0.102,-0.023 0.195,-0.058 0.278,-0.105 z m 0.5,-2.344 h 0.5 l 1.21,2.285 v -2.285 h 0.36 v 2.735 h -0.5 l -1.211,-2.29 v 2.29 h -0.359 z m 2.789,0.305 v 2.125 h 0.449 c 0.375,0 0.652,-0.086 0.828,-0.258 0.176,-0.168 0.262,-0.437 0.262,-0.809 0,-0.363 -0.086,-0.632 -0.262,-0.8 -0.176,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.368,-0.305 h 0.758 c 0.531,0 0.918,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.473 -0.125,0.817 -0.375,1.039 -0.25,0.219 -0.636,0.333 -1.164,0.333 h -0.758 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath383)"
+             id="path914" />
+          <path
+             d="m 183.688,129.023 -0.5,1.36 h 1.003 z m -0.208,-0.363 h 0.418 l 1.043,2.735 h -0.386 l -0.246,-0.704 h -1.235 l -0.25,0.704 h -0.386 z m 2.004,2.735 -1.043,-2.735 h 0.387 l 0.867,2.301 0.867,-2.301 h 0.383 l -1.039,2.735 z m 1.793,-2.43 v 2.125 h 0.446 c 0.379,0 0.652,-0.086 0.828,-0.258 0.176,-0.172 0.265,-0.441 0.265,-0.809 0,-0.367 -0.089,-0.632 -0.265,-0.804 -0.176,-0.168 -0.449,-0.254 -0.828,-0.254 z m -0.371,-0.305 h 0.762 c 0.527,0 0.918,0.11 1.164,0.332 0.25,0.219 0.371,0.563 0.371,1.031 0,0.473 -0.121,0.817 -0.371,1.039 -0.25,0.219 -0.637,0.333 -1.164,0.333 h -0.762 z m 2.676,0.305 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.824,-0.258 0.176,-0.172 0.266,-0.441 0.266,-0.809 0,-0.367 -0.09,-0.632 -0.266,-0.804 -0.171,-0.168 -0.449,-0.254 -0.824,-0.254 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.473 -0.125,0.817 -0.375,1.039 -0.25,0.219 -0.637,0.333 -1.164,0.333 h -0.758 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath384)"
+             id="path915" />
+          <path
+             d="m 209.641,122.59 v 2.125 h 0.449 c 0.375,0 0.652,-0.086 0.828,-0.258 0.176,-0.172 0.262,-0.441 0.262,-0.809 0,-0.367 -0.086,-0.632 -0.262,-0.804 -0.176,-0.172 -0.453,-0.254 -0.828,-0.254 z m -0.368,-0.305 h 0.758 c 0.531,0 0.918,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.469 -0.125,0.817 -0.375,1.04 -0.246,0.218 -0.636,0.328 -1.164,0.328 h -0.758 z m 3.129,1.434 c -0.175,0 -0.312,0.047 -0.414,0.14 -0.101,0.094 -0.152,0.223 -0.152,0.391 0,0.164 0.051,0.293 0.152,0.387 0.102,0.093 0.239,0.14 0.414,0.14 0.176,0 0.313,-0.047 0.414,-0.14 0.102,-0.098 0.153,-0.227 0.153,-0.387 0,-0.168 -0.051,-0.297 -0.153,-0.391 -0.097,-0.093 -0.238,-0.14 -0.414,-0.14 z m -0.371,-0.157 c -0.156,-0.039 -0.281,-0.113 -0.371,-0.222 -0.086,-0.11 -0.133,-0.242 -0.133,-0.399 0,-0.218 0.078,-0.39 0.235,-0.515 0.156,-0.129 0.371,-0.192 0.64,-0.192 0.274,0 0.485,0.063 0.641,0.192 0.156,0.125 0.234,0.297 0.234,0.515 0,0.157 -0.047,0.289 -0.136,0.399 -0.086,0.109 -0.211,0.183 -0.368,0.222 0.18,0.04 0.317,0.122 0.418,0.243 0.098,0.121 0.149,0.269 0.149,0.445 0,0.262 -0.082,0.465 -0.242,0.609 -0.164,0.141 -0.395,0.211 -0.696,0.211 -0.3,0 -0.535,-0.07 -0.695,-0.211 -0.16,-0.144 -0.242,-0.347 -0.242,-0.609 0,-0.176 0.051,-0.324 0.148,-0.445 0.102,-0.121 0.242,-0.203 0.418,-0.243 z m -0.133,-0.585 c 0,0.144 0.043,0.253 0.129,0.332 0.09,0.078 0.215,0.121 0.375,0.121 0.16,0 0.282,-0.043 0.371,-0.121 0.09,-0.079 0.137,-0.188 0.137,-0.332 0,-0.141 -0.047,-0.25 -0.137,-0.329 -0.089,-0.082 -0.211,-0.121 -0.371,-0.121 -0.16,0 -0.285,0.039 -0.375,0.121 -0.086,0.079 -0.129,0.188 -0.129,0.329 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath385)"
+             id="path916" />
+          <path
+             d="m 209.746,118.336 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.441 0.262,-0.809 0,-0.367 -0.086,-0.636 -0.262,-0.804 -0.175,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.114 1.168,0.332 0.246,0.223 0.371,0.567 0.371,1.035 0,0.469 -0.125,0.817 -0.375,1.036 -0.246,0.222 -0.637,0.332 -1.164,0.332 h -0.758 z m 2.348,2.68 v -0.34 c 0.093,0.047 0.187,0.078 0.281,0.102 0.097,0.023 0.191,0.035 0.281,0.035 0.246,0 0.43,-0.082 0.559,-0.246 0.129,-0.164 0.203,-0.414 0.222,-0.746 -0.07,0.101 -0.16,0.183 -0.269,0.238 -0.11,0.058 -0.231,0.086 -0.36,0.086 -0.273,0 -0.492,-0.082 -0.652,-0.246 -0.156,-0.168 -0.238,-0.395 -0.238,-0.68 0,-0.281 0.082,-0.508 0.25,-0.676 0.164,-0.168 0.387,-0.254 0.664,-0.254 0.316,0 0.555,0.121 0.723,0.364 0.167,0.242 0.25,0.593 0.25,1.054 0,0.43 -0.102,0.774 -0.309,1.032 -0.203,0.257 -0.477,0.386 -0.824,0.386 -0.09,0 -0.184,-0.011 -0.282,-0.027 -0.093,-0.02 -0.195,-0.047 -0.296,-0.082 z m 0.738,-1.16 c 0.164,0 0.297,-0.059 0.39,-0.172 0.098,-0.113 0.149,-0.27 0.149,-0.465 0,-0.195 -0.051,-0.352 -0.149,-0.465 -0.093,-0.117 -0.226,-0.172 -0.39,-0.172 -0.168,0 -0.301,0.055 -0.399,0.172 -0.093,0.113 -0.144,0.27 -0.144,0.465 0,0.195 0.051,0.352 0.144,0.465 0.098,0.113 0.231,0.172 0.399,0.172 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath386)"
+             id="path917" />
+          <path
+             d="m 209.746,114.086 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.258 0.176,-0.168 0.262,-0.437 0.262,-0.808 0,-0.364 -0.086,-0.633 -0.262,-0.801 -0.175,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.032 0,0.472 -0.125,0.816 -0.375,1.039 -0.246,0.222 -0.637,0.332 -1.164,0.332 h -0.758 z m 2.402,2.422 h 0.602 v -2.086 l -0.656,0.133 v -0.336 l 0.656,-0.133 h 0.367 v 2.422 h 0.605 v 0.313 h -1.574 z m 2.629,-2.176 c -0.191,0 -0.336,0.094 -0.433,0.282 -0.094,0.187 -0.141,0.468 -0.141,0.843 0,0.375 0.047,0.657 0.141,0.844 0.097,0.188 0.242,0.277 0.433,0.277 0.192,0 0.332,-0.089 0.43,-0.277 0.094,-0.187 0.144,-0.469 0.144,-0.844 0,-0.375 -0.05,-0.656 -0.144,-0.843 -0.098,-0.188 -0.238,-0.282 -0.43,-0.282 z m 0,-0.293 c 0.305,0 0.539,0.121 0.699,0.364 0.164,0.242 0.243,0.593 0.243,1.054 0,0.457 -0.079,0.809 -0.243,1.055 -0.16,0.238 -0.394,0.359 -0.699,0.359 -0.308,0 -0.543,-0.121 -0.703,-0.359 -0.164,-0.246 -0.242,-0.598 -0.242,-1.055 0,-0.461 0.078,-0.812 0.242,-1.054 0.16,-0.243 0.395,-0.364 0.703,-0.364 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath387)"
+             id="path918" />
+          <path
+             d="m 209.746,109.836 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.258 0.176,-0.172 0.262,-0.441 0.262,-0.808 0,-0.368 -0.086,-0.633 -0.262,-0.805 -0.175,-0.168 -0.453,-0.254 -0.828,-0.254 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.032 0,0.472 -0.125,0.816 -0.375,1.039 -0.246,0.218 -0.637,0.332 -1.164,0.332 h -0.758 z m 2.402,2.422 h 0.602 v -2.086 L 211.727,110 v -0.336 l 0.656,-0.133 h 0.367 v 2.422 h 0.605 v 0.313 h -1.574 z m 1.899,0 h 0.605 v -2.086 L 213.629,110 v -0.336 l 0.652,-0.133 h 0.371 v 2.422 h 0.606 v 0.313 h -1.578 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath388)"
+             id="path919" />
+          <path
+             d="m 209.746,105.586 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.258 0.176,-0.172 0.262,-0.441 0.262,-0.808 0,-0.368 -0.086,-0.633 -0.262,-0.805 -0.175,-0.172 -0.453,-0.254 -0.828,-0.254 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.032 0,0.468 -0.125,0.816 -0.375,1.039 -0.246,0.218 -0.637,0.328 -1.164,0.328 h -0.758 z m 2.402,2.422 h 0.602 v -2.086 l -0.656,0.133 v -0.34 l 0.656,-0.129 h 0.367 v 2.422 h 0.605 v 0.309 h -1.574 z m 2.157,0 h 1.289 v 0.309 h -1.735 v -0.309 c 0.141,-0.148 0.332,-0.34 0.57,-0.586 0.247,-0.246 0.399,-0.402 0.461,-0.472 0.118,-0.133 0.2,-0.247 0.247,-0.336 0.046,-0.094 0.07,-0.184 0.07,-0.274 0,-0.144 -0.051,-0.265 -0.152,-0.355 -0.102,-0.094 -0.235,-0.137 -0.399,-0.137 -0.117,0 -0.238,0.019 -0.367,0.059 -0.129,0.043 -0.266,0.101 -0.414,0.183 v -0.375 c 0.152,-0.058 0.289,-0.101 0.418,-0.133 0.129,-0.031 0.25,-0.047 0.355,-0.047 0.285,0 0.508,0.071 0.68,0.211 0.168,0.145 0.25,0.332 0.25,0.571 0,0.109 -0.02,0.218 -0.063,0.32 -0.043,0.098 -0.117,0.219 -0.23,0.356 -0.027,0.035 -0.125,0.136 -0.289,0.304 -0.164,0.168 -0.395,0.406 -0.691,0.711 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath389)"
+             id="path920" />
+          <path
+             d="m 209.746,101.332 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.441 0.262,-0.808 0,-0.368 -0.086,-0.637 -0.262,-0.805 -0.175,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.114 1.168,0.332 0.246,0.223 0.371,0.567 0.371,1.036 0,0.468 -0.125,0.816 -0.375,1.035 -0.246,0.222 -0.637,0.332 -1.164,0.332 h -0.758 z m 2.402,2.422 h 0.602 v -2.082 l -0.656,0.129 v -0.336 l 0.656,-0.133 h 0.367 v 2.422 h 0.605 v 0.313 h -1.574 z m 2.957,-1.16 c 0.176,0.039 0.317,0.117 0.414,0.234 0.098,0.122 0.149,0.27 0.149,0.446 0,0.269 -0.09,0.476 -0.278,0.625 -0.183,0.148 -0.449,0.222 -0.789,0.222 -0.117,0 -0.234,-0.011 -0.355,-0.035 -0.121,-0.023 -0.246,-0.054 -0.375,-0.101 v -0.356 c 0.101,0.059 0.215,0.102 0.336,0.133 0.121,0.031 0.25,0.047 0.383,0.047 0.23,0 0.406,-0.047 0.527,-0.137 0.121,-0.094 0.184,-0.226 0.184,-0.398 0,-0.164 -0.055,-0.289 -0.172,-0.379 -0.11,-0.09 -0.266,-0.137 -0.469,-0.137 h -0.32 v -0.305 h 0.336 c 0.179,0 0.32,-0.035 0.418,-0.105 0.093,-0.074 0.144,-0.18 0.144,-0.316 0,-0.141 -0.051,-0.247 -0.152,-0.321 -0.098,-0.078 -0.239,-0.117 -0.426,-0.117 -0.102,0 -0.211,0.012 -0.324,0.035 -0.117,0.024 -0.246,0.055 -0.383,0.102 v -0.328 c 0.141,-0.039 0.269,-0.071 0.391,-0.09 0.125,-0.02 0.242,-0.028 0.347,-0.028 0.281,0 0.504,0.063 0.668,0.192 0.164,0.125 0.246,0.301 0.246,0.516 0,0.152 -0.043,0.281 -0.129,0.386 -0.089,0.102 -0.211,0.176 -0.371,0.215 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath390)"
+             id="path921" />
+          <path
+             d="m 211.242,99.121 v -0.734 h -0.605 v -0.305 h 0.972 v 1.176 c -0.144,0.101 -0.3,0.176 -0.472,0.23 -0.172,0.051 -0.356,0.074 -0.551,0.074 -0.43,0 -0.762,-0.121 -1.004,-0.371 -0.242,-0.25 -0.363,-0.597 -0.363,-1.043 0,-0.449 0.121,-0.796 0.363,-1.043 0.242,-0.25 0.574,-0.375 1.004,-0.375 0.176,0 0.344,0.02 0.504,0.063 0.164,0.047 0.312,0.109 0.445,0.195 v 0.395 c -0.137,-0.117 -0.281,-0.203 -0.433,-0.262 -0.157,-0.059 -0.317,-0.09 -0.489,-0.09 -0.332,0 -0.582,0.094 -0.754,0.281 -0.164,0.188 -0.25,0.465 -0.25,0.836 0,0.368 0.086,0.645 0.25,0.832 0.172,0.188 0.422,0.282 0.754,0.282 0.133,0 0.25,-0.012 0.352,-0.035 0.101,-0.024 0.195,-0.059 0.277,-0.106 z m 0.5,-2.344 h 0.5 l 1.211,2.285 v -2.285 h 0.359 v 2.735 h -0.5 l -1.21,-2.285 v 2.285 h -0.36 z m 2.793,0.305 v 2.125 h 0.445 c 0.375,0 0.653,-0.086 0.829,-0.258 0.175,-0.168 0.261,-0.437 0.261,-0.808 0,-0.364 -0.086,-0.633 -0.261,-0.801 -0.176,-0.172 -0.454,-0.258 -0.829,-0.258 z m -0.371,-0.305 h 0.758 c 0.531,0 0.918,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.032 0,0.472 -0.125,0.816 -0.375,1.039 -0.246,0.222 -0.637,0.332 -1.164,0.332 h -0.758 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath391)"
+             id="path922" />
+          <path
+             d="m 210.293,92.891 -0.504,1.359 h 1.004 z m -0.211,-0.364 h 0.418 l 1.043,2.735 h -0.383 l -0.25,-0.703 h -1.23 l -0.25,0.703 h -0.391 z m 2.008,2.735 -1.043,-2.735 h 0.387 l 0.863,2.301 0.867,-2.301 h 0.387 l -1.043,2.735 z m 1.789,-2.43 v 2.125 h 0.449 c 0.375,0 0.652,-0.086 0.828,-0.258 0.172,-0.172 0.262,-0.441 0.262,-0.808 0,-0.368 -0.09,-0.633 -0.262,-0.805 -0.176,-0.168 -0.453,-0.254 -0.828,-0.254 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.032 0,0.472 -0.125,0.816 -0.375,1.039 -0.25,0.218 -0.637,0.332 -1.164,0.332 h -0.758 z m 2.676,0.305 v 2.125 h 0.445 c 0.379,0 0.652,-0.086 0.828,-0.258 0.176,-0.172 0.262,-0.441 0.262,-0.808 0,-0.368 -0.086,-0.633 -0.262,-0.805 -0.176,-0.168 -0.449,-0.254 -0.828,-0.254 z m -0.372,-0.305 h 0.758 c 0.531,0 0.922,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.032 0,0.472 -0.125,0.816 -0.371,1.039 -0.25,0.218 -0.64,0.332 -1.168,0.332 h -0.758 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath392)"
+             id="path923" />
+          <path
+             d="m 209.746,88.582 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.258 0.176,-0.172 0.262,-0.441 0.262,-0.808 0,-0.368 -0.086,-0.633 -0.262,-0.805 -0.175,-0.168 -0.453,-0.254 -0.828,-0.254 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.032 0,0.472 -0.125,0.816 -0.375,1.039 -0.246,0.218 -0.637,0.332 -1.164,0.332 h -0.758 z m 2.402,2.422 h 0.602 v -2.086 l -0.656,0.133 V 88.41 l 0.656,-0.133 h 0.367 v 2.422 h 0.605 v 0.313 h -1.574 z m 2.852,-2.101 -0.934,1.461 h 0.934 z m -0.098,-0.321 H 215 v 1.782 h 0.391 v 0.308 H 215 v 0.645 h -0.367 v -0.645 h -1.235 v -0.359 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath393)"
+             id="path924" />
+          <path
+             d="m 209.746,84.328 v 2.125 h 0.449 c 0.375,0 0.653,-0.082 0.828,-0.254 0.176,-0.172 0.262,-0.441 0.262,-0.808 0,-0.368 -0.086,-0.637 -0.262,-0.805 -0.175,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.367,-0.301 h 0.758 c 0.531,0 0.918,0.11 1.168,0.328 0.246,0.223 0.371,0.567 0.371,1.036 0,0.468 -0.125,0.816 -0.375,1.035 -0.246,0.222 -0.637,0.332 -1.164,0.332 h -0.758 z m 2.402,2.422 h 0.602 v -2.086 l -0.656,0.133 v -0.34 l 0.656,-0.129 h 0.367 v 2.422 h 0.605 v 0.309 h -1.574 z m 1.84,-2.422 h 1.453 v 0.309 h -1.113 v 0.672 c 0.051,-0.02 0.105,-0.031 0.16,-0.039 0.055,-0.012 0.106,-0.016 0.16,-0.016 0.305,0 0.547,0.082 0.727,0.25 0.176,0.168 0.265,0.395 0.265,0.68 0,0.293 -0.089,0.523 -0.273,0.687 -0.184,0.16 -0.441,0.242 -0.773,0.242 -0.118,0 -0.235,-0.011 -0.352,-0.031 -0.121,-0.019 -0.242,-0.047 -0.371,-0.086 v -0.371 c 0.113,0.059 0.226,0.102 0.344,0.133 0.117,0.027 0.238,0.043 0.371,0.043 0.211,0 0.379,-0.055 0.5,-0.164 0.125,-0.113 0.187,-0.262 0.187,-0.453 0,-0.192 -0.062,-0.344 -0.187,-0.453 -0.121,-0.11 -0.289,-0.168 -0.5,-0.168 -0.102,0 -0.199,0.011 -0.297,0.035 -0.098,0.019 -0.199,0.055 -0.301,0.101 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath394)"
+             id="path925" />
+          <path
+             d="m 209.746,158.715 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.258 0.176,-0.168 0.262,-0.437 0.262,-0.809 0,-0.367 -0.086,-0.632 -0.262,-0.804 -0.175,-0.168 -0.453,-0.254 -0.828,-0.254 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.473 -0.125,0.817 -0.375,1.039 -0.246,0.219 -0.637,0.333 -1.164,0.333 h -0.758 z m 3.129,0.242 c -0.192,0 -0.336,0.094 -0.43,0.286 -0.098,0.183 -0.144,0.464 -0.144,0.843 0,0.375 0.046,0.657 0.144,0.844 0.094,0.184 0.238,0.277 0.43,0.277 0.191,0 0.336,-0.093 0.43,-0.277 0.097,-0.187 0.144,-0.469 0.144,-0.844 0,-0.379 -0.047,-0.66 -0.144,-0.843 -0.094,-0.192 -0.239,-0.286 -0.43,-0.286 z m 0,-0.293 c 0.304,0 0.539,0.125 0.699,0.368 0.164,0.242 0.246,0.593 0.246,1.054 0,0.457 -0.082,0.809 -0.246,1.055 -0.16,0.238 -0.395,0.359 -0.699,0.359 -0.309,0 -0.543,-0.121 -0.703,-0.359 -0.16,-0.246 -0.243,-0.598 -0.243,-1.055 0,-0.461 0.083,-0.812 0.243,-1.054 0.16,-0.243 0.394,-0.368 0.703,-0.368 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath395)"
+             id="path926" />
+          <path
+             d="m 209.746,154.465 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.258 0.176,-0.172 0.262,-0.441 0.262,-0.809 0,-0.367 -0.086,-0.632 -0.262,-0.804 -0.175,-0.172 -0.453,-0.254 -0.828,-0.254 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.473 -0.125,0.817 -0.375,1.039 -0.246,0.219 -0.637,0.329 -1.164,0.329 h -0.758 z m 2.402,2.422 h 0.602 v -2.086 l -0.656,0.133 v -0.336 l 0.656,-0.133 h 0.367 v 2.422 h 0.605 v 0.309 h -1.574 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath396)"
+             id="path927" />
+          <path
+             d="m 209.746,150.211 v 2.125 h 0.449 c 0.375,0 0.653,-0.082 0.828,-0.254 0.176,-0.172 0.262,-0.441 0.262,-0.809 0,-0.367 -0.086,-0.636 -0.262,-0.804 -0.175,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.367,-0.301 h 0.758 c 0.531,0 0.918,0.11 1.168,0.328 0.246,0.223 0.371,0.567 0.371,1.035 0,0.469 -0.125,0.817 -0.375,1.036 -0.246,0.222 -0.637,0.332 -1.164,0.332 h -0.758 z m 2.656,2.422 h 1.289 v 0.309 h -1.734 v -0.309 c 0.14,-0.148 0.332,-0.34 0.574,-0.586 0.242,-0.246 0.395,-0.402 0.457,-0.473 0.117,-0.132 0.199,-0.246 0.246,-0.339 0.047,-0.09 0.074,-0.184 0.074,-0.27 0,-0.148 -0.054,-0.266 -0.156,-0.355 -0.101,-0.094 -0.234,-0.137 -0.398,-0.137 -0.114,0 -0.239,0.019 -0.367,0.058 -0.129,0.04 -0.266,0.102 -0.411,0.184 v -0.375 c 0.149,-0.059 0.289,-0.105 0.418,-0.133 0.129,-0.031 0.246,-0.047 0.356,-0.047 0.281,0 0.508,0.071 0.676,0.211 0.168,0.145 0.253,0.332 0.253,0.571 0,0.109 -0.023,0.218 -0.066,0.32 -0.039,0.098 -0.117,0.215 -0.226,0.351 -0.032,0.04 -0.129,0.141 -0.293,0.309 -0.165,0.168 -0.395,0.406 -0.692,0.711 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath397)"
+             id="path928" />
+          <path
+             d="m 209.746,145.961 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.441 0.262,-0.812 0,-0.364 -0.086,-0.633 -0.262,-0.801 -0.175,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.114 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.032 0,0.472 -0.125,0.82 -0.375,1.039 -0.246,0.222 -0.637,0.332 -1.164,0.332 h -0.758 z m 3.457,1.262 c 0.18,0.035 0.316,0.117 0.414,0.234 0.102,0.121 0.152,0.27 0.152,0.446 0,0.269 -0.093,0.476 -0.281,0.625 -0.183,0.148 -0.449,0.222 -0.789,0.222 -0.113,0 -0.234,-0.011 -0.355,-0.035 -0.122,-0.023 -0.247,-0.058 -0.375,-0.101 v -0.36 c 0.101,0.063 0.214,0.106 0.336,0.137 0.121,0.031 0.25,0.047 0.382,0.047 0.231,0 0.41,-0.047 0.532,-0.137 0.121,-0.094 0.179,-0.226 0.179,-0.398 0,-0.164 -0.054,-0.289 -0.168,-0.379 -0.113,-0.09 -0.269,-0.137 -0.472,-0.137 h -0.317 v -0.305 h 0.332 c 0.184,0 0.321,-0.035 0.418,-0.109 0.098,-0.07 0.145,-0.176 0.145,-0.313 0,-0.14 -0.051,-0.25 -0.149,-0.324 -0.101,-0.074 -0.242,-0.113 -0.429,-0.113 -0.102,0 -0.207,0.012 -0.325,0.035 -0.117,0.02 -0.242,0.055 -0.382,0.102 v -0.328 c 0.14,-0.039 0.273,-0.071 0.394,-0.09 0.121,-0.02 0.238,-0.028 0.348,-0.028 0.281,0 0.504,0.063 0.664,0.192 0.164,0.125 0.246,0.297 0.246,0.515 0,0.153 -0.043,0.282 -0.129,0.383 -0.086,0.106 -0.211,0.176 -0.371,0.219 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath398)"
+             id="path929" />
+          <path
+             d="m 209.746,141.711 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.258 0.176,-0.168 0.262,-0.437 0.262,-0.808 0,-0.368 -0.086,-0.633 -0.262,-0.805 -0.175,-0.168 -0.453,-0.254 -0.828,-0.254 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.032 0,0.472 -0.125,0.816 -0.375,1.039 -0.246,0.218 -0.637,0.332 -1.164,0.332 h -0.758 z m 3.355,0.324 -0.933,1.458 h 0.933 z m -0.097,-0.324 h 0.465 v 1.782 h 0.39 v 0.308 h -0.39 v 0.645 h -0.368 v -0.645 H 211.5 v -0.359 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath399)"
+             id="path930" />
+          <path
+             d="m 209.746,137.461 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.258 0.176,-0.172 0.262,-0.441 0.262,-0.808 0,-0.368 -0.086,-0.633 -0.262,-0.805 -0.175,-0.172 -0.453,-0.254 -0.828,-0.254 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.032 0,0.472 -0.125,0.816 -0.375,1.039 -0.246,0.218 -0.637,0.328 -1.164,0.328 h -0.758 z m 2.34,0 h 1.453 v 0.313 h -1.113 v 0.668 c 0.054,-0.02 0.109,-0.032 0.16,-0.039 0.054,-0.012 0.109,-0.016 0.164,-0.016 0.305,0 0.547,0.082 0.722,0.25 0.18,0.168 0.27,0.395 0.27,0.68 0,0.293 -0.094,0.523 -0.277,0.687 -0.184,0.16 -0.442,0.242 -0.774,0.242 -0.113,0 -0.23,-0.007 -0.351,-0.027 -0.118,-0.019 -0.243,-0.051 -0.368,-0.09 v -0.371 c 0.11,0.059 0.223,0.106 0.34,0.133 0.117,0.031 0.243,0.043 0.371,0.043 0.211,0 0.379,-0.055 0.504,-0.164 0.121,-0.113 0.184,-0.262 0.184,-0.453 0,-0.192 -0.063,-0.34 -0.184,-0.453 -0.125,-0.11 -0.293,-0.164 -0.504,-0.164 -0.097,0 -0.195,0.007 -0.296,0.031 -0.098,0.023 -0.196,0.054 -0.301,0.101 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath400)"
+             id="path931" />
+          <path
+             d="m 209.746,133.207 v 2.125 h 0.449 c 0.375,0 0.653,-0.082 0.828,-0.254 0.176,-0.172 0.262,-0.441 0.262,-0.808 0,-0.368 -0.086,-0.637 -0.262,-0.805 -0.175,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.367,-0.301 h 0.758 c 0.531,0 0.918,0.11 1.168,0.328 0.246,0.223 0.371,0.567 0.371,1.036 0,0.468 -0.125,0.816 -0.375,1.035 -0.246,0.222 -0.637,0.332 -1.164,0.332 h -0.758 z m 3.176,1.219 c -0.168,0 -0.301,0.055 -0.399,0.168 -0.094,0.113 -0.144,0.269 -0.144,0.469 0,0.195 0.05,0.351 0.144,0.465 0.098,0.113 0.231,0.171 0.399,0.171 0.164,0 0.297,-0.058 0.39,-0.171 0.098,-0.114 0.149,-0.27 0.149,-0.465 0,-0.2 -0.051,-0.356 -0.149,-0.469 -0.093,-0.113 -0.226,-0.168 -0.39,-0.168 z m 0.734,-1.16 v 0.336 c -0.094,-0.043 -0.187,-0.078 -0.285,-0.098 -0.094,-0.023 -0.188,-0.035 -0.277,-0.035 -0.247,0 -0.434,0.082 -0.563,0.246 -0.129,0.164 -0.199,0.414 -0.219,0.746 0.071,-0.105 0.164,-0.187 0.27,-0.242 0.109,-0.059 0.23,-0.086 0.359,-0.086 0.278,0 0.492,0.082 0.653,0.25 0.16,0.164 0.238,0.391 0.238,0.68 0,0.281 -0.082,0.504 -0.25,0.676 -0.164,0.167 -0.387,0.253 -0.66,0.253 -0.317,0 -0.559,-0.121 -0.727,-0.363 -0.168,-0.242 -0.25,-0.594 -0.25,-1.055 0,-0.429 0.102,-0.777 0.309,-1.031 0.203,-0.258 0.476,-0.387 0.824,-0.387 0.094,0 0.187,0.008 0.281,0.028 0.094,0.019 0.192,0.047 0.297,0.082 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath401)"
+             id="path932" />
+          <path
+             d="m 209.746,128.957 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.441 0.262,-0.812 0,-0.364 -0.086,-0.633 -0.262,-0.801 -0.175,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.114 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.032 0,0.472 -0.125,0.82 -0.375,1.039 -0.246,0.222 -0.637,0.332 -1.164,0.332 h -0.758 z m 2.246,0 h 1.754 v 0.16 l -0.992,2.575 h -0.383 l 0.934,-2.422 h -1.313 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath402)"
+             id="path933" />
+          <path
+             d="m 209.746,197.18 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.258 0.176,-0.168 0.262,-0.438 0.262,-0.809 0,-0.363 -0.086,-0.633 -0.262,-0.8 -0.175,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.113 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.473 -0.125,0.821 -0.375,1.039 -0.246,0.223 -0.637,0.332 -1.164,0.332 h -0.758 z m 3.457,1.262 c 0.18,0.035 0.316,0.117 0.414,0.234 0.102,0.121 0.152,0.27 0.152,0.445 0,0.27 -0.093,0.477 -0.281,0.625 -0.183,0.149 -0.449,0.219 -0.789,0.219 -0.113,0 -0.234,-0.012 -0.355,-0.031 -0.122,-0.024 -0.247,-0.059 -0.375,-0.102 v -0.359 c 0.101,0.062 0.214,0.105 0.336,0.137 0.121,0.031 0.25,0.047 0.382,0.047 0.231,0 0.41,-0.047 0.532,-0.137 0.121,-0.094 0.179,-0.227 0.179,-0.399 0,-0.164 -0.054,-0.289 -0.168,-0.378 -0.113,-0.09 -0.269,-0.137 -0.472,-0.137 h -0.317 v -0.305 h 0.332 c 0.184,0 0.321,-0.035 0.418,-0.109 0.098,-0.071 0.145,-0.176 0.145,-0.313 0,-0.14 -0.051,-0.25 -0.149,-0.324 -0.101,-0.074 -0.242,-0.113 -0.429,-0.113 -0.102,0 -0.207,0.011 -0.325,0.035 -0.117,0.019 -0.242,0.055 -0.382,0.101 v -0.328 c 0.14,-0.039 0.273,-0.07 0.394,-0.09 0.121,-0.019 0.238,-0.027 0.348,-0.027 0.281,0 0.504,0.063 0.664,0.192 0.164,0.125 0.246,0.296 0.246,0.515 0,0.153 -0.043,0.277 -0.129,0.383 -0.086,0.105 -0.211,0.176 -0.371,0.219 z m 0.785,-1.262 h 1.453 v 0.313 h -1.113 v 0.667 c 0.051,-0.015 0.105,-0.031 0.16,-0.039 0.055,-0.007 0.106,-0.015 0.16,-0.015 0.305,0 0.547,0.086 0.727,0.254 0.176,0.164 0.265,0.39 0.265,0.675 0,0.297 -0.089,0.524 -0.273,0.688 -0.184,0.164 -0.441,0.242 -0.773,0.242 -0.118,0 -0.235,-0.008 -0.352,-0.027 -0.121,-0.02 -0.242,-0.051 -0.371,-0.09 v -0.371 c 0.113,0.062 0.226,0.105 0.344,0.137 0.117,0.027 0.238,0.043 0.371,0.043 0.211,0 0.379,-0.055 0.5,-0.168 0.125,-0.11 0.187,-0.262 0.187,-0.454 0,-0.187 -0.062,-0.339 -0.187,-0.449 -0.121,-0.113 -0.289,-0.168 -0.5,-0.168 -0.102,0 -0.199,0.012 -0.297,0.032 -0.098,0.023 -0.199,0.058 -0.301,0.105 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath403)"
+             id="path934" />
+          <path
+             d="m 209.746,192.93 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.258 0.176,-0.168 0.262,-0.442 0.262,-0.809 0,-0.367 -0.086,-0.633 -0.262,-0.804 -0.175,-0.168 -0.453,-0.254 -0.828,-0.254 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.473 -0.125,0.817 -0.375,1.039 -0.246,0.219 -0.637,0.332 -1.164,0.332 h -0.758 z m 3.457,1.258 c 0.18,0.039 0.316,0.117 0.414,0.238 0.102,0.117 0.152,0.266 0.152,0.441 0,0.27 -0.093,0.481 -0.281,0.629 -0.183,0.145 -0.449,0.219 -0.789,0.219 -0.113,0 -0.234,-0.012 -0.355,-0.035 -0.122,-0.02 -0.247,-0.055 -0.375,-0.098 v -0.359 c 0.101,0.059 0.214,0.105 0.336,0.137 0.121,0.031 0.25,0.047 0.382,0.047 0.231,0 0.41,-0.047 0.532,-0.141 0.121,-0.09 0.179,-0.223 0.179,-0.399 0,-0.16 -0.054,-0.285 -0.168,-0.374 -0.113,-0.094 -0.269,-0.137 -0.472,-0.137 h -0.317 v -0.305 h 0.332 c 0.184,0 0.321,-0.035 0.418,-0.109 0.098,-0.075 0.145,-0.176 0.145,-0.313 0,-0.14 -0.051,-0.25 -0.149,-0.324 -0.101,-0.074 -0.242,-0.113 -0.429,-0.113 -0.102,0 -0.207,0.011 -0.325,0.031 -0.117,0.023 -0.242,0.059 -0.382,0.105 v -0.332 c 0.14,-0.039 0.273,-0.066 0.394,-0.086 0.121,-0.019 0.238,-0.031 0.348,-0.031 0.281,0 0.504,0.067 0.664,0.196 0.164,0.125 0.246,0.296 0.246,0.515 0,0.149 -0.043,0.277 -0.129,0.383 -0.086,0.105 -0.211,0.176 -0.371,0.215 z m 1.617,-0.039 c -0.164,0 -0.297,0.058 -0.394,0.172 -0.098,0.113 -0.145,0.269 -0.145,0.464 0,0.196 0.047,0.352 0.145,0.469 0.097,0.113 0.23,0.168 0.394,0.168 0.168,0 0.297,-0.055 0.395,-0.168 0.097,-0.117 0.148,-0.273 0.148,-0.469 0,-0.195 -0.051,-0.351 -0.148,-0.464 -0.098,-0.114 -0.227,-0.172 -0.395,-0.172 z m 0.735,-1.16 v 0.339 c -0.094,-0.046 -0.188,-0.078 -0.282,-0.101 -0.094,-0.024 -0.187,-0.035 -0.281,-0.035 -0.242,0 -0.43,0.082 -0.559,0.246 -0.128,0.164 -0.203,0.414 -0.218,0.746 0.07,-0.106 0.16,-0.184 0.269,-0.242 0.11,-0.059 0.227,-0.086 0.36,-0.086 0.273,0 0.492,0.086 0.648,0.25 0.16,0.168 0.242,0.394 0.242,0.679 0,0.282 -0.086,0.508 -0.25,0.676 -0.168,0.172 -0.387,0.254 -0.664,0.254 -0.316,0 -0.558,-0.121 -0.723,-0.363 -0.168,-0.242 -0.253,-0.594 -0.253,-1.051 0,-0.434 0.105,-0.777 0.308,-1.035 0.207,-0.258 0.481,-0.387 0.828,-0.387 0.09,0 0.184,0.012 0.278,0.028 0.097,0.019 0.195,0.046 0.297,0.082 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath404)"
+             id="path935" />
+          <path
+             d="m 209.746,188.68 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.258 0.176,-0.172 0.262,-0.442 0.262,-0.809 0,-0.367 -0.086,-0.633 -0.262,-0.804 -0.175,-0.172 -0.453,-0.254 -0.828,-0.254 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.469 -0.125,0.817 -0.375,1.039 -0.246,0.219 -0.637,0.328 -1.164,0.328 h -0.758 z m 3.457,1.258 c 0.18,0.039 0.316,0.117 0.414,0.238 0.102,0.117 0.152,0.266 0.152,0.441 0,0.27 -0.093,0.477 -0.281,0.626 -0.183,0.148 -0.449,0.222 -0.789,0.222 -0.113,0 -0.234,-0.012 -0.355,-0.035 -0.122,-0.023 -0.247,-0.055 -0.375,-0.102 v -0.355 c 0.101,0.059 0.214,0.105 0.336,0.137 0.121,0.027 0.25,0.043 0.382,0.043 0.231,0 0.41,-0.043 0.532,-0.137 0.121,-0.09 0.179,-0.223 0.179,-0.399 0,-0.16 -0.054,-0.285 -0.168,-0.378 -0.113,-0.09 -0.269,-0.137 -0.472,-0.137 h -0.317 v -0.301 h 0.332 c 0.184,0 0.321,-0.039 0.418,-0.109 0.098,-0.075 0.145,-0.18 0.145,-0.317 0,-0.14 -0.051,-0.246 -0.149,-0.32 -0.101,-0.078 -0.242,-0.113 -0.429,-0.113 -0.102,0 -0.207,0.011 -0.325,0.031 -0.117,0.023 -0.242,0.059 -0.382,0.102 v -0.329 c 0.14,-0.039 0.273,-0.066 0.394,-0.086 0.121,-0.019 0.238,-0.031 0.348,-0.031 0.281,0 0.504,0.067 0.664,0.192 0.164,0.129 0.246,0.3 0.246,0.515 0,0.153 -0.043,0.281 -0.129,0.387 -0.086,0.102 -0.211,0.176 -0.371,0.215 z m 0.687,-1.258 h 1.758 v 0.156 l -0.992,2.574 h -0.387 l 0.934,-2.421 h -1.313 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath405)"
+             id="path936" />
+          <path
+             d="m 209.746,184.426 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.442 0.262,-0.809 0,-0.367 -0.086,-0.636 -0.262,-0.804 -0.175,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.367,-0.301 h 0.758 c 0.531,0 0.918,0.109 1.168,0.328 0.246,0.223 0.371,0.567 0.371,1.035 0,0.469 -0.125,0.817 -0.375,1.035 -0.246,0.223 -0.637,0.332 -1.164,0.332 h -0.758 z m 3.457,1.258 c 0.18,0.039 0.316,0.117 0.414,0.234 0.102,0.121 0.152,0.27 0.152,0.445 0,0.27 -0.093,0.477 -0.281,0.626 -0.183,0.148 -0.449,0.222 -0.789,0.222 -0.113,0 -0.234,-0.012 -0.355,-0.035 -0.122,-0.023 -0.247,-0.055 -0.375,-0.102 v -0.355 c 0.101,0.059 0.214,0.105 0.336,0.133 0.121,0.031 0.25,0.047 0.382,0.047 0.231,0 0.41,-0.047 0.532,-0.137 0.121,-0.094 0.179,-0.227 0.179,-0.399 0,-0.16 -0.054,-0.289 -0.168,-0.378 -0.113,-0.09 -0.269,-0.137 -0.472,-0.137 h -0.317 v -0.305 h 0.332 c 0.184,0 0.321,-0.035 0.418,-0.105 0.098,-0.075 0.145,-0.18 0.145,-0.317 0,-0.14 -0.051,-0.246 -0.149,-0.32 -0.101,-0.078 -0.242,-0.113 -0.429,-0.113 -0.102,0 -0.207,0.008 -0.325,0.031 -0.117,0.023 -0.242,0.055 -0.382,0.102 v -0.329 c 0.14,-0.039 0.273,-0.07 0.394,-0.089 0.121,-0.02 0.238,-0.028 0.348,-0.028 0.281,0 0.504,0.063 0.664,0.192 0.164,0.129 0.246,0.3 0.246,0.515 0,0.153 -0.043,0.281 -0.129,0.387 -0.086,0.102 -0.211,0.176 -0.371,0.215 z m 1.574,0.176 c -0.176,0 -0.316,0.046 -0.418,0.14 -0.097,0.094 -0.148,0.223 -0.148,0.387 0,0.164 0.051,0.297 0.148,0.391 0.102,0.093 0.242,0.14 0.418,0.14 0.176,0 0.313,-0.047 0.414,-0.14 0.102,-0.098 0.153,-0.227 0.153,-0.391 0,-0.164 -0.051,-0.293 -0.153,-0.387 -0.101,-0.094 -0.238,-0.14 -0.414,-0.14 z m -0.371,-0.157 c -0.16,-0.039 -0.281,-0.113 -0.371,-0.222 -0.09,-0.11 -0.133,-0.242 -0.133,-0.399 0,-0.219 0.078,-0.39 0.231,-0.515 0.156,-0.129 0.371,-0.192 0.644,-0.192 0.27,0 0.485,0.063 0.641,0.192 0.152,0.125 0.23,0.296 0.23,0.515 0,0.157 -0.043,0.289 -0.133,0.399 -0.089,0.109 -0.21,0.183 -0.367,0.222 0.176,0.039 0.317,0.121 0.414,0.243 0.102,0.121 0.153,0.269 0.153,0.441 0,0.266 -0.082,0.469 -0.246,0.609 -0.161,0.145 -0.391,0.215 -0.692,0.215 -0.305,0 -0.535,-0.07 -0.699,-0.215 -0.16,-0.14 -0.238,-0.343 -0.238,-0.609 0,-0.172 0.047,-0.32 0.148,-0.441 0.102,-0.122 0.238,-0.204 0.418,-0.243 z m -0.137,-0.586 c 0,0.141 0.043,0.254 0.133,0.332 0.09,0.079 0.215,0.118 0.375,0.118 0.156,0 0.281,-0.039 0.371,-0.118 0.09,-0.078 0.133,-0.191 0.133,-0.332 0,-0.14 -0.043,-0.25 -0.133,-0.332 -0.09,-0.078 -0.215,-0.117 -0.371,-0.117 -0.16,0 -0.285,0.039 -0.375,0.117 -0.09,0.082 -0.133,0.192 -0.133,0.332 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath406)"
+             id="path937" />
+          <path
+             d="m 209.746,180.176 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.258 0.176,-0.168 0.262,-0.438 0.262,-0.809 0,-0.363 -0.086,-0.632 -0.262,-0.8 -0.175,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.113 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.473 -0.125,0.821 -0.375,1.039 -0.246,0.223 -0.637,0.332 -1.164,0.332 h -0.758 z m 3.457,1.262 c 0.18,0.035 0.316,0.117 0.414,0.234 0.102,0.121 0.152,0.27 0.152,0.445 0,0.27 -0.093,0.477 -0.281,0.626 -0.183,0.148 -0.449,0.218 -0.789,0.218 -0.113,0 -0.234,-0.008 -0.355,-0.031 -0.122,-0.023 -0.247,-0.059 -0.375,-0.102 v -0.359 c 0.101,0.063 0.214,0.106 0.336,0.137 0.121,0.031 0.25,0.047 0.382,0.047 0.231,0 0.41,-0.047 0.532,-0.137 0.121,-0.094 0.179,-0.227 0.179,-0.399 0,-0.164 -0.054,-0.289 -0.168,-0.378 -0.113,-0.09 -0.269,-0.137 -0.472,-0.137 h -0.317 v -0.305 h 0.332 c 0.184,0 0.321,-0.035 0.418,-0.109 0.098,-0.071 0.145,-0.176 0.145,-0.313 0,-0.14 -0.051,-0.25 -0.149,-0.324 -0.101,-0.074 -0.242,-0.113 -0.429,-0.113 -0.102,0 -0.207,0.012 -0.325,0.035 -0.117,0.02 -0.242,0.055 -0.382,0.102 v -0.329 c 0.14,-0.039 0.273,-0.07 0.394,-0.089 0.121,-0.02 0.238,-0.028 0.348,-0.028 0.281,0 0.504,0.063 0.664,0.192 0.164,0.125 0.246,0.296 0.246,0.515 0,0.153 -0.043,0.281 -0.129,0.383 -0.086,0.106 -0.211,0.176 -0.371,0.219 z m 0.793,1.414 v -0.336 c 0.094,0.043 0.187,0.078 0.281,0.101 0.094,0.024 0.188,0.036 0.281,0.036 0.243,0 0.43,-0.082 0.559,-0.246 0.129,-0.164 0.203,-0.414 0.219,-0.75 -0.071,0.105 -0.16,0.187 -0.266,0.242 -0.109,0.058 -0.23,0.086 -0.363,0.086 -0.274,0 -0.488,-0.082 -0.649,-0.246 -0.16,-0.168 -0.238,-0.395 -0.238,-0.68 0,-0.281 0.082,-0.508 0.25,-0.676 0.164,-0.172 0.387,-0.254 0.66,-0.254 0.317,0 0.559,0.121 0.723,0.364 0.168,0.242 0.254,0.593 0.254,1.054 0,0.43 -0.106,0.774 -0.309,1.031 -0.203,0.258 -0.48,0.383 -0.824,0.383 -0.094,0 -0.187,-0.008 -0.281,-0.027 -0.098,-0.016 -0.196,-0.043 -0.297,-0.082 z m 0.734,-1.156 c 0.168,0 0.297,-0.059 0.395,-0.172 0.097,-0.114 0.148,-0.27 0.148,-0.465 0,-0.199 -0.051,-0.352 -0.148,-0.465 -0.098,-0.117 -0.227,-0.172 -0.395,-0.172 -0.164,0 -0.297,0.055 -0.394,0.172 -0.098,0.113 -0.145,0.266 -0.145,0.465 0,0.195 0.047,0.351 0.145,0.465 0.097,0.113 0.23,0.172 0.394,0.172 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath407)"
+             id="path938" />
+          <path
+             d="m 209.746,175.926 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.828,-0.258 0.176,-0.168 0.262,-0.441 0.262,-0.809 0,-0.367 -0.086,-0.632 -0.262,-0.804 -0.175,-0.168 -0.453,-0.254 -0.828,-0.254 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.473 -0.125,0.817 -0.375,1.039 -0.246,0.219 -0.637,0.332 -1.164,0.332 h -0.758 z m 3.355,0.324 -0.933,1.457 h 0.933 z m -0.097,-0.324 h 0.465 v 1.781 h 0.39 v 0.309 h -0.39 v 0.644 h -0.368 v -0.644 H 211.5 v -0.359 z m 1.773,0.242 c -0.191,0 -0.336,0.094 -0.433,0.285 -0.094,0.184 -0.141,0.465 -0.141,0.844 0,0.371 0.047,0.653 0.141,0.844 0.097,0.184 0.242,0.277 0.433,0.277 0.192,0 0.332,-0.093 0.43,-0.277 0.094,-0.191 0.144,-0.473 0.144,-0.844 0,-0.379 -0.05,-0.66 -0.144,-0.844 -0.098,-0.191 -0.238,-0.285 -0.43,-0.285 z m 0,-0.293 c 0.305,0 0.539,0.121 0.699,0.368 0.164,0.238 0.243,0.589 0.243,1.054 0,0.457 -0.079,0.809 -0.243,1.051 -0.16,0.242 -0.394,0.363 -0.699,0.363 -0.308,0 -0.543,-0.121 -0.703,-0.363 -0.164,-0.242 -0.242,-0.594 -0.242,-1.051 0,-0.465 0.078,-0.816 0.242,-1.054 0.16,-0.247 0.395,-0.368 0.703,-0.368 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath408)"
+             id="path939" />
+          <path
+             d="m 211.242,173.715 v -0.735 h -0.605 v -0.304 h 0.972 v 1.172 c -0.144,0.101 -0.3,0.179 -0.472,0.23 -0.172,0.051 -0.356,0.078 -0.551,0.078 -0.43,0 -0.762,-0.125 -1.004,-0.375 -0.242,-0.25 -0.363,-0.597 -0.363,-1.043 0,-0.445 0.121,-0.793 0.363,-1.043 0.242,-0.25 0.574,-0.375 1.004,-0.375 0.176,0 0.344,0.024 0.504,0.067 0.164,0.043 0.312,0.109 0.445,0.195 v 0.391 c -0.137,-0.114 -0.281,-0.203 -0.433,-0.262 -0.157,-0.059 -0.317,-0.086 -0.489,-0.086 -0.332,0 -0.582,0.094 -0.754,0.281 -0.164,0.184 -0.25,0.465 -0.25,0.832 0,0.371 0.086,0.649 0.25,0.832 0.172,0.188 0.422,0.282 0.754,0.282 0.133,0 0.25,-0.012 0.352,-0.032 0.101,-0.023 0.195,-0.058 0.277,-0.105 z m 0.5,-2.344 h 0.5 l 1.211,2.285 v -2.285 h 0.359 v 2.731 h -0.5 l -1.21,-2.286 v 2.286 h -0.36 z m 2.793,0.305 v 2.125 h 0.445 c 0.375,0 0.653,-0.086 0.829,-0.258 0.175,-0.172 0.261,-0.441 0.261,-0.809 0,-0.367 -0.086,-0.632 -0.261,-0.804 -0.176,-0.172 -0.454,-0.254 -0.829,-0.254 z m -0.371,-0.305 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.469 -0.125,0.817 -0.375,1.039 -0.246,0.219 -0.637,0.329 -1.164,0.329 h -0.758 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath409)"
+             id="path940" />
+          <path
+             d="m 209.695,167.422 v 2.125 h 0.446 c 0.379,0 0.652,-0.086 0.828,-0.254 0.176,-0.172 0.265,-0.441 0.265,-0.809 0,-0.367 -0.089,-0.636 -0.265,-0.804 -0.176,-0.172 -0.449,-0.258 -0.828,-0.258 z m -0.371,-0.301 h 0.762 c 0.527,0 0.918,0.109 1.164,0.328 0.25,0.223 0.371,0.567 0.371,1.035 0,0.469 -0.121,0.817 -0.371,1.036 -0.25,0.222 -0.637,0.332 -1.164,0.332 h -0.762 z m 3.356,0.32 -0.934,1.457 h 0.934 z m -0.098,-0.32 h 0.465 v 1.777 h 0.391 v 0.309 h -0.391 v 0.645 h -0.367 v -0.645 h -1.235 v -0.355 z m 1.047,2.418 h 0.605 v -2.082 l -0.66,0.129 v -0.336 l 0.656,-0.129 h 0.368 v 2.418 h 0.605 v 0.313 h -1.574 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath410)"
+             id="path941" />
+          <path
+             d="m 209.695,163.172 v 2.125 h 0.446 c 0.379,0 0.652,-0.086 0.828,-0.258 0.176,-0.168 0.265,-0.437 0.265,-0.809 0,-0.363 -0.089,-0.632 -0.265,-0.8 -0.176,-0.172 -0.449,-0.258 -0.828,-0.258 z m -0.371,-0.305 h 0.762 c 0.527,0 0.918,0.113 1.164,0.332 0.25,0.219 0.371,0.563 0.371,1.031 0,0.473 -0.121,0.821 -0.371,1.04 -0.25,0.222 -0.637,0.332 -1.164,0.332 h -0.762 z m 3.356,0.324 -0.934,1.457 h 0.934 z m -0.098,-0.324 h 0.465 v 1.781 h 0.391 v 0.309 h -0.391 v 0.645 h -0.367 v -0.645 h -1.235 v -0.355 z m 1.301,2.422 h 1.293 v 0.313 h -1.738 v -0.313 c 0.14,-0.144 0.332,-0.34 0.574,-0.582 0.242,-0.246 0.394,-0.406 0.457,-0.477 0.117,-0.132 0.203,-0.242 0.246,-0.335 0.051,-0.094 0.074,-0.184 0.074,-0.274 0,-0.144 -0.051,-0.262 -0.156,-0.355 -0.102,-0.09 -0.231,-0.137 -0.395,-0.137 -0.117,0 -0.238,0.019 -0.371,0.062 -0.125,0.039 -0.265,0.102 -0.41,0.184 V 163 c 0.148,-0.059 0.289,-0.105 0.418,-0.137 0.129,-0.027 0.246,-0.043 0.355,-0.043 0.282,0 0.508,0.071 0.676,0.211 0.168,0.141 0.254,0.332 0.254,0.567 0,0.113 -0.023,0.218 -0.066,0.32 -0.039,0.102 -0.117,0.219 -0.227,0.355 -0.031,0.036 -0.129,0.137 -0.293,0.309 -0.164,0.168 -0.394,0.402 -0.691,0.707 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath411)"
+             id="path942" />
+          <path
+             d="m 68.836,197.176 v 1.027 h 0.465 c 0.172,0 0.304,-0.043 0.398,-0.133 0.094,-0.09 0.141,-0.215 0.141,-0.382 0,-0.161 -0.047,-0.29 -0.141,-0.379 -0.094,-0.086 -0.226,-0.133 -0.398,-0.133 z m -0.371,-0.301 h 0.836 c 0.304,0 0.535,0.066 0.691,0.207 0.16,0.137 0.238,0.34 0.238,0.606 0,0.273 -0.078,0.476 -0.238,0.613 -0.156,0.137 -0.387,0.207 -0.691,0.207 h -0.465 v 1.097 h -0.371 z m 3.801,2.34 v -0.735 h -0.602 v -0.3 h 0.969 v 1.172 c -0.145,0.101 -0.301,0.179 -0.473,0.23 -0.172,0.051 -0.355,0.078 -0.551,0.078 -0.425,0 -0.761,-0.125 -1.004,-0.375 -0.238,-0.25 -0.359,-0.597 -0.359,-1.043 0,-0.445 0.121,-0.793 0.359,-1.043 0.243,-0.25 0.579,-0.375 1.004,-0.375 0.18,0 0.348,0.02 0.508,0.067 0.16,0.043 0.309,0.109 0.445,0.191 v 0.395 c -0.136,-0.118 -0.281,-0.204 -0.437,-0.262 -0.152,-0.059 -0.316,-0.086 -0.484,-0.086 -0.336,0 -0.586,0.094 -0.754,0.277 -0.168,0.188 -0.25,0.465 -0.25,0.836 0,0.367 0.082,0.645 0.25,0.832 0.168,0.188 0.418,0.281 0.754,0.281 0.129,0 0.246,-0.011 0.351,-0.035 0.102,-0.019 0.192,-0.058 0.274,-0.105 z m 1.328,-2.098 c -0.192,0 -0.336,0.094 -0.43,0.281 -0.098,0.188 -0.144,0.469 -0.144,0.844 0,0.375 0.046,0.656 0.144,0.844 0.094,0.187 0.238,0.281 0.43,0.281 0.191,0 0.336,-0.094 0.429,-0.281 0.098,-0.188 0.145,-0.469 0.145,-0.844 0,-0.375 -0.047,-0.656 -0.145,-0.844 -0.093,-0.187 -0.238,-0.281 -0.429,-0.281 z m 0,-0.293 c 0.304,0 0.539,0.121 0.699,0.364 0.164,0.242 0.246,0.593 0.246,1.054 0,0.461 -0.082,0.813 -0.246,1.055 -0.16,0.242 -0.395,0.363 -0.699,0.363 -0.309,0 -0.543,-0.121 -0.703,-0.363 -0.161,-0.242 -0.243,-0.594 -0.243,-1.055 0,-0.461 0.082,-0.812 0.243,-1.054 0.16,-0.243 0.394,-0.364 0.703,-0.364 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath412)"
+             id="path943" />
+          <path
+             d="m 68.887,192.926 v 1.027 h 0.465 c 0.171,0 0.304,-0.043 0.398,-0.133 0.094,-0.09 0.141,-0.218 0.141,-0.382 0,-0.165 -0.047,-0.29 -0.141,-0.379 -0.094,-0.09 -0.227,-0.133 -0.398,-0.133 z m -0.371,-0.305 h 0.836 c 0.304,0 0.539,0.07 0.695,0.211 0.156,0.137 0.234,0.34 0.234,0.606 0,0.269 -0.078,0.472 -0.234,0.613 -0.156,0.137 -0.391,0.207 -0.695,0.207 h -0.465 v 1.097 h -0.371 z m 2.308,0.305 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.825,-0.258 0.175,-0.168 0.265,-0.438 0.265,-0.809 0,-0.363 -0.09,-0.632 -0.265,-0.8 -0.172,-0.172 -0.45,-0.258 -0.825,-0.258 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.113 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.473 -0.125,0.817 -0.375,1.039 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.758 z m 2.402,2.422 h 0.602 v -2.086 l -0.656,0.133 v -0.336 l 0.652,-0.133 h 0.371 v 2.422 h 0.606 v 0.312 h -1.575 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath413)"
+             id="path944" />
+          <path
+             d="m 68.887,188.676 v 1.027 h 0.465 c 0.171,0 0.304,-0.047 0.398,-0.137 0.094,-0.086 0.141,-0.214 0.141,-0.378 0,-0.165 -0.047,-0.29 -0.141,-0.379 -0.094,-0.09 -0.227,-0.133 -0.398,-0.133 z m -0.371,-0.305 h 0.836 c 0.304,0 0.539,0.07 0.695,0.207 0.156,0.141 0.234,0.344 0.234,0.61 0,0.269 -0.078,0.472 -0.234,0.609 -0.156,0.141 -0.391,0.207 -0.695,0.207 h -0.465 v 1.101 h -0.371 z m 2.308,0.305 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.825,-0.258 0.175,-0.172 0.265,-0.441 0.265,-0.809 0,-0.367 -0.09,-0.632 -0.265,-0.804 -0.172,-0.168 -0.45,-0.254 -0.825,-0.254 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.473 -0.125,0.817 -0.375,1.039 -0.25,0.219 -0.637,0.332 -1.164,0.332 h -0.758 z m 3.129,0.242 c -0.191,0 -0.336,0.094 -0.43,0.282 -0.097,0.187 -0.144,0.468 -0.144,0.847 0,0.371 0.047,0.653 0.144,0.844 0.094,0.184 0.239,0.277 0.43,0.277 0.191,0 0.336,-0.093 0.43,-0.277 0.097,-0.191 0.144,-0.473 0.144,-0.844 0,-0.379 -0.047,-0.66 -0.144,-0.847 -0.094,-0.188 -0.239,-0.282 -0.43,-0.282 z m 0,-0.293 c 0.305,0 0.539,0.121 0.699,0.368 0.164,0.238 0.246,0.589 0.246,1.054 0,0.457 -0.082,0.809 -0.246,1.051 -0.16,0.242 -0.394,0.363 -0.699,0.363 -0.309,0 -0.543,-0.121 -0.703,-0.363 -0.16,-0.242 -0.242,-0.594 -0.242,-1.051 0,-0.465 0.082,-0.816 0.242,-1.054 0.16,-0.247 0.394,-0.368 0.703,-0.368 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath414)"
+             id="path945" />
+          <path
+             d="m 69.438,186.465 v -0.735 h -0.606 v -0.304 h 0.969 v 1.172 c -0.141,0.101 -0.301,0.179 -0.473,0.23 -0.172,0.051 -0.355,0.078 -0.551,0.078 -0.425,0 -0.761,-0.125 -1.004,-0.375 -0.238,-0.25 -0.359,-0.597 -0.359,-1.043 0,-0.445 0.121,-0.793 0.359,-1.043 0.243,-0.25 0.579,-0.375 1.004,-0.375 0.18,0 0.348,0.024 0.508,0.067 0.16,0.043 0.309,0.109 0.445,0.195 v 0.391 c -0.136,-0.114 -0.281,-0.203 -0.437,-0.262 -0.152,-0.059 -0.313,-0.086 -0.484,-0.086 -0.332,0 -0.586,0.094 -0.754,0.281 -0.168,0.184 -0.25,0.465 -0.25,0.832 0,0.371 0.082,0.649 0.25,0.832 0.168,0.188 0.422,0.282 0.754,0.282 0.132,0 0.25,-0.012 0.351,-0.032 0.102,-0.023 0.195,-0.058 0.278,-0.105 z m 0.5,-2.344 h 0.496 l 1.214,2.285 v -2.285 h 0.356 v 2.731 h -0.496 l -1.211,-2.286 v 2.286 h -0.359 z m 2.789,0.305 v 2.125 h 0.449 c 0.375,0 0.652,-0.086 0.828,-0.258 0.176,-0.172 0.262,-0.441 0.262,-0.809 0,-0.367 -0.086,-0.632 -0.262,-0.804 -0.176,-0.172 -0.453,-0.254 -0.828,-0.254 z m -0.368,-0.305 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.469 -0.125,0.817 -0.375,1.039 -0.25,0.219 -0.636,0.329 -1.164,0.329 h -0.758 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath415)"
+             id="path946" />
+          <path
+             d="m 69.496,180.172 v 1.027 h 0.469 c 0.172,0 0.305,-0.043 0.398,-0.133 0.094,-0.089 0.141,-0.214 0.141,-0.382 0,-0.161 -0.047,-0.289 -0.141,-0.379 -0.093,-0.086 -0.226,-0.133 -0.398,-0.133 z m -0.367,-0.301 h 0.836 c 0.305,0 0.535,0.067 0.691,0.207 0.156,0.137 0.239,0.34 0.239,0.606 0,0.273 -0.083,0.476 -0.239,0.613 -0.156,0.137 -0.386,0.207 -0.691,0.207 h -0.469 v 1.098 h -0.367 z m 1.937,0 h 1.571 v 0.309 h -1.199 v 0.804 h 1.082 v 0.313 h -1.082 v 1.305 h -0.372 z m 2.547,0.242 c -0.191,0 -0.336,0.094 -0.433,0.282 -0.094,0.187 -0.141,0.468 -0.141,0.843 0,0.375 0.047,0.657 0.141,0.844 0.097,0.188 0.242,0.281 0.433,0.281 0.192,0 0.332,-0.093 0.43,-0.281 0.094,-0.187 0.145,-0.469 0.145,-0.844 0,-0.375 -0.051,-0.656 -0.145,-0.843 -0.098,-0.188 -0.238,-0.282 -0.43,-0.282 z m 0,-0.293 c 0.305,0 0.539,0.121 0.699,0.364 0.165,0.242 0.243,0.593 0.243,1.054 0,0.461 -0.078,0.813 -0.243,1.055 -0.16,0.242 -0.394,0.363 -0.699,0.363 -0.308,0 -0.543,-0.121 -0.703,-0.363 -0.164,-0.242 -0.242,-0.594 -0.242,-1.055 0,-0.461 0.078,-0.812 0.242,-1.054 0.16,-0.243 0.395,-0.364 0.703,-0.364 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath416)"
+             id="path947" />
+          <path
+             d="m 69.473,175.922 v 1.027 h 0.465 c 0.171,0 0.304,-0.043 0.398,-0.133 0.094,-0.089 0.141,-0.218 0.141,-0.382 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.227,-0.133 -0.398,-0.133 z m -0.371,-0.305 h 0.836 c 0.304,0 0.535,0.071 0.691,0.211 0.16,0.137 0.238,0.34 0.238,0.606 0,0.269 -0.078,0.472 -0.238,0.613 -0.156,0.137 -0.387,0.207 -0.691,0.207 h -0.465 v 1.098 h -0.371 z m 1.937,0 h 1.57 v 0.313 H 71.41 v 0.804 h 1.082 v 0.313 H 71.41 v 1.305 h -0.371 z m 1.82,2.422 h 0.602 v -2.086 l -0.656,0.133 v -0.336 l 0.652,-0.133 h 0.371 v 2.422 h 0.606 v 0.313 h -1.575 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath417)"
+             id="path948" />
+          <path
+             d="m 69.473,171.672 v 1.027 h 0.465 c 0.171,0 0.304,-0.047 0.398,-0.137 0.094,-0.085 0.141,-0.214 0.141,-0.378 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.227,-0.133 -0.398,-0.133 z m -0.371,-0.305 h 0.836 c 0.304,0 0.535,0.071 0.691,0.207 0.16,0.141 0.238,0.344 0.238,0.61 0,0.269 -0.078,0.472 -0.238,0.609 -0.156,0.141 -0.387,0.207 -0.691,0.207 h -0.465 v 1.102 h -0.371 z m 1.937,0 h 1.57 v 0.313 H 71.41 v 0.804 h 1.082 v 0.309 H 71.41 v 1.309 h -0.371 z m 2.074,2.422 h 1.289 v 0.313 h -1.734 v -0.313 c 0.141,-0.144 0.332,-0.34 0.574,-0.586 0.242,-0.242 0.395,-0.402 0.457,-0.473 0.117,-0.132 0.199,-0.246 0.246,-0.335 0.047,-0.094 0.071,-0.184 0.071,-0.274 0,-0.144 -0.051,-0.262 -0.153,-0.355 -0.101,-0.09 -0.234,-0.137 -0.398,-0.137 -0.113,0 -0.238,0.019 -0.367,0.059 -0.129,0.042 -0.266,0.101 -0.41,0.183 V 171.5 c 0.148,-0.062 0.285,-0.105 0.417,-0.137 0.129,-0.031 0.247,-0.047 0.352,-0.047 0.285,0 0.512,0.071 0.68,0.215 0.168,0.141 0.254,0.328 0.254,0.567 0,0.113 -0.024,0.218 -0.067,0.32 -0.039,0.102 -0.117,0.219 -0.226,0.355 -0.032,0.036 -0.129,0.137 -0.293,0.309 -0.164,0.168 -0.395,0.402 -0.692,0.707 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath418)"
+             id="path949" />
+          <path
+             d="m 69.395,167.422 v 1.023 h 0.464 c 0.172,0 0.305,-0.043 0.399,-0.133 0.094,-0.089 0.14,-0.214 0.14,-0.378 0,-0.164 -0.046,-0.289 -0.14,-0.379 -0.094,-0.09 -0.227,-0.133 -0.399,-0.133 z m -0.372,-0.305 h 0.836 c 0.305,0 0.536,0.071 0.692,0.207 0.16,0.137 0.238,0.34 0.238,0.61 0,0.269 -0.078,0.472 -0.238,0.609 -0.156,0.141 -0.387,0.207 -0.692,0.207 h -0.464 v 1.098 h -0.372 z m 1.938,0 h 1.73 v 0.309 h -1.359 v 0.812 h 1.301 v 0.309 h -1.301 v 0.992 h 1.391 v 0.309 h -1.762 z m 1.875,2.676 v -0.336 c 0.094,0.043 0.187,0.074 0.281,0.098 0.094,0.023 0.188,0.035 0.281,0.035 0.243,0 0.43,-0.082 0.559,-0.246 0.129,-0.164 0.203,-0.414 0.219,-0.746 -0.071,0.105 -0.16,0.183 -0.27,0.242 -0.105,0.055 -0.226,0.082 -0.359,0.082 -0.274,0 -0.488,-0.082 -0.649,-0.246 -0.16,-0.164 -0.238,-0.391 -0.238,-0.68 0,-0.281 0.082,-0.504 0.25,-0.676 0.164,-0.168 0.387,-0.254 0.66,-0.254 0.317,0 0.559,0.122 0.723,0.364 0.168,0.242 0.254,0.593 0.254,1.054 0,0.434 -0.106,0.778 -0.309,1.036 -0.203,0.253 -0.48,0.382 -0.824,0.382 -0.094,0 -0.187,-0.007 -0.281,-0.027 -0.098,-0.02 -0.195,-0.047 -0.297,-0.082 z m 0.734,-1.16 c 0.168,0 0.297,-0.055 0.395,-0.168 0.097,-0.113 0.148,-0.27 0.148,-0.469 0,-0.195 -0.051,-0.351 -0.148,-0.465 -0.098,-0.113 -0.227,-0.172 -0.395,-0.172 -0.164,0 -0.297,0.059 -0.394,0.172 -0.098,0.114 -0.145,0.27 -0.145,0.465 0,0.199 0.047,0.356 0.145,0.469 0.097,0.113 0.23,0.168 0.394,0.168 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath419)"
+             id="path950" />
+          <path
+             d="m 69.156,163.168 v 1.027 h 0.465 c 0.172,0 0.305,-0.043 0.399,-0.133 0.093,-0.089 0.14,-0.214 0.14,-0.382 0,-0.16 -0.047,-0.289 -0.14,-0.379 -0.094,-0.086 -0.227,-0.133 -0.399,-0.133 z m -0.371,-0.301 h 0.836 c 0.309,0 0.539,0.067 0.695,0.207 0.157,0.137 0.235,0.34 0.235,0.606 0,0.273 -0.078,0.476 -0.235,0.613 -0.156,0.137 -0.386,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.371 z m 2.309,1.426 v 1 h 0.594 c 0.199,0 0.347,-0.039 0.441,-0.121 0.098,-0.082 0.144,-0.211 0.144,-0.379 0,-0.172 -0.046,-0.297 -0.144,-0.379 -0.094,-0.082 -0.242,-0.121 -0.441,-0.121 z m 0,-1.125 v 0.824 h 0.551 c 0.179,0 0.312,-0.031 0.402,-0.101 0.086,-0.067 0.133,-0.172 0.133,-0.309 0,-0.141 -0.047,-0.242 -0.133,-0.309 -0.09,-0.07 -0.223,-0.105 -0.402,-0.105 z m -0.367,-0.301 h 0.945 c 0.281,0 0.496,0.055 0.648,0.172 0.153,0.117 0.231,0.285 0.231,0.5 0,0.168 -0.039,0.301 -0.117,0.402 -0.079,0.098 -0.192,0.161 -0.344,0.184 0.18,0.039 0.324,0.121 0.422,0.246 0.101,0.121 0.152,0.277 0.152,0.461 0,0.246 -0.082,0.434 -0.25,0.566 -0.164,0.133 -0.402,0.2 -0.707,0.2 h -0.98 z m 2.39,2.418 h 1.289 v 0.313 h -1.734 v -0.313 c 0.14,-0.144 0.332,-0.34 0.574,-0.582 0.242,-0.246 0.395,-0.402 0.457,-0.473 0.117,-0.132 0.199,-0.246 0.246,-0.339 0.047,-0.09 0.071,-0.184 0.071,-0.27 0,-0.148 -0.051,-0.266 -0.153,-0.355 -0.101,-0.094 -0.234,-0.137 -0.398,-0.137 -0.114,0 -0.239,0.019 -0.367,0.059 -0.129,0.039 -0.266,0.101 -0.411,0.183 v -0.375 c 0.149,-0.058 0.286,-0.105 0.418,-0.133 0.129,-0.031 0.246,-0.047 0.352,-0.047 0.285,0 0.512,0.071 0.68,0.211 0.168,0.141 0.254,0.332 0.254,0.567 0,0.113 -0.024,0.222 -0.067,0.32 -0.039,0.102 -0.117,0.219 -0.226,0.356 -0.032,0.035 -0.129,0.14 -0.293,0.308 -0.164,0.168 -0.395,0.406 -0.692,0.707 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath420)"
+             id="path951" />
+          <path
+             d="m 69.875,131.379 -1.043,-2.731 h 0.387 l 0.863,2.301 0.867,-2.301 h 0.387 l -1.043,2.731 z m 1.422,-2.731 h 0.367 v 2.731 h -0.367 z m 0.941,0 h 0.5 l 1.211,2.286 v -2.286 h 0.36 v 2.731 h -0.497 l -1.214,-2.285 v 2.285 h -0.36 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath421)"
+             id="path952" />
+          <path
+             d="m 69.461,126.738 v -0.734 h -0.602 v -0.301 h 0.969 v 1.172 c -0.144,0.102 -0.301,0.18 -0.473,0.23 -0.171,0.051 -0.355,0.079 -0.55,0.079 -0.426,0 -0.762,-0.125 -1.004,-0.375 -0.239,-0.25 -0.36,-0.598 -0.36,-1.043 0,-0.446 0.121,-0.793 0.36,-1.043 0.242,-0.25 0.578,-0.375 1.004,-0.375 0.179,0 0.347,0.023 0.507,0.066 0.161,0.043 0.309,0.109 0.446,0.191 V 125 c -0.137,-0.117 -0.281,-0.203 -0.438,-0.262 -0.152,-0.058 -0.316,-0.086 -0.484,-0.086 -0.336,0 -0.586,0.094 -0.754,0.278 -0.168,0.187 -0.25,0.465 -0.25,0.836 0,0.367 0.082,0.644 0.25,0.832 0.168,0.187 0.418,0.281 0.754,0.281 0.129,0 0.246,-0.012 0.352,-0.031 0.101,-0.024 0.191,-0.059 0.273,-0.11 z m 0.504,-2.34 h 0.496 l 1.211,2.286 v -2.286 h 0.359 v 2.731 h -0.496 l -1.215,-2.285 v 2.285 h -0.355 z m 2.789,0.301 v 2.125 h 0.445 c 0.379,0 0.656,-0.086 0.828,-0.254 0.176,-0.172 0.266,-0.441 0.266,-0.808 0,-0.367 -0.09,-0.637 -0.266,-0.805 -0.172,-0.172 -0.449,-0.258 -0.828,-0.258 z m -0.371,-0.301 h 0.762 c 0.527,0 0.917,0.11 1.164,0.329 0.25,0.222 0.375,0.566 0.375,1.035 0,0.468 -0.125,0.816 -0.375,1.035 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.762 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath422)"
+             id="path953" />
+          <path
+             d="m 69.461,122.488 v -0.734 h -0.602 v -0.301 h 0.969 v 1.172 c -0.144,0.102 -0.301,0.18 -0.473,0.23 -0.171,0.051 -0.355,0.079 -0.55,0.079 -0.426,0 -0.762,-0.125 -1.004,-0.375 -0.239,-0.25 -0.36,-0.598 -0.36,-1.043 0,-0.446 0.121,-0.793 0.36,-1.043 0.242,-0.25 0.578,-0.375 1.004,-0.375 0.179,0 0.347,0.019 0.507,0.066 0.161,0.043 0.309,0.109 0.446,0.191 v 0.395 c -0.137,-0.117 -0.281,-0.203 -0.438,-0.262 -0.152,-0.058 -0.316,-0.086 -0.484,-0.086 -0.336,0 -0.586,0.094 -0.754,0.278 -0.168,0.187 -0.25,0.465 -0.25,0.836 0,0.367 0.082,0.644 0.25,0.832 0.168,0.187 0.418,0.281 0.754,0.281 0.129,0 0.246,-0.012 0.352,-0.035 0.101,-0.02 0.191,-0.059 0.273,-0.106 z m 0.504,-2.343 h 0.496 l 1.211,2.289 v -2.289 h 0.359 v 2.734 h -0.496 l -1.215,-2.285 v 2.285 h -0.355 z m 2.789,0.304 v 2.125 h 0.445 c 0.379,0 0.656,-0.086 0.828,-0.254 0.176,-0.172 0.266,-0.441 0.266,-0.808 0,-0.367 -0.09,-0.637 -0.266,-0.805 -0.172,-0.172 -0.449,-0.258 -0.828,-0.258 z m -0.371,-0.304 h 0.762 c 0.527,0 0.917,0.113 1.164,0.332 0.25,0.222 0.375,0.566 0.375,1.035 0,0.468 -0.125,0.816 -0.375,1.035 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.762 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath423)"
+             id="path954" />
+          <path
+             d="m 70.676,115.895 h 1.453 v 0.312 h -1.113 v 0.668 c 0.05,-0.016 0.105,-0.031 0.16,-0.039 0.054,-0.008 0.105,-0.016 0.16,-0.016 0.305,0 0.547,0.086 0.726,0.254 0.176,0.164 0.266,0.391 0.266,0.676 0,0.297 -0.09,0.523 -0.273,0.688 -0.184,0.164 -0.442,0.242 -0.774,0.242 -0.117,0 -0.234,-0.008 -0.351,-0.028 -0.121,-0.019 -0.242,-0.05 -0.371,-0.09 v -0.371 c 0.113,0.063 0.226,0.106 0.343,0.133 0.118,0.031 0.239,0.047 0.371,0.047 0.211,0 0.379,-0.055 0.5,-0.168 0.125,-0.109 0.188,-0.262 0.188,-0.453 0,-0.188 -0.063,-0.34 -0.188,-0.449 -0.121,-0.113 -0.289,-0.168 -0.5,-0.168 -0.101,0 -0.199,0.012 -0.296,0.031 -0.098,0.024 -0.2,0.059 -0.301,0.106 z m 2.57,2.734 -1.043,-2.734 h 0.383 l 0.867,2.3 0.867,-2.3 h 0.387 l -1.043,2.734 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath424)"
+             id="path955" />
+          <path
+             d="m 69.887,112.902 c 0.179,0.039 0.316,0.118 0.414,0.239 0.101,0.117 0.152,0.265 0.152,0.441 0,0.27 -0.094,0.48 -0.281,0.625 -0.184,0.148 -0.449,0.223 -0.789,0.223 -0.113,0 -0.235,-0.012 -0.356,-0.035 -0.121,-0.02 -0.246,-0.055 -0.375,-0.102 v -0.355 c 0.102,0.058 0.215,0.105 0.336,0.136 0.121,0.031 0.25,0.043 0.383,0.043 0.231,0 0.41,-0.043 0.531,-0.137 0.121,-0.089 0.18,-0.222 0.18,-0.398 0,-0.16 -0.055,-0.285 -0.168,-0.375 -0.113,-0.094 -0.269,-0.137 -0.473,-0.137 h -0.316 v -0.304 h 0.332 c 0.184,0 0.32,-0.036 0.418,-0.11 0.098,-0.074 0.145,-0.179 0.145,-0.316 0,-0.137 -0.051,-0.246 -0.149,-0.32 -0.101,-0.075 -0.242,-0.114 -0.43,-0.114 -0.101,0 -0.207,0.012 -0.324,0.032 -0.117,0.023 -0.242,0.058 -0.383,0.105 v -0.332 c 0.141,-0.039 0.274,-0.066 0.395,-0.086 0.121,-0.02 0.238,-0.031 0.348,-0.031 0.281,0 0.503,0.066 0.664,0.195 0.164,0.125 0.246,0.297 0.246,0.516 0,0.148 -0.043,0.277 -0.129,0.383 -0.086,0.105 -0.211,0.175 -0.371,0.214 z m 1.453,1.477 -1.043,-2.734 h 0.387 l 0.867,2.3 0.867,-2.3 h 0.383 l -1.043,2.734 z m 2.574,-1.477 c 0.176,0.039 0.316,0.118 0.414,0.239 0.102,0.117 0.152,0.265 0.152,0.441 0,0.27 -0.093,0.48 -0.281,0.625 -0.183,0.148 -0.449,0.223 -0.789,0.223 -0.117,0 -0.234,-0.012 -0.355,-0.035 -0.121,-0.02 -0.246,-0.055 -0.375,-0.102 v -0.355 c 0.101,0.058 0.215,0.105 0.336,0.136 0.121,0.031 0.25,0.043 0.382,0.043 0.231,0 0.411,-0.043 0.528,-0.137 0.125,-0.089 0.183,-0.222 0.183,-0.398 0,-0.16 -0.054,-0.285 -0.168,-0.375 -0.113,-0.094 -0.269,-0.137 -0.472,-0.137 h -0.317 v -0.304 h 0.332 c 0.184,0 0.321,-0.036 0.418,-0.11 0.098,-0.074 0.145,-0.179 0.145,-0.316 0,-0.137 -0.051,-0.246 -0.152,-0.32 -0.098,-0.075 -0.239,-0.114 -0.426,-0.114 -0.102,0 -0.207,0.012 -0.324,0.032 -0.118,0.023 -0.243,0.058 -0.383,0.105 v -0.332 c 0.14,-0.039 0.269,-0.066 0.394,-0.086 0.121,-0.02 0.239,-0.031 0.348,-0.031 0.281,0 0.5,0.066 0.664,0.195 0.164,0.125 0.246,0.297 0.246,0.516 0,0.148 -0.043,0.277 -0.129,0.383 -0.086,0.105 -0.211,0.175 -0.371,0.214 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath425)"
+             id="path956" />
+          <path
+             d="m 66.684,107.395 h 0.496 l 1.215,2.285 v -2.285 h 0.359 v 2.73 h -0.5 l -1.211,-2.285 v 2.285 h -0.359 z m 3.714,1.449 c 0.082,0.027 0.157,0.086 0.231,0.172 0.078,0.089 0.152,0.211 0.23,0.363 l 0.375,0.746 h -0.398 l -0.352,-0.699 c -0.089,-0.184 -0.175,-0.305 -0.261,-0.364 -0.086,-0.062 -0.2,-0.089 -0.348,-0.089 h -0.402 v 1.152 h -0.368 v -2.73 h 0.833 c 0.312,0 0.546,0.062 0.699,0.195 0.156,0.129 0.23,0.328 0.23,0.59 0,0.172 -0.039,0.316 -0.121,0.429 -0.078,0.114 -0.195,0.192 -0.348,0.235 z m -0.925,-1.145 v 0.969 h 0.465 c 0.179,0 0.312,-0.043 0.402,-0.125 0.094,-0.082 0.14,-0.203 0.14,-0.363 0,-0.16 -0.046,-0.278 -0.14,-0.36 -0.09,-0.082 -0.223,-0.121 -0.402,-0.121 z m 3.257,-0.215 v 0.36 c -0.14,-0.067 -0.273,-0.117 -0.398,-0.149 -0.125,-0.035 -0.246,-0.05 -0.359,-0.05 -0.203,0 -0.36,0.039 -0.469,0.117 -0.109,0.078 -0.16,0.187 -0.16,0.332 0,0.121 0.035,0.215 0.105,0.273 0.074,0.063 0.211,0.113 0.414,0.149 l 0.223,0.046 c 0.277,0.055 0.48,0.145 0.609,0.278 0.133,0.133 0.2,0.308 0.2,0.531 0,0.266 -0.09,0.465 -0.266,0.602 -0.18,0.136 -0.438,0.207 -0.781,0.207 -0.129,0 -0.27,-0.016 -0.414,-0.043 -0.145,-0.032 -0.297,-0.075 -0.454,-0.133 v -0.379 c 0.153,0.082 0.297,0.148 0.442,0.191 0.144,0.043 0.285,0.063 0.426,0.063 0.211,0 0.375,-0.043 0.488,-0.125 0.113,-0.082 0.172,-0.199 0.172,-0.356 0,-0.132 -0.043,-0.238 -0.125,-0.312 -0.082,-0.078 -0.215,-0.133 -0.403,-0.172 l -0.226,-0.043 c -0.277,-0.055 -0.477,-0.141 -0.598,-0.258 -0.125,-0.117 -0.187,-0.281 -0.187,-0.488 0,-0.242 0.086,-0.434 0.258,-0.574 0.168,-0.137 0.402,-0.207 0.703,-0.207 0.129,0 0.258,0.011 0.39,0.035 0.133,0.023 0.27,0.059 0.41,0.105 z m -0.32,-0.089 h 2.313 v 0.308 H 73.75 v 2.422 h -0.371 v -2.422 H 72.41 Z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath426)"
+             id="path957" />
+          <path
+             d="m 65.645,103.141 h 0.371 v 2.734 h -0.371 z m 2.054,0.254 c -0.269,0 -0.48,0.097 -0.64,0.3 -0.157,0.2 -0.239,0.473 -0.239,0.817 0,0.343 0.082,0.617 0.239,0.816 0.16,0.199 0.371,0.301 0.64,0.301 0.27,0 0.481,-0.102 0.637,-0.301 0.156,-0.199 0.238,-0.473 0.238,-0.816 0,-0.344 -0.082,-0.617 -0.238,-0.817 -0.156,-0.203 -0.367,-0.3 -0.637,-0.3 z m 0,-0.301 c 0.383,0 0.692,0.129 0.918,0.386 0.231,0.254 0.344,0.598 0.344,1.032 0,0.429 -0.113,0.773 -0.344,1.031 -0.226,0.258 -0.535,0.387 -0.918,0.387 -0.383,0 -0.691,-0.129 -0.922,-0.387 -0.23,-0.254 -0.343,-0.598 -0.343,-1.031 0,-0.434 0.113,-0.778 0.343,-1.032 0.231,-0.257 0.539,-0.386 0.922,-0.386 z m 2.668,1.5 c 0.082,0.027 0.156,0.086 0.231,0.172 0.078,0.089 0.152,0.211 0.226,0.363 l 0.375,0.746 h -0.394 l -0.352,-0.699 c -0.09,-0.184 -0.176,-0.305 -0.262,-0.367 -0.086,-0.059 -0.199,-0.09 -0.347,-0.09 h -0.403 v 1.156 H 69.07 v -2.734 h 0.836 c 0.313,0 0.547,0.066 0.699,0.199 0.157,0.129 0.231,0.324 0.231,0.59 0,0.172 -0.039,0.316 -0.121,0.429 -0.078,0.114 -0.195,0.192 -0.348,0.235 z m -0.926,-1.149 v 0.973 h 0.465 c 0.18,0 0.313,-0.043 0.403,-0.125 0.093,-0.082 0.136,-0.203 0.136,-0.363 0,-0.16 -0.043,-0.282 -0.136,-0.36 -0.09,-0.082 -0.223,-0.125 -0.403,-0.125 z m 1.668,-0.304 h 1.727 v 0.312 h -1.359 v 0.809 h 1.304 v 0.312 h -1.304 v 0.988 h 1.39 v 0.313 h -1.758 z m 1.829,0 h 1.57 v 0.312 h -1.199 v 0.805 h 1.082 v 0.312 h -1.082 v 1.305 h -0.371 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath427)"
+             id="path958" />
+          <path
+             d="m 70.27,98.891 h 0.496 l 1.211,2.285 v -2.285 h 0.359 v 2.734 H 71.84 L 70.625,99.34 v 2.285 H 70.27 Z m 4.464,0.211 v 0.39 c -0.125,-0.117 -0.257,-0.203 -0.398,-0.262 -0.141,-0.054 -0.289,-0.085 -0.449,-0.085 -0.313,0 -0.551,0.097 -0.719,0.289 -0.164,0.191 -0.246,0.464 -0.246,0.828 0,0.359 0.082,0.633 0.246,0.828 0.168,0.187 0.406,0.285 0.719,0.285 0.16,0 0.308,-0.031 0.449,-0.086 0.141,-0.059 0.273,-0.144 0.398,-0.262 v 0.387 c -0.129,0.086 -0.265,0.152 -0.41,0.199 -0.144,0.043 -0.297,0.063 -0.457,0.063 -0.414,0 -0.742,-0.125 -0.98,-0.379 -0.239,-0.254 -0.356,-0.598 -0.356,-1.035 0,-0.442 0.117,-0.785 0.356,-1.039 0.238,-0.254 0.566,-0.379 0.98,-0.379 0.16,0 0.317,0.019 0.461,0.062 0.145,0.043 0.281,0.11 0.406,0.196 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath428)"
+             id="path959" />
+          <path
+             d="m 67.602,158.703 v 1.027 h 0.464 c 0.172,0 0.305,-0.042 0.399,-0.132 0.094,-0.09 0.14,-0.215 0.14,-0.379 0,-0.164 -0.046,-0.293 -0.14,-0.379 -0.094,-0.09 -0.227,-0.137 -0.399,-0.137 z m -0.372,-0.301 h 0.836 c 0.305,0 0.536,0.067 0.692,0.207 0.16,0.137 0.238,0.34 0.238,0.61 0,0.269 -0.078,0.472 -0.238,0.609 -0.156,0.137 -0.387,0.207 -0.692,0.207 h -0.464 v 1.098 H 67.23 Z m 1.938,0 h 1.57 v 0.309 h -1.199 v 0.805 h 1.082 v 0.312 h -1.082 v 1.305 h -0.371 z m 1.82,2.422 h 0.602 v -2.086 l -0.656,0.133 v -0.34 l 0.656,-0.129 h 0.367 v 2.422 h 0.605 v 0.309 h -1.574 z m 2.625,-2.179 c -0.187,0 -0.332,0.093 -0.429,0.281 -0.094,0.187 -0.141,0.469 -0.141,0.844 0,0.375 0.047,0.656 0.141,0.843 0.097,0.188 0.242,0.282 0.429,0.282 0.196,0 0.336,-0.094 0.434,-0.282 0.094,-0.187 0.144,-0.468 0.144,-0.843 0,-0.375 -0.05,-0.657 -0.144,-0.844 -0.098,-0.188 -0.238,-0.281 -0.434,-0.281 z m 0,-0.293 c 0.309,0 0.543,0.121 0.703,0.363 0.164,0.242 0.243,0.594 0.243,1.055 0,0.46 -0.079,0.812 -0.243,1.054 -0.16,0.242 -0.394,0.364 -0.703,0.364 -0.304,0 -0.539,-0.122 -0.699,-0.364 -0.164,-0.242 -0.242,-0.594 -0.242,-1.054 0,-0.461 0.078,-0.813 0.242,-1.055 0.16,-0.242 0.395,-0.363 0.699,-0.363 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath429)"
+             id="path960" />
+          <path
+             d="m 69.219,154.453 v 1.027 h 0.465 c 0.175,0 0.308,-0.042 0.402,-0.132 0.094,-0.09 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.293 -0.141,-0.379 -0.094,-0.09 -0.227,-0.137 -0.402,-0.137 z m -0.367,-0.301 h 0.832 c 0.308,0 0.539,0.067 0.695,0.207 0.156,0.137 0.238,0.34 0.238,0.61 0,0.269 -0.082,0.472 -0.238,0.609 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 3.984,0.207 v 0.391 c -0.125,-0.113 -0.258,-0.203 -0.398,-0.258 -0.141,-0.058 -0.29,-0.086 -0.45,-0.086 -0.312,0 -0.55,0.094 -0.718,0.285 -0.165,0.192 -0.247,0.469 -0.247,0.829 0,0.359 0.082,0.636 0.247,0.828 0.168,0.191 0.406,0.285 0.718,0.285 0.16,0 0.309,-0.028 0.45,-0.086 0.14,-0.059 0.273,-0.145 0.398,-0.262 v 0.387 c -0.129,0.09 -0.266,0.156 -0.41,0.199 -0.145,0.043 -0.297,0.067 -0.461,0.067 -0.414,0 -0.738,-0.129 -0.977,-0.379 -0.238,-0.254 -0.355,-0.602 -0.355,-1.039 0,-0.438 0.117,-0.786 0.355,-1.04 0.239,-0.253 0.563,-0.378 0.977,-0.378 0.164,0 0.32,0.023 0.461,0.066 0.148,0.043 0.285,0.105 0.41,0.191 z m 0.305,2.215 h 1.289 v 0.309 h -1.735 v -0.309 c 0.141,-0.148 0.332,-0.34 0.571,-0.586 0.246,-0.246 0.398,-0.402 0.461,-0.472 0.117,-0.133 0.199,-0.246 0.246,-0.34 0.047,-0.09 0.07,-0.184 0.07,-0.27 0,-0.148 -0.051,-0.265 -0.152,-0.355 -0.102,-0.094 -0.235,-0.137 -0.399,-0.137 -0.117,0 -0.238,0.02 -0.367,0.059 -0.129,0.039 -0.266,0.101 -0.414,0.183 v -0.375 c 0.152,-0.058 0.289,-0.105 0.418,-0.133 0.129,-0.031 0.25,-0.046 0.355,-0.046 0.286,0 0.508,0.07 0.68,0.21 0.168,0.145 0.25,0.333 0.25,0.571 0,0.109 -0.019,0.219 -0.062,0.32 -0.043,0.098 -0.118,0.215 -0.231,0.352 -0.031,0.039 -0.125,0.14 -0.289,0.308 -0.164,0.168 -0.394,0.407 -0.691,0.711 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath430)"
+             id="path961" />
+          <path
+             d="m 69.184,150.203 v 1.027 h 0.464 c 0.172,0 0.305,-0.042 0.399,-0.132 0.094,-0.09 0.141,-0.219 0.141,-0.383 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.086 -0.227,-0.133 -0.399,-0.133 z m -0.372,-0.305 h 0.836 c 0.305,0 0.54,0.071 0.696,0.211 0.156,0.137 0.234,0.34 0.234,0.606 0,0.269 -0.078,0.476 -0.234,0.613 -0.156,0.137 -0.391,0.207 -0.696,0.207 h -0.464 v 1.098 h -0.372 z m 2.309,1.43 v 1 h 0.594 c 0.199,0 0.347,-0.039 0.441,-0.121 0.098,-0.082 0.145,-0.211 0.145,-0.379 0,-0.172 -0.047,-0.297 -0.145,-0.379 -0.094,-0.082 -0.242,-0.121 -0.441,-0.121 z m 0,-1.125 v 0.824 h 0.547 c 0.18,0 0.316,-0.035 0.402,-0.101 0.09,-0.067 0.137,-0.172 0.137,-0.309 0,-0.14 -0.047,-0.242 -0.137,-0.312 -0.086,-0.067 -0.222,-0.102 -0.402,-0.102 z m -0.371,-0.305 h 0.945 c 0.282,0 0.5,0.059 0.653,0.176 0.152,0.117 0.23,0.285 0.23,0.5 0,0.168 -0.039,0.301 -0.117,0.399 -0.078,0.101 -0.195,0.16 -0.344,0.187 0.18,0.039 0.321,0.121 0.422,0.246 0.102,0.121 0.152,0.278 0.152,0.461 0,0.246 -0.082,0.434 -0.25,0.567 -0.164,0.132 -0.402,0.199 -0.707,0.199 H 70.75 Z m 2.137,2.422 h 0.605 v -2.082 l -0.656,0.129 v -0.336 l 0.652,-0.133 h 0.371 v 2.422 h 0.602 v 0.313 h -1.574 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath431)"
+             id="path962" />
+          <path
+             d="m 69.219,145.953 v 1.027 h 0.465 c 0.175,0 0.308,-0.046 0.402,-0.132 0.094,-0.09 0.141,-0.219 0.141,-0.383 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.227,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.207 0.156,0.141 0.238,0.344 0.238,0.61 0,0.269 -0.082,0.473 -0.238,0.613 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 3.984,0.211 v 0.391 c -0.125,-0.117 -0.258,-0.203 -0.398,-0.262 -0.141,-0.054 -0.29,-0.086 -0.45,-0.086 -0.312,0 -0.55,0.098 -0.718,0.289 -0.165,0.192 -0.247,0.465 -0.247,0.829 0,0.359 0.082,0.632 0.247,0.824 0.168,0.191 0.406,0.285 0.718,0.285 0.16,0 0.309,-0.027 0.45,-0.086 0.14,-0.055 0.273,-0.141 0.398,-0.258 v 0.387 c -0.129,0.086 -0.266,0.152 -0.41,0.195 -0.145,0.047 -0.297,0.067 -0.461,0.067 -0.414,0 -0.738,-0.125 -0.977,-0.379 -0.238,-0.254 -0.355,-0.598 -0.355,-1.035 0,-0.442 0.117,-0.786 0.355,-1.04 0.239,-0.253 0.563,-0.382 0.977,-0.382 0.164,0 0.32,0.023 0.461,0.066 0.148,0.043 0.285,0.109 0.41,0.195 z m 1.105,1.047 c 0.176,0.039 0.317,0.117 0.414,0.239 0.098,0.121 0.149,0.265 0.149,0.441 0,0.269 -0.09,0.48 -0.277,0.629 -0.184,0.144 -0.45,0.219 -0.789,0.219 -0.118,0 -0.235,-0.012 -0.356,-0.036 -0.121,-0.019 -0.246,-0.054 -0.375,-0.097 v -0.36 c 0.102,0.063 0.215,0.106 0.336,0.137 0.121,0.031 0.25,0.047 0.383,0.047 0.23,0 0.406,-0.047 0.527,-0.141 0.121,-0.089 0.184,-0.222 0.184,-0.398 0,-0.16 -0.055,-0.285 -0.172,-0.375 -0.11,-0.094 -0.266,-0.137 -0.469,-0.137 h -0.32 v -0.304 h 0.336 c 0.179,0 0.32,-0.036 0.418,-0.11 0.093,-0.074 0.144,-0.176 0.144,-0.312 0,-0.141 -0.051,-0.25 -0.152,-0.325 -0.098,-0.074 -0.238,-0.113 -0.426,-0.113 -0.101,0 -0.211,0.012 -0.324,0.035 -0.117,0.02 -0.246,0.055 -0.383,0.102 v -0.332 c 0.141,-0.039 0.27,-0.067 0.391,-0.086 0.125,-0.02 0.242,-0.031 0.347,-0.031 0.282,0 0.504,0.066 0.668,0.195 0.164,0.125 0.246,0.297 0.246,0.516 0,0.148 -0.043,0.277 -0.129,0.382 -0.089,0.106 -0.21,0.176 -0.371,0.215 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath432)"
+             id="path963" />
+          <path
+             d="m 69.219,141.703 v 1.024 h 0.465 c 0.175,0 0.308,-0.043 0.402,-0.133 0.094,-0.09 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.227,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.207 0.156,0.141 0.238,0.34 0.238,0.61 0,0.269 -0.082,0.473 -0.238,0.609 -0.156,0.141 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 3.984,0.211 V 142 c -0.125,-0.117 -0.258,-0.203 -0.398,-0.262 -0.141,-0.058 -0.29,-0.086 -0.45,-0.086 -0.312,0 -0.55,0.094 -0.718,0.289 -0.165,0.188 -0.247,0.465 -0.247,0.825 0,0.359 0.082,0.636 0.247,0.828 0.168,0.191 0.406,0.285 0.718,0.285 0.16,0 0.309,-0.027 0.45,-0.086 0.14,-0.055 0.273,-0.145 0.398,-0.258 v 0.387 c -0.129,0.086 -0.266,0.152 -0.41,0.195 -0.145,0.043 -0.297,0.067 -0.461,0.067 -0.414,0 -0.738,-0.125 -0.977,-0.379 -0.238,-0.254 -0.355,-0.602 -0.355,-1.039 0,-0.438 0.117,-0.786 0.355,-1.036 0.239,-0.253 0.563,-0.382 0.977,-0.382 0.164,0 0.32,0.023 0.461,0.066 0.148,0.043 0.285,0.109 0.41,0.195 z m 0.777,0.032 c -0.191,0 -0.336,0.093 -0.433,0.281 -0.094,0.187 -0.141,0.469 -0.141,0.844 0,0.375 0.047,0.656 0.141,0.843 0.097,0.188 0.242,0.282 0.433,0.282 0.192,0 0.332,-0.094 0.43,-0.282 0.094,-0.187 0.145,-0.468 0.145,-0.843 0,-0.375 -0.051,-0.657 -0.145,-0.844 -0.098,-0.188 -0.238,-0.281 -0.43,-0.281 z m 0,-0.293 c 0.305,0 0.539,0.121 0.699,0.363 0.165,0.242 0.243,0.594 0.243,1.055 0,0.461 -0.078,0.812 -0.243,1.054 -0.16,0.242 -0.394,0.364 -0.699,0.364 -0.308,0 -0.543,-0.122 -0.703,-0.364 -0.164,-0.242 -0.242,-0.593 -0.242,-1.054 0,-0.461 0.078,-0.813 0.242,-1.055 0.16,-0.242 0.395,-0.363 0.703,-0.363 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath433)"
+             id="path964" />
+          <path
+             d="m 69.027,137.449 v 1.028 h 0.469 c 0.172,0 0.305,-0.043 0.399,-0.133 0.093,-0.09 0.14,-0.215 0.14,-0.379 0,-0.164 -0.047,-0.293 -0.14,-0.379 -0.094,-0.09 -0.227,-0.137 -0.399,-0.137 z m -0.367,-0.301 h 0.836 c 0.305,0 0.535,0.067 0.692,0.207 0.156,0.137 0.238,0.34 0.238,0.61 0,0.269 -0.082,0.473 -0.238,0.609 -0.157,0.137 -0.387,0.207 -0.692,0.207 h -0.469 v 1.098 H 68.66 Z m 2.574,0.364 -0.504,1.359 h 1.008 z m -0.211,-0.364 h 0.422 l 1.039,2.731 h -0.382 l -0.25,-0.699 h -1.231 l -0.25,0.699 H 69.98 Z m 2.622,1.258 c 0.175,0.039 0.312,0.117 0.414,0.235 0.097,0.121 0.148,0.269 0.148,0.445 0,0.269 -0.094,0.476 -0.277,0.625 -0.188,0.148 -0.45,0.223 -0.793,0.223 -0.114,0 -0.231,-0.012 -0.356,-0.036 -0.121,-0.023 -0.246,-0.054 -0.375,-0.101 v -0.356 c 0.106,0.059 0.215,0.106 0.34,0.133 0.121,0.031 0.246,0.047 0.383,0.047 0.23,0 0.406,-0.047 0.527,-0.137 0.121,-0.089 0.184,-0.226 0.184,-0.398 0,-0.16 -0.059,-0.289 -0.172,-0.379 -0.109,-0.09 -0.27,-0.137 -0.469,-0.137 h -0.32 v -0.304 h 0.336 c 0.18,0 0.32,-0.036 0.414,-0.106 0.098,-0.074 0.144,-0.18 0.144,-0.316 0,-0.141 -0.046,-0.246 -0.148,-0.321 -0.098,-0.078 -0.242,-0.113 -0.426,-0.113 -0.101,0 -0.211,0.008 -0.328,0.031 -0.113,0.024 -0.242,0.055 -0.383,0.102 v -0.328 c 0.141,-0.039 0.274,-0.07 0.395,-0.09 0.125,-0.02 0.238,-0.027 0.347,-0.027 0.282,0 0.504,0.062 0.668,0.191 0.164,0.129 0.247,0.301 0.247,0.516 0,0.152 -0.043,0.281 -0.133,0.386 -0.086,0.102 -0.207,0.176 -0.367,0.215 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath434)"
+             id="path965" />
+          <path
+             d="m 126.844,99.195 v 1.028 h 0.465 c 0.171,0 0.304,-0.043 0.398,-0.133 0.094,-0.09 0.141,-0.219 0.141,-0.383 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.227,-0.133 -0.398,-0.133 z m -0.371,-0.304 h 0.836 c 0.304,0 0.535,0.07 0.691,0.211 0.16,0.136 0.238,0.339 0.238,0.605 0,0.27 -0.078,0.473 -0.238,0.613 -0.156,0.137 -0.387,0.207 -0.691,0.207 h -0.465 v 1.098 h -0.371 z m 3.984,0.211 v 0.39 c -0.125,-0.117 -0.258,-0.203 -0.398,-0.262 -0.141,-0.054 -0.289,-0.085 -0.45,-0.085 -0.312,0 -0.55,0.097 -0.714,0.289 -0.168,0.191 -0.25,0.464 -0.25,0.828 0,0.359 0.082,0.636 0.25,0.828 0.164,0.187 0.402,0.285 0.714,0.285 0.161,0 0.309,-0.031 0.45,-0.086 0.14,-0.059 0.273,-0.144 0.398,-0.262 v 0.387 c -0.129,0.09 -0.266,0.152 -0.41,0.199 -0.145,0.043 -0.297,0.063 -0.457,0.063 -0.414,0 -0.742,-0.125 -0.981,-0.379 -0.238,-0.25 -0.355,-0.598 -0.355,-1.035 0,-0.442 0.117,-0.785 0.355,-1.039 0.239,-0.254 0.567,-0.379 0.981,-0.379 0.16,0 0.316,0.019 0.461,0.066 0.144,0.039 0.281,0.106 0.406,0.192 z m 0.777,1.226 c -0.175,0 -0.316,0.047 -0.418,0.141 -0.097,0.093 -0.148,0.222 -0.148,0.386 0,0.165 0.051,0.293 0.148,0.387 0.102,0.094 0.243,0.145 0.418,0.145 0.176,0 0.313,-0.051 0.414,-0.145 0.102,-0.094 0.153,-0.222 0.153,-0.387 0,-0.164 -0.051,-0.293 -0.153,-0.386 -0.097,-0.094 -0.238,-0.141 -0.414,-0.141 z m -0.371,-0.16 c -0.16,-0.039 -0.281,-0.113 -0.371,-0.219 -0.09,-0.109 -0.133,-0.242 -0.133,-0.398 0,-0.219 0.079,-0.391 0.235,-0.52 0.156,-0.125 0.367,-0.187 0.64,-0.187 0.27,0 0.485,0.062 0.641,0.187 0.152,0.129 0.23,0.301 0.23,0.52 0,0.156 -0.043,0.289 -0.132,0.398 -0.086,0.106 -0.211,0.18 -0.368,0.219 0.18,0.043 0.317,0.125 0.415,0.246 0.101,0.121 0.152,0.266 0.152,0.441 0,0.266 -0.082,0.469 -0.246,0.61 -0.16,0.14 -0.391,0.211 -0.692,0.211 -0.3,0 -0.535,-0.071 -0.695,-0.211 -0.164,-0.141 -0.242,-0.344 -0.242,-0.61 0,-0.175 0.051,-0.32 0.148,-0.441 0.102,-0.121 0.239,-0.203 0.418,-0.246 z m -0.136,-0.582 c 0,0.141 0.046,0.25 0.132,0.332 0.09,0.078 0.215,0.117 0.375,0.117 0.157,0 0.282,-0.039 0.371,-0.117 0.09,-0.082 0.137,-0.191 0.137,-0.332 0,-0.141 -0.047,-0.254 -0.137,-0.332 -0.089,-0.078 -0.214,-0.117 -0.371,-0.117 -0.16,0 -0.285,0.039 -0.375,0.117 -0.086,0.078 -0.132,0.191 -0.132,0.332 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath435)"
+             id="path966" />
+          <path
+             d="m 126.844,128.949 v 1.028 h 0.465 c 0.171,0 0.304,-0.047 0.398,-0.133 0.094,-0.09 0.141,-0.219 0.141,-0.383 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.227,-0.133 -0.398,-0.133 z m -0.371,-0.304 h 0.836 c 0.304,0 0.535,0.07 0.691,0.21 0.16,0.137 0.238,0.34 0.238,0.606 0,0.269 -0.078,0.473 -0.238,0.613 -0.156,0.137 -0.387,0.207 -0.691,0.207 h -0.465 v 1.098 h -0.371 z m 3.8,2.343 v -0.734 h -0.605 v -0.305 h 0.973 v 1.176 c -0.145,0.098 -0.301,0.176 -0.473,0.23 -0.172,0.051 -0.356,0.075 -0.551,0.075 -0.429,0 -0.762,-0.125 -1.004,-0.371 -0.242,-0.25 -0.359,-0.598 -0.359,-1.043 0,-0.45 0.117,-0.797 0.359,-1.047 0.242,-0.25 0.575,-0.375 1.004,-0.375 0.176,0 0.348,0.023 0.508,0.066 0.16,0.047 0.309,0.11 0.445,0.195 v 0.395 c -0.136,-0.117 -0.285,-0.203 -0.437,-0.262 -0.153,-0.058 -0.317,-0.09 -0.485,-0.09 -0.336,0 -0.586,0.094 -0.753,0.282 -0.168,0.187 -0.254,0.465 -0.254,0.836 0,0.367 0.086,0.644 0.254,0.832 0.167,0.187 0.417,0.277 0.753,0.277 0.129,0 0.247,-0.008 0.348,-0.031 0.106,-0.024 0.195,-0.059 0.277,-0.106 z m 1.657,-1.086 c 0.175,0.039 0.312,0.118 0.414,0.239 0.097,0.121 0.148,0.265 0.148,0.441 0,0.27 -0.094,0.48 -0.277,0.629 -0.188,0.144 -0.449,0.219 -0.793,0.219 -0.113,0 -0.231,-0.012 -0.356,-0.035 -0.121,-0.02 -0.246,-0.055 -0.375,-0.098 v -0.359 c 0.102,0.062 0.215,0.105 0.336,0.136 0.125,0.031 0.25,0.047 0.383,0.047 0.235,0 0.41,-0.047 0.531,-0.141 0.121,-0.089 0.184,-0.222 0.184,-0.398 0,-0.16 -0.059,-0.285 -0.172,-0.375 -0.113,-0.094 -0.269,-0.137 -0.469,-0.137 h -0.32 v -0.304 h 0.332 c 0.184,0 0.324,-0.036 0.418,-0.11 0.098,-0.074 0.145,-0.176 0.145,-0.312 0,-0.141 -0.047,-0.25 -0.149,-0.324 -0.098,-0.075 -0.242,-0.114 -0.426,-0.114 -0.101,0 -0.211,0.012 -0.328,0.035 -0.113,0.02 -0.242,0.055 -0.383,0.102 v -0.332 c 0.141,-0.039 0.274,-0.066 0.395,-0.086 0.125,-0.02 0.238,-0.031 0.348,-0.031 0.281,0 0.504,0.066 0.668,0.195 0.164,0.125 0.246,0.297 0.246,0.516 0,0.152 -0.047,0.277 -0.133,0.383 -0.086,0.105 -0.207,0.175 -0.367,0.214 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath436)"
+             id="path967" />
+          <path
+             d="m 126.844,124.699 v 1.024 h 0.465 c 0.171,0 0.304,-0.043 0.398,-0.133 0.094,-0.09 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.227,-0.133 -0.398,-0.133 z m -0.371,-0.304 h 0.836 c 0.304,0 0.535,0.07 0.691,0.207 0.16,0.14 0.238,0.339 0.238,0.609 0,0.269 -0.078,0.473 -0.238,0.609 -0.156,0.141 -0.387,0.207 -0.691,0.207 h -0.465 v 1.098 h -0.371 z m 3.8,2.343 v -0.734 h -0.605 v -0.305 h 0.973 v 1.172 c -0.145,0.102 -0.301,0.18 -0.473,0.231 -0.172,0.05 -0.356,0.078 -0.551,0.078 -0.429,0 -0.762,-0.125 -1.004,-0.375 -0.242,-0.25 -0.359,-0.598 -0.359,-1.043 0,-0.446 0.117,-0.793 0.359,-1.043 0.242,-0.25 0.575,-0.375 1.004,-0.375 0.176,0 0.348,0.023 0.508,0.066 0.16,0.043 0.309,0.11 0.445,0.195 v 0.391 c -0.136,-0.113 -0.285,-0.203 -0.437,-0.262 -0.153,-0.058 -0.317,-0.086 -0.485,-0.086 -0.336,0 -0.586,0.094 -0.753,0.282 -0.168,0.183 -0.254,0.465 -0.254,0.832 0,0.371 0.086,0.648 0.254,0.836 0.167,0.183 0.417,0.277 0.753,0.277 0.129,0 0.247,-0.012 0.348,-0.031 0.106,-0.024 0.195,-0.059 0.277,-0.106 z m 0.852,0.078 h 1.293 v 0.309 h -1.738 v -0.309 c 0.14,-0.144 0.332,-0.339 0.574,-0.586 0.242,-0.242 0.394,-0.402 0.457,-0.472 0.121,-0.133 0.203,-0.246 0.25,-0.336 0.047,-0.094 0.07,-0.184 0.07,-0.274 0,-0.144 -0.051,-0.265 -0.156,-0.355 -0.098,-0.09 -0.23,-0.137 -0.395,-0.137 -0.117,0 -0.238,0.02 -0.367,0.059 -0.129,0.043 -0.265,0.101 -0.414,0.183 v -0.371 c 0.149,-0.062 0.289,-0.105 0.418,-0.136 0.129,-0.032 0.246,-0.047 0.356,-0.047 0.281,0 0.507,0.07 0.675,0.215 0.168,0.14 0.254,0.328 0.254,0.566 0,0.113 -0.019,0.219 -0.062,0.32 -0.043,0.098 -0.121,0.219 -0.231,0.356 -0.031,0.035 -0.129,0.137 -0.293,0.304 -0.16,0.172 -0.39,0.407 -0.691,0.711 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath437)"
+             id="path968" />
+          <path
+             d="m 126.844,120.445 v 1.028 h 0.465 c 0.171,0 0.304,-0.043 0.398,-0.133 0.094,-0.09 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.293 -0.141,-0.379 -0.094,-0.09 -0.227,-0.137 -0.398,-0.137 z m -0.371,-0.3 h 0.836 c 0.304,0 0.535,0.066 0.691,0.207 0.16,0.136 0.238,0.339 0.238,0.609 0,0.269 -0.078,0.473 -0.238,0.609 -0.156,0.137 -0.387,0.207 -0.691,0.207 h -0.465 v 1.098 h -0.371 z m 2.308,0.3 v 2.125 h 0.446 c 0.378,0 0.652,-0.082 0.828,-0.254 0.175,-0.171 0.265,-0.441 0.265,-0.808 0,-0.367 -0.09,-0.637 -0.265,-0.805 -0.176,-0.172 -0.45,-0.258 -0.828,-0.258 z m -0.371,-0.3 h 0.762 c 0.527,0 0.918,0.109 1.164,0.328 0.25,0.222 0.371,0.566 0.371,1.035 0,0.469 -0.121,0.816 -0.371,1.035 -0.25,0.223 -0.637,0.332 -1.164,0.332 h -0.762 z m 2.66,2.421 h 1.289 v 0.309 h -1.734 v -0.309 c 0.141,-0.148 0.328,-0.339 0.57,-0.586 0.246,-0.246 0.399,-0.402 0.461,-0.472 0.117,-0.133 0.199,-0.246 0.246,-0.34 0.047,-0.09 0.071,-0.184 0.071,-0.27 0,-0.148 -0.051,-0.265 -0.153,-0.355 -0.101,-0.094 -0.234,-0.137 -0.398,-0.137 -0.117,0 -0.238,0.02 -0.367,0.059 -0.129,0.039 -0.266,0.101 -0.414,0.183 v -0.375 c 0.148,-0.058 0.289,-0.105 0.418,-0.132 0.129,-0.032 0.25,-0.047 0.355,-0.047 0.285,0 0.508,0.07 0.68,0.211 0.168,0.144 0.25,0.332 0.25,0.57 0,0.109 -0.02,0.219 -0.063,0.32 -0.043,0.098 -0.117,0.215 -0.23,0.352 -0.031,0.039 -0.125,0.141 -0.289,0.308 -0.164,0.168 -0.395,0.407 -0.692,0.711 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath438)"
+             id="path969" />
+          <path
+             d="m 126.844,116.195 v 1.028 h 0.465 c 0.171,0 0.304,-0.043 0.398,-0.133 0.094,-0.09 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.293 -0.141,-0.379 -0.094,-0.09 -0.227,-0.137 -0.398,-0.137 z m -0.371,-0.3 h 0.836 c 0.304,0 0.535,0.066 0.691,0.207 0.16,0.136 0.238,0.339 0.238,0.609 0,0.269 -0.078,0.473 -0.238,0.609 -0.156,0.137 -0.387,0.207 -0.691,0.207 h -0.465 v 1.098 h -0.371 z m 3.984,0.207 v 0.39 c -0.125,-0.113 -0.258,-0.203 -0.398,-0.258 -0.141,-0.058 -0.289,-0.086 -0.45,-0.086 -0.312,0 -0.55,0.094 -0.714,0.286 -0.168,0.191 -0.25,0.468 -0.25,0.828 0,0.359 0.082,0.636 0.25,0.828 0.164,0.191 0.402,0.285 0.714,0.285 0.161,0 0.309,-0.027 0.45,-0.086 0.14,-0.059 0.273,-0.144 0.398,-0.262 v 0.387 c -0.129,0.09 -0.266,0.156 -0.41,0.199 -0.145,0.043 -0.297,0.067 -0.457,0.067 -0.414,0 -0.742,-0.129 -0.981,-0.379 -0.238,-0.254 -0.355,-0.602 -0.355,-1.039 0,-0.438 0.117,-0.785 0.355,-1.039 0.239,-0.254 0.567,-0.379 0.981,-0.379 0.16,0 0.316,0.023 0.461,0.066 0.144,0.043 0.281,0.106 0.406,0.192 z m 0.051,2.21 h 0.601 v -2.082 l -0.656,0.129 v -0.336 l 0.652,-0.128 h 0.372 v 2.417 h 0.605 v 0.313 h -1.574 z m 2.152,0 h 1.293 v 0.313 h -1.734 v -0.313 c 0.14,-0.144 0.328,-0.339 0.57,-0.582 0.242,-0.246 0.399,-0.402 0.457,-0.472 0.121,-0.133 0.203,-0.246 0.25,-0.34 0.047,-0.09 0.07,-0.184 0.07,-0.27 0,-0.148 -0.05,-0.265 -0.152,-0.355 -0.102,-0.094 -0.234,-0.137 -0.398,-0.137 -0.118,0 -0.239,0.02 -0.368,0.059 -0.128,0.039 -0.265,0.101 -0.414,0.183 v -0.375 c 0.149,-0.058 0.289,-0.105 0.418,-0.132 0.129,-0.032 0.25,-0.047 0.356,-0.047 0.285,0 0.508,0.07 0.676,0.211 0.171,0.14 0.254,0.332 0.254,0.57 0,0.109 -0.02,0.219 -0.063,0.32 -0.043,0.098 -0.117,0.215 -0.23,0.352 -0.032,0.035 -0.125,0.141 -0.29,0.308 -0.164,0.168 -0.394,0.407 -0.695,0.707 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath439)"
+             id="path970" />
+          <path
+             d="m 126.844,111.945 v 1.028 h 0.465 c 0.171,0 0.304,-0.043 0.398,-0.133 0.094,-0.09 0.141,-0.219 0.141,-0.383 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.227,-0.133 -0.398,-0.133 z m -0.371,-0.304 h 0.836 c 0.304,0 0.535,0.07 0.691,0.211 0.16,0.136 0.238,0.339 0.238,0.605 0,0.27 -0.078,0.473 -0.238,0.613 -0.156,0.137 -0.387,0.207 -0.691,0.207 h -0.465 v 1.098 h -0.371 z m 3.984,0.211 v 0.39 c -0.125,-0.117 -0.258,-0.203 -0.398,-0.262 -0.141,-0.054 -0.289,-0.085 -0.45,-0.085 -0.312,0 -0.55,0.097 -0.714,0.289 -0.168,0.191 -0.25,0.464 -0.25,0.828 0,0.359 0.082,0.636 0.25,0.828 0.164,0.187 0.402,0.285 0.714,0.285 0.161,0 0.309,-0.031 0.45,-0.086 0.14,-0.059 0.273,-0.144 0.398,-0.262 v 0.387 c -0.129,0.086 -0.266,0.152 -0.41,0.199 -0.145,0.043 -0.297,0.063 -0.457,0.063 -0.414,0 -0.742,-0.125 -0.981,-0.379 -0.238,-0.254 -0.355,-0.598 -0.355,-1.035 0,-0.442 0.117,-0.785 0.355,-1.039 0.239,-0.254 0.567,-0.379 0.981,-0.379 0.16,0 0.316,0.019 0.461,0.066 0.144,0.039 0.281,0.106 0.406,0.192 z m 0.051,2.21 h 0.601 v -2.082 l -0.656,0.129 v -0.336 l 0.652,-0.132 h 0.372 v 2.421 h 0.605 v 0.313 h -1.574 z m 1.898,0 h 0.606 v -2.082 l -0.657,0.129 v -0.336 l 0.653,-0.132 h 0.371 v 2.421 h 0.601 v 0.313 h -1.574 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath440)"
+             id="path971" />
+          <path
+             d="m 126.844,107.695 v 1.028 h 0.465 c 0.171,0 0.304,-0.047 0.398,-0.137 0.094,-0.086 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.227,-0.133 -0.398,-0.133 z m -0.371,-0.304 h 0.836 c 0.304,0 0.535,0.07 0.691,0.207 0.16,0.14 0.238,0.343 0.238,0.609 0,0.27 -0.078,0.473 -0.238,0.613 -0.156,0.137 -0.387,0.203 -0.691,0.203 h -0.465 v 1.102 h -0.371 z m 3.984,0.211 v 0.39 c -0.125,-0.117 -0.258,-0.203 -0.398,-0.262 -0.141,-0.054 -0.289,-0.085 -0.45,-0.085 -0.312,0 -0.55,0.097 -0.714,0.289 -0.168,0.187 -0.25,0.464 -0.25,0.828 0,0.359 0.082,0.633 0.25,0.824 0.164,0.191 0.402,0.285 0.714,0.285 0.161,0 0.309,-0.027 0.45,-0.086 0.14,-0.055 0.273,-0.14 0.398,-0.258 v 0.387 c -0.129,0.086 -0.266,0.152 -0.41,0.195 -0.145,0.047 -0.297,0.067 -0.457,0.067 -0.414,0 -0.742,-0.125 -0.981,-0.379 -0.238,-0.254 -0.355,-0.598 -0.355,-1.035 0,-0.442 0.117,-0.785 0.355,-1.039 0.239,-0.254 0.567,-0.383 0.981,-0.383 0.16,0 0.316,0.023 0.461,0.066 0.144,0.043 0.281,0.11 0.406,0.196 z m 0.051,2.21 h 0.601 v -2.085 l -0.656,0.132 v -0.336 l 0.652,-0.132 h 0.372 v 2.421 h 0.605 v 0.313 h -1.574 z m 2.625,-2.179 c -0.188,0 -0.332,0.094 -0.43,0.285 -0.094,0.184 -0.141,0.465 -0.141,0.844 0,0.371 0.047,0.652 0.141,0.843 0.098,0.184 0.242,0.278 0.43,0.278 0.191,0 0.336,-0.094 0.433,-0.278 0.094,-0.191 0.145,-0.472 0.145,-0.843 0,-0.379 -0.051,-0.66 -0.145,-0.844 -0.097,-0.191 -0.242,-0.285 -0.433,-0.285 z m 0,-0.293 c 0.308,0 0.543,0.121 0.703,0.367 0.16,0.238 0.242,0.59 0.242,1.055 0,0.457 -0.082,0.808 -0.242,1.05 -0.16,0.243 -0.395,0.364 -0.703,0.364 -0.305,0 -0.539,-0.121 -0.703,-0.364 -0.16,-0.242 -0.239,-0.593 -0.239,-1.05 0,-0.465 0.079,-0.817 0.239,-1.055 0.164,-0.246 0.398,-0.367 0.703,-0.367 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath441)"
+             id="path972" />
+          <path
+             d="m 126.844,103.445 v 1.024 h 0.465 c 0.171,0 0.304,-0.043 0.398,-0.133 0.094,-0.09 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.227,-0.133 -0.398,-0.133 z m -0.371,-0.304 h 0.836 c 0.304,0 0.535,0.07 0.691,0.207 0.16,0.136 0.238,0.34 0.238,0.609 0,0.27 -0.078,0.473 -0.238,0.609 -0.156,0.141 -0.387,0.207 -0.691,0.207 h -0.465 v 1.098 h -0.371 z m 3.984,0.211 v 0.386 c -0.125,-0.113 -0.258,-0.199 -0.398,-0.258 -0.141,-0.058 -0.289,-0.085 -0.45,-0.085 -0.312,0 -0.55,0.093 -0.714,0.285 -0.168,0.191 -0.25,0.468 -0.25,0.828 0,0.359 0.082,0.637 0.25,0.828 0.164,0.191 0.402,0.285 0.714,0.285 0.161,0 0.309,-0.027 0.45,-0.086 0.14,-0.058 0.273,-0.144 0.398,-0.258 v 0.383 c -0.129,0.09 -0.266,0.156 -0.41,0.199 -0.145,0.043 -0.297,0.067 -0.457,0.067 -0.414,0 -0.742,-0.125 -0.981,-0.379 -0.238,-0.254 -0.355,-0.602 -0.355,-1.039 0,-0.438 0.117,-0.785 0.355,-1.035 0.239,-0.254 0.567,-0.383 0.981,-0.383 0.16,0 0.316,0.023 0.461,0.066 0.144,0.043 0.281,0.106 0.406,0.196 z m -0.004,2.464 v -0.336 c 0.094,0.043 0.188,0.075 0.281,0.098 0.098,0.024 0.192,0.035 0.282,0.035 0.242,0 0.429,-0.082 0.558,-0.242 0.129,-0.168 0.203,-0.418 0.223,-0.75 -0.074,0.106 -0.16,0.184 -0.27,0.242 -0.109,0.055 -0.23,0.082 -0.363,0.082 -0.273,0 -0.488,-0.082 -0.648,-0.246 -0.161,-0.164 -0.239,-0.39 -0.239,-0.679 0,-0.282 0.082,-0.504 0.25,-0.676 0.164,-0.168 0.387,-0.254 0.661,-0.254 0.316,0 0.558,0.121 0.726,0.363 0.164,0.242 0.25,0.594 0.25,1.055 0,0.433 -0.102,0.777 -0.309,1.035 -0.203,0.254 -0.476,0.383 -0.824,0.383 -0.093,0 -0.187,-0.008 -0.281,-0.028 -0.094,-0.019 -0.195,-0.046 -0.297,-0.082 z m 0.735,-1.16 c 0.167,0 0.3,-0.054 0.394,-0.168 0.098,-0.113 0.148,-0.269 0.148,-0.468 0,-0.196 -0.05,-0.352 -0.148,-0.465 -0.094,-0.114 -0.227,-0.172 -0.394,-0.172 -0.165,0 -0.297,0.058 -0.395,0.172 -0.094,0.113 -0.145,0.269 -0.145,0.465 0,0.199 0.051,0.355 0.145,0.468 0.098,0.114 0.23,0.168 0.395,0.168 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath442)"
+             id="path973" />
+          <path
+             d="m 128.285,160.742 v -0.734 h -0.605 v -0.305 h 0.968 v 1.172 c -0.14,0.102 -0.296,0.18 -0.472,0.23 -0.172,0.055 -0.356,0.079 -0.551,0.079 -0.426,0 -0.762,-0.125 -1,-0.372 -0.242,-0.253 -0.363,-0.601 -0.363,-1.046 0,-0.446 0.121,-0.793 0.363,-1.043 0.238,-0.25 0.574,-0.375 1,-0.375 0.18,0 0.348,0.023 0.508,0.066 0.16,0.043 0.308,0.109 0.445,0.195 v 0.395 c -0.137,-0.117 -0.281,-0.203 -0.433,-0.262 -0.157,-0.058 -0.317,-0.09 -0.489,-0.09 -0.332,0 -0.586,0.094 -0.754,0.282 -0.168,0.187 -0.25,0.464 -0.25,0.832 0,0.371 0.082,0.648 0.25,0.836 0.168,0.183 0.422,0.277 0.754,0.277 0.133,0 0.25,-0.008 0.352,-0.031 0.101,-0.024 0.195,-0.059 0.277,-0.106 z m 0.5,-2.344 h 0.496 l 1.215,2.286 v -2.286 h 0.359 v 2.735 h -0.5 l -1.21,-2.289 v 2.289 h -0.36 z m 2.789,0.305 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.829,-0.258 0.175,-0.172 0.261,-0.441 0.261,-0.808 0,-0.367 -0.086,-0.633 -0.261,-0.805 -0.176,-0.168 -0.454,-0.254 -0.829,-0.254 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.032 0,0.472 -0.125,0.816 -0.375,1.039 -0.246,0.219 -0.637,0.332 -1.164,0.332 h -0.758 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath443)"
+             id="path974" />
+          <path
+             d="m 126.789,154.453 v 1.027 h 0.465 c 0.172,0 0.305,-0.046 0.398,-0.136 0.098,-0.086 0.145,-0.215 0.145,-0.379 0,-0.164 -0.047,-0.289 -0.145,-0.379 -0.093,-0.09 -0.226,-0.133 -0.398,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.207 0.156,0.141 0.235,0.34 0.235,0.61 0,0.269 -0.079,0.473 -0.235,0.609 -0.156,0.141 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 2.305,0.305 v 2.125 h 0.449 c 0.375,0 0.652,-0.086 0.828,-0.258 0.176,-0.172 0.262,-0.441 0.262,-0.808 0,-0.367 -0.086,-0.633 -0.262,-0.805 -0.176,-0.168 -0.453,-0.254 -0.828,-0.254 z m -0.368,-0.305 h 0.758 c 0.531,0 0.918,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.032 0,0.472 -0.125,0.816 -0.375,1.039 -0.246,0.219 -0.636,0.328 -1.164,0.328 h -0.758 z m 3.457,1.258 c 0.18,0.039 0.317,0.117 0.414,0.239 0.102,0.117 0.153,0.265 0.153,0.441 0,0.269 -0.094,0.48 -0.278,0.625 -0.187,0.148 -0.449,0.223 -0.793,0.223 -0.113,0 -0.234,-0.012 -0.355,-0.036 -0.121,-0.019 -0.246,-0.054 -0.375,-0.101 v -0.356 c 0.102,0.059 0.215,0.106 0.336,0.137 0.125,0.031 0.25,0.043 0.383,0.043 0.234,0 0.41,-0.043 0.531,-0.137 0.121,-0.089 0.184,-0.222 0.184,-0.398 0,-0.16 -0.059,-0.285 -0.172,-0.375 -0.114,-0.094 -0.27,-0.141 -0.473,-0.141 h -0.316 v -0.3 h 0.332 c 0.183,0 0.32,-0.04 0.418,-0.11 0.097,-0.074 0.144,-0.18 0.144,-0.316 0,-0.141 -0.051,-0.246 -0.148,-0.321 -0.102,-0.074 -0.242,-0.113 -0.43,-0.113 -0.098,0 -0.207,0.012 -0.324,0.031 -0.117,0.024 -0.242,0.059 -0.383,0.106 v -0.332 c 0.141,-0.039 0.274,-0.067 0.395,-0.086 0.121,-0.02 0.238,-0.031 0.347,-0.031 0.282,0 0.504,0.066 0.668,0.191 0.16,0.129 0.242,0.301 0.242,0.52 0,0.148 -0.043,0.277 -0.128,0.382 -0.086,0.106 -0.211,0.176 -0.372,0.215 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath444)"
+             id="path975" />
+          <path
+             d="m 126.789,150.199 v 1.028 h 0.465 c 0.172,0 0.305,-0.043 0.398,-0.133 0.098,-0.09 0.145,-0.215 0.145,-0.379 0,-0.164 -0.047,-0.293 -0.145,-0.379 -0.093,-0.09 -0.226,-0.137 -0.398,-0.137 z m -0.367,-0.301 h 0.832 c 0.308,0 0.539,0.067 0.695,0.207 0.156,0.137 0.235,0.34 0.235,0.61 0,0.269 -0.079,0.473 -0.235,0.609 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 2.305,0.301 v 2.125 h 0.449 c 0.375,0 0.652,-0.082 0.828,-0.254 0.176,-0.172 0.262,-0.441 0.262,-0.808 0,-0.367 -0.086,-0.637 -0.262,-0.805 -0.176,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.368,-0.301 h 0.758 c 0.531,0 0.918,0.11 1.168,0.329 0.246,0.222 0.371,0.566 0.371,1.035 0,0.468 -0.125,0.816 -0.375,1.035 -0.246,0.223 -0.636,0.332 -1.164,0.332 h -0.758 z m 3.356,0.321 -0.934,1.461 h 0.934 z m -0.098,-0.321 h 0.465 v 1.782 h 0.391 v 0.304 h -0.391 v 0.645 h -0.367 v -0.645 h -1.235 v -0.355 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath445)"
+             id="path976" />
+          <path
+             d="m 126.789,145.949 v 1.028 h 0.465 c 0.172,0 0.305,-0.043 0.398,-0.133 0.098,-0.09 0.145,-0.215 0.145,-0.383 0,-0.16 -0.047,-0.289 -0.145,-0.379 -0.093,-0.086 -0.226,-0.133 -0.398,-0.133 z m -0.367,-0.304 h 0.832 c 0.308,0 0.539,0.07 0.695,0.21 0.156,0.137 0.235,0.34 0.235,0.606 0,0.269 -0.079,0.477 -0.235,0.613 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 2.305,0.304 v 2.125 h 0.449 c 0.375,0 0.652,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.441 0.262,-0.812 0,-0.363 -0.086,-0.633 -0.262,-0.801 -0.176,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.368,-0.304 h 0.758 c 0.531,0 0.918,0.113 1.168,0.332 0.246,0.218 0.371,0.566 0.371,1.031 0,0.472 -0.125,0.82 -0.375,1.039 -0.246,0.223 -0.636,0.332 -1.164,0.332 h -0.758 z m 2.34,0 h 1.453 v 0.312 h -1.113 v 0.672 c 0.055,-0.02 0.109,-0.035 0.16,-0.043 0.055,-0.008 0.11,-0.016 0.164,-0.016 0.305,0 0.547,0.086 0.723,0.254 0.18,0.164 0.269,0.391 0.269,0.68 0,0.293 -0.093,0.519 -0.277,0.684 -0.18,0.164 -0.441,0.246 -0.773,0.246 -0.114,0 -0.231,-0.012 -0.352,-0.032 -0.117,-0.019 -0.242,-0.047 -0.367,-0.086 v -0.375 c 0.109,0.063 0.223,0.106 0.34,0.137 0.117,0.027 0.242,0.043 0.371,0.043 0.211,0 0.379,-0.055 0.504,-0.168 0.121,-0.109 0.183,-0.262 0.183,-0.449 0,-0.192 -0.062,-0.344 -0.183,-0.453 -0.125,-0.113 -0.293,-0.168 -0.504,-0.168 -0.098,0 -0.195,0.012 -0.297,0.035 -0.098,0.02 -0.195,0.055 -0.301,0.102 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath446)"
+             id="path977" />
+          <path
+             d="m 126.789,141.699 v 1.028 h 0.465 c 0.172,0 0.305,-0.047 0.398,-0.133 0.098,-0.09 0.145,-0.219 0.145,-0.383 0,-0.164 -0.047,-0.289 -0.145,-0.379 -0.093,-0.09 -0.226,-0.133 -0.398,-0.133 z m -0.367,-0.304 h 0.832 c 0.308,0 0.539,0.07 0.695,0.21 0.156,0.137 0.235,0.34 0.235,0.606 0,0.269 -0.079,0.473 -0.235,0.613 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 2.305,0.304 v 2.125 h 0.449 c 0.375,0 0.652,-0.086 0.828,-0.258 0.176,-0.168 0.262,-0.437 0.262,-0.808 0,-0.363 -0.086,-0.633 -0.262,-0.801 -0.176,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.368,-0.304 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.218 0.371,0.562 0.371,1.031 0,0.472 -0.125,0.816 -0.375,1.039 -0.246,0.219 -0.636,0.332 -1.164,0.332 h -0.758 z m 3.176,1.218 c -0.168,0 -0.297,0.059 -0.394,0.172 -0.098,0.113 -0.149,0.27 -0.149,0.465 0,0.199 0.051,0.352 0.149,0.469 0.097,0.113 0.226,0.168 0.394,0.168 0.164,0 0.297,-0.055 0.395,-0.168 0.097,-0.117 0.144,-0.27 0.144,-0.469 0,-0.195 -0.047,-0.352 -0.144,-0.465 -0.098,-0.113 -0.231,-0.172 -0.395,-0.172 z m 0.735,-1.156 v 0.336 c -0.094,-0.043 -0.188,-0.078 -0.282,-0.102 -0.097,-0.023 -0.187,-0.035 -0.281,-0.035 -0.246,0 -0.434,0.082 -0.562,0.246 -0.125,0.168 -0.2,0.414 -0.219,0.75 0.074,-0.109 0.164,-0.187 0.273,-0.246 0.106,-0.054 0.227,-0.086 0.356,-0.086 0.277,0 0.492,0.086 0.652,0.25 0.16,0.168 0.238,0.395 0.238,0.68 0,0.281 -0.082,0.508 -0.25,0.676 -0.164,0.172 -0.386,0.254 -0.66,0.254 -0.316,0 -0.558,-0.121 -0.726,-0.36 -0.168,-0.246 -0.25,-0.597 -0.25,-1.054 0,-0.434 0.101,-0.778 0.308,-1.036 0.203,-0.257 0.481,-0.386 0.824,-0.386 0.094,0 0.188,0.011 0.282,0.031 0.093,0.016 0.191,0.043 0.297,0.082 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath447)"
+             id="path978" />
+          <path
+             d="m 126.789,137.449 v 1.028 h 0.465 c 0.172,0 0.305,-0.047 0.398,-0.137 0.098,-0.086 0.145,-0.215 0.145,-0.379 0,-0.164 -0.047,-0.289 -0.145,-0.379 -0.093,-0.09 -0.226,-0.133 -0.398,-0.133 z m -0.367,-0.304 h 0.832 c 0.308,0 0.539,0.07 0.695,0.207 0.156,0.14 0.235,0.339 0.235,0.609 0,0.269 -0.079,0.473 -0.235,0.609 -0.156,0.141 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 2.305,0.304 v 2.125 h 0.449 c 0.375,0 0.652,-0.086 0.828,-0.258 0.176,-0.171 0.262,-0.441 0.262,-0.808 0,-0.367 -0.086,-0.633 -0.262,-0.805 -0.176,-0.168 -0.453,-0.254 -0.828,-0.254 z m -0.368,-0.304 h 0.758 c 0.531,0 0.918,0.109 1.168,0.332 0.246,0.218 0.371,0.562 0.371,1.031 0,0.472 -0.125,0.816 -0.375,1.039 -0.246,0.219 -0.636,0.328 -1.164,0.328 h -0.758 z m 2.246,0 h 1.758 v 0.156 l -0.992,2.574 h -0.387 l 0.934,-2.418 h -1.313 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath448)"
+             id="path979" />
+          <path
+             d="m 126.789,197.168 v 1.027 h 0.465 c 0.172,0 0.305,-0.047 0.398,-0.133 0.098,-0.089 0.145,-0.218 0.145,-0.382 0,-0.164 -0.047,-0.289 -0.145,-0.379 -0.093,-0.09 -0.226,-0.133 -0.398,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.207 0.156,0.141 0.235,0.344 0.235,0.61 0,0.269 -0.079,0.472 -0.235,0.613 -0.156,0.137 -0.387,0.203 -0.695,0.203 h -0.465 v 1.102 h -0.367 z m 3.801,2.344 v -0.734 h -0.606 v -0.305 h 0.969 v 1.176 c -0.141,0.097 -0.297,0.176 -0.473,0.23 -0.172,0.051 -0.355,0.074 -0.551,0.074 -0.425,0 -0.761,-0.125 -1,-0.371 -0.242,-0.25 -0.363,-0.597 -0.363,-1.043 0,-0.449 0.121,-0.796 0.363,-1.046 0.239,-0.25 0.575,-0.376 1,-0.376 0.18,0 0.348,0.024 0.508,0.067 0.16,0.047 0.309,0.109 0.446,0.195 v 0.395 c -0.137,-0.117 -0.282,-0.203 -0.434,-0.262 -0.156,-0.059 -0.316,-0.09 -0.488,-0.09 -0.332,0 -0.586,0.094 -0.754,0.281 -0.168,0.188 -0.25,0.465 -0.25,0.836 0,0.368 0.082,0.645 0.25,0.832 0.168,0.188 0.422,0.278 0.754,0.278 0.133,0 0.25,-0.008 0.351,-0.032 0.102,-0.023 0.196,-0.058 0.278,-0.105 z m 0.597,0.078 h 0.602 v -2.086 l -0.656,0.133 v -0.336 l 0.652,-0.133 h 0.371 v 2.422 h 0.606 v 0.313 h -1.575 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath449)"
+             id="path980" />
+          <path
+             d="m 126.789,192.918 v 1.023 h 0.465 c 0.172,0 0.305,-0.043 0.398,-0.132 0.098,-0.09 0.145,-0.215 0.145,-0.379 0,-0.164 -0.047,-0.289 -0.145,-0.379 -0.093,-0.09 -0.226,-0.133 -0.398,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.207 0.156,0.141 0.235,0.34 0.235,0.61 0,0.269 -0.079,0.472 -0.235,0.609 -0.156,0.141 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 1.937,0 h 1.571 v 0.309 h -1.203 v 0.808 h 1.085 v 0.309 h -1.085 v 1.305 h -0.368 z m 1.766,2.676 v -0.336 c 0.09,0.043 0.184,0.074 0.281,0.098 0.094,0.023 0.188,0.035 0.282,0.035 0.242,0 0.429,-0.082 0.554,-0.242 0.133,-0.168 0.203,-0.418 0.223,-0.75 -0.07,0.105 -0.16,0.183 -0.27,0.242 -0.109,0.055 -0.226,0.082 -0.359,0.082 -0.274,0 -0.492,-0.082 -0.648,-0.246 -0.161,-0.164 -0.239,-0.391 -0.239,-0.68 0,-0.281 0.082,-0.504 0.246,-0.676 0.168,-0.168 0.387,-0.254 0.664,-0.254 0.317,0 0.559,0.122 0.723,0.364 0.168,0.242 0.25,0.594 0.25,1.054 0,0.434 -0.102,0.778 -0.305,1.036 -0.207,0.254 -0.48,0.382 -0.824,0.382 -0.094,0 -0.187,-0.007 -0.281,-0.027 -0.098,-0.019 -0.195,-0.047 -0.297,-0.082 z m 0.734,-1.16 c 0.168,0 0.297,-0.055 0.395,-0.168 0.098,-0.113 0.144,-0.27 0.144,-0.469 0,-0.195 -0.046,-0.351 -0.144,-0.465 -0.098,-0.113 -0.227,-0.172 -0.395,-0.172 -0.164,0 -0.297,0.059 -0.394,0.172 -0.098,0.114 -0.145,0.27 -0.145,0.465 0,0.199 0.047,0.356 0.145,0.469 0.097,0.113 0.23,0.168 0.394,0.168 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath450)"
+             id="path981" />
+          <path
+             d="m 126.789,188.668 v 1.023 h 0.465 c 0.172,0 0.305,-0.043 0.398,-0.132 0.098,-0.09 0.145,-0.215 0.145,-0.379 0,-0.164 -0.047,-0.289 -0.145,-0.379 -0.093,-0.09 -0.226,-0.133 -0.398,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.207 0.156,0.137 0.235,0.34 0.235,0.61 0,0.269 -0.079,0.472 -0.235,0.609 -0.156,0.141 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 1.937,0 h 1.571 v 0.309 h -1.203 v 0.808 h 1.085 v 0.309 h -1.085 v 1.305 h -0.368 z m 1.661,0 h 1.757 v 0.157 l -0.992,2.574 h -0.387 l 0.934,-2.422 h -1.312 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath451)"
+             id="path982" />
+          <path
+             d="m 126.789,184.414 v 1.027 h 0.465 c 0.172,0 0.305,-0.043 0.398,-0.132 0.098,-0.09 0.145,-0.215 0.145,-0.383 0,-0.16 -0.047,-0.289 -0.145,-0.379 -0.093,-0.086 -0.226,-0.133 -0.398,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.211 0.156,0.137 0.235,0.34 0.235,0.606 0,0.273 -0.079,0.476 -0.235,0.613 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 1.937,0 h 1.571 v 0.313 h -1.203 v 0.805 h 1.085 v 0.312 h -1.085 v 1.305 h -0.368 z m 2.543,1.438 c -0.175,0 -0.312,0.047 -0.414,0.141 -0.101,0.093 -0.152,0.222 -0.152,0.386 0,0.164 0.051,0.297 0.152,0.391 0.102,0.094 0.239,0.14 0.414,0.14 0.176,0 0.317,-0.046 0.418,-0.14 0.102,-0.098 0.153,-0.227 0.153,-0.391 0,-0.164 -0.051,-0.293 -0.153,-0.386 -0.101,-0.094 -0.238,-0.141 -0.418,-0.141 z m -0.367,-0.156 c -0.16,-0.039 -0.285,-0.114 -0.375,-0.223 -0.086,-0.109 -0.129,-0.242 -0.129,-0.398 0,-0.219 0.078,-0.391 0.231,-0.516 0.156,-0.129 0.371,-0.192 0.64,-0.192 0.274,0 0.489,0.063 0.641,0.192 0.156,0.125 0.234,0.297 0.234,0.516 0,0.156 -0.047,0.289 -0.132,0.398 -0.09,0.109 -0.211,0.184 -0.372,0.223 0.18,0.039 0.321,0.121 0.418,0.242 0.098,0.121 0.149,0.269 0.149,0.441 0,0.266 -0.082,0.469 -0.242,0.61 -0.16,0.144 -0.395,0.214 -0.696,0.214 -0.3,0 -0.531,-0.07 -0.695,-0.214 -0.16,-0.141 -0.242,-0.344 -0.242,-0.61 0,-0.172 0.051,-0.32 0.152,-0.441 0.098,-0.121 0.238,-0.203 0.418,-0.242 z m -0.137,-0.586 c 0,0.14 0.043,0.254 0.133,0.332 0.086,0.078 0.211,0.117 0.371,0.117 0.16,0 0.286,-0.039 0.371,-0.117 0.094,-0.078 0.137,-0.192 0.137,-0.332 0,-0.141 -0.043,-0.25 -0.137,-0.332 -0.085,-0.078 -0.211,-0.118 -0.371,-0.118 -0.16,0 -0.285,0.04 -0.371,0.118 -0.09,0.082 -0.133,0.191 -0.133,0.332 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath452)"
+             id="path983" />
+          <path
+             d="m 126.789,180.164 v 1.027 h 0.465 c 0.172,0 0.305,-0.043 0.398,-0.132 0.098,-0.09 0.145,-0.219 0.145,-0.383 0,-0.164 -0.047,-0.289 -0.145,-0.379 -0.093,-0.09 -0.226,-0.133 -0.398,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.211 0.156,0.137 0.235,0.34 0.235,0.606 0,0.269 -0.079,0.472 -0.235,0.613 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 1.937,0 h 1.727 v 0.313 h -1.359 v 0.808 h 1.304 v 0.313 h -1.304 v 0.988 h 1.394 v 0.313 h -1.762 z m 2.981,1.262 c 0.18,0.035 0.316,0.113 0.414,0.234 0.101,0.122 0.152,0.266 0.152,0.442 0,0.273 -0.094,0.48 -0.277,0.629 -0.188,0.148 -0.449,0.219 -0.793,0.219 -0.113,0 -0.234,-0.012 -0.356,-0.032 -0.121,-0.023 -0.246,-0.058 -0.375,-0.101 v -0.36 c 0.102,0.063 0.215,0.106 0.336,0.137 0.125,0.031 0.25,0.047 0.383,0.047 0.235,0 0.41,-0.047 0.531,-0.137 0.122,-0.094 0.184,-0.226 0.184,-0.402 0,-0.16 -0.059,-0.285 -0.172,-0.375 -0.113,-0.09 -0.269,-0.137 -0.469,-0.137 h -0.32 v -0.305 h 0.332 c 0.184,0 0.324,-0.035 0.418,-0.109 0.098,-0.07 0.145,-0.176 0.145,-0.312 0,-0.141 -0.051,-0.25 -0.149,-0.325 -0.101,-0.074 -0.242,-0.113 -0.426,-0.113 -0.101,0 -0.21,0.012 -0.328,0.035 -0.117,0.02 -0.242,0.055 -0.382,0.102 v -0.328 c 0.14,-0.039 0.273,-0.071 0.394,-0.09 0.125,-0.02 0.238,-0.028 0.348,-0.028 0.281,0 0.504,0.063 0.668,0.192 0.164,0.125 0.242,0.297 0.242,0.516 0,0.152 -0.043,0.277 -0.129,0.382 -0.086,0.106 -0.211,0.176 -0.371,0.219 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath453)"
+             id="path984" />
+          <path
+             d="m 126.789,175.914 v 1.027 h 0.465 c 0.172,0 0.305,-0.046 0.398,-0.136 0.098,-0.086 0.145,-0.215 0.145,-0.379 0,-0.164 -0.047,-0.289 -0.145,-0.379 -0.093,-0.09 -0.226,-0.133 -0.398,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.207 0.156,0.141 0.235,0.344 0.235,0.61 0,0.269 -0.079,0.472 -0.235,0.609 -0.156,0.141 -0.387,0.207 -0.695,0.207 h -0.465 v 1.102 h -0.367 z m 1.937,0 h 1.727 v 0.313 h -1.359 v 0.808 h 1.304 v 0.309 h -1.304 v 0.992 h 1.394 v 0.313 h -1.762 z m 2.7,1.219 c -0.168,0 -0.297,0.059 -0.395,0.172 -0.098,0.113 -0.144,0.27 -0.144,0.465 0,0.195 0.046,0.351 0.144,0.469 0.098,0.113 0.227,0.168 0.395,0.168 0.164,0 0.296,-0.055 0.394,-0.168 0.098,-0.118 0.145,-0.274 0.145,-0.469 0,-0.195 -0.047,-0.352 -0.145,-0.465 -0.098,-0.113 -0.23,-0.172 -0.394,-0.172 z m 0.734,-1.16 v 0.34 c -0.094,-0.047 -0.188,-0.078 -0.281,-0.102 -0.094,-0.023 -0.188,-0.035 -0.282,-0.035 -0.246,0 -0.429,0.082 -0.562,0.246 -0.125,0.164 -0.199,0.414 -0.219,0.746 0.074,-0.105 0.164,-0.187 0.274,-0.242 0.105,-0.059 0.226,-0.086 0.355,-0.086 0.277,0 0.492,0.082 0.652,0.25 0.161,0.168 0.239,0.395 0.239,0.68 0,0.281 -0.082,0.508 -0.246,0.676 -0.168,0.168 -0.391,0.254 -0.664,0.254 -0.317,0 -0.559,-0.122 -0.727,-0.364 -0.168,-0.242 -0.25,-0.593 -0.25,-1.054 0,-0.43 0.102,-0.774 0.309,-1.032 0.203,-0.257 0.48,-0.386 0.824,-0.386 0.094,0 0.187,0.011 0.281,0.027 0.094,0.019 0.195,0.047 0.297,0.082 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath454)"
+             id="path985" />
+          <path
+             d="m 126.789,167.41 v 1.028 h 0.465 c 0.172,0 0.305,-0.043 0.398,-0.133 0.098,-0.09 0.145,-0.215 0.145,-0.383 0,-0.16 -0.047,-0.289 -0.145,-0.379 -0.093,-0.086 -0.226,-0.133 -0.398,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.211 0.156,0.137 0.235,0.34 0.235,0.606 0,0.273 -0.079,0.476 -0.235,0.613 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 1.937,0 h 1.727 v 0.313 h -1.359 v 0.809 h 1.304 v 0.312 h -1.304 v 0.988 h 1.394 v 0.313 h -1.762 z m 2.879,0.325 -0.933,1.457 h 0.933 z m -0.097,-0.325 h 0.464 v 1.782 h 0.391 v 0.308 h -0.391 v 0.645 h -0.367 v -0.645 h -1.234 v -0.355 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath455)"
+             id="path986" />
+          <path
+             d="m 126.789,163.16 v 1.028 h 0.465 c 0.172,0 0.305,-0.043 0.398,-0.133 0.098,-0.09 0.145,-0.219 0.145,-0.383 0,-0.164 -0.047,-0.289 -0.145,-0.379 -0.093,-0.09 -0.226,-0.133 -0.398,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.211 0.156,0.137 0.235,0.34 0.235,0.606 0,0.269 -0.079,0.473 -0.235,0.613 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 1.937,0 h 1.727 v 0.313 h -1.359 v 0.809 h 1.304 v 0.312 h -1.304 v 0.988 h 1.394 v 0.313 h -1.762 z m 2.18,2.422 h 1.293 v 0.313 h -1.738 v -0.313 c 0.14,-0.144 0.332,-0.339 0.574,-0.582 0.242,-0.246 0.394,-0.406 0.457,-0.476 0.117,-0.133 0.203,-0.242 0.246,-0.336 0.051,-0.094 0.074,-0.184 0.074,-0.274 0,-0.144 -0.05,-0.261 -0.156,-0.355 -0.101,-0.09 -0.23,-0.137 -0.394,-0.137 -0.118,0 -0.239,0.02 -0.372,0.063 -0.125,0.039 -0.265,0.101 -0.41,0.183 v -0.375 c 0.149,-0.058 0.289,-0.105 0.418,-0.136 0.129,-0.028 0.246,-0.043 0.356,-0.043 0.281,0 0.508,0.07 0.675,0.211 0.168,0.14 0.254,0.332 0.254,0.566 0,0.113 -0.023,0.219 -0.066,0.32 -0.039,0.102 -0.117,0.219 -0.227,0.356 -0.031,0.035 -0.128,0.136 -0.293,0.308 -0.16,0.168 -0.394,0.403 -0.691,0.707 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath456)"
+             id="path987" />
+          <path
+             d="m 126.789,171.664 v 1.024 h 0.465 c 0.172,0 0.305,-0.043 0.398,-0.133 0.098,-0.09 0.145,-0.215 0.145,-0.379 0,-0.164 -0.047,-0.289 -0.145,-0.379 -0.093,-0.09 -0.226,-0.133 -0.398,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.207 0.156,0.137 0.235,0.34 0.235,0.61 0,0.269 -0.079,0.472 -0.235,0.609 -0.156,0.141 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 1.937,0 h 1.727 v 0.309 h -1.359 v 0.812 h 1.304 v 0.309 h -1.304 v 0.992 h 1.394 v 0.309 h -1.762 z m 1.868,0 h 1.449 v 0.309 h -1.114 v 0.672 c 0.055,-0.02 0.11,-0.031 0.165,-0.039 0.05,-0.012 0.105,-0.016 0.16,-0.016 0.304,0 0.547,0.082 0.722,0.25 0.18,0.168 0.27,0.395 0.27,0.68 0,0.293 -0.094,0.523 -0.274,0.687 -0.183,0.16 -0.441,0.243 -0.777,0.243 -0.113,0 -0.23,-0.012 -0.351,-0.032 -0.118,-0.019 -0.239,-0.047 -0.368,-0.086 v -0.371 c 0.11,0.059 0.223,0.106 0.34,0.133 0.117,0.031 0.242,0.043 0.371,0.043 0.211,0 0.379,-0.055 0.504,-0.164 0.121,-0.113 0.184,-0.262 0.184,-0.453 0,-0.192 -0.063,-0.34 -0.184,-0.453 -0.125,-0.11 -0.293,-0.164 -0.504,-0.164 -0.097,0 -0.195,0.007 -0.297,0.031 -0.097,0.023 -0.195,0.055 -0.296,0.101 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath457)"
+             id="path988" />
+          <path
+             d="m 170.445,197.164 v 1.027 h 0.465 c 0.172,0 0.305,-0.046 0.399,-0.132 0.093,-0.09 0.14,-0.219 0.14,-0.383 0,-0.164 -0.047,-0.289 -0.14,-0.379 -0.094,-0.09 -0.227,-0.133 -0.399,-0.133 z m -0.371,-0.305 h 0.836 c 0.305,0 0.539,0.071 0.695,0.211 0.157,0.137 0.235,0.34 0.235,0.606 0,0.269 -0.078,0.472 -0.235,0.613 -0.156,0.137 -0.39,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.371 z m 1.942,0 h 1.726 v 0.313 h -1.359 v 0.808 h 1.301 v 0.313 h -1.301 v 0.988 h 1.39 v 0.313 h -1.757 z m 2.652,0.243 c -0.191,0 -0.336,0.097 -0.43,0.285 -0.097,0.183 -0.144,0.465 -0.144,0.843 0,0.375 0.047,0.657 0.144,0.844 0.094,0.184 0.239,0.278 0.43,0.278 0.191,0 0.336,-0.094 0.43,-0.278 0.097,-0.187 0.144,-0.469 0.144,-0.844 0,-0.378 -0.047,-0.66 -0.144,-0.843 -0.094,-0.188 -0.239,-0.285 -0.43,-0.285 z m 0,-0.29 c 0.305,0 0.539,0.122 0.699,0.364 0.164,0.242 0.246,0.594 0.246,1.054 0,0.458 -0.082,0.809 -0.246,1.055 -0.16,0.238 -0.394,0.36 -0.699,0.36 -0.309,0 -0.543,-0.122 -0.703,-0.36 -0.16,-0.246 -0.242,-0.597 -0.242,-1.055 0,-0.46 0.082,-0.812 0.242,-1.054 0.16,-0.242 0.394,-0.364 0.703,-0.364 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath458)"
+             id="path989" />
+          <path
+             d="m 170.234,192.914 v 1.027 h 0.465 c 0.172,0 0.305,-0.046 0.399,-0.136 0.093,-0.086 0.14,-0.215 0.14,-0.379 0,-0.164 -0.047,-0.289 -0.14,-0.379 -0.094,-0.09 -0.227,-0.133 -0.399,-0.133 z m -0.367,-0.305 h 0.832 c 0.309,0 0.539,0.071 0.696,0.207 0.156,0.141 0.234,0.344 0.234,0.61 0,0.269 -0.078,0.472 -0.234,0.609 -0.157,0.141 -0.387,0.207 -0.696,0.207 h -0.465 v 1.102 h -0.367 z m 2.305,1.426 v 1.004 h 0.594 c 0.199,0 0.347,-0.043 0.441,-0.125 0.098,-0.082 0.145,-0.207 0.145,-0.379 0,-0.168 -0.047,-0.297 -0.145,-0.375 -0.094,-0.082 -0.242,-0.125 -0.441,-0.125 z m 0,-1.121 v 0.824 h 0.551 c 0.179,0 0.312,-0.035 0.402,-0.101 0.086,-0.071 0.133,-0.172 0.133,-0.313 0,-0.136 -0.047,-0.242 -0.133,-0.308 -0.09,-0.071 -0.223,-0.102 -0.402,-0.102 z m -0.367,-0.305 h 0.945 c 0.281,0 0.496,0.059 0.648,0.176 0.157,0.117 0.231,0.285 0.231,0.5 0,0.168 -0.039,0.301 -0.117,0.399 -0.078,0.097 -0.192,0.16 -0.344,0.183 0.18,0.039 0.324,0.121 0.422,0.246 0.101,0.125 0.152,0.278 0.152,0.465 0,0.242 -0.082,0.43 -0.25,0.563 -0.164,0.132 -0.402,0.203 -0.707,0.203 h -0.98 z m 2.863,0.243 c -0.191,0 -0.336,0.093 -0.43,0.281 -0.097,0.187 -0.144,0.469 -0.144,0.844 0,0.375 0.047,0.656 0.144,0.843 0.094,0.188 0.239,0.282 0.43,0.282 0.191,0 0.336,-0.094 0.43,-0.282 0.097,-0.187 0.144,-0.468 0.144,-0.843 0,-0.375 -0.047,-0.657 -0.144,-0.844 -0.094,-0.188 -0.239,-0.281 -0.43,-0.281 z m 0,-0.293 c 0.305,0 0.539,0.121 0.699,0.367 0.164,0.238 0.246,0.59 0.246,1.051 0,0.461 -0.082,0.812 -0.246,1.054 -0.16,0.242 -0.394,0.364 -0.699,0.364 -0.309,0 -0.543,-0.122 -0.703,-0.364 -0.16,-0.242 -0.242,-0.593 -0.242,-1.054 0,-0.461 0.082,-0.813 0.242,-1.051 0.16,-0.246 0.394,-0.367 0.703,-0.367 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath459)"
+             id="path990" />
+          <path
+             d="m 170.109,188.664 v 1.027 h 0.465 c 0.172,0 0.305,-0.046 0.399,-0.136 0.093,-0.086 0.14,-0.215 0.14,-0.379 0,-0.164 -0.047,-0.289 -0.14,-0.379 -0.094,-0.09 -0.227,-0.133 -0.399,-0.133 z m -0.371,-0.305 h 0.836 c 0.305,0 0.535,0.071 0.692,0.207 0.16,0.141 0.238,0.34 0.238,0.61 0,0.269 -0.078,0.472 -0.238,0.609 -0.157,0.141 -0.387,0.207 -0.692,0.207 h -0.465 v 1.098 h -0.371 z m 2.574,0.364 -0.5,1.359 h 1.004 z m -0.207,-0.364 h 0.418 l 1.043,2.731 h -0.386 l -0.25,-0.699 h -1.231 l -0.25,0.699 h -0.39 z m 2.286,0.243 c -0.188,0 -0.332,0.093 -0.43,0.281 -0.094,0.187 -0.141,0.469 -0.141,0.844 0,0.375 0.047,0.656 0.141,0.843 0.098,0.188 0.242,0.282 0.43,0.282 0.191,0 0.336,-0.094 0.433,-0.282 0.094,-0.187 0.145,-0.468 0.145,-0.843 0,-0.375 -0.051,-0.657 -0.145,-0.844 -0.097,-0.188 -0.242,-0.281 -0.433,-0.281 z m 0,-0.293 c 0.308,0 0.543,0.121 0.703,0.363 0.16,0.242 0.242,0.594 0.242,1.055 0,0.461 -0.082,0.812 -0.242,1.054 -0.16,0.242 -0.395,0.364 -0.703,0.364 -0.305,0 -0.539,-0.122 -0.703,-0.364 -0.161,-0.242 -0.239,-0.593 -0.239,-1.054 0,-0.461 0.078,-0.813 0.239,-1.055 0.164,-0.242 0.398,-0.363 0.703,-0.363 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath460)"
+             id="path991" />
+          <path
+             d="m 170.516,186.449 v -0.73 h -0.606 v -0.305 h 0.969 v 1.172 c -0.141,0.102 -0.297,0.18 -0.473,0.23 -0.172,0.051 -0.355,0.079 -0.551,0.079 -0.425,0 -0.761,-0.125 -1,-0.375 -0.242,-0.25 -0.363,-0.598 -0.363,-1.043 0,-0.446 0.121,-0.793 0.363,-1.043 0.239,-0.25 0.575,-0.375 1,-0.375 0.18,0 0.348,0.023 0.508,0.066 0.16,0.043 0.309,0.109 0.446,0.195 v 0.391 c -0.137,-0.113 -0.282,-0.203 -0.434,-0.262 -0.156,-0.058 -0.316,-0.086 -0.488,-0.086 -0.332,0 -0.586,0.094 -0.754,0.278 -0.168,0.187 -0.25,0.464 -0.25,0.836 0,0.367 0.082,0.648 0.25,0.832 0.168,0.187 0.422,0.281 0.754,0.281 0.133,0 0.25,-0.012 0.351,-0.031 0.102,-0.024 0.196,-0.059 0.278,-0.11 z m 0.5,-2.34 h 0.496 l 1.215,2.286 v -2.286 h 0.359 v 2.731 h -0.5 l -1.211,-2.285 v 2.285 h -0.359 z m 2.789,0.301 v 2.125 h 0.449 c 0.375,0 0.652,-0.082 0.828,-0.254 0.176,-0.172 0.262,-0.441 0.262,-0.808 0,-0.368 -0.086,-0.637 -0.262,-0.805 -0.176,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.367,-0.301 h 0.757 c 0.532,0 0.918,0.11 1.168,0.329 0.246,0.222 0.371,0.566 0.371,1.035 0,0.468 -0.125,0.816 -0.375,1.035 -0.246,0.222 -0.636,0.332 -1.164,0.332 h -0.757 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath461)"
+             id="path992" />
+          <path
+             d="m 170.473,180.16 v 1.028 h 0.465 c 0.171,0 0.304,-0.043 0.398,-0.133 0.094,-0.09 0.141,-0.215 0.141,-0.383 0,-0.16 -0.047,-0.289 -0.141,-0.379 -0.094,-0.086 -0.227,-0.133 -0.398,-0.133 z m -0.371,-0.305 h 0.836 c 0.304,0 0.535,0.071 0.691,0.211 0.16,0.137 0.238,0.34 0.238,0.606 0,0.269 -0.078,0.476 -0.238,0.613 -0.156,0.137 -0.387,0.207 -0.691,0.207 h -0.465 v 1.098 h -0.371 z m 1.937,0 h 1.731 v 0.313 h -1.36 v 0.809 h 1.301 v 0.312 h -1.301 v 0.988 h 1.391 v 0.313 h -1.762 z m 2.184,2.422 h 1.289 v 0.313 h -1.735 v -0.313 c 0.141,-0.144 0.332,-0.339 0.571,-0.582 0.246,-0.246 0.398,-0.402 0.461,-0.476 0.117,-0.133 0.199,-0.242 0.246,-0.336 0.047,-0.09 0.07,-0.184 0.07,-0.274 0,-0.144 -0.051,-0.261 -0.152,-0.351 -0.102,-0.094 -0.235,-0.141 -0.399,-0.141 -0.117,0 -0.238,0.024 -0.367,0.063 -0.129,0.039 -0.266,0.101 -0.414,0.183 v -0.375 c 0.152,-0.058 0.289,-0.105 0.418,-0.136 0.129,-0.028 0.25,-0.043 0.355,-0.043 0.286,0 0.512,0.07 0.68,0.211 0.168,0.14 0.25,0.332 0.25,0.566 0,0.113 -0.019,0.219 -0.062,0.32 -0.043,0.102 -0.118,0.219 -0.231,0.356 -0.027,0.035 -0.125,0.14 -0.289,0.308 -0.164,0.168 -0.394,0.407 -0.691,0.707 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath462)"
+             id="path993" />
+          <path
+             d="m 168.066,175.91 v 1.028 h 0.465 c 0.172,0 0.309,-0.047 0.403,-0.133 0.093,-0.09 0.14,-0.219 0.14,-0.383 0,-0.164 -0.047,-0.289 -0.14,-0.379 -0.094,-0.09 -0.231,-0.133 -0.403,-0.133 z m -0.367,-0.305 h 0.832 c 0.309,0 0.539,0.071 0.696,0.211 0.156,0.137 0.238,0.34 0.238,0.606 0,0.269 -0.082,0.473 -0.238,0.613 -0.157,0.137 -0.387,0.207 -0.696,0.207 h -0.465 v 1.098 h -0.367 z m 2.309,0.305 v 2.125 h 0.445 c 0.379,0 0.652,-0.086 0.828,-0.258 0.176,-0.168 0.262,-0.437 0.262,-0.808 0,-0.367 -0.086,-0.633 -0.262,-0.801 -0.176,-0.172 -0.449,-0.258 -0.828,-0.258 z m -0.371,-0.305 h 0.758 c 0.531,0 0.921,0.11 1.167,0.333 0.247,0.218 0.372,0.562 0.372,1.031 0,0.472 -0.125,0.816 -0.372,1.039 -0.25,0.219 -0.64,0.332 -1.167,0.332 h -0.758 z m 2.402,2.422 h 0.606 v -2.086 l -0.657,0.133 v -0.336 l 0.653,-0.133 h 0.371 v 2.422 h 0.601 v 0.313 h -1.574 z m 1.902,0 h 0.602 v -2.086 l -0.656,0.133 v -0.336 l 0.652,-0.133 h 0.371 v 2.422 h 0.606 v 0.313 h -1.575 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath463)"
+             id="path994" />
+          <path
+             d="m 168.066,171.66 v 1.028 h 0.465 c 0.172,0 0.309,-0.047 0.403,-0.137 0.093,-0.086 0.14,-0.215 0.14,-0.379 0,-0.164 -0.047,-0.289 -0.14,-0.379 -0.094,-0.09 -0.231,-0.133 -0.403,-0.133 z m -0.367,-0.305 h 0.832 c 0.309,0 0.539,0.071 0.696,0.207 0.156,0.141 0.238,0.34 0.238,0.61 0,0.269 -0.082,0.473 -0.238,0.609 -0.157,0.141 -0.387,0.207 -0.696,0.207 h -0.465 v 1.098 h -0.367 z m 2.309,0.305 v 2.125 h 0.445 c 0.379,0 0.652,-0.086 0.828,-0.258 0.176,-0.172 0.262,-0.441 0.262,-0.808 0,-0.367 -0.086,-0.633 -0.262,-0.805 -0.176,-0.168 -0.449,-0.254 -0.828,-0.254 z m -0.371,-0.305 h 0.758 c 0.531,0 0.921,0.11 1.167,0.333 0.247,0.218 0.372,0.562 0.372,1.031 0,0.472 -0.125,0.816 -0.372,1.039 -0.25,0.219 -0.64,0.328 -1.167,0.328 h -0.758 z m 2.402,2.422 h 0.606 v -2.086 l -0.657,0.133 v -0.336 l 0.653,-0.133 h 0.371 v 2.422 h 0.601 v 0.309 h -1.574 z m 2.156,0 h 1.289 v 0.309 h -1.734 v -0.309 c 0.141,-0.144 0.332,-0.339 0.574,-0.586 0.242,-0.242 0.395,-0.402 0.457,-0.472 0.117,-0.133 0.199,-0.246 0.246,-0.336 0.047,-0.094 0.071,-0.184 0.071,-0.274 0,-0.144 -0.051,-0.265 -0.153,-0.355 -0.101,-0.09 -0.234,-0.137 -0.398,-0.137 -0.113,0 -0.238,0.02 -0.367,0.059 -0.129,0.043 -0.266,0.101 -0.41,0.183 v -0.371 c 0.148,-0.062 0.285,-0.105 0.418,-0.136 0.128,-0.032 0.246,-0.047 0.351,-0.047 0.285,0 0.512,0.07 0.68,0.215 0.168,0.14 0.254,0.328 0.254,0.566 0,0.113 -0.024,0.219 -0.067,0.32 -0.039,0.098 -0.117,0.219 -0.226,0.356 -0.032,0.035 -0.129,0.136 -0.293,0.304 -0.164,0.172 -0.395,0.407 -0.692,0.711 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath464)"
+             id="path995" />
+          <path
+             d="m 168.094,167.406 v 1.028 h 0.465 c 0.171,0 0.304,-0.043 0.398,-0.133 0.094,-0.09 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.293 -0.141,-0.379 -0.094,-0.09 -0.227,-0.137 -0.398,-0.137 z m -0.371,-0.301 h 0.836 c 0.308,0 0.539,0.067 0.695,0.207 0.156,0.137 0.234,0.34 0.234,0.61 0,0.269 -0.078,0.473 -0.234,0.609 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.371 z m 2.308,0.301 v 2.125 h 0.449 c 0.375,0 0.653,-0.082 0.829,-0.254 0.175,-0.172 0.261,-0.441 0.261,-0.808 0,-0.367 -0.086,-0.637 -0.261,-0.805 -0.176,-0.172 -0.454,-0.258 -0.829,-0.258 z m -0.367,-0.301 h 0.758 c 0.531,0 0.918,0.11 1.168,0.329 0.246,0.222 0.371,0.566 0.371,1.035 0,0.469 -0.125,0.816 -0.375,1.035 -0.246,0.223 -0.637,0.332 -1.164,0.332 h -0.758 z m 2.402,2.422 h 0.602 v -2.086 l -0.656,0.133 v -0.34 l 0.656,-0.129 h 0.367 v 2.422 h 0.606 v 0.309 h -1.575 z m 2.957,-1.164 c 0.176,0.039 0.317,0.117 0.415,0.235 0.097,0.121 0.148,0.269 0.148,0.445 0,0.269 -0.09,0.477 -0.277,0.625 -0.184,0.148 -0.45,0.223 -0.789,0.223 -0.118,0 -0.235,-0.012 -0.356,-0.036 -0.121,-0.023 -0.246,-0.054 -0.375,-0.101 v -0.356 c 0.102,0.059 0.215,0.106 0.336,0.133 0.121,0.031 0.25,0.047 0.383,0.047 0.23,0 0.406,-0.047 0.527,-0.137 0.121,-0.089 0.184,-0.222 0.184,-0.398 0,-0.16 -0.055,-0.289 -0.172,-0.379 -0.109,-0.09 -0.266,-0.137 -0.469,-0.137 h -0.32 v -0.304 h 0.336 c 0.179,0 0.32,-0.035 0.418,-0.106 0.093,-0.074 0.144,-0.179 0.144,-0.316 0,-0.141 -0.051,-0.246 -0.152,-0.321 -0.098,-0.078 -0.238,-0.113 -0.426,-0.113 -0.101,0 -0.211,0.008 -0.324,0.031 -0.117,0.024 -0.246,0.055 -0.383,0.102 v -0.328 c 0.141,-0.039 0.27,-0.07 0.391,-0.09 0.125,-0.02 0.242,-0.027 0.347,-0.027 0.282,0 0.504,0.062 0.668,0.191 0.164,0.129 0.246,0.301 0.246,0.516 0,0.152 -0.043,0.281 -0.128,0.386 -0.09,0.102 -0.211,0.176 -0.372,0.215 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath465)"
+             id="path996" />
+          <path
+             d="m 170.516,165.195 v -0.734 h -0.606 v -0.305 h 0.969 v 1.176 c -0.141,0.102 -0.297,0.176 -0.473,0.23 -0.172,0.051 -0.355,0.079 -0.551,0.079 -0.425,0 -0.761,-0.125 -1,-0.375 -0.242,-0.25 -0.363,-0.598 -0.363,-1.043 0,-0.446 0.121,-0.793 0.363,-1.043 0.239,-0.25 0.575,-0.375 1,-0.375 0.18,0 0.348,0.019 0.508,0.066 0.16,0.043 0.309,0.106 0.446,0.191 v 0.395 c -0.137,-0.117 -0.282,-0.203 -0.434,-0.262 -0.156,-0.058 -0.316,-0.086 -0.488,-0.086 -0.332,0 -0.586,0.09 -0.754,0.278 -0.168,0.187 -0.25,0.465 -0.25,0.836 0,0.367 0.082,0.644 0.25,0.832 0.168,0.187 0.422,0.281 0.754,0.281 0.133,0 0.25,-0.012 0.351,-0.035 0.102,-0.024 0.196,-0.059 0.278,-0.106 z m 0.5,-2.343 h 0.496 l 1.215,2.289 v -2.289 h 0.359 v 2.734 h -0.5 l -1.211,-2.285 v 2.285 h -0.359 z m 2.789,0.304 v 2.125 h 0.449 c 0.375,0 0.652,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.441 0.262,-0.812 0,-0.363 -0.086,-0.633 -0.262,-0.801 -0.176,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.367,-0.304 h 0.757 c 0.532,0 0.918,0.113 1.168,0.332 0.246,0.218 0.371,0.566 0.371,1.031 0,0.473 -0.125,0.82 -0.375,1.039 -0.246,0.223 -0.636,0.332 -1.164,0.332 h -0.757 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath466)"
+             id="path997" />
+          <path
+             d="m 170.234,122.562 v 1.028 h 0.465 c 0.172,0 0.305,-0.043 0.399,-0.133 0.093,-0.09 0.14,-0.219 0.14,-0.383 0,-0.164 -0.047,-0.289 -0.14,-0.379 -0.094,-0.09 -0.227,-0.133 -0.399,-0.133 z m -0.367,-0.304 h 0.832 c 0.309,0 0.539,0.07 0.696,0.211 0.156,0.136 0.234,0.34 0.234,0.605 0,0.27 -0.078,0.473 -0.234,0.614 -0.157,0.136 -0.387,0.207 -0.696,0.207 h -0.465 v 1.097 h -0.367 z m 2.305,1.43 v 1 h 0.594 c 0.199,0 0.347,-0.04 0.441,-0.122 0.098,-0.086 0.145,-0.211 0.145,-0.378 0,-0.172 -0.047,-0.297 -0.145,-0.379 -0.094,-0.082 -0.242,-0.121 -0.441,-0.121 z m 0,-1.126 v 0.825 h 0.551 c 0.179,0 0.312,-0.035 0.402,-0.102 0.086,-0.066 0.133,-0.172 0.133,-0.312 0,-0.137 -0.047,-0.239 -0.133,-0.309 -0.09,-0.066 -0.223,-0.102 -0.402,-0.102 z m -0.367,-0.304 h 0.945 c 0.281,0 0.496,0.058 0.648,0.176 0.157,0.117 0.231,0.285 0.231,0.5 0,0.168 -0.039,0.3 -0.117,0.398 -0.078,0.102 -0.192,0.16 -0.344,0.188 0.18,0.039 0.324,0.121 0.422,0.242 0.101,0.125 0.152,0.281 0.152,0.465 0,0.242 -0.082,0.433 -0.25,0.566 -0.164,0.133 -0.402,0.199 -0.707,0.199 h -0.98 z m 3.086,0.324 -0.934,1.457 h 0.934 z m -0.094,-0.324 h 0.465 v 1.781 h 0.39 v 0.309 h -0.39 v 0.644 h -0.371 v -0.644 h -1.231 v -0.356 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath467)"
+             id="path998" />
+          <path
+             d="m 170.133,118.312 v 1.028 h 0.465 c 0.172,0 0.304,-0.047 0.398,-0.137 0.098,-0.086 0.145,-0.215 0.145,-0.379 0,-0.164 -0.047,-0.289 -0.145,-0.379 -0.094,-0.09 -0.226,-0.133 -0.398,-0.133 z m -0.367,-0.304 h 0.832 c 0.308,0 0.539,0.07 0.695,0.207 0.156,0.14 0.234,0.344 0.234,0.609 0,0.27 -0.078,0.473 -0.234,0.614 -0.156,0.136 -0.387,0.203 -0.695,0.203 h -0.465 v 1.101 h -0.367 z m 2.574,0.363 -0.504,1.359 h 1.008 z m -0.211,-0.363 h 0.422 l 1.039,2.734 h -0.383 l -0.25,-0.703 h -1.23 l -0.25,0.703 h -0.391 z m 2.516,0.32 -0.934,1.461 h 0.934 z m -0.098,-0.32 h 0.465 v 1.781 h 0.39 v 0.309 h -0.39 v 0.644 h -0.367 v -0.644 h -1.235 v -0.36 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath468)"
+             id="path999" />
+          <path
+             d="m 170.262,114.062 v 1.028 h 0.465 c 0.171,0 0.304,-0.047 0.398,-0.137 0.094,-0.086 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.227,-0.133 -0.398,-0.133 z m -0.371,-0.304 h 0.836 c 0.304,0 0.539,0.07 0.695,0.207 0.156,0.14 0.234,0.344 0.234,0.609 0,0.27 -0.078,0.473 -0.234,0.61 -0.156,0.14 -0.391,0.207 -0.695,0.207 h -0.465 v 1.101 h -0.371 z m 2.308,1.426 v 1.004 h 0.594 c 0.199,0 0.348,-0.043 0.441,-0.126 0.098,-0.082 0.145,-0.207 0.145,-0.378 0,-0.168 -0.047,-0.297 -0.145,-0.375 -0.093,-0.082 -0.242,-0.125 -0.441,-0.125 z m 0,-1.122 v 0.825 h 0.547 c 0.184,0 0.316,-0.035 0.402,-0.102 0.09,-0.07 0.137,-0.172 0.137,-0.312 0,-0.137 -0.047,-0.243 -0.137,-0.309 -0.086,-0.07 -0.218,-0.102 -0.402,-0.102 z m -0.371,-0.304 h 0.945 c 0.282,0 0.5,0.058 0.653,0.176 0.152,0.117 0.23,0.285 0.23,0.5 0,0.168 -0.039,0.3 -0.117,0.398 -0.078,0.098 -0.195,0.16 -0.344,0.184 0.18,0.039 0.321,0.121 0.422,0.246 0.102,0.125 0.153,0.277 0.153,0.465 0,0.242 -0.082,0.429 -0.25,0.562 -0.165,0.137 -0.403,0.203 -0.708,0.203 h -0.984 z m 3.195,1.258 c 0.176,0.039 0.317,0.117 0.415,0.238 0.097,0.117 0.148,0.266 0.148,0.441 0,0.27 -0.09,0.481 -0.277,0.625 -0.184,0.149 -0.45,0.223 -0.789,0.223 -0.118,0 -0.235,-0.012 -0.356,-0.035 -0.121,-0.02 -0.246,-0.055 -0.375,-0.102 v -0.355 c 0.102,0.058 0.215,0.105 0.336,0.137 0.121,0.031 0.25,0.042 0.383,0.042 0.23,0 0.406,-0.042 0.527,-0.136 0.121,-0.09 0.184,-0.223 0.184,-0.399 0,-0.16 -0.055,-0.285 -0.172,-0.375 -0.109,-0.093 -0.266,-0.136 -0.469,-0.136 h -0.32 v -0.305 h 0.336 c 0.179,0 0.32,-0.035 0.418,-0.109 0.093,-0.075 0.144,-0.18 0.144,-0.317 0,-0.137 -0.051,-0.246 -0.152,-0.32 -0.098,-0.074 -0.238,-0.113 -0.426,-0.113 -0.101,0 -0.211,0.011 -0.324,0.031 -0.117,0.023 -0.246,0.058 -0.383,0.105 v -0.332 c 0.141,-0.039 0.27,-0.066 0.391,-0.086 0.125,-0.019 0.242,-0.031 0.347,-0.031 0.282,0 0.504,0.066 0.668,0.191 0.164,0.129 0.246,0.301 0.246,0.52 0,0.148 -0.043,0.277 -0.128,0.383 -0.09,0.105 -0.211,0.176 -0.372,0.215 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath469)"
+             id="path1000" />
+          <path
+             d="m 170.234,109.809 v 1.027 h 0.465 c 0.172,0 0.305,-0.043 0.399,-0.133 0.093,-0.09 0.14,-0.215 0.14,-0.379 0,-0.164 -0.047,-0.289 -0.14,-0.379 -0.094,-0.09 -0.227,-0.136 -0.399,-0.136 z m -0.367,-0.301 h 0.832 c 0.309,0 0.539,0.07 0.696,0.207 0.156,0.137 0.234,0.34 0.234,0.609 0,0.27 -0.078,0.473 -0.234,0.61 -0.157,0.14 -0.387,0.207 -0.696,0.207 h -0.465 v 1.097 h -0.367 z m 2.305,1.426 v 1.004 h 0.594 c 0.199,0 0.347,-0.043 0.441,-0.126 0.098,-0.082 0.145,-0.207 0.145,-0.378 0,-0.172 -0.047,-0.297 -0.145,-0.375 -0.094,-0.082 -0.242,-0.125 -0.441,-0.125 z m 0,-1.125 v 0.824 h 0.551 c 0.179,0 0.312,-0.031 0.402,-0.098 0.086,-0.07 0.133,-0.172 0.133,-0.312 0,-0.137 -0.047,-0.243 -0.133,-0.309 -0.09,-0.07 -0.223,-0.105 -0.402,-0.105 z m -0.367,-0.301 h 0.945 c 0.281,0 0.496,0.058 0.648,0.176 0.157,0.117 0.231,0.281 0.231,0.5 0,0.164 -0.039,0.296 -0.117,0.398 -0.078,0.098 -0.192,0.16 -0.344,0.184 0.18,0.039 0.324,0.121 0.422,0.246 0.101,0.121 0.152,0.277 0.152,0.461 0,0.246 -0.082,0.433 -0.25,0.566 -0.164,0.133 -0.402,0.199 -0.707,0.199 h -0.98 z m 2.074,0 h 1.453 v 0.308 h -1.113 v 0.672 c 0.054,-0.019 0.105,-0.031 0.16,-0.039 0.055,-0.011 0.109,-0.015 0.16,-0.015 0.309,0 0.547,0.082 0.727,0.25 0.179,0.168 0.269,0.394 0.269,0.679 0,0.293 -0.094,0.524 -0.277,0.688 -0.184,0.16 -0.442,0.242 -0.774,0.242 -0.113,0 -0.23,-0.012 -0.351,-0.031 -0.117,-0.02 -0.242,-0.047 -0.367,-0.086 v -0.371 c 0.109,0.058 0.222,0.101 0.339,0.133 0.118,0.027 0.243,0.042 0.372,0.042 0.211,0 0.378,-0.054 0.503,-0.164 0.122,-0.113 0.184,-0.261 0.184,-0.453 0,-0.191 -0.062,-0.34 -0.184,-0.453 -0.125,-0.109 -0.292,-0.168 -0.503,-0.168 -0.098,0 -0.2,0.012 -0.297,0.035 -0.098,0.024 -0.196,0.055 -0.301,0.102 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath470)"
+             id="path1001" />
+          <path
+             d="m 170.273,105.559 v 1.027 h 0.465 c 0.172,0 0.305,-0.043 0.399,-0.133 0.093,-0.09 0.14,-0.215 0.14,-0.383 0,-0.16 -0.047,-0.289 -0.14,-0.379 -0.094,-0.086 -0.227,-0.132 -0.399,-0.132 z m -0.371,-0.305 h 0.836 c 0.305,0 0.535,0.07 0.692,0.211 0.16,0.137 0.238,0.34 0.238,0.605 0,0.27 -0.078,0.477 -0.238,0.614 -0.157,0.136 -0.387,0.207 -0.692,0.207 h -0.465 v 1.097 h -0.371 z m 3.985,0.211 v 0.39 c -0.125,-0.117 -0.258,-0.203 -0.399,-0.257 -0.14,-0.059 -0.289,-0.086 -0.449,-0.086 -0.312,0 -0.551,0.093 -0.715,0.285 -0.168,0.191 -0.25,0.465 -0.25,0.828 0,0.359 0.082,0.637 0.25,0.828 0.164,0.188 0.403,0.285 0.715,0.285 0.16,0 0.309,-0.027 0.449,-0.086 0.141,-0.058 0.274,-0.144 0.399,-0.261 v 0.386 c -0.129,0.09 -0.266,0.157 -0.41,0.2 -0.145,0.043 -0.297,0.066 -0.457,0.066 -0.415,0 -0.743,-0.129 -0.981,-0.379 -0.234,-0.254 -0.355,-0.602 -0.355,-1.039 0,-0.437 0.121,-0.785 0.355,-1.039 0.238,-0.254 0.566,-0.379 0.981,-0.379 0.164,0 0.316,0.02 0.46,0.066 0.145,0.043 0.282,0.106 0.407,0.192 z m -0.11,-0.211 h 1.758 v 0.16 l -0.992,2.574 h -0.383 l 0.934,-2.422 h -1.317 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath471)"
+             id="path1002" />
+          <path
+             d="m 168.23,101.309 v 1.027 h 0.465 c 0.172,0 0.305,-0.047 0.399,-0.133 0.094,-0.09 0.14,-0.219 0.14,-0.383 0,-0.164 -0.046,-0.289 -0.14,-0.379 -0.094,-0.089 -0.227,-0.132 -0.399,-0.132 z m -0.371,-0.305 h 0.836 c 0.305,0 0.535,0.07 0.692,0.211 0.16,0.137 0.238,0.34 0.238,0.605 0,0.27 -0.078,0.473 -0.238,0.614 -0.157,0.136 -0.387,0.207 -0.692,0.207 h -0.465 v 1.097 h -0.371 z m 2.575,0.363 -0.5,1.363 h 1.004 z m -0.207,-0.363 h 0.418 l 1.043,2.734 h -0.387 l -0.25,-0.703 h -1.231 l -0.25,0.703 h -0.39 z m 1.562,2.422 h 0.602 v -2.086 l -0.657,0.133 v -0.336 l 0.653,-0.133 h 0.371 v 2.422 h 0.605 v 0.312 h -1.574 z m 1.84,-2.422 h 1.453 v 0.312 h -1.113 v 0.668 c 0.051,-0.015 0.105,-0.031 0.16,-0.039 0.055,-0.007 0.105,-0.015 0.16,-0.015 0.305,0 0.547,0.086 0.727,0.254 0.175,0.164 0.265,0.39 0.265,0.675 0,0.297 -0.09,0.524 -0.273,0.688 -0.184,0.164 -0.442,0.242 -0.774,0.242 -0.117,0 -0.234,-0.008 -0.351,-0.027 -0.121,-0.02 -0.242,-0.051 -0.371,-0.09 v -0.371 c 0.109,0.062 0.226,0.105 0.343,0.137 0.118,0.027 0.239,0.042 0.372,0.042 0.211,0 0.378,-0.054 0.5,-0.168 0.125,-0.109 0.183,-0.261 0.183,-0.453 0,-0.187 -0.058,-0.339 -0.183,-0.449 -0.122,-0.113 -0.289,-0.168 -0.5,-0.168 -0.102,0 -0.2,0.012 -0.297,0.031 -0.098,0.024 -0.2,0.059 -0.301,0.106 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath472)"
+             id="path1003" />
+          <path
+             d="m 168.34,97.047 v 1.027 h 0.465 c 0.172,0 0.304,-0.047 0.398,-0.136 0.094,-0.086 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.226,-0.133 -0.398,-0.133 z m -0.371,-0.305 h 0.836 c 0.304,0 0.535,0.07 0.691,0.207 0.16,0.141 0.238,0.344 0.238,0.61 0,0.269 -0.078,0.472 -0.238,0.613 -0.156,0.137 -0.387,0.203 -0.691,0.203 h -0.465 v 1.102 h -0.371 z m 2.308,1.43 v 1 h 0.594 c 0.199,0 0.344,-0.043 0.441,-0.125 0.094,-0.082 0.145,-0.207 0.145,-0.379 0,-0.168 -0.051,-0.293 -0.145,-0.375 -0.097,-0.082 -0.242,-0.121 -0.441,-0.121 z m 0,-1.125 v 0.824 h 0.547 c 0.18,0 0.317,-0.035 0.403,-0.101 0.089,-0.071 0.132,-0.172 0.132,-0.313 0,-0.137 -0.043,-0.238 -0.132,-0.309 -0.086,-0.066 -0.223,-0.101 -0.403,-0.101 z m -0.371,-0.305 h 0.946 c 0.281,0 0.5,0.059 0.652,0.176 0.152,0.117 0.23,0.285 0.23,0.5 0,0.168 -0.039,0.301 -0.117,0.398 -0.078,0.098 -0.195,0.161 -0.347,0.184 0.183,0.039 0.324,0.121 0.425,0.246 0.102,0.125 0.153,0.277 0.153,0.465 0,0.242 -0.086,0.43 -0.25,0.566 -0.168,0.133 -0.403,0.2 -0.707,0.2 h -0.985 z m 2.137,2.422 h 0.605 v -2.086 l -0.656,0.133 v -0.336 l 0.653,-0.133 h 0.371 v 2.422 h 0.601 v 0.313 h -1.574 z m 2.156,0 h 1.293 v 0.313 h -1.738 v -0.313 c 0.141,-0.144 0.332,-0.34 0.574,-0.586 0.242,-0.242 0.395,-0.402 0.457,-0.473 0.117,-0.132 0.199,-0.246 0.246,-0.335 0.051,-0.094 0.074,-0.184 0.074,-0.274 0,-0.144 -0.05,-0.262 -0.156,-0.355 -0.101,-0.09 -0.234,-0.137 -0.394,-0.137 -0.117,0 -0.243,0.019 -0.371,0.058 -0.125,0.043 -0.266,0.102 -0.411,0.184 v -0.371 c 0.149,-0.063 0.289,-0.105 0.418,-0.137 0.129,-0.031 0.247,-0.047 0.356,-0.047 0.281,0 0.508,0.071 0.676,0.215 0.168,0.141 0.254,0.328 0.254,0.567 0,0.113 -0.024,0.218 -0.067,0.32 -0.039,0.102 -0.117,0.219 -0.226,0.355 -0.032,0.036 -0.129,0.137 -0.293,0.309 -0.164,0.168 -0.395,0.402 -0.692,0.707 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath473)"
+             id="path1004" />
+          <path
+             d="m 168.363,92.797 v 1.023 h 0.465 c 0.176,0 0.309,-0.043 0.402,-0.132 0.094,-0.09 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.093,-0.09 -0.226,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.309,0 0.539,0.07 0.695,0.207 0.157,0.137 0.239,0.34 0.239,0.61 0,0.269 -0.082,0.472 -0.239,0.609 -0.156,0.141 -0.386,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 2.309,1.426 v 1.004 h 0.593 c 0.196,0 0.344,-0.043 0.442,-0.125 0.094,-0.082 0.144,-0.207 0.144,-0.379 0,-0.172 -0.05,-0.297 -0.144,-0.375 -0.098,-0.082 -0.246,-0.125 -0.442,-0.125 z m 0,-1.121 v 0.82 h 0.547 c 0.179,0 0.312,-0.031 0.402,-0.097 0.09,-0.071 0.133,-0.172 0.133,-0.313 0,-0.137 -0.043,-0.242 -0.133,-0.309 -0.09,-0.07 -0.223,-0.101 -0.402,-0.101 z m -0.371,-0.305 h 0.945 c 0.281,0 0.5,0.059 0.652,0.176 0.153,0.117 0.227,0.281 0.227,0.5 0,0.164 -0.039,0.301 -0.117,0.398 -0.079,0.098 -0.192,0.161 -0.344,0.184 0.183,0.039 0.324,0.121 0.422,0.246 0.101,0.121 0.152,0.277 0.152,0.461 0,0.246 -0.082,0.434 -0.246,0.566 -0.168,0.133 -0.402,0.2 -0.711,0.2 h -0.98 z m 2.136,2.422 h 0.606 v -2.086 l -0.66,0.133 v -0.336 l 0.656,-0.133 h 0.367 v 2.422 h 0.606 v 0.309 h -1.575 z m 2.957,-1.164 c 0.176,0.039 0.317,0.117 0.414,0.238 0.102,0.117 0.149,0.266 0.149,0.442 0,0.269 -0.09,0.476 -0.278,0.625 -0.183,0.148 -0.449,0.222 -0.789,0.222 -0.117,0 -0.234,-0.011 -0.355,-0.035 -0.121,-0.023 -0.246,-0.054 -0.375,-0.101 v -0.356 c 0.102,0.059 0.215,0.106 0.336,0.137 0.121,0.027 0.25,0.043 0.383,0.043 0.23,0 0.406,-0.043 0.527,-0.137 0.125,-0.09 0.184,-0.223 0.184,-0.398 0,-0.16 -0.055,-0.285 -0.168,-0.379 -0.114,-0.09 -0.27,-0.137 -0.473,-0.137 h -0.316 v -0.301 h 0.332 c 0.183,0 0.32,-0.039 0.418,-0.109 0.097,-0.074 0.144,-0.18 0.144,-0.316 0,-0.141 -0.051,-0.247 -0.152,-0.321 -0.098,-0.078 -0.238,-0.113 -0.426,-0.113 -0.102,0 -0.211,0.012 -0.324,0.031 -0.117,0.024 -0.246,0.059 -0.383,0.102 v -0.328 c 0.141,-0.039 0.27,-0.067 0.395,-0.086 0.121,-0.02 0.238,-0.032 0.347,-0.032 0.281,0 0.5,0.063 0.664,0.192 0.164,0.129 0.246,0.301 0.246,0.515 0,0.153 -0.043,0.282 -0.129,0.387 -0.086,0.102 -0.21,0.176 -0.371,0.215 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath474)"
+             id="path1005" />
+          <path
+             d="m 168.363,88.543 v 1.027 h 0.465 c 0.176,0 0.309,-0.043 0.402,-0.132 0.094,-0.09 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.293 -0.141,-0.379 -0.093,-0.09 -0.226,-0.137 -0.402,-0.137 z m -0.367,-0.301 h 0.832 c 0.309,0 0.539,0.067 0.695,0.207 0.157,0.137 0.239,0.34 0.239,0.61 0,0.269 -0.082,0.472 -0.239,0.609 -0.156,0.137 -0.386,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 2.309,1.426 v 1 h 0.593 c 0.196,0 0.344,-0.039 0.442,-0.121 0.094,-0.082 0.144,-0.211 0.144,-0.379 0,-0.172 -0.05,-0.297 -0.144,-0.379 -0.098,-0.082 -0.246,-0.121 -0.442,-0.121 z m 0,-1.125 v 0.824 h 0.547 c 0.179,0 0.312,-0.031 0.402,-0.101 0.09,-0.067 0.133,-0.172 0.133,-0.309 0,-0.141 -0.043,-0.242 -0.133,-0.309 -0.09,-0.07 -0.223,-0.105 -0.402,-0.105 z m -0.371,-0.301 h 0.945 c 0.281,0 0.5,0.059 0.652,0.176 0.153,0.113 0.227,0.281 0.227,0.496 0,0.168 -0.039,0.301 -0.117,0.402 -0.079,0.098 -0.192,0.161 -0.344,0.184 0.183,0.039 0.324,0.121 0.422,0.246 0.101,0.121 0.152,0.277 0.152,0.461 0,0.246 -0.082,0.434 -0.246,0.566 -0.168,0.133 -0.402,0.2 -0.711,0.2 h -0.98 z m 2.136,2.418 h 0.606 v -2.082 l -0.66,0.129 v -0.336 l 0.656,-0.129 h 0.367 v 2.418 h 0.606 v 0.313 h -1.575 z m 1.84,-2.418 h 1.453 v 0.309 h -1.113 v 0.672 c 0.055,-0.02 0.105,-0.032 0.16,-0.043 0.055,-0.008 0.11,-0.012 0.16,-0.012 0.309,0 0.547,0.082 0.727,0.25 0.18,0.168 0.265,0.394 0.265,0.68 0,0.293 -0.089,0.523 -0.273,0.683 -0.184,0.164 -0.441,0.246 -0.773,0.246 -0.114,0 -0.231,-0.011 -0.352,-0.031 -0.117,-0.019 -0.242,-0.047 -0.367,-0.086 v -0.371 c 0.109,0.059 0.223,0.102 0.34,0.133 0.117,0.027 0.242,0.043 0.371,0.043 0.211,0 0.379,-0.055 0.5,-0.168 0.125,-0.109 0.187,-0.262 0.187,-0.449 0,-0.192 -0.062,-0.344 -0.187,-0.453 -0.121,-0.114 -0.289,-0.168 -0.5,-0.168 -0.098,0 -0.199,0.011 -0.297,0.035 -0.098,0.019 -0.199,0.054 -0.301,0.101 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath475)"
+             id="path1006" />
+          <path
+             d="m 170.301,84.293 v 1.027 h 0.465 c 0.172,0 0.304,-0.043 0.398,-0.132 0.094,-0.09 0.141,-0.219 0.141,-0.383 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.226,-0.133 -0.398,-0.133 z m -0.371,-0.305 h 0.836 c 0.304,0 0.535,0.071 0.691,0.211 0.16,0.137 0.238,0.34 0.238,0.606 0,0.269 -0.078,0.472 -0.238,0.613 -0.156,0.137 -0.387,0.207 -0.691,0.207 h -0.465 v 1.098 h -0.371 z m 3.984,0.211 v 0.391 c -0.125,-0.117 -0.258,-0.203 -0.398,-0.262 -0.141,-0.055 -0.289,-0.086 -0.45,-0.086 -0.312,0 -0.55,0.098 -0.714,0.289 -0.168,0.192 -0.25,0.465 -0.25,0.828 0,0.36 0.082,0.637 0.25,0.829 0.164,0.187 0.402,0.285 0.714,0.285 0.161,0 0.309,-0.032 0.45,-0.086 0.14,-0.059 0.273,-0.145 0.398,-0.262 v 0.387 c -0.129,0.086 -0.266,0.152 -0.41,0.199 -0.145,0.043 -0.297,0.062 -0.457,0.062 -0.414,0 -0.742,-0.125 -0.981,-0.378 -0.238,-0.254 -0.355,-0.598 -0.355,-1.036 0,-0.441 0.117,-0.785 0.355,-1.039 0.239,-0.254 0.567,-0.379 0.981,-0.379 0.164,0 0.316,0.02 0.461,0.067 0.144,0.039 0.281,0.105 0.406,0.191 z m 0.824,1.008 c -0.168,0 -0.3,0.059 -0.398,0.172 -0.094,0.113 -0.145,0.269 -0.145,0.465 0,0.199 0.051,0.355 0.145,0.468 0.098,0.114 0.23,0.168 0.398,0.168 0.164,0 0.297,-0.054 0.391,-0.168 0.098,-0.113 0.148,-0.269 0.148,-0.468 0,-0.196 -0.05,-0.352 -0.148,-0.465 -0.094,-0.113 -0.227,-0.172 -0.391,-0.172 z m 0.731,-1.156 v 0.336 c -0.09,-0.043 -0.184,-0.078 -0.281,-0.102 -0.094,-0.023 -0.188,-0.035 -0.278,-0.035 -0.246,0 -0.433,0.082 -0.562,0.25 -0.129,0.164 -0.2,0.41 -0.219,0.746 0.07,-0.105 0.164,-0.187 0.269,-0.246 0.11,-0.055 0.231,-0.086 0.36,-0.086 0.273,0 0.492,0.086 0.652,0.254 0.156,0.164 0.238,0.391 0.238,0.676 0,0.281 -0.082,0.508 -0.25,0.676 -0.164,0.171 -0.386,0.253 -0.66,0.253 -0.316,0 -0.558,-0.117 -0.726,-0.359 -0.168,-0.242 -0.25,-0.594 -0.25,-1.055 0,-0.433 0.101,-0.777 0.304,-1.035 0.207,-0.254 0.481,-0.383 0.829,-0.383 0.093,0 0.187,0.008 0.281,0.028 0.094,0.015 0.191,0.043 0.293,0.082 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath476)"
+             id="path1007" />
+          <path
+             d="m 170.262,158.676 v 1.027 h 0.465 c 0.171,0 0.304,-0.043 0.398,-0.133 0.094,-0.09 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.293 -0.141,-0.379 -0.094,-0.089 -0.227,-0.136 -0.398,-0.136 z m -0.371,-0.301 h 0.836 c 0.308,0 0.539,0.07 0.695,0.207 0.156,0.137 0.234,0.34 0.234,0.609 0,0.27 -0.078,0.473 -0.234,0.61 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.097 h -0.371 z m 2.308,1.426 v 1.004 h 0.594 c 0.199,0 0.348,-0.043 0.441,-0.125 0.098,-0.082 0.145,-0.207 0.145,-0.379 0,-0.172 -0.047,-0.297 -0.145,-0.375 -0.093,-0.082 -0.242,-0.125 -0.441,-0.125 z m 0,-1.125 v 0.824 h 0.551 c 0.18,0 0.312,-0.031 0.402,-0.098 0.086,-0.07 0.133,-0.172 0.133,-0.312 0,-0.137 -0.047,-0.242 -0.133,-0.309 -0.09,-0.07 -0.222,-0.105 -0.402,-0.105 z m -0.367,-0.301 h 0.945 c 0.282,0 0.496,0.059 0.649,0.176 0.152,0.117 0.23,0.281 0.23,0.5 0,0.164 -0.039,0.297 -0.117,0.398 -0.078,0.098 -0.191,0.16 -0.344,0.184 0.18,0.039 0.325,0.121 0.422,0.246 0.102,0.121 0.153,0.277 0.153,0.461 0,0.246 -0.082,0.433 -0.25,0.566 -0.165,0.133 -0.403,0.199 -0.708,0.199 h -0.98 z m 2.391,2.422 h 1.289 v 0.308 h -1.735 v -0.308 c 0.141,-0.149 0.332,-0.34 0.575,-0.586 0.242,-0.246 0.394,-0.402 0.457,-0.473 0.117,-0.133 0.199,-0.246 0.246,-0.336 0.047,-0.093 0.07,-0.183 0.07,-0.273 0,-0.145 -0.051,-0.266 -0.152,-0.356 -0.102,-0.093 -0.235,-0.136 -0.399,-0.136 -0.113,0 -0.238,0.019 -0.367,0.058 -0.129,0.039 -0.266,0.102 -0.41,0.184 v -0.375 c 0.148,-0.059 0.285,-0.102 0.418,-0.133 0.129,-0.031 0.246,-0.047 0.351,-0.047 0.286,0 0.512,0.071 0.68,0.211 0.168,0.145 0.254,0.332 0.254,0.57 0,0.11 -0.023,0.219 -0.066,0.321 -0.039,0.097 -0.118,0.219 -0.227,0.355 -0.031,0.035 -0.129,0.137 -0.293,0.305 -0.164,0.168 -0.394,0.406 -0.691,0.711 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath477)"
+             id="path1008" />
+          <path
+             d="m 169.941,154.426 v 1.027 h 0.465 c 0.172,0 0.305,-0.043 0.399,-0.133 0.093,-0.09 0.14,-0.215 0.14,-0.382 0,-0.161 -0.047,-0.29 -0.14,-0.379 -0.094,-0.086 -0.227,-0.133 -0.399,-0.133 z m -0.371,-0.305 h 0.836 c 0.305,0 0.535,0.07 0.692,0.211 0.16,0.137 0.238,0.34 0.238,0.606 0,0.269 -0.078,0.476 -0.238,0.613 -0.157,0.137 -0.387,0.207 -0.692,0.207 h -0.465 v 1.097 h -0.371 z m 3.801,2.344 v -0.735 h -0.601 v -0.3 h 0.968 v 1.172 c -0.144,0.101 -0.3,0.179 -0.472,0.23 -0.172,0.051 -0.356,0.078 -0.551,0.078 -0.426,0 -0.762,-0.125 -1.004,-0.375 -0.238,-0.25 -0.359,-0.597 -0.359,-1.043 0,-0.445 0.121,-0.793 0.359,-1.043 0.242,-0.25 0.578,-0.375 1.004,-0.375 0.18,0 0.347,0.02 0.508,0.067 0.16,0.043 0.308,0.105 0.445,0.191 v 0.395 c -0.137,-0.118 -0.281,-0.204 -0.438,-0.262 -0.152,-0.059 -0.316,-0.086 -0.484,-0.086 -0.336,0 -0.586,0.09 -0.754,0.277 -0.168,0.188 -0.25,0.465 -0.25,0.836 0,0.367 0.082,0.645 0.25,0.832 0.168,0.188 0.418,0.281 0.754,0.281 0.129,0 0.246,-0.011 0.352,-0.035 0.101,-0.023 0.191,-0.058 0.273,-0.105 z m 1.371,-1.121 c -0.164,0 -0.297,0.054 -0.394,0.168 -0.094,0.113 -0.145,0.269 -0.145,0.468 0,0.196 0.051,0.352 0.145,0.465 0.097,0.114 0.23,0.172 0.394,0.172 0.168,0 0.301,-0.058 0.395,-0.172 0.097,-0.113 0.148,-0.269 0.148,-0.465 0,-0.199 -0.051,-0.355 -0.148,-0.468 -0.094,-0.114 -0.227,-0.168 -0.395,-0.168 z m 0.735,-1.16 v 0.336 c -0.09,-0.043 -0.184,-0.079 -0.282,-0.102 -0.093,-0.023 -0.187,-0.035 -0.277,-0.035 -0.246,0 -0.434,0.086 -0.563,0.25 -0.128,0.164 -0.199,0.414 -0.218,0.746 0.07,-0.106 0.16,-0.188 0.269,-0.242 0.11,-0.059 0.231,-0.086 0.36,-0.086 0.273,0 0.492,0.082 0.648,0.25 0.16,0.164 0.242,0.39 0.242,0.679 0,0.278 -0.082,0.504 -0.25,0.672 -0.164,0.172 -0.386,0.258 -0.664,0.258 -0.312,0 -0.554,-0.121 -0.722,-0.363 -0.168,-0.242 -0.25,-0.594 -0.25,-1.055 0,-0.433 0.101,-0.777 0.304,-1.031 0.207,-0.258 0.481,-0.387 0.828,-0.387 0.094,0 0.184,0.008 0.278,0.028 0.097,0.019 0.195,0.046 0.297,0.082 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath478)"
+             id="path1009" />
+          <path
+             d="m 170.578,150.176 v 1.027 h 0.465 c 0.172,0 0.305,-0.047 0.398,-0.133 0.094,-0.09 0.141,-0.218 0.141,-0.382 0,-0.165 -0.047,-0.29 -0.141,-0.379 -0.093,-0.09 -0.226,-0.133 -0.398,-0.133 z m -0.371,-0.305 h 0.836 c 0.305,0 0.535,0.07 0.691,0.211 0.161,0.137 0.239,0.34 0.239,0.606 0,0.269 -0.078,0.472 -0.239,0.613 -0.156,0.137 -0.386,0.207 -0.691,0.207 h -0.465 v 1.097 h -0.371 z m 1.938,0 h 1.57 v 0.313 h -1.199 v 0.804 h 1.082 v 0.313 h -1.082 v 1.304 h -0.371 z m 2.593,1.219 c -0.168,0 -0.3,0.058 -0.398,0.172 -0.094,0.113 -0.145,0.269 -0.145,0.465 0,0.199 0.051,0.351 0.145,0.468 0.098,0.114 0.23,0.168 0.398,0.168 0.164,0 0.297,-0.054 0.391,-0.168 0.098,-0.117 0.148,-0.269 0.148,-0.468 0,-0.196 -0.05,-0.352 -0.148,-0.465 -0.094,-0.114 -0.227,-0.172 -0.391,-0.172 z m 0.731,-1.156 v 0.336 c -0.09,-0.043 -0.184,-0.079 -0.281,-0.102 -0.094,-0.023 -0.188,-0.035 -0.278,-0.035 -0.246,0 -0.433,0.082 -0.562,0.246 -0.129,0.168 -0.2,0.414 -0.219,0.75 0.07,-0.109 0.164,-0.188 0.269,-0.246 0.11,-0.055 0.231,-0.086 0.36,-0.086 0.273,0 0.492,0.086 0.652,0.25 0.156,0.168 0.238,0.394 0.238,0.68 0,0.281 -0.082,0.507 -0.25,0.675 -0.164,0.172 -0.386,0.254 -0.66,0.254 -0.316,0 -0.558,-0.121 -0.726,-0.359 -0.168,-0.246 -0.25,-0.598 -0.25,-1.055 0,-0.433 0.101,-0.777 0.304,-1.035 0.207,-0.258 0.481,-0.383 0.829,-0.383 0.093,0 0.187,0.008 0.281,0.028 0.094,0.015 0.191,0.043 0.293,0.082 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath479)"
+             id="path1010" />
+          <path
+             d="m 170.578,145.926 v 1.027 h 0.465 c 0.172,0 0.305,-0.047 0.398,-0.133 0.094,-0.09 0.141,-0.218 0.141,-0.382 0,-0.165 -0.047,-0.29 -0.141,-0.379 -0.093,-0.09 -0.226,-0.133 -0.398,-0.133 z m -0.371,-0.305 h 0.836 c 0.305,0 0.535,0.07 0.691,0.211 0.161,0.137 0.239,0.34 0.239,0.606 0,0.269 -0.078,0.472 -0.239,0.613 -0.156,0.137 -0.386,0.207 -0.691,0.207 h -0.465 v 1.097 h -0.371 z m 1.938,0 h 1.57 v 0.313 h -1.199 v 0.804 h 1.082 v 0.313 h -1.082 v 1.304 h -0.371 z m 1.757,0 h 1.453 v 0.313 h -1.113 v 0.668 c 0.055,-0.016 0.11,-0.032 0.16,-0.04 0.055,-0.011 0.11,-0.015 0.16,-0.015 0.309,0 0.547,0.086 0.727,0.25 0.18,0.168 0.27,0.394 0.27,0.68 0,0.296 -0.094,0.523 -0.278,0.687 -0.183,0.164 -0.441,0.242 -0.773,0.242 -0.113,0 -0.231,-0.008 -0.352,-0.027 -0.117,-0.02 -0.242,-0.051 -0.367,-0.09 v -0.371 c 0.109,0.062 0.223,0.105 0.34,0.133 0.117,0.031 0.242,0.047 0.371,0.047 0.211,0 0.379,-0.059 0.504,-0.168 0.121,-0.11 0.184,-0.262 0.184,-0.453 0,-0.188 -0.063,-0.34 -0.184,-0.45 -0.125,-0.113 -0.293,-0.168 -0.504,-0.168 -0.098,0 -0.199,0.012 -0.297,0.032 -0.098,0.023 -0.195,0.058 -0.301,0.105 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath480)"
+             id="path1011" />
+          <path
+             d="m 170.578,141.676 v 1.027 h 0.465 c 0.172,0 0.305,-0.047 0.398,-0.137 0.094,-0.086 0.141,-0.214 0.141,-0.378 0,-0.165 -0.047,-0.29 -0.141,-0.379 -0.093,-0.09 -0.226,-0.133 -0.398,-0.133 z m -0.371,-0.305 h 0.836 c 0.305,0 0.535,0.07 0.691,0.207 0.161,0.141 0.239,0.34 0.239,0.61 0,0.269 -0.078,0.472 -0.239,0.609 -0.156,0.141 -0.386,0.207 -0.691,0.207 h -0.465 v 1.098 h -0.371 z m 1.938,0 h 1.57 v 0.313 h -1.199 v 0.804 h 1.082 v 0.309 h -1.082 v 1.305 h -0.371 z m 2.769,0.32 -0.934,1.461 h 0.934 z m -0.094,-0.32 h 0.465 v 1.781 h 0.391 v 0.309 h -0.391 v 0.641 h -0.371 v -0.641 h -1.23 v -0.359 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath481)"
+             id="path1012" />
+          <path
+             d="m 170.516,139.461 v -0.731 h -0.606 v -0.304 h 0.973 v 1.172 c -0.145,0.101 -0.301,0.179 -0.473,0.23 -0.172,0.051 -0.355,0.078 -0.551,0.078 -0.429,0 -0.761,-0.125 -1.004,-0.375 -0.242,-0.25 -0.363,-0.597 -0.363,-1.043 0,-0.445 0.121,-0.793 0.363,-1.043 0.243,-0.25 0.575,-0.375 1.004,-0.375 0.176,0 0.348,0.024 0.504,0.067 0.164,0.043 0.313,0.109 0.446,0.195 v 0.391 c -0.137,-0.114 -0.282,-0.203 -0.434,-0.262 -0.156,-0.059 -0.316,-0.086 -0.484,-0.086 -0.336,0 -0.586,0.094 -0.758,0.277 -0.164,0.188 -0.25,0.465 -0.25,0.836 0,0.367 0.086,0.649 0.25,0.832 0.172,0.188 0.422,0.282 0.758,0.282 0.129,0 0.246,-0.012 0.347,-0.032 0.102,-0.023 0.196,-0.058 0.278,-0.109 z m 0.5,-2.34 h 0.5 l 1.211,2.285 v -2.285 h 0.359 v 2.731 h -0.5 l -1.211,-2.286 v 2.286 h -0.359 z m 2.793,0.301 v 2.125 h 0.445 c 0.379,0 0.652,-0.082 0.828,-0.254 0.176,-0.172 0.262,-0.441 0.262,-0.809 0,-0.367 -0.086,-0.636 -0.262,-0.804 -0.176,-0.172 -0.449,-0.258 -0.828,-0.258 z m -0.371,-0.301 h 0.757 c 0.532,0 0.922,0.109 1.168,0.328 0.246,0.223 0.371,0.567 0.371,1.035 0,0.469 -0.125,0.817 -0.371,1.036 -0.25,0.222 -0.64,0.332 -1.168,0.332 h -0.757 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath482)"
+             id="path1013" />
+          <path
+             d="m 167.398,133.234 -0.503,1.36 h 1.007 z m -0.21,-0.367 h 0.421 l 1.039,2.735 h -0.382 l -0.25,-0.7 h -1.231 l -0.25,0.7 h -0.39 z m 3.3,2.344 v -0.734 h -0.601 v -0.305 h 0.968 v 1.176 c -0.14,0.101 -0.3,0.175 -0.472,0.23 -0.172,0.051 -0.356,0.078 -0.551,0.078 -0.426,0 -0.762,-0.125 -1.004,-0.375 -0.238,-0.25 -0.359,-0.597 -0.359,-1.043 0,-0.445 0.121,-0.793 0.359,-1.043 0.242,-0.25 0.578,-0.375 1.004,-0.375 0.18,0 0.348,0.02 0.508,0.067 0.16,0.043 0.308,0.105 0.445,0.191 v 0.395 c -0.137,-0.118 -0.281,-0.203 -0.437,-0.262 -0.153,-0.059 -0.313,-0.086 -0.485,-0.086 -0.332,0 -0.586,0.09 -0.754,0.277 -0.168,0.188 -0.25,0.465 -0.25,0.836 0,0.367 0.082,0.645 0.25,0.832 0.168,0.188 0.422,0.282 0.754,0.282 0.133,0 0.246,-0.012 0.352,-0.036 0.101,-0.023 0.195,-0.058 0.273,-0.105 z m 0.504,-2.344 h 0.496 l 1.215,2.289 v -2.289 h 0.359 v 2.735 h -0.5 l -1.21,-2.286 v 2.286 h -0.36 z m 2.789,0.305 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.825,-0.254 0.175,-0.172 0.265,-0.441 0.265,-0.813 0,-0.363 -0.09,-0.632 -0.265,-0.8 -0.172,-0.172 -0.45,-0.258 -0.825,-0.258 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.113 1.168,0.332 0.246,0.219 0.371,0.567 0.371,1.031 0,0.473 -0.125,0.821 -0.375,1.04 -0.25,0.222 -0.637,0.332 -1.164,0.332 h -0.758 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath483)"
+             id="path1014" />
+          <path
+             d="m 167.535,131.352 -1.043,-2.735 h 0.383 l 0.867,2.301 0.867,-2.301 h 0.387 l -1.043,2.735 z m 1.789,-2.43 v 2.125 h 0.449 c 0.375,0 0.653,-0.086 0.825,-0.258 0.175,-0.168 0.265,-0.437 0.265,-0.809 0,-0.363 -0.09,-0.632 -0.265,-0.8 -0.172,-0.172 -0.45,-0.258 -0.825,-0.258 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.473 -0.125,0.817 -0.375,1.04 -0.25,0.218 -0.637,0.332 -1.164,0.332 h -0.758 z m 2.672,0.305 v 2.125 h 0.449 c 0.375,0 0.652,-0.086 0.828,-0.258 0.176,-0.168 0.262,-0.437 0.262,-0.809 0,-0.363 -0.086,-0.632 -0.262,-0.8 -0.176,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.367,-0.305 h 0.758 c 0.531,0 0.918,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.473 -0.125,0.817 -0.375,1.04 -0.246,0.218 -0.637,0.332 -1.164,0.332 h -0.758 z m 3.164,0.363 -0.5,1.364 h 1.004 z m -0.207,-0.363 h 0.418 l 1.043,2.735 h -0.387 l -0.246,-0.704 h -1.235 l -0.25,0.704 h -0.386 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath484)"
+             id="path1015" />
+          <path
+             d="m 226.75,122.547 v 1.023 h 0.465 c 0.172,0 0.308,-0.043 0.402,-0.132 0.094,-0.09 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.23,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.07 0.695,0.207 0.156,0.137 0.238,0.34 0.238,0.61 0,0.269 -0.082,0.472 -0.238,0.609 -0.156,0.141 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 1.937,0 h 1.571 v 0.309 h -1.2 v 0.808 h 1.082 v 0.309 h -1.082 v 1.305 h -0.371 z m 2.875,1.258 c 0.176,0.039 0.313,0.117 0.414,0.238 0.098,0.117 0.149,0.266 0.149,0.442 0,0.269 -0.094,0.476 -0.278,0.625 -0.187,0.148 -0.449,0.222 -0.792,0.222 -0.114,0 -0.231,-0.011 -0.352,-0.035 -0.121,-0.023 -0.246,-0.054 -0.379,-0.101 v -0.356 c 0.105,0.059 0.215,0.106 0.34,0.137 0.121,0.027 0.25,0.043 0.383,0.043 0.23,0 0.406,-0.043 0.527,-0.137 0.121,-0.09 0.184,-0.223 0.184,-0.398 0,-0.16 -0.059,-0.285 -0.172,-0.379 -0.11,-0.09 -0.27,-0.137 -0.469,-0.137 h -0.32 v -0.301 h 0.336 c 0.179,0 0.32,-0.039 0.418,-0.109 0.093,-0.074 0.144,-0.18 0.144,-0.316 0,-0.141 -0.051,-0.247 -0.152,-0.321 -0.098,-0.078 -0.242,-0.113 -0.426,-0.113 -0.102,0 -0.211,0.012 -0.328,0.031 -0.113,0.024 -0.242,0.059 -0.379,0.102 v -0.328 c 0.137,-0.039 0.269,-0.067 0.391,-0.086 0.125,-0.02 0.242,-0.032 0.347,-0.032 0.281,0 0.504,0.063 0.668,0.192 0.164,0.129 0.246,0.301 0.246,0.515 0,0.153 -0.043,0.282 -0.133,0.387 -0.085,0.102 -0.207,0.176 -0.367,0.215 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath485)"
+             id="path1016" />
+          <path
+             d="m 226.75,118.293 v 1.027 h 0.465 c 0.172,0 0.308,-0.043 0.402,-0.132 0.094,-0.09 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.293 -0.141,-0.379 -0.094,-0.09 -0.23,-0.137 -0.402,-0.137 z m -0.367,-0.301 h 0.832 c 0.308,0 0.539,0.067 0.695,0.207 0.156,0.137 0.238,0.34 0.238,0.61 0,0.269 -0.082,0.472 -0.238,0.609 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 2.308,0.301 v 2.125 h 0.446 c 0.379,0 0.652,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.441 0.262,-0.809 0,-0.367 -0.086,-0.636 -0.262,-0.804 -0.176,-0.172 -0.449,-0.258 -0.828,-0.258 z m -0.371,-0.301 h 0.758 c 0.531,0 0.922,0.11 1.168,0.328 0.246,0.223 0.371,0.567 0.371,1.035 0,0.469 -0.125,0.817 -0.371,1.036 -0.25,0.222 -0.641,0.332 -1.168,0.332 h -0.758 z m 2.403,2.418 h 0.605 v -2.082 l -0.656,0.129 v -0.336 l 0.652,-0.129 h 0.371 v 2.418 h 0.602 v 0.313 h -1.574 z m 1.839,-2.418 h 1.454 v 0.309 h -1.114 v 0.672 c 0.055,-0.02 0.11,-0.032 0.16,-0.043 0.055,-0.008 0.11,-0.012 0.161,-0.012 0.308,0 0.547,0.082 0.726,0.25 0.18,0.168 0.27,0.394 0.27,0.68 0,0.293 -0.094,0.523 -0.278,0.683 -0.183,0.164 -0.441,0.246 -0.773,0.246 -0.113,0 -0.23,-0.011 -0.352,-0.031 -0.117,-0.019 -0.242,-0.047 -0.367,-0.086 v -0.371 c 0.11,0.059 0.223,0.102 0.34,0.133 0.117,0.027 0.242,0.043 0.371,0.043 0.211,0 0.379,-0.055 0.504,-0.168 0.121,-0.109 0.184,-0.262 0.184,-0.449 0,-0.192 -0.063,-0.344 -0.184,-0.453 -0.125,-0.114 -0.293,-0.168 -0.504,-0.168 -0.098,0 -0.199,0.011 -0.297,0.035 -0.097,0.019 -0.195,0.054 -0.301,0.101 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath486)"
+             id="path1017" />
+          <path
+             d="m 226.75,114.043 v 1.027 h 0.465 c 0.172,0 0.308,-0.043 0.402,-0.132 0.094,-0.09 0.141,-0.219 0.141,-0.383 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.23,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.211 0.156,0.137 0.238,0.34 0.238,0.606 0,0.269 -0.082,0.472 -0.238,0.613 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 2.308,0.305 v 2.125 h 0.446 c 0.379,0 0.652,-0.086 0.828,-0.258 0.176,-0.168 0.262,-0.437 0.262,-0.808 0,-0.364 -0.086,-0.633 -0.262,-0.801 -0.176,-0.172 -0.449,-0.258 -0.828,-0.258 z m -0.371,-0.305 h 0.758 c 0.531,0 0.922,0.114 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.032 0,0.472 -0.125,0.82 -0.371,1.039 -0.25,0.222 -0.641,0.332 -1.168,0.332 h -0.758 z m 2.403,2.422 h 0.605 v -2.086 l -0.656,0.133 v -0.336 l 0.652,-0.133 h 0.371 v 2.422 h 0.602 v 0.313 h -1.574 z m 2.851,-2.098 -0.933,1.458 h 0.933 z m -0.094,-0.324 h 0.465 v 1.782 h 0.391 v 0.308 h -0.391 v 0.645 h -0.371 v -0.645 h -1.23 v -0.355 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath487)"
+             id="path1018" />
+          <path
+             d="m 226.75,109.793 v 1.027 h 0.465 c 0.172,0 0.308,-0.047 0.402,-0.132 0.094,-0.09 0.141,-0.219 0.141,-0.383 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.23,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.211 0.156,0.137 0.238,0.34 0.238,0.606 0,0.269 -0.082,0.472 -0.238,0.613 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 2.308,1.43 v 1 h 0.59 c 0.199,0 0.348,-0.039 0.442,-0.121 0.097,-0.086 0.144,-0.211 0.144,-0.379 0,-0.172 -0.047,-0.297 -0.144,-0.379 -0.094,-0.082 -0.243,-0.121 -0.442,-0.121 z m 0,-1.125 v 0.824 h 0.547 c 0.18,0 0.313,-0.035 0.403,-0.101 0.089,-0.067 0.132,-0.172 0.132,-0.313 0,-0.137 -0.043,-0.238 -0.132,-0.308 -0.09,-0.067 -0.223,-0.102 -0.403,-0.102 z m -0.371,-0.305 h 0.946 c 0.281,0 0.5,0.059 0.652,0.176 0.152,0.117 0.227,0.285 0.227,0.5 0,0.168 -0.04,0.301 -0.118,0.398 -0.078,0.102 -0.191,0.161 -0.343,0.188 0.183,0.039 0.324,0.121 0.421,0.242 0.102,0.125 0.153,0.278 0.153,0.465 0,0.242 -0.082,0.434 -0.246,0.566 -0.168,0.133 -0.403,0.2 -0.711,0.2 h -0.981 z m 2.075,0 h 1.453 v 0.313 h -1.114 v 0.668 c 0.055,-0.016 0.11,-0.031 0.161,-0.039 0.054,-0.008 0.109,-0.016 0.164,-0.016 0.304,0 0.546,0.086 0.722,0.254 0.18,0.164 0.27,0.391 0.27,0.676 0,0.297 -0.094,0.523 -0.278,0.687 -0.179,0.164 -0.441,0.242 -0.773,0.242 -0.113,0 -0.23,-0.007 -0.352,-0.027 -0.117,-0.019 -0.242,-0.051 -0.367,-0.09 v -0.371 c 0.11,0.063 0.223,0.106 0.34,0.133 0.117,0.031 0.242,0.047 0.371,0.047 0.211,0 0.379,-0.055 0.504,-0.168 0.121,-0.109 0.184,-0.262 0.184,-0.453 0,-0.188 -0.063,-0.34 -0.184,-0.449 -0.125,-0.114 -0.293,-0.168 -0.504,-0.168 -0.097,0 -0.195,0.011 -0.297,0.031 -0.097,0.023 -0.195,0.058 -0.3,0.105 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath488)"
+             id="path1019" />
+          <path
+             d="m 226.75,105.543 v 1.027 h 0.465 c 0.172,0 0.308,-0.047 0.402,-0.136 0.094,-0.086 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.23,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.207 0.156,0.141 0.238,0.344 0.238,0.61 0,0.269 -0.082,0.472 -0.238,0.609 -0.156,0.141 -0.387,0.207 -0.695,0.207 h -0.465 v 1.102 h -0.367 z m 2.574,0.364 -0.504,1.359 h 1.008 z m -0.211,-0.364 h 0.422 l 1.039,2.735 h -0.383 l -0.25,-0.703 h -1.23 l -0.25,0.703 h -0.391 z m 2.336,1.219 c -0.168,0 -0.297,0.059 -0.394,0.172 -0.098,0.113 -0.145,0.266 -0.145,0.465 0,0.195 0.047,0.351 0.145,0.468 0.097,0.114 0.226,0.168 0.394,0.168 0.164,0 0.297,-0.054 0.395,-0.168 0.097,-0.117 0.144,-0.273 0.144,-0.468 0,-0.199 -0.047,-0.352 -0.144,-0.465 -0.098,-0.113 -0.231,-0.172 -0.395,-0.172 z m 0.734,-1.16 v 0.34 c -0.093,-0.047 -0.187,-0.078 -0.281,-0.102 -0.094,-0.023 -0.187,-0.035 -0.281,-0.035 -0.242,0 -0.43,0.082 -0.559,0.246 -0.129,0.164 -0.203,0.414 -0.222,0.746 0.074,-0.105 0.164,-0.187 0.273,-0.242 0.109,-0.059 0.227,-0.086 0.359,-0.086 0.274,0 0.489,0.082 0.649,0.25 0.16,0.168 0.238,0.395 0.238,0.68 0,0.281 -0.082,0.508 -0.246,0.676 -0.168,0.168 -0.387,0.253 -0.664,0.253 -0.316,0 -0.559,-0.121 -0.727,-0.363 -0.164,-0.242 -0.25,-0.594 -0.25,-1.055 0,-0.429 0.102,-0.773 0.309,-1.031 0.203,-0.258 0.481,-0.386 0.824,-0.386 0.094,0 0.188,0.011 0.282,0.027 0.093,0.019 0.195,0.047 0.296,0.082 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath489)"
+             id="path1020" />
+          <path
+             d="m 226.75,101.289 v 1.027 h 0.465 c 0.172,0 0.308,-0.043 0.402,-0.132 0.094,-0.09 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.23,-0.137 -0.402,-0.137 z m -0.367,-0.301 h 0.832 c 0.308,0 0.539,0.071 0.695,0.207 0.156,0.137 0.238,0.34 0.238,0.61 0,0.269 -0.082,0.472 -0.238,0.609 -0.156,0.141 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 2.574,0.364 -0.504,1.359 h 1.008 z m -0.211,-0.364 h 0.422 l 1.039,2.731 h -0.383 l -0.25,-0.699 h -1.23 l -0.25,0.699 h -0.391 z m 1.504,0 h 1.449 v 0.309 h -1.113 v 0.672 c 0.055,-0.02 0.109,-0.031 0.164,-0.039 0.051,-0.012 0.105,-0.016 0.16,-0.016 0.305,0 0.547,0.082 0.723,0.25 0.179,0.168 0.269,0.395 0.269,0.68 0,0.293 -0.093,0.523 -0.273,0.687 -0.184,0.16 -0.441,0.242 -0.777,0.242 -0.114,0 -0.231,-0.011 -0.352,-0.031 -0.117,-0.019 -0.238,-0.047 -0.367,-0.086 v -0.371 c 0.109,0.059 0.222,0.106 0.34,0.133 0.117,0.027 0.242,0.043 0.371,0.043 0.215,0 0.379,-0.055 0.504,-0.164 0.121,-0.113 0.183,-0.262 0.183,-0.453 0,-0.192 -0.062,-0.34 -0.183,-0.453 -0.125,-0.11 -0.289,-0.168 -0.504,-0.168 -0.098,0 -0.196,0.011 -0.293,0.035 -0.098,0.023 -0.199,0.054 -0.301,0.101 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath490)"
+             id="path1021" />
+          <path
+             d="m 228.246,99.078 v -0.734 h -0.605 v -0.301 h 0.972 v 1.172 c -0.144,0.101 -0.301,0.18 -0.472,0.23 -0.172,0.051 -0.356,0.078 -0.551,0.078 -0.43,0 -0.762,-0.125 -1.004,-0.375 -0.242,-0.25 -0.363,-0.597 -0.363,-1.043 0,-0.445 0.121,-0.793 0.363,-1.043 0.242,-0.25 0.574,-0.374 1.004,-0.374 0.176,0 0.344,0.019 0.504,0.066 0.164,0.043 0.312,0.105 0.445,0.191 v 0.395 c -0.137,-0.117 -0.281,-0.203 -0.434,-0.262 -0.156,-0.058 -0.316,-0.086 -0.484,-0.086 -0.336,0 -0.586,0.09 -0.758,0.278 -0.164,0.187 -0.25,0.464 -0.25,0.835 0,0.368 0.086,0.645 0.25,0.833 0.172,0.187 0.422,0.281 0.758,0.281 0.129,0 0.246,-0.012 0.348,-0.035 0.101,-0.024 0.195,-0.059 0.277,-0.106 z m 0.5,-2.344 h 0.5 l 1.211,2.289 v -2.289 h 0.359 v 2.735 h -0.5 l -1.211,-2.285 v 2.285 h -0.359 z m 2.793,0.305 v 2.125 h 0.445 c 0.375,0 0.653,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.441 0.262,-0.808 0,-0.368 -0.086,-0.637 -0.262,-0.805 -0.175,-0.172 -0.453,-0.258 -0.828,-0.258 z m -0.371,-0.305 h 0.758 c 0.531,0 0.922,0.114 1.168,0.332 0.246,0.223 0.371,0.567 0.371,1.036 0,0.468 -0.125,0.816 -0.375,1.035 -0.246,0.222 -0.637,0.332 -1.164,0.332 h -0.758 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath491)"
+             id="path1022" />
+          <path
+             d="m 227.086,95.219 -1.043,-2.735 h 0.387 l 0.867,2.301 0.867,-2.301 h 0.383 l -1.043,2.735 z m 2.719,-1.281 c 0.078,0.027 0.156,0.082 0.23,0.171 0.074,0.086 0.153,0.207 0.227,0.364 l 0.375,0.746 h -0.399 l -0.347,-0.703 c -0.09,-0.184 -0.18,-0.305 -0.266,-0.364 -0.082,-0.058 -0.199,-0.09 -0.344,-0.09 h -0.402 v 1.157 h -0.371 v -2.735 h 0.836 c 0.312,0 0.543,0.067 0.699,0.196 0.152,0.132 0.23,0.328 0.23,0.593 0,0.172 -0.043,0.313 -0.121,0.426 -0.078,0.113 -0.195,0.196 -0.347,0.239 z m -0.926,-1.149 v 0.969 h 0.465 c 0.176,0 0.312,-0.039 0.402,-0.121 0.09,-0.082 0.137,-0.203 0.137,-0.364 0,-0.16 -0.047,-0.281 -0.137,-0.363 -0.09,-0.082 -0.226,-0.121 -0.402,-0.121 z m 1.664,-0.305 h 1.73 v 0.313 h -1.359 v 0.808 h 1.301 v 0.313 h -1.301 v 0.988 h 1.391 v 0.313 h -1.762 z m 1.832,0 h 1.57 v 0.313 h -1.203 v 0.805 h 1.086 v 0.312 h -1.086 v 1.305 h -0.367 z m 2.09,0.305 v 1.027 h 0.465 c 0.172,0 0.304,-0.046 0.398,-0.132 0.094,-0.09 0.141,-0.219 0.141,-0.383 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.226,-0.133 -0.398,-0.133 z m -0.371,-0.305 h 0.836 c 0.304,0 0.539,0.071 0.695,0.211 0.156,0.137 0.234,0.34 0.234,0.606 0,0.269 -0.078,0.472 -0.234,0.613 -0.156,0.137 -0.391,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.371 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath492)"
+             id="path1023" />
+          <path
+             d="m 226.75,88.539 v 1.027 h 0.465 c 0.172,0 0.308,-0.046 0.402,-0.136 0.094,-0.086 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.23,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.207 0.156,0.141 0.238,0.344 0.238,0.61 0,0.269 -0.082,0.472 -0.238,0.609 -0.156,0.141 -0.387,0.207 -0.695,0.207 h -0.465 v 1.102 h -0.367 z m 2.308,1.426 v 1.004 h 0.59 c 0.199,0 0.348,-0.043 0.442,-0.125 0.097,-0.082 0.144,-0.207 0.144,-0.379 0,-0.168 -0.047,-0.297 -0.144,-0.375 -0.094,-0.082 -0.243,-0.125 -0.442,-0.125 z m 0,-1.121 v 0.824 h 0.547 c 0.18,0 0.313,-0.035 0.403,-0.101 0.089,-0.071 0.132,-0.172 0.132,-0.313 0,-0.137 -0.043,-0.242 -0.132,-0.308 -0.09,-0.071 -0.223,-0.102 -0.403,-0.102 z m -0.371,-0.305 h 0.946 c 0.281,0 0.5,0.059 0.652,0.176 0.152,0.117 0.227,0.285 0.227,0.5 0,0.168 -0.04,0.301 -0.118,0.399 -0.078,0.097 -0.191,0.16 -0.343,0.183 0.183,0.039 0.324,0.121 0.421,0.246 0.102,0.125 0.153,0.278 0.153,0.465 0,0.242 -0.082,0.43 -0.246,0.563 -0.168,0.136 -0.403,0.203 -0.711,0.203 h -0.981 z m 2.082,2.676 v -0.336 c 0.094,0.043 0.188,0.078 0.286,0.102 0.093,0.023 0.187,0.031 0.277,0.031 0.246,0 0.43,-0.078 0.558,-0.242 0.129,-0.164 0.204,-0.414 0.223,-0.75 -0.07,0.105 -0.16,0.187 -0.269,0.242 -0.11,0.055 -0.231,0.082 -0.36,0.082 -0.273,0 -0.492,-0.082 -0.652,-0.246 -0.156,-0.164 -0.238,-0.391 -0.238,-0.68 0,-0.277 0.085,-0.504 0.25,-0.675 0.168,-0.168 0.386,-0.254 0.664,-0.254 0.316,0 0.554,0.121 0.722,0.367 0.168,0.238 0.25,0.59 0.25,1.051 0,0.433 -0.101,0.777 -0.308,1.035 -0.203,0.254 -0.477,0.383 -0.825,0.383 -0.089,0 -0.183,-0.008 -0.281,-0.028 -0.094,-0.019 -0.191,-0.047 -0.297,-0.082 z m 0.739,-1.16 c 0.164,0 0.297,-0.055 0.394,-0.168 0.098,-0.113 0.145,-0.27 0.145,-0.469 0,-0.195 -0.047,-0.351 -0.145,-0.465 -0.097,-0.113 -0.23,-0.171 -0.394,-0.171 -0.168,0 -0.297,0.058 -0.395,0.171 -0.098,0.114 -0.144,0.27 -0.144,0.465 0,0.199 0.046,0.356 0.144,0.469 0.098,0.113 0.227,0.168 0.395,0.168 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath493)"
+             id="path1024" />
+          <path
+             d="m 226.75,84.285 v 1.027 h 0.465 c 0.172,0 0.308,-0.042 0.402,-0.132 0.094,-0.09 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.23,-0.137 -0.402,-0.137 z m -0.367,-0.301 h 0.832 c 0.308,0 0.539,0.071 0.695,0.207 0.156,0.137 0.238,0.34 0.238,0.61 0,0.269 -0.082,0.472 -0.238,0.609 -0.156,0.141 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 2.308,1.426 v 1.004 h 0.59 c 0.199,0 0.348,-0.043 0.442,-0.125 0.097,-0.082 0.144,-0.207 0.144,-0.379 0,-0.172 -0.047,-0.297 -0.144,-0.375 -0.094,-0.082 -0.243,-0.125 -0.442,-0.125 z m 0,-1.125 v 0.824 h 0.547 c 0.18,0 0.313,-0.031 0.403,-0.097 0.089,-0.071 0.132,-0.172 0.132,-0.313 0,-0.137 -0.043,-0.242 -0.132,-0.308 -0.09,-0.071 -0.223,-0.106 -0.403,-0.106 z m -0.371,-0.301 h 0.946 c 0.281,0 0.5,0.059 0.652,0.176 0.152,0.117 0.227,0.281 0.227,0.5 0,0.164 -0.04,0.297 -0.118,0.399 -0.078,0.097 -0.191,0.16 -0.343,0.183 0.183,0.039 0.324,0.121 0.421,0.246 0.102,0.121 0.153,0.278 0.153,0.461 0,0.246 -0.082,0.434 -0.246,0.567 -0.168,0.132 -0.403,0.199 -0.711,0.199 h -0.981 z m 2.864,1.434 c -0.176,0 -0.313,0.047 -0.414,0.141 -0.102,0.093 -0.153,0.222 -0.153,0.39 0,0.164 0.051,0.293 0.153,0.387 0.101,0.094 0.238,0.141 0.414,0.141 0.175,0 0.312,-0.047 0.414,-0.141 0.101,-0.098 0.152,-0.227 0.152,-0.387 0,-0.168 -0.051,-0.297 -0.152,-0.39 -0.098,-0.094 -0.239,-0.141 -0.414,-0.141 z m -0.372,-0.156 c -0.156,-0.039 -0.281,-0.114 -0.371,-0.223 -0.086,-0.109 -0.132,-0.242 -0.132,-0.398 0,-0.219 0.078,-0.391 0.234,-0.516 0.156,-0.129 0.371,-0.191 0.641,-0.191 0.273,0 0.484,0.062 0.64,0.191 0.156,0.125 0.235,0.297 0.235,0.516 0,0.156 -0.047,0.289 -0.137,0.398 -0.086,0.109 -0.211,0.184 -0.367,0.223 0.179,0.039 0.316,0.121 0.418,0.242 0.097,0.121 0.148,0.269 0.148,0.445 0,0.262 -0.082,0.465 -0.242,0.61 -0.164,0.14 -0.395,0.211 -0.695,0.211 -0.301,0 -0.536,-0.071 -0.696,-0.211 -0.16,-0.145 -0.242,-0.348 -0.242,-0.61 0,-0.176 0.051,-0.324 0.149,-0.445 0.101,-0.121 0.242,-0.203 0.417,-0.242 z m -0.132,-0.586 c 0,0.144 0.043,0.254 0.129,0.332 0.089,0.078 0.214,0.121 0.375,0.121 0.16,0 0.281,-0.043 0.371,-0.121 0.09,-0.078 0.136,-0.188 0.136,-0.332 0,-0.141 -0.046,-0.25 -0.136,-0.332 -0.09,-0.078 -0.211,-0.117 -0.371,-0.117 -0.161,0 -0.286,0.039 -0.375,0.117 -0.086,0.082 -0.129,0.191 -0.129,0.332 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath494)"
+             id="path1025" />
+          <path
+             d="m 226.75,158.672 v 1.027 h 0.465 c 0.172,0 0.308,-0.047 0.402,-0.133 0.094,-0.089 0.141,-0.218 0.141,-0.382 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.23,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.211 0.156,0.137 0.238,0.34 0.238,0.606 0,0.269 -0.082,0.472 -0.238,0.613 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 2.308,1.43 v 1 h 0.59 c 0.199,0 0.348,-0.043 0.442,-0.121 0.097,-0.086 0.144,-0.211 0.144,-0.379 0,-0.172 -0.047,-0.297 -0.144,-0.379 -0.094,-0.082 -0.243,-0.121 -0.442,-0.121 z m 0,-1.125 v 0.824 h 0.547 c 0.18,0 0.313,-0.035 0.403,-0.101 0.089,-0.067 0.132,-0.172 0.132,-0.313 0,-0.137 -0.043,-0.238 -0.132,-0.309 -0.09,-0.066 -0.223,-0.101 -0.403,-0.101 z m -0.371,-0.305 h 0.946 c 0.281,0 0.5,0.059 0.652,0.176 0.152,0.117 0.227,0.285 0.227,0.5 0,0.168 -0.04,0.301 -0.118,0.398 -0.078,0.098 -0.191,0.161 -0.343,0.188 0.183,0.039 0.324,0.117 0.421,0.242 0.102,0.125 0.153,0.277 0.153,0.465 0,0.242 -0.082,0.434 -0.246,0.566 -0.168,0.133 -0.403,0.2 -0.711,0.2 h -0.981 z m 1.981,0 h 1.758 v 0.156 l -0.993,2.579 h -0.386 l 0.933,-2.422 h -1.312 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath495)"
+             id="path1026" />
+          <path
+             d="m 226.75,154.422 v 1.027 h 0.465 c 0.172,0 0.308,-0.047 0.402,-0.137 0.094,-0.085 0.141,-0.214 0.141,-0.378 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.23,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.207 0.156,0.141 0.238,0.34 0.238,0.61 0,0.269 -0.082,0.472 -0.238,0.609 -0.156,0.141 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 2.308,1.426 v 1.004 h 0.59 c 0.199,0 0.348,-0.043 0.442,-0.125 0.097,-0.082 0.144,-0.207 0.144,-0.379 0,-0.168 -0.047,-0.297 -0.144,-0.375 -0.094,-0.082 -0.243,-0.125 -0.442,-0.125 z m 0,-1.121 v 0.824 h 0.547 c 0.18,0 0.313,-0.035 0.403,-0.101 0.089,-0.071 0.132,-0.172 0.132,-0.313 0,-0.137 -0.043,-0.242 -0.132,-0.309 -0.09,-0.07 -0.223,-0.101 -0.403,-0.101 z m -0.371,-0.305 h 0.946 c 0.281,0 0.5,0.059 0.652,0.176 0.152,0.117 0.227,0.285 0.227,0.5 0,0.168 -0.04,0.301 -0.118,0.398 -0.078,0.098 -0.191,0.161 -0.343,0.184 0.183,0.039 0.324,0.121 0.421,0.246 0.102,0.125 0.153,0.277 0.153,0.465 0,0.242 -0.082,0.43 -0.246,0.562 -0.168,0.133 -0.403,0.2 -0.711,0.2 h -0.981 z m 2.91,1.219 c -0.168,0 -0.296,0.055 -0.394,0.172 -0.098,0.113 -0.148,0.265 -0.148,0.465 0,0.195 0.05,0.351 0.148,0.468 0.098,0.114 0.226,0.168 0.394,0.168 0.165,0 0.297,-0.054 0.395,-0.168 0.098,-0.117 0.145,-0.273 0.145,-0.468 0,-0.2 -0.047,-0.352 -0.145,-0.465 -0.098,-0.117 -0.23,-0.172 -0.395,-0.172 z m 0.735,-1.16 v 0.34 c -0.094,-0.047 -0.188,-0.078 -0.281,-0.102 -0.098,-0.023 -0.188,-0.035 -0.282,-0.035 -0.246,0 -0.429,0.082 -0.562,0.246 -0.125,0.164 -0.199,0.414 -0.219,0.746 0.074,-0.105 0.164,-0.187 0.274,-0.242 0.105,-0.059 0.226,-0.086 0.355,-0.086 0.277,0 0.492,0.082 0.652,0.25 0.16,0.168 0.239,0.395 0.239,0.68 0,0.281 -0.082,0.507 -0.25,0.675 -0.164,0.168 -0.387,0.254 -0.661,0.254 -0.316,0 -0.558,-0.121 -0.726,-0.363 -0.168,-0.242 -0.25,-0.594 -0.25,-1.055 0,-0.429 0.101,-0.773 0.308,-1.031 0.204,-0.258 0.481,-0.387 0.825,-0.387 0.093,0 0.187,0.012 0.281,0.028 0.094,0.019 0.191,0.047 0.297,0.082 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath496)"
+             id="path1027" />
+          <path
+             d="m 226.75,150.168 v 1.027 h 0.465 c 0.172,0 0.308,-0.043 0.402,-0.133 0.094,-0.089 0.141,-0.214 0.141,-0.378 0,-0.164 -0.047,-0.293 -0.141,-0.379 -0.094,-0.09 -0.23,-0.137 -0.402,-0.137 z m -0.367,-0.301 h 0.832 c 0.308,0 0.539,0.067 0.695,0.207 0.156,0.137 0.238,0.34 0.238,0.61 0,0.269 -0.082,0.472 -0.238,0.609 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 3.801,2.34 v -0.73 h -0.606 v -0.305 h 0.973 v 1.172 c -0.145,0.101 -0.301,0.179 -0.473,0.23 -0.172,0.051 -0.355,0.078 -0.551,0.078 -0.429,0 -0.761,-0.125 -1.004,-0.375 -0.242,-0.25 -0.359,-0.597 -0.359,-1.043 0,-0.445 0.117,-0.793 0.359,-1.043 0.243,-0.25 0.575,-0.375 1.004,-0.375 0.176,0 0.348,0.024 0.508,0.067 0.16,0.043 0.309,0.109 0.442,0.195 v 0.391 c -0.137,-0.114 -0.282,-0.203 -0.434,-0.262 -0.152,-0.059 -0.316,-0.086 -0.484,-0.086 -0.336,0 -0.586,0.094 -0.754,0.277 -0.168,0.188 -0.254,0.465 -0.254,0.836 0,0.368 0.086,0.649 0.254,0.832 0.168,0.188 0.418,0.282 0.754,0.282 0.129,0 0.246,-0.012 0.347,-0.032 0.102,-0.023 0.196,-0.058 0.278,-0.109 z m 0.597,0.082 h 0.606 v -2.086 l -0.657,0.133 v -0.34 l 0.653,-0.129 h 0.371 v 2.422 h 0.601 v 0.309 h -1.574 z m 2.856,-2.101 -0.934,1.46 h 0.934 z m -0.098,-0.321 h 0.465 v 1.781 h 0.391 v 0.305 h -0.391 v 0.645 h -0.367 v -0.645 h -1.235 v -0.355 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath497)"
+             id="path1028" />
+          <path
+             d="m 226.75,145.918 v 1.027 h 0.465 c 0.172,0 0.308,-0.043 0.402,-0.133 0.094,-0.089 0.141,-0.214 0.141,-0.378 0,-0.164 -0.047,-0.293 -0.141,-0.379 -0.094,-0.09 -0.23,-0.137 -0.402,-0.137 z m -0.367,-0.301 h 0.832 c 0.308,0 0.539,0.067 0.695,0.207 0.156,0.137 0.238,0.34 0.238,0.61 0,0.269 -0.082,0.472 -0.238,0.609 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 1.937,0 h 1.727 v 0.309 h -1.356 v 0.808 h 1.301 v 0.313 h -1.301 v 0.992 h 1.391 v 0.309 h -1.762 z m 1.926,2.422 h 0.606 v -2.086 l -0.657,0.133 v -0.34 l 0.653,-0.129 h 0.371 v 2.422 h 0.601 v 0.309 h -1.574 z m 2.957,-1.164 c 0.18,0.039 0.317,0.117 0.414,0.234 0.102,0.121 0.153,0.27 0.153,0.446 0,0.269 -0.094,0.476 -0.282,0.625 -0.183,0.148 -0.449,0.222 -0.789,0.222 -0.113,0 -0.234,-0.011 -0.355,-0.035 -0.121,-0.023 -0.246,-0.055 -0.375,-0.101 v -0.356 c 0.101,0.059 0.215,0.106 0.336,0.133 0.121,0.031 0.25,0.047 0.383,0.047 0.23,0 0.41,-0.047 0.531,-0.137 0.121,-0.09 0.179,-0.226 0.179,-0.398 0,-0.16 -0.054,-0.289 -0.168,-0.379 -0.113,-0.09 -0.269,-0.137 -0.472,-0.137 h -0.317 v -0.305 h 0.332 c 0.184,0 0.321,-0.035 0.418,-0.105 0.098,-0.074 0.145,-0.18 0.145,-0.317 0,-0.14 -0.051,-0.246 -0.148,-0.32 -0.102,-0.078 -0.243,-0.113 -0.43,-0.113 -0.102,0 -0.207,0.008 -0.324,0.031 -0.118,0.024 -0.243,0.055 -0.383,0.102 v -0.328 c 0.14,-0.039 0.273,-0.071 0.394,-0.09 0.121,-0.02 0.239,-0.028 0.348,-0.028 0.281,0 0.504,0.063 0.664,0.192 0.164,0.129 0.246,0.301 0.246,0.515 0,0.153 -0.043,0.282 -0.129,0.387 -0.086,0.102 -0.211,0.176 -0.371,0.215 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath498)"
+             id="path1029" />
+          <path
+             d="m 226.75,141.668 v 1.027 h 0.465 c 0.172,0 0.308,-0.043 0.402,-0.133 0.094,-0.089 0.141,-0.218 0.141,-0.382 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.086 -0.23,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.211 0.156,0.137 0.238,0.34 0.238,0.606 0,0.269 -0.082,0.476 -0.238,0.613 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 1.937,0 h 1.727 v 0.313 h -1.356 v 0.808 h 1.301 v 0.313 h -1.301 v 0.988 h 1.391 v 0.313 h -1.762 z m 1.926,2.422 h 0.606 v -2.082 l -0.657,0.129 v -0.336 l 0.653,-0.133 h 0.371 v 2.422 h 0.601 v 0.313 h -1.574 z m 2.856,-2.097 -0.934,1.457 h 0.934 z m -0.098,-0.325 h 0.465 v 1.782 h 0.39 v 0.308 h -0.39 v 0.645 h -0.367 v -0.645 h -1.235 v -0.355 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath499)"
+             id="path1030" />
+          <path
+             d="m 226.75,137.418 v 1.027 h 0.465 c 0.172,0 0.308,-0.047 0.402,-0.133 0.094,-0.089 0.141,-0.218 0.141,-0.382 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.23,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.211 0.156,0.137 0.238,0.34 0.238,0.606 0,0.269 -0.082,0.472 -0.238,0.613 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 1.937,0 h 1.727 v 0.313 h -1.356 v 0.808 h 1.301 v 0.313 h -1.301 v 0.988 h 1.391 v 0.313 h -1.762 z m 1.926,2.422 h 0.606 v -2.086 l -0.657,0.133 v -0.336 l 0.653,-0.133 h 0.371 v 2.422 h 0.601 v 0.313 h -1.574 z m 1.902,0 h 0.606 v -2.086 l -0.66,0.133 v -0.336 l 0.656,-0.133 h 0.367 v 2.422 h 0.606 v 0.313 h -1.575 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath500)"
+             id="path1031" />
+          <path
+             d="m 226.75,133.168 v 1.023 h 0.465 c 0.172,0 0.308,-0.043 0.402,-0.132 0.094,-0.09 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.289 -0.141,-0.379 -0.094,-0.09 -0.23,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.071 0.695,0.207 0.156,0.141 0.238,0.34 0.238,0.61 0,0.269 -0.082,0.472 -0.238,0.609 -0.156,0.141 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 1.937,0 h 1.727 v 0.309 h -1.356 v 0.812 h 1.301 v 0.309 h -1.301 v 0.992 h 1.391 v 0.309 h -1.762 z m 1.875,2.676 v -0.336 c 0.09,0.043 0.184,0.078 0.282,0.098 0.093,0.023 0.187,0.035 0.281,0.035 0.242,0 0.43,-0.082 0.554,-0.242 0.133,-0.168 0.204,-0.414 0.223,-0.75 -0.07,0.105 -0.16,0.183 -0.269,0.242 -0.11,0.055 -0.227,0.082 -0.36,0.082 -0.273,0 -0.492,-0.082 -0.648,-0.246 -0.16,-0.164 -0.238,-0.391 -0.238,-0.68 0,-0.281 0.082,-0.504 0.246,-0.676 0.168,-0.168 0.386,-0.254 0.664,-0.254 0.316,0 0.558,0.122 0.722,0.364 0.168,0.242 0.25,0.594 0.25,1.054 0,0.434 -0.101,0.778 -0.304,1.036 -0.207,0.254 -0.481,0.382 -0.825,0.382 -0.093,0 -0.187,-0.007 -0.281,-0.027 -0.097,-0.019 -0.195,-0.047 -0.297,-0.082 z m 0.735,-1.16 c 0.168,0 0.297,-0.055 0.394,-0.168 0.098,-0.113 0.145,-0.27 0.145,-0.469 0,-0.195 -0.047,-0.351 -0.145,-0.465 -0.097,-0.113 -0.226,-0.172 -0.394,-0.172 -0.164,0 -0.297,0.059 -0.395,0.172 -0.097,0.114 -0.144,0.27 -0.144,0.465 0,0.199 0.047,0.356 0.144,0.469 0.098,0.113 0.231,0.168 0.395,0.168 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath501)"
+             id="path1032" />
+          <path
+             d="m 226.75,128.914 v 1.027 h 0.465 c 0.172,0 0.308,-0.043 0.402,-0.132 0.094,-0.09 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.293 -0.141,-0.379 -0.094,-0.09 -0.23,-0.137 -0.402,-0.137 z m -0.367,-0.301 h 0.832 c 0.308,0 0.539,0.067 0.695,0.207 0.156,0.137 0.238,0.34 0.238,0.61 0,0.269 -0.082,0.472 -0.238,0.609 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 3.801,2.34 v -0.734 h -0.606 v -0.301 h 0.973 v 1.172 c -0.145,0.101 -0.301,0.18 -0.473,0.23 -0.172,0.051 -0.355,0.078 -0.551,0.078 -0.429,0 -0.761,-0.125 -1.004,-0.375 -0.242,-0.25 -0.359,-0.597 -0.359,-1.043 0,-0.445 0.117,-0.792 0.359,-1.042 0.243,-0.25 0.575,-0.376 1.004,-0.376 0.176,0 0.348,0.024 0.508,0.067 0.16,0.043 0.309,0.109 0.442,0.191 v 0.395 c -0.137,-0.113 -0.282,-0.203 -0.434,-0.262 -0.152,-0.058 -0.316,-0.086 -0.484,-0.086 -0.336,0 -0.586,0.094 -0.754,0.278 -0.168,0.187 -0.254,0.464 -0.254,0.835 0,0.368 0.086,0.645 0.254,0.832 0.168,0.188 0.418,0.282 0.754,0.282 0.129,0 0.246,-0.012 0.347,-0.032 0.102,-0.023 0.196,-0.058 0.278,-0.109 z m 0.597,0.082 h 0.606 v -2.086 l -0.657,0.133 v -0.34 l 0.653,-0.129 h 0.371 v 2.422 h 0.601 v 0.309 h -1.574 z m 2.157,0 h 1.289 v 0.309 h -1.735 v -0.309 c 0.141,-0.148 0.332,-0.34 0.574,-0.586 0.243,-0.246 0.395,-0.402 0.457,-0.472 0.118,-0.133 0.2,-0.247 0.247,-0.34 0.046,-0.09 0.074,-0.184 0.074,-0.27 0,-0.148 -0.055,-0.265 -0.156,-0.355 -0.102,-0.094 -0.235,-0.137 -0.399,-0.137 -0.113,0 -0.238,0.02 -0.367,0.059 -0.129,0.039 -0.266,0.101 -0.41,0.183 v -0.375 c 0.148,-0.058 0.289,-0.105 0.418,-0.133 0.129,-0.031 0.246,-0.047 0.355,-0.047 0.281,0 0.508,0.071 0.676,0.211 0.168,0.145 0.254,0.332 0.254,0.571 0,0.109 -0.024,0.218 -0.067,0.32 -0.039,0.098 -0.117,0.215 -0.226,0.352 -0.031,0.039 -0.129,0.14 -0.293,0.308 -0.164,0.168 -0.395,0.406 -0.691,0.711 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath502)"
+             id="path1033" />
+          <path
+             d="m 226.75,197.137 v 1.027 h 0.465 c 0.172,0 0.308,-0.043 0.402,-0.133 0.094,-0.09 0.141,-0.219 0.141,-0.383 0,-0.164 -0.047,-0.289 -0.141,-0.378 -0.094,-0.086 -0.23,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.07 0.695,0.211 0.156,0.137 0.238,0.34 0.238,0.605 0,0.27 -0.082,0.477 -0.238,0.614 -0.156,0.136 -0.387,0.207 -0.695,0.207 h -0.465 v 1.097 h -0.367 z m 2.308,1.43 v 1 h 0.59 c 0.199,0 0.348,-0.039 0.442,-0.121 0.097,-0.086 0.144,-0.211 0.144,-0.379 0,-0.172 -0.047,-0.297 -0.144,-0.379 -0.094,-0.082 -0.243,-0.121 -0.442,-0.121 z m 0,-1.125 v 0.824 h 0.547 c 0.18,0 0.313,-0.035 0.403,-0.102 0.089,-0.066 0.132,-0.171 0.132,-0.308 0,-0.141 -0.043,-0.242 -0.132,-0.313 -0.09,-0.066 -0.223,-0.101 -0.403,-0.101 z m -0.371,-0.305 h 0.946 c 0.281,0 0.5,0.059 0.652,0.176 0.152,0.117 0.227,0.285 0.227,0.5 0,0.168 -0.04,0.301 -0.118,0.398 -0.078,0.102 -0.191,0.16 -0.343,0.188 0.183,0.039 0.324,0.121 0.421,0.246 0.102,0.121 0.153,0.277 0.153,0.461 0,0.246 -0.082,0.433 -0.246,0.566 -0.168,0.133 -0.403,0.199 -0.711,0.199 h -0.981 z m 2.137,2.422 h 0.605 v -2.082 l -0.66,0.129 v -0.336 l 0.657,-0.133 h 0.367 v 2.422 h 0.605 v 0.312 h -1.574 z m 1.902,0 h 0.602 v -2.082 l -0.656,0.129 v -0.336 l 0.652,-0.133 h 0.371 v 2.422 h 0.606 v 0.312 h -1.575 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath503)"
+             id="path1034" />
+          <path
+             d="m 226.75,192.887 v 1.027 h 0.465 c 0.172,0 0.308,-0.047 0.402,-0.133 0.094,-0.09 0.141,-0.219 0.141,-0.383 0,-0.164 -0.047,-0.289 -0.141,-0.378 -0.094,-0.09 -0.23,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.07 0.695,0.207 0.156,0.141 0.238,0.344 0.238,0.609 0,0.27 -0.082,0.473 -0.238,0.614 -0.156,0.136 -0.387,0.207 -0.695,0.207 h -0.465 v 1.097 h -0.367 z m 2.308,1.43 v 1 h 0.59 c 0.199,0 0.348,-0.043 0.442,-0.125 0.097,-0.082 0.144,-0.207 0.144,-0.379 0,-0.168 -0.047,-0.293 -0.144,-0.375 -0.094,-0.082 -0.243,-0.121 -0.442,-0.121 z m 0,-1.125 v 0.824 h 0.547 c 0.18,0 0.313,-0.035 0.403,-0.102 0.089,-0.07 0.132,-0.171 0.132,-0.312 0,-0.137 -0.043,-0.238 -0.132,-0.309 -0.09,-0.066 -0.223,-0.101 -0.403,-0.101 z m -0.371,-0.305 h 0.946 c 0.281,0 0.5,0.059 0.652,0.176 0.152,0.117 0.227,0.285 0.227,0.5 0,0.168 -0.04,0.301 -0.118,0.398 -0.078,0.098 -0.191,0.16 -0.343,0.184 0.183,0.039 0.324,0.121 0.421,0.246 0.102,0.125 0.153,0.277 0.153,0.465 0,0.242 -0.082,0.433 -0.246,0.566 -0.168,0.133 -0.403,0.199 -0.711,0.199 h -0.981 z m 2.137,2.422 h 0.605 v -2.086 l -0.66,0.133 v -0.336 l 0.657,-0.133 h 0.367 v 2.422 h 0.605 v 0.312 h -1.574 z m 2.629,-2.18 c -0.191,0 -0.336,0.094 -0.43,0.285 -0.097,0.184 -0.144,0.465 -0.144,0.844 0,0.371 0.047,0.652 0.144,0.844 0.094,0.183 0.239,0.277 0.43,0.277 0.191,0 0.332,-0.094 0.43,-0.277 0.097,-0.192 0.144,-0.473 0.144,-0.844 0,-0.379 -0.047,-0.66 -0.144,-0.844 -0.098,-0.191 -0.239,-0.285 -0.43,-0.285 z m 0,-0.293 c 0.305,0 0.539,0.125 0.699,0.367 0.164,0.243 0.246,0.59 0.246,1.055 0,0.457 -0.082,0.809 -0.246,1.051 -0.16,0.242 -0.394,0.363 -0.699,0.363 -0.309,0 -0.543,-0.121 -0.703,-0.363 -0.164,-0.242 -0.242,-0.594 -0.242,-1.051 0,-0.465 0.078,-0.812 0.242,-1.055 0.16,-0.242 0.394,-0.367 0.703,-0.367 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath504)"
+             id="path1035" />
+          <path
+             d="m 226.75,188.637 v 1.023 h 0.465 c 0.172,0 0.308,-0.043 0.402,-0.133 0.094,-0.089 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.289 -0.141,-0.378 -0.094,-0.09 -0.23,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.07 0.695,0.207 0.156,0.141 0.238,0.34 0.238,0.609 0,0.27 -0.082,0.473 -0.238,0.61 -0.156,0.14 -0.387,0.207 -0.695,0.207 h -0.465 v 1.097 h -0.367 z m 1.937,0 h 1.727 v 0.309 h -1.356 v 0.812 h 1.301 v 0.309 h -1.301 v 0.992 h 1.391 v 0.308 h -1.762 z m 1.926,2.422 h 0.606 v -2.086 l -0.657,0.133 v -0.336 l 0.653,-0.133 h 0.371 v 2.422 h 0.601 v 0.308 h -1.574 z m 1.84,-2.422 h 1.453 v 0.309 h -1.113 v 0.671 c 0.054,-0.019 0.109,-0.031 0.16,-0.039 0.055,-0.011 0.109,-0.015 0.164,-0.015 0.305,0 0.547,0.082 0.723,0.25 0.179,0.168 0.269,0.394 0.269,0.68 0,0.292 -0.094,0.523 -0.277,0.687 -0.184,0.16 -0.442,0.242 -0.774,0.242 -0.113,0 -0.23,-0.008 -0.351,-0.027 -0.117,-0.02 -0.242,-0.051 -0.367,-0.09 v -0.371 c 0.109,0.059 0.222,0.105 0.339,0.133 0.118,0.031 0.243,0.043 0.372,0.043 0.211,0 0.378,-0.055 0.504,-0.164 0.121,-0.114 0.183,-0.262 0.183,-0.453 0,-0.192 -0.062,-0.34 -0.183,-0.454 -0.126,-0.109 -0.293,-0.164 -0.504,-0.164 -0.098,0 -0.196,0.008 -0.297,0.032 -0.098,0.023 -0.196,0.054 -0.301,0.101 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath505)"
+             id="path1036" />
+          <path
+             d="m 226.75,184.383 v 1.027 h 0.465 c 0.172,0 0.308,-0.043 0.402,-0.133 0.094,-0.089 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.293 -0.141,-0.378 -0.094,-0.09 -0.23,-0.137 -0.402,-0.137 z m -0.367,-0.301 h 0.832 c 0.308,0 0.539,0.066 0.695,0.207 0.156,0.137 0.238,0.34 0.238,0.609 0,0.27 -0.082,0.473 -0.238,0.61 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.097 h -0.367 z m 1.937,0 h 1.727 v 0.309 h -1.356 v 0.808 h 1.301 v 0.313 h -1.301 v 0.992 h 1.391 v 0.308 h -1.762 z m 2.7,1.219 c -0.165,0 -0.297,0.054 -0.395,0.168 -0.098,0.113 -0.145,0.269 -0.145,0.469 0,0.195 0.047,0.351 0.145,0.464 0.098,0.114 0.23,0.172 0.395,0.172 0.164,0 0.296,-0.058 0.394,-0.172 0.098,-0.113 0.145,-0.269 0.145,-0.464 0,-0.2 -0.047,-0.356 -0.145,-0.469 -0.098,-0.114 -0.23,-0.168 -0.394,-0.168 z m 0.734,-1.16 v 0.336 c -0.094,-0.043 -0.188,-0.079 -0.281,-0.102 -0.094,-0.02 -0.188,-0.031 -0.282,-0.031 -0.242,0 -0.429,0.082 -0.558,0.246 -0.129,0.164 -0.203,0.414 -0.223,0.746 0.074,-0.106 0.164,-0.188 0.274,-0.242 0.109,-0.059 0.226,-0.086 0.359,-0.086 0.273,0 0.488,0.082 0.648,0.25 0.161,0.164 0.239,0.39 0.239,0.68 0,0.281 -0.082,0.503 -0.246,0.675 -0.168,0.168 -0.387,0.254 -0.664,0.254 -0.317,0 -0.559,-0.121 -0.727,-0.363 -0.164,-0.242 -0.25,-0.594 -0.25,-1.055 0,-0.433 0.102,-0.777 0.309,-1.031 0.203,-0.258 0.48,-0.387 0.824,-0.387 0.094,0 0.187,0.008 0.281,0.028 0.094,0.019 0.195,0.046 0.297,0.082 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath506)"
+             id="path1037" />
+          <path
+             d="m 226.75,180.133 v 1.027 h 0.465 c 0.172,0 0.308,-0.043 0.402,-0.133 0.094,-0.089 0.141,-0.215 0.141,-0.379 0,-0.164 -0.047,-0.293 -0.141,-0.378 -0.094,-0.09 -0.23,-0.137 -0.402,-0.137 z m -0.367,-0.301 h 0.832 c 0.308,0 0.539,0.066 0.695,0.207 0.156,0.137 0.238,0.34 0.238,0.609 0,0.27 -0.082,0.473 -0.238,0.61 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.097 h -0.367 z m 1.937,0 h 1.727 v 0.309 h -1.356 v 0.808 h 1.301 v 0.313 h -1.301 v 0.988 h 1.391 v 0.312 h -1.762 z m 1.926,2.418 h 0.606 v -2.082 l -0.657,0.129 v -0.336 l 0.653,-0.129 h 0.371 v 2.418 h 0.601 v 0.312 h -1.574 z m 2.156,0 h 1.289 v 0.312 h -1.734 v -0.312 c 0.141,-0.145 0.332,-0.34 0.574,-0.582 0.242,-0.246 0.395,-0.402 0.457,-0.473 0.117,-0.133 0.2,-0.246 0.246,-0.34 0.047,-0.089 0.075,-0.183 0.075,-0.269 0,-0.148 -0.055,-0.266 -0.157,-0.356 -0.101,-0.093 -0.234,-0.136 -0.398,-0.136 -0.113,0 -0.238,0.019 -0.367,0.058 -0.129,0.039 -0.266,0.102 -0.41,0.184 v -0.375 c 0.148,-0.059 0.289,-0.106 0.418,-0.133 0.128,-0.031 0.246,-0.047 0.355,-0.047 0.281,0 0.508,0.071 0.676,0.211 0.168,0.141 0.254,0.332 0.254,0.567 0,0.113 -0.024,0.222 -0.067,0.32 -0.039,0.101 -0.117,0.219 -0.226,0.355 -0.032,0.036 -0.129,0.141 -0.293,0.309 -0.164,0.168 -0.395,0.406 -0.692,0.707 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath507)"
+             id="path1038" />
+          <path
+             d="m 226.75,175.883 v 1.027 h 0.465 c 0.172,0 0.308,-0.043 0.402,-0.133 0.094,-0.089 0.141,-0.218 0.141,-0.382 0,-0.165 -0.047,-0.29 -0.141,-0.379 -0.094,-0.09 -0.23,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.07 0.695,0.211 0.156,0.137 0.238,0.34 0.238,0.606 0,0.269 -0.082,0.472 -0.238,0.613 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.097 h -0.367 z m 1.937,0 h 1.727 v 0.313 h -1.356 v 0.808 h 1.301 v 0.313 h -1.301 V 178 h 1.391 v 0.312 h -1.762 z m 1.926,2.422 h 0.606 v -2.086 l -0.657,0.133 v -0.336 l 0.653,-0.133 h 0.371 V 178 h 0.601 v 0.312 h -1.574 z m 2.629,-2.176 c -0.191,0 -0.336,0.094 -0.43,0.281 -0.097,0.188 -0.144,0.469 -0.144,0.844 0,0.375 0.047,0.656 0.144,0.844 0.094,0.187 0.239,0.277 0.43,0.277 0.191,0 0.336,-0.09 0.43,-0.277 0.097,-0.188 0.144,-0.469 0.144,-0.844 0,-0.375 -0.047,-0.656 -0.144,-0.844 -0.094,-0.187 -0.239,-0.281 -0.43,-0.281 z m 0,-0.293 c 0.305,0 0.539,0.121 0.699,0.364 0.164,0.242 0.246,0.593 0.246,1.054 0,0.461 -0.082,0.813 -0.246,1.055 -0.16,0.242 -0.394,0.359 -0.699,0.359 -0.305,0 -0.539,-0.117 -0.703,-0.359 -0.16,-0.242 -0.242,-0.594 -0.242,-1.055 0,-0.461 0.082,-0.812 0.242,-1.054 0.164,-0.243 0.398,-0.364 0.703,-0.364 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath508)"
+             id="path1039" />
+          <path
+             d="m 226.75,167.383 v 1.023 h 0.465 c 0.172,0 0.308,-0.043 0.402,-0.133 0.094,-0.089 0.141,-0.214 0.141,-0.378 0,-0.165 -0.047,-0.29 -0.141,-0.379 -0.094,-0.09 -0.23,-0.133 -0.402,-0.133 z m -0.367,-0.305 h 0.832 c 0.308,0 0.539,0.07 0.695,0.207 0.156,0.137 0.238,0.34 0.238,0.61 0,0.269 -0.082,0.472 -0.238,0.609 -0.156,0.141 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 1.937,0 h 1.727 v 0.309 h -1.356 v 0.812 h 1.301 v 0.309 h -1.301 v 0.992 h 1.391 v 0.309 h -1.762 z m 1.77,0 h 1.758 v 0.156 l -0.993,2.575 h -0.386 l 0.933,-2.422 h -1.312 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath509)"
+             id="path1040" />
+          <path
+             d="m 226.75,163.129 v 1.027 h 0.465 c 0.172,0 0.308,-0.043 0.402,-0.133 0.094,-0.089 0.141,-0.214 0.141,-0.378 0,-0.165 -0.047,-0.293 -0.141,-0.379 -0.094,-0.09 -0.23,-0.137 -0.402,-0.137 z m -0.367,-0.301 h 0.832 c 0.308,0 0.539,0.067 0.695,0.207 0.156,0.137 0.238,0.34 0.238,0.61 0,0.269 -0.082,0.472 -0.238,0.609 -0.156,0.137 -0.387,0.207 -0.695,0.207 h -0.465 v 1.098 h -0.367 z m 1.937,0 h 1.727 v 0.309 h -1.356 v 0.808 h 1.301 v 0.313 h -1.301 v 0.988 h 1.391 v 0.313 h -1.762 z m 2.653,1.434 c -0.176,0 -0.313,0.047 -0.414,0.14 -0.102,0.094 -0.153,0.223 -0.153,0.387 0,0.164 0.051,0.297 0.153,0.391 0.101,0.093 0.238,0.14 0.414,0.14 0.175,0 0.316,-0.047 0.418,-0.14 0.101,-0.098 0.152,-0.227 0.152,-0.391 0,-0.164 -0.051,-0.293 -0.152,-0.387 -0.102,-0.093 -0.239,-0.14 -0.418,-0.14 z m -0.368,-0.157 c -0.16,-0.039 -0.285,-0.113 -0.375,-0.222 -0.085,-0.11 -0.128,-0.242 -0.128,-0.399 0,-0.218 0.078,-0.39 0.23,-0.515 0.156,-0.129 0.371,-0.192 0.641,-0.192 0.273,0 0.488,0.063 0.64,0.192 0.157,0.125 0.235,0.297 0.235,0.515 0,0.157 -0.047,0.289 -0.133,0.399 -0.09,0.109 -0.211,0.183 -0.371,0.222 0.179,0.04 0.32,0.122 0.418,0.243 0.097,0.121 0.148,0.269 0.148,0.441 0,0.266 -0.082,0.469 -0.242,0.609 -0.16,0.145 -0.395,0.215 -0.695,0.215 -0.301,0 -0.532,-0.07 -0.696,-0.215 -0.16,-0.14 -0.242,-0.343 -0.242,-0.609 0,-0.172 0.051,-0.32 0.153,-0.441 0.097,-0.121 0.238,-0.203 0.417,-0.243 z m -0.136,-0.585 c 0,0.14 0.043,0.253 0.133,0.332 0.086,0.078 0.21,0.117 0.371,0.117 0.16,0 0.285,-0.039 0.371,-0.117 0.094,-0.079 0.136,-0.192 0.136,-0.332 0,-0.141 -0.042,-0.25 -0.136,-0.332 -0.086,-0.079 -0.211,-0.118 -0.371,-0.118 -0.161,0 -0.285,0.039 -0.371,0.118 -0.09,0.082 -0.133,0.191 -0.133,0.332 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath510)"
+             id="path1041" />
+          <path
+             d="m 228.246,173.672 v -0.734 h -0.605 v -0.305 h 0.972 v 1.172 c -0.144,0.101 -0.301,0.179 -0.472,0.234 -0.172,0.051 -0.356,0.074 -0.551,0.074 -0.43,0 -0.762,-0.125 -1.004,-0.371 -0.242,-0.25 -0.363,-0.597 -0.363,-1.043 0,-0.449 0.121,-0.797 0.363,-1.047 0.242,-0.25 0.574,-0.375 1.004,-0.375 0.176,0 0.344,0.024 0.504,0.067 0.164,0.043 0.312,0.109 0.445,0.195 v 0.395 c -0.137,-0.118 -0.281,-0.204 -0.434,-0.262 -0.156,-0.059 -0.316,-0.09 -0.484,-0.09 -0.336,0 -0.586,0.094 -0.758,0.281 -0.164,0.188 -0.25,0.465 -0.25,0.836 0,0.367 0.086,0.645 0.25,0.832 0.172,0.188 0.422,0.278 0.758,0.278 0.129,0 0.246,-0.008 0.348,-0.032 0.101,-0.023 0.195,-0.058 0.277,-0.105 z m 0.5,-2.344 h 0.5 l 1.211,2.285 v -2.285 h 0.359 v 2.734 h -0.5 l -1.211,-2.289 v 2.289 h -0.359 z m 2.793,0.305 v 2.125 h 0.445 c 0.375,0 0.653,-0.086 0.828,-0.258 0.176,-0.172 0.262,-0.441 0.262,-0.809 0,-0.367 -0.086,-0.632 -0.262,-0.804 -0.175,-0.168 -0.453,-0.254 -0.828,-0.254 z m -0.371,-0.305 h 0.758 c 0.531,0 0.922,0.11 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.473 -0.125,0.817 -0.375,1.039 -0.246,0.219 -0.637,0.332 -1.164,0.332 h -0.758 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath511)"
+             id="path1042" />
+          <path
+             d="m 115.109,277.023 -0.5,1.36 h 1.004 z m -0.207,-0.367 h 0.418 l 1.043,2.735 h -0.383 l -0.25,-0.7 h -1.234 l -0.246,0.7 h -0.391 z m 2.641,1 c -0.039,-0.023 -0.082,-0.039 -0.125,-0.047 -0.043,-0.011 -0.094,-0.019 -0.148,-0.019 -0.188,0 -0.336,0.062 -0.438,0.187 -0.102,0.125 -0.152,0.301 -0.152,0.535 v 1.079 h -0.34 v -2.051 h 0.34 v 0.32 c 0.07,-0.125 0.164,-0.219 0.277,-0.277 0.113,-0.063 0.25,-0.09 0.414,-0.09 0.024,0 0.047,0 0.074,0.004 0.028,0 0.059,0.008 0.094,0.012 z m 1.414,-0.004 v -1.109 h 0.34 v 2.848 h -0.34 v -0.309 c -0.07,0.121 -0.16,0.215 -0.266,0.273 -0.109,0.059 -0.238,0.09 -0.39,0.09 -0.246,0 -0.449,-0.101 -0.606,-0.297 -0.156,-0.199 -0.23,-0.46 -0.23,-0.781 0,-0.32 0.074,-0.582 0.23,-0.781 0.157,-0.195 0.36,-0.297 0.606,-0.297 0.152,0 0.281,0.031 0.39,0.09 0.106,0.059 0.196,0.152 0.266,0.273 z m -1.145,0.715 c 0,0.246 0.051,0.442 0.149,0.586 0.105,0.137 0.246,0.207 0.422,0.207 0.179,0 0.32,-0.07 0.422,-0.207 0.101,-0.144 0.152,-0.34 0.152,-0.586 0,-0.246 -0.051,-0.441 -0.152,-0.582 -0.102,-0.14 -0.243,-0.211 -0.422,-0.211 -0.176,0 -0.317,0.071 -0.422,0.211 -0.098,0.141 -0.149,0.336 -0.149,0.582 z m 1.731,0.215 v -1.242 h 0.336 v 1.23 c 0,0.192 0.039,0.34 0.113,0.438 0.078,0.094 0.192,0.144 0.34,0.144 0.184,0 0.328,-0.058 0.434,-0.175 0.105,-0.118 0.156,-0.274 0.156,-0.473 v -1.164 h 0.34 v 2.051 h -0.34 v -0.317 c -0.082,0.125 -0.176,0.219 -0.285,0.281 -0.106,0.059 -0.231,0.09 -0.375,0.09 -0.235,0 -0.414,-0.074 -0.535,-0.222 -0.122,-0.145 -0.184,-0.36 -0.184,-0.641 z m 2.004,-1.242 h 0.336 v 2.051 h -0.336 z m 0,-0.797 h 0.336 v 0.426 h -0.336 z m 2.562,1.609 v 1.239 h -0.336 v -1.227 c 0,-0.195 -0.039,-0.34 -0.117,-0.437 -0.074,-0.094 -0.187,-0.145 -0.34,-0.145 -0.179,0 -0.324,0.059 -0.429,0.176 -0.106,0.117 -0.157,0.273 -0.157,0.472 v 1.161 h -0.339 v -2.051 h 0.339 v 0.32 c 0.079,-0.125 0.176,-0.215 0.282,-0.277 0.113,-0.063 0.238,-0.094 0.379,-0.094 0.238,0 0.414,0.074 0.535,0.223 0.121,0.144 0.183,0.359 0.183,0.64 z m 1.059,-0.574 c -0.184,0 -0.324,0.07 -0.43,0.211 -0.105,0.141 -0.156,0.332 -0.156,0.578 0,0.246 0.051,0.438 0.156,0.582 0.102,0.137 0.246,0.207 0.43,0.207 0.18,0 0.32,-0.07 0.426,-0.211 0.105,-0.14 0.156,-0.332 0.156,-0.578 0,-0.242 -0.051,-0.433 -0.156,-0.578 -0.106,-0.141 -0.246,-0.211 -0.426,-0.211 z m 0,-0.289 c 0.293,0 0.523,0.098 0.687,0.289 0.168,0.188 0.254,0.453 0.254,0.789 0,0.336 -0.086,0.598 -0.254,0.789 -0.164,0.192 -0.394,0.289 -0.687,0.289 -0.297,0 -0.527,-0.097 -0.695,-0.289 -0.164,-0.191 -0.246,-0.453 -0.246,-0.789 0,-0.336 0.082,-0.601 0.246,-0.789 0.168,-0.191 0.398,-0.289 0.695,-0.289 z m 3.336,0.113 v 0.317 c -0.098,-0.047 -0.195,-0.086 -0.297,-0.11 -0.105,-0.023 -0.211,-0.035 -0.32,-0.035 -0.168,0 -0.293,0.024 -0.375,0.074 -0.086,0.051 -0.125,0.129 -0.125,0.231 0,0.078 0.027,0.141 0.09,0.187 0.058,0.043 0.179,0.086 0.359,0.125 l 0.113,0.028 c 0.242,0.051 0.41,0.121 0.512,0.215 0.101,0.093 0.152,0.222 0.152,0.39 0,0.192 -0.078,0.34 -0.226,0.453 -0.153,0.11 -0.36,0.168 -0.621,0.168 -0.11,0 -0.227,-0.011 -0.344,-0.035 -0.121,-0.019 -0.246,-0.051 -0.379,-0.094 v -0.347 c 0.125,0.062 0.25,0.113 0.371,0.144 0.121,0.032 0.238,0.047 0.359,0.047 0.157,0 0.278,-0.023 0.364,-0.078 0.086,-0.055 0.129,-0.133 0.129,-0.23 0,-0.094 -0.032,-0.164 -0.094,-0.211 -0.059,-0.051 -0.195,-0.098 -0.402,-0.141 l -0.118,-0.027 c -0.211,-0.043 -0.359,-0.114 -0.453,-0.203 -0.094,-0.09 -0.14,-0.215 -0.14,-0.375 0,-0.192 0.07,-0.34 0.207,-0.446 0.136,-0.105 0.328,-0.156 0.582,-0.156 0.125,0 0.242,0.008 0.351,0.027 0.11,0.016 0.211,0.043 0.305,0.082 z m 0.121,1.18 v -1.242 h 0.336 v 1.23 c 0,0.192 0.039,0.34 0.117,0.438 0.074,0.094 0.188,0.144 0.34,0.144 0.18,0 0.324,-0.058 0.43,-0.175 0.105,-0.118 0.16,-0.274 0.16,-0.473 v -1.164 h 0.336 v 2.051 h -0.336 v -0.317 c -0.082,0.125 -0.18,0.219 -0.289,0.281 -0.106,0.059 -0.231,0.09 -0.375,0.09 -0.235,0 -0.414,-0.074 -0.535,-0.222 -0.121,-0.145 -0.184,-0.36 -0.184,-0.641 z m 3.477,-0.215 c 0,-0.246 -0.051,-0.441 -0.157,-0.582 -0.101,-0.14 -0.238,-0.211 -0.418,-0.211 -0.179,0 -0.316,0.071 -0.422,0.211 -0.101,0.141 -0.152,0.336 -0.152,0.582 0,0.246 0.051,0.442 0.152,0.586 0.106,0.137 0.243,0.207 0.422,0.207 0.18,0 0.317,-0.07 0.418,-0.207 0.106,-0.144 0.157,-0.34 0.157,-0.586 z m -1.149,-0.715 c 0.074,-0.121 0.16,-0.214 0.27,-0.273 0.109,-0.059 0.238,-0.09 0.386,-0.09 0.25,0 0.453,0.102 0.606,0.297 0.156,0.199 0.234,0.461 0.234,0.781 0,0.321 -0.078,0.582 -0.234,0.781 -0.153,0.196 -0.356,0.297 -0.606,0.297 -0.148,0 -0.277,-0.031 -0.386,-0.09 -0.11,-0.058 -0.196,-0.152 -0.27,-0.273 v 0.309 h -0.336 v -2.848 h 0.336 z m 2.949,-0.25 v 0.317 c -0.093,-0.047 -0.191,-0.086 -0.293,-0.11 -0.105,-0.023 -0.211,-0.035 -0.32,-0.035 -0.168,0 -0.293,0.024 -0.379,0.074 -0.082,0.051 -0.121,0.129 -0.121,0.231 0,0.078 0.027,0.141 0.09,0.187 0.059,0.043 0.18,0.086 0.359,0.125 l 0.114,0.028 c 0.242,0.051 0.41,0.121 0.511,0.215 0.102,0.093 0.153,0.222 0.153,0.39 0,0.192 -0.078,0.34 -0.231,0.453 -0.148,0.11 -0.355,0.168 -0.617,0.168 -0.113,0 -0.227,-0.011 -0.348,-0.035 -0.117,-0.019 -0.242,-0.051 -0.375,-0.094 v -0.347 c 0.125,0.062 0.25,0.113 0.371,0.144 0.122,0.032 0.239,0.047 0.356,0.047 0.16,0 0.281,-0.023 0.367,-0.078 0.086,-0.055 0.129,-0.133 0.129,-0.23 0,-0.094 -0.031,-0.164 -0.094,-0.211 -0.062,-0.051 -0.195,-0.098 -0.406,-0.141 l -0.117,-0.027 c -0.207,-0.043 -0.36,-0.114 -0.449,-0.203 -0.094,-0.09 -0.141,-0.215 -0.141,-0.375 0,-0.192 0.07,-0.34 0.207,-0.446 0.137,-0.105 0.328,-0.156 0.582,-0.156 0.125,0 0.242,0.008 0.352,0.027 0.109,0.016 0.21,0.043 0.3,0.082 z m 1.914,0.879 v 0.164 h -1.55 c 0.015,0.235 0.086,0.41 0.211,0.532 0.125,0.121 0.3,0.179 0.523,0.179 0.129,0 0.254,-0.015 0.375,-0.047 0.121,-0.031 0.242,-0.078 0.363,-0.14 v 0.316 c -0.121,0.051 -0.246,0.09 -0.371,0.117 -0.129,0.028 -0.258,0.043 -0.387,0.043 -0.328,0 -0.585,-0.097 -0.777,-0.289 -0.191,-0.187 -0.285,-0.445 -0.285,-0.769 0,-0.336 0.09,-0.602 0.27,-0.801 0.179,-0.195 0.425,-0.297 0.734,-0.297 0.273,0 0.492,0.09 0.652,0.27 0.16,0.175 0.242,0.418 0.242,0.722 z m -0.336,-0.097 c -0.003,-0.184 -0.054,-0.332 -0.156,-0.442 -0.101,-0.109 -0.234,-0.164 -0.398,-0.164 -0.188,0 -0.34,0.051 -0.453,0.156 -0.114,0.11 -0.176,0.258 -0.196,0.45 z m 0.762,-1.426 v 0.582 h 0.692 v 0.262 h -0.692 v 1.113 c 0,0.168 0.024,0.273 0.067,0.324 0.046,0.047 0.14,0.07 0.281,0.07 h 0.344 v 0.282 h -0.344 c -0.262,0 -0.442,-0.047 -0.539,-0.145 -0.098,-0.098 -0.149,-0.273 -0.149,-0.531 v -1.113 h -0.246 v -0.262 h 0.246 v -0.582 z m 2.563,0.82 c -0.18,0 -0.325,0.07 -0.426,0.211 -0.106,0.141 -0.16,0.332 -0.16,0.578 0,0.246 0.054,0.438 0.156,0.582 0.105,0.137 0.25,0.207 0.43,0.207 0.179,0 0.324,-0.07 0.425,-0.211 0.106,-0.14 0.161,-0.332 0.161,-0.578 0,-0.242 -0.055,-0.433 -0.161,-0.578 -0.101,-0.141 -0.246,-0.211 -0.425,-0.211 z m 0,-0.289 c 0.293,0 0.523,0.098 0.691,0.289 0.168,0.188 0.25,0.453 0.25,0.789 0,0.336 -0.082,0.598 -0.25,0.789 -0.168,0.192 -0.398,0.289 -0.691,0.289 -0.293,0 -0.524,-0.097 -0.692,-0.289 -0.164,-0.191 -0.25,-0.453 -0.25,-0.789 0,-0.336 0.086,-0.601 0.25,-0.789 0.168,-0.191 0.399,-0.289 0.692,-0.289 z m 2.218,-0.746 v 0.281 h -0.32 c -0.121,0 -0.207,0.024 -0.254,0.071 -0.047,0.05 -0.07,0.136 -0.07,0.265 v 0.18 h 0.555 v 0.262 h -0.555 v 1.789 h -0.336 v -1.789 h -0.324 v -0.262 h 0.324 v -0.141 c 0,-0.23 0.051,-0.394 0.156,-0.5 0.11,-0.105 0.278,-0.156 0.508,-0.156 z m 0.813,0.113 h 2.144 v 0.285 l -1.726,2.137 h 1.769 v 0.313 h -2.23 v -0.282 l 1.727,-2.14 h -1.684 z m 1.894,0.684 h 0.34 v 2.051 h -0.34 z m 0,-0.797 h 0.34 v 0.426 h -0.34 z m 1.653,1.035 c -0.18,0 -0.321,0.07 -0.426,0.211 -0.105,0.141 -0.16,0.332 -0.16,0.578 0,0.246 0.055,0.438 0.156,0.582 0.106,0.137 0.25,0.207 0.43,0.207 0.179,0 0.324,-0.07 0.429,-0.211 0.106,-0.14 0.157,-0.332 0.157,-0.578 0,-0.242 -0.051,-0.433 -0.157,-0.578 -0.105,-0.141 -0.25,-0.211 -0.429,-0.211 z m 0,-0.289 c 0.293,0 0.523,0.098 0.691,0.289 0.168,0.188 0.25,0.453 0.25,0.789 0,0.336 -0.082,0.598 -0.25,0.789 -0.168,0.192 -0.398,0.289 -0.691,0.289 -0.293,0 -0.524,-0.097 -0.692,-0.289 -0.164,-0.191 -0.246,-0.453 -0.246,-0.789 0,-0.336 0.082,-0.601 0.246,-0.789 0.168,-0.191 0.399,-0.289 0.692,-0.289 z m 2.074,0.399 h 2.348 v 0.308 h -2.348 z m 0,0.746 h 2.348 v 0.312 h -2.348 z m 7.836,-1.411 -0.504,1.36 h 1.008 z m -0.211,-0.367 h 0.422 l 1.039,2.735 h -0.383 l -0.25,-0.703 h -1.23 l -0.25,0.703 h -0.391 z m 2.289,0.246 c -0.187,0 -0.332,0.094 -0.43,0.282 -0.093,0.187 -0.14,0.468 -0.14,0.843 0,0.375 0.047,0.657 0.14,0.844 0.098,0.188 0.243,0.281 0.43,0.281 0.195,0 0.336,-0.093 0.434,-0.281 0.093,-0.187 0.144,-0.469 0.144,-0.844 0,-0.375 -0.051,-0.656 -0.144,-0.843 -0.098,-0.188 -0.239,-0.282 -0.434,-0.282 z m 0,-0.293 c 0.309,0 0.543,0.121 0.703,0.364 0.164,0.242 0.242,0.593 0.242,1.054 0,0.461 -0.078,0.813 -0.242,1.055 -0.16,0.242 -0.394,0.363 -0.703,0.363 -0.305,0 -0.539,-0.121 -0.699,-0.363 -0.164,-0.242 -0.242,-0.594 -0.242,-1.055 0,-0.461 0.078,-0.812 0.242,-1.054 0.16,-0.243 0.394,-0.364 0.699,-0.364 z m 2.246,0.149 v 0.582 h 0.692 v 0.262 h -0.692 v 1.113 c 0,0.168 0.02,0.273 0.067,0.324 0.046,0.047 0.14,0.07 0.281,0.07 h 0.344 v 0.282 h -0.344 c -0.262,0 -0.442,-0.047 -0.539,-0.145 -0.098,-0.098 -0.149,-0.273 -0.149,-0.531 v -1.113 h -0.246 v -0.262 h 0.246 v -0.582 z m 1.68,0.82 c -0.18,0 -0.324,0.07 -0.43,0.211 -0.105,0.141 -0.156,0.332 -0.156,0.578 0,0.246 0.051,0.438 0.156,0.582 0.106,0.137 0.246,0.207 0.43,0.207 0.18,0 0.32,-0.07 0.426,-0.211 0.105,-0.14 0.156,-0.332 0.156,-0.578 0,-0.242 -0.051,-0.433 -0.156,-0.578 -0.106,-0.141 -0.246,-0.211 -0.426,-0.211 z m 0,-0.289 c 0.293,0 0.523,0.098 0.691,0.289 0.164,0.188 0.25,0.453 0.25,0.789 0,0.336 -0.086,0.598 -0.25,0.789 -0.168,0.192 -0.398,0.289 -0.691,0.289 -0.293,0 -0.524,-0.097 -0.692,-0.289 -0.167,-0.191 -0.25,-0.453 -0.25,-0.789 0,-0.336 0.083,-0.601 0.25,-0.789 0.168,-0.191 0.399,-0.289 0.692,-0.289 z m 2.957,-0.266 -0.504,1.36 h 1.008 z m -0.211,-0.367 h 0.422 l 1.039,2.735 h -0.383 l -0.25,-0.703 h -1.23 l -0.25,0.703 H 163 Z m 1.504,0 H 167 v 0.313 h -1.113 v 0.672 c 0.051,-0.02 0.105,-0.036 0.16,-0.043 0.055,-0.008 0.105,-0.016 0.16,-0.016 0.305,0 0.547,0.086 0.727,0.254 0.175,0.164 0.265,0.391 0.265,0.68 0,0.293 -0.09,0.519 -0.273,0.683 -0.184,0.164 -0.442,0.246 -0.774,0.246 -0.117,0 -0.234,-0.011 -0.351,-0.031 -0.121,-0.019 -0.242,-0.047 -0.371,-0.086 v -0.375 c 0.113,0.063 0.226,0.106 0.343,0.137 0.118,0.027 0.239,0.043 0.372,0.043 0.21,0 0.378,-0.055 0.5,-0.168 0.125,-0.11 0.187,-0.262 0.187,-0.449 0,-0.192 -0.062,-0.344 -0.187,-0.454 -0.122,-0.113 -0.29,-0.167 -0.5,-0.167 -0.098,0 -0.2,0.011 -0.297,0.035 -0.098,0.019 -0.2,0.054 -0.301,0.101 z m 3.629,1.703 c -0.274,0 -0.461,0.032 -0.567,0.094 -0.105,0.063 -0.156,0.168 -0.156,0.32 0,0.118 0.039,0.215 0.117,0.286 0.078,0.066 0.188,0.101 0.321,0.101 0.187,0 0.336,-0.062 0.449,-0.195 0.113,-0.133 0.172,-0.309 0.172,-0.531 v -0.075 z m 0.672,-0.136 v 1.168 h -0.336 v -0.313 c -0.078,0.125 -0.172,0.219 -0.289,0.277 -0.114,0.059 -0.254,0.09 -0.422,0.09 -0.207,0 -0.375,-0.058 -0.5,-0.175 -0.125,-0.122 -0.184,-0.278 -0.184,-0.477 0,-0.231 0.074,-0.402 0.231,-0.52 0.152,-0.117 0.382,-0.175 0.691,-0.175 h 0.473 v -0.036 c 0,-0.152 -0.051,-0.273 -0.157,-0.359 -0.101,-0.082 -0.242,-0.125 -0.425,-0.125 -0.118,0 -0.235,0.012 -0.344,0.039 -0.109,0.031 -0.219,0.071 -0.32,0.129 v -0.312 c 0.125,-0.047 0.242,-0.082 0.359,-0.106 0.117,-0.023 0.227,-0.035 0.34,-0.035 0.297,0 0.515,0.074 0.664,0.23 0.144,0.153 0.219,0.387 0.219,0.7 z m 1.894,-0.071 v 1.239 h -0.336 v -1.227 c 0,-0.195 -0.039,-0.34 -0.113,-0.437 -0.074,-0.094 -0.188,-0.145 -0.34,-0.145 -0.183,0 -0.324,0.059 -0.43,0.176 -0.105,0.117 -0.16,0.273 -0.16,0.472 v 1.161 h -0.336 v -2.051 h 0.336 v 0.32 c 0.082,-0.125 0.176,-0.215 0.285,-0.277 0.11,-0.063 0.239,-0.09 0.379,-0.09 0.235,0 0.414,0.07 0.535,0.219 0.122,0.144 0.18,0.359 0.18,0.64 z m 1.613,-0.5 v -1.109 h 0.34 v 2.848 h -0.34 v -0.309 c -0.07,0.121 -0.16,0.215 -0.269,0.273 -0.106,0.059 -0.234,0.09 -0.387,0.09 -0.246,0 -0.449,-0.101 -0.605,-0.297 -0.156,-0.199 -0.235,-0.46 -0.235,-0.781 0,-0.32 0.079,-0.582 0.235,-0.781 0.156,-0.195 0.359,-0.293 0.605,-0.293 0.153,0 0.281,0.027 0.387,0.086 0.109,0.059 0.199,0.152 0.269,0.273 z m -1.148,0.715 c 0,0.246 0.051,0.442 0.152,0.586 0.106,0.137 0.246,0.207 0.422,0.207 0.18,0 0.321,-0.07 0.422,-0.207 0.102,-0.144 0.152,-0.34 0.152,-0.586 0,-0.246 -0.05,-0.441 -0.152,-0.582 -0.101,-0.14 -0.242,-0.211 -0.422,-0.211 -0.176,0 -0.316,0.071 -0.422,0.211 -0.101,0.141 -0.152,0.336 -0.152,0.582 z m 3,-1.406 v 2.125 h 0.445 c 0.379,0 0.657,-0.086 0.828,-0.254 0.176,-0.172 0.266,-0.441 0.266,-0.812 0,-0.364 -0.09,-0.633 -0.266,-0.801 -0.171,-0.172 -0.449,-0.258 -0.828,-0.258 z m -0.371,-0.305 h 0.762 c 0.531,0 0.918,0.114 1.164,0.332 0.25,0.219 0.375,0.567 0.375,1.032 0,0.472 -0.125,0.82 -0.375,1.039 -0.25,0.222 -0.637,0.332 -1.164,0.332 h -0.762 z m 3.133,0.246 c -0.192,0 -0.336,0.094 -0.434,0.282 -0.094,0.187 -0.14,0.468 -0.14,0.843 0,0.375 0.046,0.657 0.14,0.844 0.098,0.188 0.242,0.281 0.434,0.281 0.191,0 0.332,-0.093 0.429,-0.281 0.094,-0.187 0.145,-0.469 0.145,-0.844 0,-0.375 -0.051,-0.656 -0.145,-0.843 -0.097,-0.188 -0.238,-0.282 -0.429,-0.282 z m 0,-0.293 c 0.304,0 0.539,0.121 0.699,0.364 0.164,0.242 0.242,0.593 0.242,1.054 0,0.461 -0.078,0.813 -0.242,1.055 -0.16,0.242 -0.395,0.363 -0.699,0.363 -0.309,0 -0.543,-0.121 -0.703,-0.363 -0.164,-0.242 -0.243,-0.594 -0.243,-1.055 0,-0.461 0.079,-0.812 0.243,-1.054 0.16,-0.243 0.394,-0.364 0.703,-0.364 z m 2.242,0.149 v 0.582 h 0.691 v 0.262 h -0.691 v 1.113 c 0,0.168 0.019,0.273 0.066,0.324 0.047,0.047 0.141,0.07 0.282,0.07 h 0.343 v 0.282 h -0.343 c -0.262,0 -0.442,-0.047 -0.539,-0.145 -0.098,-0.098 -0.149,-0.273 -0.149,-0.531 v -1.113 h -0.246 v -0.262 h 0.246 v -0.582 z m 1.68,0.82 c -0.18,0 -0.325,0.07 -0.43,0.211 -0.106,0.141 -0.156,0.332 -0.156,0.578 0,0.246 0.05,0.438 0.156,0.582 0.105,0.137 0.246,0.207 0.43,0.207 0.179,0 0.32,-0.07 0.425,-0.211 0.106,-0.14 0.157,-0.332 0.157,-0.578 0,-0.242 -0.051,-0.433 -0.157,-0.578 -0.105,-0.141 -0.246,-0.211 -0.425,-0.211 z m 0,-0.285 c 0.293,0 0.523,0.094 0.691,0.285 0.164,0.188 0.25,0.453 0.25,0.789 0,0.336 -0.086,0.598 -0.25,0.789 -0.168,0.192 -0.398,0.289 -0.691,0.289 -0.293,0 -0.524,-0.097 -0.692,-0.289 -0.168,-0.191 -0.25,-0.453 -0.25,-0.789 0,-0.336 0.082,-0.601 0.25,-0.789 0.168,-0.191 0.399,-0.285 0.692,-0.285 z m 2.414,-0.332 v 2.125 h 0.445 c 0.379,0 0.652,-0.086 0.828,-0.254 0.176,-0.172 0.262,-0.441 0.262,-0.812 0,-0.364 -0.086,-0.633 -0.262,-0.801 -0.176,-0.172 -0.449,-0.258 -0.828,-0.258 z m -0.371,-0.305 h 0.761 c 0.528,0 0.918,0.114 1.164,0.332 0.25,0.219 0.371,0.567 0.371,1.032 0,0.472 -0.125,0.82 -0.371,1.039 -0.25,0.222 -0.636,0.332 -1.164,0.332 h -0.761 z m 2.402,2.422 h 0.605 v -2.082 l -0.656,0.129 v -0.336 l 0.653,-0.133 h 0.371 v 2.422 h 0.601 v 0.313 h -1.574 z m 1.84,-2.422 h 1.453 v 0.313 h -1.113 v 0.672 c 0.054,-0.02 0.105,-0.036 0.16,-0.043 0.054,-0.008 0.109,-0.016 0.16,-0.016 0.305,0 0.547,0.086 0.726,0.254 0.18,0.164 0.266,0.391 0.266,0.68 0,0.293 -0.09,0.519 -0.273,0.683 -0.184,0.164 -0.442,0.246 -0.774,0.246 -0.117,0 -0.234,-0.011 -0.351,-0.031 -0.118,-0.019 -0.242,-0.047 -0.368,-0.086 v -0.375 c 0.11,0.063 0.223,0.106 0.34,0.137 0.118,0.027 0.243,0.043 0.371,0.043 0.211,0 0.379,-0.055 0.5,-0.168 0.125,-0.11 0.188,-0.262 0.188,-0.449 0,-0.192 -0.063,-0.344 -0.188,-0.454 -0.121,-0.113 -0.289,-0.167 -0.5,-0.167 -0.097,0 -0.199,0.011 -0.296,0.035 -0.098,0.019 -0.2,0.054 -0.301,0.101 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath512)"
+             id="path1043" />
+          <path
+             d="m 105.52,275.996 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#ff00ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath513)"
+             id="path1044" />
+          <path
+             d="m 105.52,-275.996 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath514)"
+             id="path1045" />
+          <path
+             d="m 105.52,283.434 h 4.25 v 4.25 h -4.25 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath515)"
+             id="path1046" />
+          <path
+             d="m 105.52,-283.434 h 4.25 v -4.25 h -4.25 z"
+             style="fill:none;stroke:#000000;stroke-width:0.54;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath516)"
+             id="path1047" />
+          <path
+             d="m 114.324,283.953 h 2.149 v 0.281 l -1.727,2.141 h 1.77 v 0.309 h -2.231 v -0.282 l 1.727,-2.136 h -1.688 z m 1.899,0.684 h 0.336 v 2.047 h -0.336 z m 0,-0.801 h 0.336 v 0.43 h -0.336 z m 1.652,1.035 c -0.18,0 -0.324,0.07 -0.426,0.211 -0.105,0.141 -0.16,0.336 -0.16,0.582 0,0.242 0.055,0.438 0.156,0.578 0.106,0.141 0.25,0.211 0.43,0.211 0.18,0 0.324,-0.07 0.43,-0.211 0.101,-0.144 0.156,-0.336 0.156,-0.578 0,-0.246 -0.055,-0.437 -0.156,-0.578 -0.106,-0.145 -0.25,-0.215 -0.43,-0.215 z m 0,-0.285 c 0.293,0 0.523,0.094 0.691,0.285 0.168,0.191 0.25,0.453 0.25,0.793 0,0.332 -0.082,0.598 -0.25,0.789 -0.168,0.192 -0.398,0.285 -0.691,0.285 -0.293,0 -0.523,-0.093 -0.691,-0.285 -0.164,-0.191 -0.25,-0.457 -0.25,-0.789 0,-0.34 0.086,-0.602 0.25,-0.793 0.168,-0.191 0.398,-0.285 0.691,-0.285 z m 3.785,0.992 v 0.164 h -1.551 c 0.016,0.231 0.086,0.406 0.211,0.531 0.125,0.122 0.297,0.18 0.524,0.18 0.129,0 0.254,-0.015 0.375,-0.047 0.121,-0.031 0.242,-0.082 0.363,-0.144 v 0.32 c -0.121,0.051 -0.246,0.09 -0.375,0.117 -0.125,0.028 -0.254,0.039 -0.387,0.039 -0.324,0 -0.586,-0.093 -0.777,-0.285 -0.188,-0.191 -0.285,-0.449 -0.285,-0.773 0,-0.336 0.09,-0.602 0.273,-0.797 0.18,-0.199 0.426,-0.297 0.731,-0.297 0.277,0 0.496,0.09 0.656,0.266 0.16,0.179 0.242,0.418 0.242,0.726 z m -0.34,-0.101 c 0,-0.184 -0.05,-0.332 -0.152,-0.442 -0.102,-0.109 -0.234,-0.164 -0.402,-0.164 -0.188,0 -0.336,0.055 -0.45,0.16 -0.113,0.106 -0.179,0.254 -0.195,0.449 z m 2.098,-0.84 -0.742,0.996 0.781,1.051 h -0.398 l -0.598,-0.805 -0.594,0.805 h -0.398 l 0.797,-1.071 -0.731,-0.976 h 0.399 l 0.543,0.73 0.543,-0.73 z m 0.266,-0.582 v 0.582 h 0.691 v 0.261 h -0.691 v 1.114 c 0,0.164 0.019,0.273 0.066,0.32 0.047,0.047 0.141,0.07 0.281,0.07 h 0.344 v 0.286 h -0.344 c -0.261,0 -0.441,-0.051 -0.539,-0.149 -0.101,-0.098 -0.148,-0.273 -0.148,-0.527 v -1.114 h -0.246 v -0.261 h 0.246 v -0.582 z m 2.632,1.523 v 0.164 h -1.546 c 0.015,0.231 0.082,0.406 0.207,0.531 0.128,0.122 0.3,0.18 0.523,0.18 0.129,0 0.258,-0.015 0.375,-0.047 0.125,-0.031 0.246,-0.082 0.363,-0.144 v 0.32 c -0.121,0.051 -0.242,0.09 -0.371,0.117 -0.125,0.028 -0.254,0.039 -0.387,0.039 -0.328,0 -0.585,-0.093 -0.777,-0.285 -0.191,-0.191 -0.285,-0.449 -0.285,-0.773 0,-0.336 0.09,-0.602 0.27,-0.797 0.183,-0.199 0.425,-0.297 0.734,-0.297 0.277,0 0.496,0.09 0.656,0.266 0.16,0.179 0.238,0.418 0.238,0.726 z m -0.336,-0.101 c 0,-0.184 -0.054,-0.332 -0.156,-0.442 -0.097,-0.109 -0.23,-0.164 -0.398,-0.164 -0.188,0 -0.34,0.055 -0.453,0.16 -0.11,0.106 -0.176,0.254 -0.192,0.449 z m 2.157,-0.028 v 1.239 h -0.336 v -1.227 c 0,-0.195 -0.039,-0.34 -0.117,-0.438 -0.075,-0.097 -0.188,-0.144 -0.34,-0.144 -0.18,0 -0.324,0.059 -0.43,0.176 -0.105,0.113 -0.156,0.273 -0.156,0.472 v 1.161 h -0.34 v -2.051 h 0.34 v 0.316 c 0.078,-0.121 0.176,-0.215 0.281,-0.277 0.113,-0.059 0.238,-0.09 0.383,-0.09 0.234,0 0.41,0.074 0.531,0.219 0.121,0.144 0.184,0.359 0.184,0.644 z m 1.57,-0.754 v 0.321 c -0.094,-0.051 -0.195,-0.086 -0.297,-0.11 -0.101,-0.027 -0.207,-0.039 -0.316,-0.039 -0.168,0 -0.293,0.028 -0.379,0.078 -0.082,0.051 -0.125,0.129 -0.125,0.231 0,0.078 0.031,0.14 0.09,0.183 0.058,0.047 0.179,0.086 0.359,0.129 l 0.117,0.024 c 0.239,0.05 0.41,0.125 0.508,0.218 0.102,0.094 0.152,0.223 0.152,0.391 0,0.188 -0.074,0.34 -0.226,0.449 -0.149,0.114 -0.356,0.168 -0.621,0.168 -0.11,0 -0.223,-0.011 -0.344,-0.031 -0.117,-0.023 -0.242,-0.055 -0.375,-0.098 v -0.347 c 0.125,0.066 0.246,0.113 0.367,0.148 0.121,0.031 0.242,0.047 0.36,0.047 0.16,0 0.281,-0.027 0.367,-0.082 0.086,-0.055 0.129,-0.129 0.129,-0.23 0,-0.09 -0.032,-0.161 -0.094,-0.211 -0.063,-0.047 -0.199,-0.094 -0.406,-0.141 l -0.118,-0.027 c -0.207,-0.043 -0.359,-0.11 -0.453,-0.2 -0.09,-0.093 -0.136,-0.218 -0.136,-0.375 0,-0.195 0.066,-0.343 0.203,-0.449 0.136,-0.101 0.332,-0.156 0.582,-0.156 0.125,0 0.242,0.008 0.351,0.027 0.11,0.02 0.211,0.047 0.305,0.082 z m 0.16,-0.058 h 0.336 v 2.051 h -0.336 z m 0,-0.801 h 0.336 v 0.43 h -0.336 z m 1.653,1.035 c -0.18,0 -0.325,0.07 -0.43,0.215 -0.106,0.137 -0.156,0.332 -0.156,0.578 0,0.242 0.05,0.438 0.156,0.578 0.105,0.141 0.246,0.211 0.43,0.211 0.179,0 0.32,-0.07 0.425,-0.211 0.106,-0.144 0.157,-0.336 0.157,-0.578 0,-0.246 -0.051,-0.437 -0.157,-0.578 -0.105,-0.145 -0.246,-0.215 -0.425,-0.215 z m 0,-0.285 c 0.292,0 0.523,0.094 0.691,0.285 0.164,0.191 0.25,0.453 0.25,0.793 0,0.332 -0.086,0.598 -0.25,0.789 -0.168,0.192 -0.399,0.285 -0.691,0.285 -0.293,0 -0.524,-0.093 -0.692,-0.285 -0.168,-0.191 -0.25,-0.457 -0.25,-0.789 0,-0.34 0.082,-0.602 0.25,-0.793 0.168,-0.191 0.399,-0.285 0.692,-0.285 z m 2.886,0.863 v 1.239 h -0.34 v -1.227 c 0,-0.195 -0.035,-0.34 -0.113,-0.438 -0.074,-0.097 -0.187,-0.144 -0.34,-0.144 -0.179,0 -0.324,0.059 -0.429,0.176 -0.106,0.113 -0.157,0.273 -0.157,0.472 v 1.161 h -0.339 v -2.051 h 0.339 v 0.316 c 0.078,-0.121 0.176,-0.215 0.282,-0.277 0.113,-0.059 0.238,-0.09 0.379,-0.09 0.238,0 0.414,0.074 0.535,0.219 0.121,0.144 0.183,0.359 0.183,0.644 z m 1.153,-0.465 h 2.347 v 0.305 h -2.347 z m 0,0.746 h 2.347 v 0.313 h -2.347 z m 18.007,-1.414 -0.504,1.36 h 1.004 z m -0.211,-0.363 h 0.418 l 1.043,2.735 h -0.382 l -0.25,-0.704 h -1.231 l -0.25,0.704 h -0.391 z m 2.336,1.219 c -0.164,0 -0.296,0.058 -0.394,0.172 -0.098,0.113 -0.145,0.265 -0.145,0.465 0,0.195 0.047,0.351 0.145,0.468 0.098,0.114 0.23,0.168 0.394,0.168 0.168,0 0.297,-0.054 0.395,-0.168 0.098,-0.117 0.144,-0.273 0.144,-0.468 0,-0.2 -0.046,-0.352 -0.144,-0.465 -0.098,-0.114 -0.227,-0.172 -0.395,-0.172 z m 0.735,-1.16 v 0.34 c -0.094,-0.047 -0.188,-0.079 -0.281,-0.102 -0.094,-0.023 -0.188,-0.035 -0.282,-0.035 -0.242,0 -0.429,0.082 -0.558,0.246 -0.129,0.164 -0.203,0.414 -0.223,0.746 0.074,-0.105 0.164,-0.187 0.273,-0.242 0.11,-0.059 0.227,-0.086 0.36,-0.086 0.273,0 0.488,0.082 0.648,0.25 0.16,0.168 0.239,0.394 0.239,0.68 0,0.281 -0.082,0.507 -0.247,0.675 -0.167,0.168 -0.386,0.254 -0.664,0.254 -0.316,0 -0.558,-0.121 -0.726,-0.363 -0.164,-0.242 -0.25,-0.594 -0.25,-1.055 0,-0.429 0.105,-0.773 0.308,-1.031 0.207,-0.258 0.481,-0.387 0.825,-0.387 0.093,0 0.187,0.012 0.281,0.028 0.094,0.019 0.195,0.047 0.297,0.082 z m 1.465,0.043 v 0.582 h 0.691 v 0.261 h -0.691 v 1.114 c 0,0.164 0.019,0.273 0.066,0.32 0.047,0.047 0.141,0.07 0.281,0.07 h 0.344 v 0.286 h -0.344 c -0.261,0 -0.441,-0.051 -0.539,-0.145 -0.097,-0.098 -0.148,-0.277 -0.148,-0.531 v -1.114 h -0.246 v -0.261 h 0.246 v -0.582 z m 1.679,0.816 c -0.179,0 -0.324,0.07 -0.429,0.215 -0.106,0.137 -0.157,0.332 -0.157,0.578 0,0.242 0.051,0.438 0.157,0.578 0.105,0.141 0.246,0.211 0.429,0.211 0.18,0 0.321,-0.07 0.426,-0.211 0.106,-0.144 0.156,-0.336 0.156,-0.578 0,-0.246 -0.05,-0.437 -0.156,-0.578 -0.105,-0.145 -0.246,-0.215 -0.426,-0.215 z m 0,-0.285 c 0.293,0 0.524,0.094 0.692,0.285 0.164,0.191 0.25,0.453 0.25,0.793 0,0.332 -0.086,0.598 -0.25,0.789 -0.168,0.192 -0.399,0.285 -0.692,0.285 -0.293,0 -0.523,-0.093 -0.691,-0.285 -0.168,-0.191 -0.25,-0.457 -0.25,-0.789 0,-0.34 0.082,-0.602 0.25,-0.793 0.168,-0.191 0.398,-0.285 0.691,-0.285 z m 2.957,-0.27 -0.504,1.36 h 1.008 z m -0.211,-0.363 h 0.422 l 1.039,2.735 h -0.382 l -0.25,-0.704 h -1.231 l -0.25,0.704 h -0.391 z m 2.293,1.434 c -0.175,0 -0.316,0.047 -0.418,0.14 -0.097,0.094 -0.148,0.227 -0.148,0.391 0,0.164 0.051,0.293 0.148,0.387 0.102,0.093 0.243,0.14 0.418,0.14 0.176,0 0.313,-0.047 0.414,-0.14 0.102,-0.094 0.153,-0.223 0.153,-0.387 0,-0.164 -0.051,-0.297 -0.153,-0.391 -0.101,-0.093 -0.238,-0.14 -0.414,-0.14 z m -0.371,-0.157 c -0.16,-0.039 -0.281,-0.113 -0.371,-0.222 -0.09,-0.11 -0.133,-0.238 -0.133,-0.395 0,-0.218 0.078,-0.394 0.235,-0.519 0.156,-0.125 0.367,-0.192 0.64,-0.192 0.27,0 0.485,0.067 0.641,0.192 0.152,0.125 0.23,0.301 0.23,0.519 0,0.157 -0.042,0.285 -0.132,0.395 -0.086,0.109 -0.211,0.183 -0.368,0.222 0.176,0.043 0.317,0.122 0.415,0.243 0.101,0.121 0.152,0.269 0.152,0.445 0,0.266 -0.082,0.469 -0.246,0.609 -0.16,0.141 -0.391,0.211 -0.692,0.211 -0.304,0 -0.535,-0.07 -0.695,-0.211 -0.164,-0.14 -0.242,-0.343 -0.242,-0.609 0,-0.176 0.051,-0.324 0.148,-0.445 0.102,-0.121 0.239,-0.2 0.418,-0.243 z m -0.136,-0.582 c 0,0.141 0.046,0.25 0.132,0.329 0.09,0.082 0.215,0.121 0.375,0.121 0.157,0 0.282,-0.039 0.371,-0.121 0.09,-0.079 0.133,-0.188 0.133,-0.329 0,-0.144 -0.043,-0.253 -0.133,-0.332 -0.089,-0.082 -0.214,-0.121 -0.371,-0.121 -0.16,0 -0.285,0.039 -0.375,0.121 -0.086,0.079 -0.132,0.188 -0.132,0.332 z m 3.347,1.008 c -0.273,0 -0.461,0.032 -0.566,0.094 -0.106,0.062 -0.156,0.168 -0.156,0.316 0,0.122 0.039,0.215 0.117,0.286 0.078,0.07 0.187,0.105 0.32,0.105 0.188,0 0.34,-0.066 0.449,-0.199 0.114,-0.133 0.172,-0.309 0.172,-0.528 v -0.074 z m 0.672,-0.14 v 1.172 h -0.336 v -0.313 c -0.078,0.125 -0.172,0.215 -0.289,0.277 -0.113,0.059 -0.254,0.086 -0.418,0.086 -0.211,0 -0.379,-0.058 -0.504,-0.176 -0.121,-0.117 -0.183,-0.277 -0.183,-0.472 0,-0.231 0.074,-0.406 0.23,-0.524 0.156,-0.117 0.387,-0.175 0.691,-0.175 h 0.473 v -0.032 c 0,-0.156 -0.051,-0.273 -0.152,-0.359 -0.102,-0.086 -0.246,-0.129 -0.43,-0.129 -0.117,0 -0.23,0.016 -0.344,0.043 -0.109,0.027 -0.218,0.07 -0.32,0.125 v -0.309 c 0.125,-0.05 0.242,-0.085 0.359,-0.109 0.118,-0.023 0.231,-0.035 0.34,-0.035 0.297,0 0.516,0.078 0.664,0.23 0.145,0.153 0.219,0.387 0.219,0.7 z m 1.899,-0.067 v 1.239 h -0.34 v -1.227 c 0,-0.195 -0.035,-0.34 -0.114,-0.438 -0.074,-0.097 -0.187,-0.144 -0.339,-0.144 -0.18,0 -0.325,0.059 -0.43,0.176 -0.106,0.113 -0.156,0.273 -0.156,0.472 v 1.161 h -0.34 v -2.051 h 0.34 v 0.316 c 0.078,-0.121 0.175,-0.215 0.281,-0.277 0.113,-0.059 0.238,-0.09 0.379,-0.09 0.238,0 0.414,0.074 0.535,0.219 0.121,0.144 0.184,0.359 0.184,0.644 z m 1.613,-0.504 v -1.109 h 0.336 v 2.852 h -0.336 v -0.309 c -0.071,0.121 -0.16,0.211 -0.27,0.273 -0.109,0.059 -0.238,0.086 -0.39,0.086 -0.246,0 -0.45,-0.097 -0.606,-0.297 -0.152,-0.195 -0.23,-0.457 -0.23,-0.777 0,-0.324 0.078,-0.582 0.23,-0.781 0.156,-0.199 0.36,-0.297 0.606,-0.297 0.152,0 0.281,0.031 0.39,0.09 0.11,0.058 0.199,0.148 0.27,0.269 z m -1.149,0.719 c 0,0.246 0.051,0.441 0.153,0.582 0.101,0.141 0.242,0.211 0.422,0.211 0.175,0 0.316,-0.07 0.418,-0.211 0.105,-0.141 0.156,-0.336 0.156,-0.582 0,-0.25 -0.051,-0.445 -0.156,-0.582 -0.102,-0.144 -0.243,-0.215 -0.418,-0.215 -0.18,0 -0.321,0.071 -0.422,0.215 -0.102,0.137 -0.153,0.332 -0.153,0.582 z m 3,-1.406 v 2.125 h 0.446 c 0.375,0 0.652,-0.086 0.828,-0.258 0.176,-0.172 0.262,-0.441 0.262,-0.809 0,-0.367 -0.086,-0.632 -0.262,-0.804 -0.176,-0.168 -0.453,-0.254 -0.828,-0.254 z m -0.371,-0.305 h 0.758 c 0.531,0 0.922,0.109 1.168,0.332 0.246,0.219 0.371,0.563 0.371,1.031 0,0.473 -0.125,0.817 -0.375,1.039 -0.246,0.219 -0.637,0.333 -1.164,0.333 h -0.758 z m 2.403,2.422 h 0.605 v -2.086 l -0.66,0.133 v -0.336 l 0.656,-0.133 h 0.367 v 2.422 h 0.606 v 0.313 h -1.574 z m 2.672,-1.203 c -0.165,0 -0.297,0.058 -0.395,0.172 -0.094,0.113 -0.145,0.265 -0.145,0.465 0,0.195 0.051,0.351 0.145,0.468 0.098,0.114 0.23,0.168 0.395,0.168 0.167,0 0.3,-0.054 0.394,-0.168 0.098,-0.117 0.148,-0.273 0.148,-0.468 0,-0.2 -0.05,-0.352 -0.148,-0.465 -0.094,-0.114 -0.227,-0.172 -0.394,-0.172 z m 0.734,-1.16 v 0.34 c -0.09,-0.047 -0.184,-0.079 -0.281,-0.102 -0.094,-0.023 -0.188,-0.035 -0.278,-0.035 -0.246,0 -0.433,0.082 -0.562,0.246 -0.129,0.164 -0.199,0.414 -0.219,0.746 0.07,-0.105 0.16,-0.187 0.27,-0.242 0.109,-0.059 0.23,-0.086 0.359,-0.086 0.273,0 0.492,0.082 0.648,0.25 0.161,0.168 0.243,0.394 0.243,0.68 0,0.281 -0.082,0.507 -0.25,0.675 -0.164,0.168 -0.387,0.254 -0.664,0.254 -0.313,0 -0.555,-0.121 -0.723,-0.363 -0.168,-0.242 -0.25,-0.594 -0.25,-1.055 0,-0.429 0.101,-0.773 0.305,-1.031 0.207,-0.258 0.48,-0.387 0.828,-0.387 0.093,0 0.183,0.012 0.277,0.028 0.098,0.019 0.195,0.047 0.297,0.082 z m 1.465,0.043 v 0.582 h 0.695 v 0.261 h -0.695 v 1.114 c 0,0.164 0.023,0.273 0.066,0.32 0.047,0.047 0.141,0.07 0.281,0.07 h 0.348 v 0.286 h -0.348 c -0.261,0 -0.437,-0.051 -0.539,-0.145 -0.097,-0.098 -0.148,-0.277 -0.148,-0.531 v -1.114 h -0.246 v -0.261 h 0.246 v -0.582 z m 1.679,0.816 c -0.179,0 -0.324,0.07 -0.425,0.215 -0.106,0.137 -0.161,0.332 -0.161,0.578 0,0.242 0.055,0.438 0.157,0.578 0.105,0.141 0.25,0.211 0.429,0.211 0.18,0 0.325,-0.07 0.426,-0.211 0.106,-0.144 0.16,-0.336 0.16,-0.578 0,-0.246 -0.054,-0.437 -0.16,-0.578 -0.101,-0.145 -0.246,-0.215 -0.426,-0.215 z m 0,-0.285 c 0.293,0 0.524,0.094 0.692,0.285 0.168,0.191 0.25,0.453 0.25,0.793 0,0.332 -0.082,0.598 -0.25,0.789 -0.168,0.192 -0.399,0.285 -0.692,0.285 -0.293,0 -0.523,-0.093 -0.691,-0.285 -0.164,-0.191 -0.25,-0.457 -0.25,-0.789 0,-0.34 0.086,-0.602 0.25,-0.793 0.168,-0.191 0.398,-0.285 0.691,-0.285 z m 2.414,-0.328 v 2.125 h 0.446 c 0.379,0 0.656,-0.086 0.828,-0.258 0.176,-0.172 0.266,-0.441 0.266,-0.809 0,-0.367 -0.09,-0.632 -0.266,-0.804 -0.172,-0.168 -0.449,-0.254 -0.828,-0.254 z m -0.371,-0.305 h 0.762 c 0.527,0 0.918,0.109 1.164,0.332 0.25,0.219 0.375,0.563 0.375,1.031 0,0.473 -0.125,0.817 -0.375,1.039 -0.25,0.219 -0.637,0.333 -1.164,0.333 h -0.762 z m 2.246,0 h 1.758 v 0.156 l -0.992,2.579 h -0.387 l 0.934,-2.422 h -1.313 z m 2.313,2.422 h 1.293 v 0.313 h -1.738 v -0.313 c 0.14,-0.145 0.332,-0.34 0.574,-0.586 0.242,-0.242 0.394,-0.402 0.457,-0.473 0.121,-0.132 0.203,-0.246 0.25,-0.336 0.047,-0.093 0.07,-0.183 0.07,-0.273 0,-0.145 -0.051,-0.262 -0.156,-0.355 -0.098,-0.09 -0.23,-0.137 -0.395,-0.137 -0.117,0 -0.238,0.019 -0.367,0.058 -0.129,0.043 -0.265,0.102 -0.414,0.184 v -0.371 c 0.149,-0.063 0.289,-0.106 0.418,-0.137 0.129,-0.031 0.246,-0.047 0.356,-0.047 0.281,0 0.507,0.071 0.675,0.215 0.168,0.141 0.254,0.328 0.254,0.567 0,0.113 -0.019,0.218 -0.062,0.32 -0.043,0.101 -0.121,0.219 -0.231,0.355 -0.031,0.036 -0.129,0.137 -0.293,0.309 -0.16,0.168 -0.39,0.402 -0.691,0.707 z"
+             style="fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath517)"
+             id="path1048" />
+          <path
+             d="m 97.016,253.512 h 23.383 v 14.961 H 97.016 Z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath518)"
+             id="path1049" />
+          <path
+             d="m 97.016,-253.512 h 23.383 v -14.961 H 97.016 Z"
+             style="fill:none;stroke:#000000;stroke-width:0.9;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath519)"
+             id="path1050" />
+          <path
+             d="m 105.402,256.359 h 0.446 v 1.993 c 0,0.351 0.062,0.605 0.191,0.761 0.125,0.153 0.332,0.231 0.617,0.231 0.285,0 0.492,-0.078 0.617,-0.231 0.129,-0.156 0.192,-0.41 0.192,-0.761 v -1.993 h 0.445 v 2.051 c 0,0.426 -0.105,0.75 -0.316,0.969 -0.211,0.215 -0.524,0.324 -0.938,0.324 -0.414,0 -0.726,-0.109 -0.937,-0.324 -0.211,-0.219 -0.317,-0.543 -0.317,-0.969 z m 4.903,0.11 v 0.433 c -0.168,-0.082 -0.325,-0.14 -0.477,-0.179 -0.148,-0.039 -0.293,-0.059 -0.433,-0.059 -0.239,0 -0.426,0.047 -0.559,0.141 -0.129,0.09 -0.195,0.226 -0.195,0.398 0,0.145 0.043,0.254 0.129,0.328 0.089,0.074 0.253,0.133 0.496,0.18 l 0.269,0.055 c 0.332,0.062 0.574,0.172 0.731,0.332 0.16,0.16 0.238,0.371 0.238,0.636 0,0.321 -0.106,0.559 -0.32,0.723 -0.215,0.164 -0.524,0.246 -0.938,0.246 -0.156,0 -0.32,-0.015 -0.496,-0.051 -0.172,-0.035 -0.355,-0.09 -0.543,-0.156 v -0.457 c 0.18,0.102 0.359,0.176 0.531,0.227 0.172,0.054 0.34,0.078 0.508,0.078 0.254,0 0.449,-0.051 0.586,-0.149 0.141,-0.101 0.207,-0.242 0.207,-0.425 0,-0.161 -0.047,-0.29 -0.148,-0.379 -0.098,-0.09 -0.262,-0.161 -0.485,-0.203 l -0.269,-0.055 c -0.332,-0.067 -0.571,-0.168 -0.719,-0.309 -0.148,-0.14 -0.223,-0.336 -0.223,-0.586 0,-0.289 0.102,-0.519 0.305,-0.687 0.207,-0.164 0.488,-0.25 0.848,-0.25 0.152,0 0.308,0.015 0.468,0.043 0.161,0.027 0.325,0.07 0.489,0.125 z m 0.543,1.605 v 1.203 h 0.711 c 0.242,0 0.418,-0.05 0.531,-0.148 0.117,-0.102 0.172,-0.25 0.172,-0.453 0,-0.207 -0.055,-0.36 -0.172,-0.453 -0.113,-0.098 -0.289,-0.149 -0.531,-0.149 z m 0,-1.347 v 0.988 h 0.656 c 0.219,0 0.379,-0.039 0.484,-0.121 0.11,-0.082 0.16,-0.207 0.16,-0.375 0,-0.164 -0.05,-0.289 -0.16,-0.371 -0.105,-0.082 -0.265,-0.121 -0.484,-0.121 z m -0.442,-0.368 h 1.133 c 0.336,0 0.598,0.071 0.781,0.211 0.184,0.141 0.274,0.344 0.274,0.602 0,0.199 -0.047,0.359 -0.141,0.48 -0.094,0.118 -0.23,0.192 -0.41,0.219 0.219,0.047 0.387,0.145 0.508,0.297 0.121,0.148 0.179,0.332 0.179,0.555 0,0.293 -0.097,0.519 -0.296,0.679 -0.2,0.16 -0.485,0.239 -0.852,0.239 h -1.176 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath520)"
+             id="path1051" />
+          <path
+             d="m 106.477,262.059 c -0.325,0 -0.579,0.121 -0.77,0.363 -0.187,0.238 -0.281,0.566 -0.281,0.98 0,0.414 0.094,0.739 0.281,0.981 0.191,0.238 0.445,0.359 0.77,0.359 0.32,0 0.578,-0.121 0.765,-0.359 0.188,-0.242 0.281,-0.567 0.281,-0.981 0,-0.414 -0.093,-0.742 -0.281,-0.98 -0.187,-0.242 -0.445,-0.363 -0.765,-0.363 z m 0,-0.36 c 0.461,0 0.828,0.156 1.101,0.465 0.277,0.305 0.414,0.719 0.414,1.238 0,0.516 -0.137,0.93 -0.414,1.239 -0.273,0.308 -0.64,0.461 -1.101,0.461 -0.461,0 -0.832,-0.153 -1.106,-0.461 -0.277,-0.309 -0.414,-0.719 -0.414,-1.239 0,-0.519 0.137,-0.933 0.414,-1.238 0.274,-0.309 0.645,-0.465 1.106,-0.465 z m 1.066,0.059 h 2.773 v 0.375 h -1.164 v 2.906 h -0.445 v -2.906 h -1.164 z m 4.758,2.812 v -0.879 h -0.727 v -0.367 h 1.164 v 1.41 c -0.168,0.121 -0.359,0.211 -0.566,0.274 -0.207,0.062 -0.426,0.094 -0.66,0.094 -0.512,0 -0.914,-0.149 -1.203,-0.45 -0.289,-0.297 -0.434,-0.714 -0.434,-1.25 0,-0.535 0.145,-0.953 0.434,-1.254 0.289,-0.296 0.691,-0.449 1.203,-0.449 0.215,0 0.418,0.028 0.609,0.078 0.191,0.055 0.371,0.133 0.531,0.235 v 0.472 c -0.164,-0.14 -0.336,-0.246 -0.519,-0.316 -0.188,-0.07 -0.379,-0.106 -0.582,-0.106 -0.403,0 -0.703,0.114 -0.906,0.336 -0.204,0.227 -0.301,0.559 -0.301,1.004 0,0.442 0.097,0.774 0.301,1 0.203,0.223 0.503,0.336 0.906,0.336 0.156,0 0.293,-0.015 0.418,-0.039 0.121,-0.027 0.234,-0.07 0.332,-0.129 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath521)"
+             id="path1052" />
+          <path
+             d="m 179.918,8 h 23.383 v 14.961 h -23.383 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath522)"
+             id="path1053" />
+          <path
+             d="m 179.918,-8 h 23.383 v -14.961 h -23.383 z"
+             style="fill:none;stroke:#000000;stroke-width:0.9;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath523)"
+             id="path1054" />
+          <path
+             d="m 188.305,10.848 h 0.445 v 1.992 c 0,0.351 0.062,0.605 0.191,0.762 0.129,0.152 0.332,0.23 0.621,0.23 0.282,0 0.489,-0.078 0.618,-0.23 0.125,-0.157 0.191,-0.411 0.191,-0.762 v -1.992 h 0.445 v 2.05 c 0,0.426 -0.105,0.75 -0.32,0.965 -0.211,0.219 -0.523,0.328 -0.934,0.328 -0.417,0 -0.73,-0.109 -0.941,-0.328 -0.211,-0.215 -0.316,-0.539 -0.316,-0.965 z m 4.906,0.109 v 0.434 c -0.168,-0.082 -0.328,-0.141 -0.477,-0.18 -0.152,-0.039 -0.296,-0.063 -0.433,-0.063 -0.242,0 -0.43,0.047 -0.563,0.141 -0.129,0.094 -0.195,0.231 -0.195,0.402 0,0.145 0.043,0.254 0.133,0.329 0.086,0.074 0.25,0.132 0.496,0.179 l 0.266,0.055 c 0.332,0.062 0.574,0.172 0.734,0.332 0.156,0.16 0.234,0.371 0.234,0.637 0,0.32 -0.105,0.558 -0.32,0.722 -0.211,0.164 -0.524,0.246 -0.934,0.246 -0.156,0 -0.324,-0.015 -0.5,-0.05 -0.172,-0.036 -0.351,-0.09 -0.539,-0.157 v -0.457 c 0.18,0.102 0.356,0.176 0.528,0.227 0.171,0.051 0.343,0.078 0.511,0.078 0.25,0 0.45,-0.051 0.586,-0.148 0.137,-0.102 0.207,-0.243 0.207,-0.426 0,-0.164 -0.05,-0.289 -0.152,-0.379 -0.098,-0.09 -0.258,-0.16 -0.484,-0.203 l -0.27,-0.055 c -0.332,-0.066 -0.57,-0.168 -0.719,-0.309 -0.148,-0.14 -0.222,-0.335 -0.222,-0.585 0,-0.289 0.101,-0.52 0.304,-0.688 0.207,-0.164 0.489,-0.25 0.848,-0.25 0.152,0 0.309,0.016 0.469,0.043 0.16,0.027 0.324,0.07 0.492,0.125 z m 0.543,1.605 v 1.204 h 0.711 c 0.238,0 0.414,-0.051 0.527,-0.149 0.117,-0.101 0.176,-0.25 0.176,-0.453 0,-0.207 -0.059,-0.359 -0.176,-0.453 -0.113,-0.098 -0.289,-0.149 -0.527,-0.149 z m 0,-1.347 v 0.988 h 0.656 c 0.215,0 0.379,-0.039 0.485,-0.121 0.105,-0.082 0.16,-0.207 0.16,-0.375 0,-0.164 -0.055,-0.289 -0.16,-0.371 -0.106,-0.082 -0.27,-0.121 -0.485,-0.121 z m -0.445,-0.367 h 1.132 c 0.34,0 0.602,0.07 0.782,0.211 0.183,0.14 0.277,0.343 0.277,0.601 0,0.199 -0.047,0.36 -0.141,0.481 -0.093,0.117 -0.23,0.191 -0.414,0.218 0.219,0.047 0.387,0.145 0.508,0.297 0.121,0.149 0.184,0.332 0.184,0.555 0,0.293 -0.102,0.519 -0.301,0.68 -0.199,0.16 -0.481,0.238 -0.852,0.238 h -1.175 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath524)"
+             id="path1055" />
+          <path
+             d="m 187.066,16.355 v 0.434 c -0.168,-0.082 -0.324,-0.141 -0.476,-0.18 -0.149,-0.043 -0.293,-0.062 -0.43,-0.062 -0.242,0 -0.43,0.047 -0.562,0.141 -0.129,0.093 -0.196,0.226 -0.196,0.402 0,0.144 0.043,0.254 0.129,0.328 0.09,0.074 0.254,0.133 0.496,0.18 l 0.27,0.054 c 0.332,0.063 0.574,0.172 0.73,0.332 0.161,0.161 0.239,0.371 0.239,0.637 0,0.32 -0.106,0.559 -0.321,0.723 -0.211,0.164 -0.523,0.246 -0.937,0.246 -0.153,0 -0.32,-0.016 -0.496,-0.051 -0.172,-0.035 -0.356,-0.09 -0.543,-0.156 v -0.457 c 0.179,0.101 0.359,0.176 0.531,0.226 0.172,0.051 0.344,0.078 0.508,0.078 0.254,0 0.449,-0.05 0.586,-0.148 0.14,-0.102 0.207,-0.242 0.207,-0.426 0,-0.164 -0.047,-0.289 -0.149,-0.379 -0.097,-0.089 -0.257,-0.16 -0.484,-0.203 l -0.27,-0.054 c -0.332,-0.067 -0.57,-0.168 -0.718,-0.309 -0.149,-0.141 -0.223,-0.336 -0.223,-0.586 0,-0.293 0.102,-0.52 0.305,-0.687 0.207,-0.165 0.488,-0.25 0.847,-0.25 0.153,0 0.309,0.015 0.469,0.042 0.16,0.028 0.324,0.071 0.488,0.125 z m -0.382,-0.109 h 2.773 v 0.375 h -1.164 v 2.906 h -0.445 v -2.906 h -1.164 z m 2.425,1.867 h 1.184 v 0.364 h -1.184 z m 1.598,-1.867 h 0.445 v 2.906 h 1.598 v 0.375 h -2.043 z m 1.891,0 h 0.441 v 3.281 h -0.441 z m 1.132,0 h 0.598 l 1.453,2.746 v -2.746 h 0.43 v 3.281 h -0.598 l -1.453,-2.742 v 2.742 h -0.43 z m 2.907,0 h 0.445 v 1.387 l 1.469,-1.387 h 0.574 l -1.629,1.531 1.742,1.75 h -0.582 l -1.574,-1.578 v 1.578 h -0.445 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath525)"
+             id="path1056" />
+          <path
+             d="m 175.426,253.766 h 32.992 v 14.961 h -32.992 z"
+             style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath526)"
+             id="path1057" />
+          <path
+             d="m 175.426,-253.766 h 32.992 v -14.961 h -32.992 z"
+             style="fill:none;stroke:#000000;stroke-width:0.9;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath527)"
+             id="path1058" />
+          <path
+             d="m 182.797,259.312 h 2.074 v 0.376 h -1.629 v 0.968 h 1.563 v 0.375 h -1.563 v 1.188 h 1.668 v 0.375 h -2.113 z m 1.742,0 h 2.773 v 0.376 h -1.164 v 2.906 h -0.445 v -2.906 h -1.164 z m 2.645,0 h 0.445 v 1.344 h 1.613 v -1.344 h 0.442 v 3.282 h -0.442 v -1.563 h -1.613 v 1.563 h -0.445 z m 2.804,0 h 2.074 v 0.376 h -1.628 v 0.968 h 1.558 v 0.375 h -1.558 v 1.188 h 1.668 v 0.375 h -2.114 z m 3.75,1.743 c 0.098,0.031 0.188,0.101 0.278,0.207 0.089,0.105 0.183,0.25 0.273,0.433 l 0.449,0.899 h -0.476 l -0.418,-0.844 c -0.11,-0.219 -0.215,-0.363 -0.317,-0.434 -0.101,-0.074 -0.242,-0.109 -0.418,-0.109 h -0.48 v 1.387 h -0.445 v -3.282 h 1 c 0.375,0 0.656,0.079 0.839,0.235 0.188,0.16 0.278,0.394 0.278,0.711 0,0.207 -0.047,0.379 -0.145,0.515 -0.094,0.137 -0.234,0.231 -0.418,0.282 z m -1.109,-1.375 v 1.164 h 0.555 c 0.214,0 0.375,-0.051 0.484,-0.149 0.109,-0.097 0.164,-0.246 0.164,-0.437 0,-0.192 -0.055,-0.336 -0.164,-0.434 -0.109,-0.097 -0.27,-0.144 -0.484,-0.144 z m 1.996,-0.368 h 0.598 l 1.457,2.747 v -2.747 h 0.429 v 3.282 h -0.597 l -1.453,-2.742 v 2.742 h -0.434 z m 2.91,0 h 2.074 v 0.376 h -1.632 v 0.968 h 1.562 v 0.375 h -1.562 v 1.188 h 1.671 v 0.375 h -2.113 z m 1.738,0 h 2.778 v 0.376 h -1.164 v 2.906 h -0.449 v -2.906 h -1.165 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             transform="scale(1.3333333)"
+             clip-path="url(#clipPath528)"
+             id="path1059" />
+          <path
+             d="m 194.32,-142.297 h 11.106 v 59.188"
+             style="fill:none;stroke:#000000;stroke-width:0.1875;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             transform="scale(1.3333333,-1.3333333)"
+             clip-path="url(#clipPath529)"
+             id="path1060" />
+        </g>
+      </g>
+    </g>
+    <g
+       id="g1063">
+      <path
+         d="M 0.18,0.008 H 302.176 V 0.367 H 0.18 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="scale(1.3333333)"
+         clip-path="url(#clipPath1062)"
+         id="path1063" />
+    </g>
+    <g
+       id="g1065">
+      <path
+         d="m 301.816,0.188 h 0.359 v 297.449 h -0.359 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="scale(1.3333333)"
+         clip-path="url(#clipPath1064)"
+         id="path1065" />
+    </g>
+    <g
+       id="g1067">
+      <path
+         d="m 0,297.277 h 301.996 v 0.359 H 0 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="scale(1.3333333)"
+         clip-path="url(#clipPath1066)"
+         id="path1067" />
+    </g>
+    <g
+       id="g1069">
+      <path
+         d="M 0,0.008 H 0.359 V 297.457 H 0 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="scale(1.3333333)"
+         clip-path="url(#clipPath1068)"
+         id="path1069" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
### Contribution description

This PR adds pinout diagram to the `nucleo-h753zi` board.

### Testing procedure

Generate doc and see if everything is fine.

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-h753zi.html
```

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
