### PR TITLE
pkg/qcbor: disable HW FPU support for ESP32S2&ESP8266

### DIFF
--- a/pkg/qcbor/Makefile
+++ b/pkg/qcbor/Makefile
@@ -13,5 +13,12 @@ include $(RIOTBASE)/pkg/pkg.mk
 CFLAGS += -Wno-maybe-uninitialized
 CFLAGS += -Wno-type-limits
 
+# The newlib implementation of some ESP variants does not implement the
+# `feclearexcept` and `fetestexcept` functions from `fenv.h` used by
+# QCBOR. Disabling the HW FPU support works around this issue.
+ifneq (,$(filter esp8266 esp32s2, $(CPU_FAM)))
+  CFLAGS += -DQCBOR_DISABLE_FLOAT_HW_USE
+endif
+
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)

--- a/tests/pkg/qcbor/main.c
+++ b/tests/pkg/qcbor/main.c
@@ -16,6 +16,7 @@
  */
 
 #include "qcbor.h"
+#include "qcbor_spiffy_decode.h"
 #include <string.h>
 #include "embUnit.h"
 
@@ -29,14 +30,15 @@
             0: false,
             -999: "hello world"
         },
-        true
+        true,
+        1.5
     ]
 */
 static const uint8_t expected[] = {
-    0x85, 0xF6, 0x1A, 0x00, 0x01, 0xE2, 0x40, 0x3A, 0x00, 0x01, 0xE2, 0x3F,
+    0x86, 0xF6, 0x1A, 0x00, 0x01, 0xE2, 0x40, 0x3A, 0x00, 0x01, 0xE2, 0x3F,
     0xA3, 0x20, 0x47, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x00, 0x00, 0xF4,
     0x39, 0x03, 0xE6, 0x6B, 0x68, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0x77, 0x6F,
-    0x72, 0x6C, 0x64, 0xF5};
+    0x72, 0x6C, 0x64, 0xF5, 0xF9, 0x3E, 0x00 };
 static uint8_t buf[sizeof(expected)];
 
 static void test_qcbor_encode(void)
@@ -62,6 +64,7 @@ static void test_qcbor_encode(void)
                               UsefulBuf_FROM_SZ_LITERAL("hello world"));
     QCBOREncode_CloseMap(&encode_context);
     QCBOREncode_AddBool(&encode_context, true);
+    QCBOREncode_AddFloat(&encode_context, 1.5);
     QCBOREncode_CloseArray(&encode_context);
     error = QCBOREncode_Finish(&encode_context, &encoded_cbor);
     TEST_ASSERT_EQUAL_INT(QCBOR_SUCCESS, error);
@@ -109,6 +112,10 @@ static void test_qcbor_decode(void)
     error = QCBORDecode_GetNext(&decode_context, &cbor_item);
     TEST_ASSERT_EQUAL_INT(QCBOR_SUCCESS, error);
     TEST_ASSERT_EQUAL_INT(QCBOR_TYPE_TRUE, cbor_item.uDataType);
+    uint64_t val;
+    /* trigger the use of `feclearexcept` and `fetestexcept` */
+    QCBORDecode_GetUInt64ConvertAll(&decode_context, QCBOR_TYPE_FLOAT, &val);
+    TEST_ASSERT_EQUAL_INT(2, val);
     error = QCBORDecode_Finish(&decode_context);
     TEST_ASSERT_EQUAL_INT(QCBOR_SUCCESS, error);
 }


### PR DESCRIPTION
### Contribution description

The newlib implementation of some ESP variants does not implement the
`feclearexcept` and `fetestexcept` functions from `fenv.h` used by
QCBOR. Disabling the HW FPU support works around this issue.

### Testing procedure

I added a test case in the `qcbor` test. Comment out the `CFLAGS` line and the compilation will fail, with the line commented in it will succeed.

Commented out:
```
buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ BUILD_IN_DOCKER=1 BOARD=esp8266-sparkfun-thing make -C tests/pkg/qcbor/ -j
make: Entering directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/tests/pkg/qcbor'
Launching build container using image "docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736".
docker run --rm --tty --user $(id -u) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-vanilla/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=esp8266-sparkfun-thing' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=test_utils_interactive_sync test_utils_print_stack_usage' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=embunit' -e 'USEPKG=qcbor'  -w '/data/riotbuild/riotbase/tests/pkg/qcbor/' 'docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736' make    -j
Building application "tests_qcbor" for "esp8266-sparkfun-thing" with CPU "esp8266".

"make" -C /data/riotbuild/riotbase/pkg/esp8266_sdk/
...
"make" -C /data/riotbuild/riotbase/cpu/esp8266/vendor/esp-idf/wpa_supplicant/src/crypto
esptool v5.0.0
Creating ESP8266 image...
Merged 1 ELF section.
Successfully created ESP8266 image.
/data/riotbuild/riotbase/tests/pkg/qcbor/bin/esp8266-sparkfun-thing/qcbor/qcbor_decode.o: In function `QCBOR_Private_DecodeDateEpoch':
/data/riotbuild/riotbase/build/pkg/qcbor/src/qcbor_decode.c:6042: undefined reference to `feclearexcept'
/data/riotbuild/riotbase/build/pkg/qcbor/src/qcbor_decode.c:6042: undefined reference to `fetestexcept'
/data/riotbuild/riotbase/tests/pkg/qcbor/bin/esp8266-sparkfun-thing/qcbor/qcbor_decode.o: In function `QCBOR_Private_ConvertUInt64':
/data/riotbuild/riotbase/build/pkg/qcbor/src/qcbor_decode.c:6042: undefined reference to `feclearexcept'
/data/riotbuild/riotbase/build/pkg/qcbor/src/qcbor_decode.c:6042: undefined reference to `fetestexcept'
collect2: error: ld returned 1 exit status
make: *** [/data/riotbuild/riotbase/Makefile.include:734: /data/riotbuild/riotbase/tests/pkg/qcbor/bin/esp8266-sparkfun-thing/tests_qcbor.elf] Error 1
make: *** [/home/buechse/RIOTstuff/riot-vanilla/RIOT/makefiles/docker.inc.mk:395: ..in-docker-container] Error 2
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/tests/pkg/qcbor'
```

Commented in:
```
buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ BUILD_IN_DOCKER=1 BOARD=esp8266-sparkfun-thing make -C tests/pkg/qcbor/ -j
make: Entering directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/tests/pkg/qcbor'
Launching build container using image "docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736".
docker run --rm --tty --user $(id -u) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-vanilla/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=esp8266-sparkfun-thing' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=test_utils_interactive_sync test_utils_print_stack_usage' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=embunit' -e 'USEPKG=qcbor'  -w '/data/riotbuild/riotbase/tests/pkg/qcbor/' 'docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736' make    -j
Building application "tests_qcbor" for "esp8266-sparkfun-thing" with CPU "esp8266".

"make" -C /data/riotbuild/riotbase/pkg/esp8266_sdk/
...
Generating bootloader image /data/riotbuild/riotbase/tests/pkg/qcbor/bin/esp8266-sparkfun-thing/esp_bootloader/bootloader.bin
esptool v5.0.0
Creating ESP8266 image...
Merged 1 ELF section.
Successfully created ESP8266 image.
esptool v5.0.0
Creating ESP8266 image...
Merged 1 ELF section.
Successfully created ESP8266 image.
# append size of /data/riotbuild/riotbase/tests/pkg/qcbor/bin/esp8266-sparkfun-thing/tests_qcbor.elf.bin
Parsing CSV input...
   text    data     bss     dec     hex filename
 286104    5292   28712  320108   4e26c /data/riotbuild/riotbase/tests/pkg/qcbor/bin/esp8266-sparkfun-thing/tests_qcbor.elf
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/tests/pkg/qcbor'
```

### Issues/PRs references

Discovered while building the `Makefile.ci` for #22091.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
