### PR TITLE
cpu/efm32: don't add CMSIS/DSP include path explicitly

### DIFF
--- a/cpu/efm32/Makefile.include
+++ b/cpu/efm32/Makefile.include
@@ -19,9 +19,6 @@ INCLUDES += -I$(RIOTCPU)/efm32/include/drivers
 # include EFM32 specific vendor headers
 INCLUDES += -I$(RIOTCPU)/efm32/include/vendor
 
-# arm_math.h is required by vendor headers and is located in CMSIS DSP includes
-INCLUDES += -I$(PKGDIRBASE)/cmsis/CMSIS/DSP/Include
-
 # include cortexm_common
 LINKER_SCRIPT = cortexm.ld
 


### PR DESCRIPTION
### Contribution description

Pull request #18056 changed the behavior the CMSIS packages are included. For the Cortex-M0+ based EFM32 CPUs the `cmsis-dsp` package is always included since the `arm_math.h` header file is required.

While the package was included conditionally, the include path was added unconditionally. This led to compilation errors in #22091 when generating the `Makefile.ci`, as the `stk3200` board was built first and then the `stk3600` board afterwards.
The include path existed when adding it to the `INCLUDES` variable since the build folder still contained the DSP folder from the `stk3200`, but it did not exist anymore during compilation because `pkg/pkg.mk` deletes it in the sparse checkout procedure.

This led then to a `cc1: error: /data/riotbuild/riotbase/build/pkg/cmsis/CMSIS/DSP/Include: No such file or directory [-Werror=missing-include-dirs]` error for the `stk3600` board, even though the path was not actually needed by that board.

It is not actually necessary to add the include path in the `cpu/efm32/Makefile.include` as it is already included by `pkg/cmsis/Makefile.include`.

### Testing procedure

This is not so easy to test I guess? You could checkout PR #22091 and run `BUILD_IN_DOCKER=1 BOARD=stk3200 make -C examples/networking/dtn/bplib_cla_udp/` first and then `BUILD_IN_DOCKER=1 BOARD=stk3600 make -C examples/networking/dtn/bplib_cla_udp/` afterwards.

With current `master`:
```
buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ BUILD_IN_DOCKER=1 BOARD=stk3200 make -C examples/networking/dtn/bplib_cla_udp/
make: Entering directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/examples/networking/dtn/bplib_cla_udp'
Makefile:33: REMOTE IPv6 address not set, defaulting to [::1]
Makefile:38: REMOTE_EID_NODE destination node number not set, defaulting to 100
Makefile:44: LOCAL_EID_NODE destination node number not set, defaulting to 100
Launching build container using image "docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736".
docker run --rm --tty --user $(id -u) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-vanilla/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=stk3200' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=auto_init_gnrc_netif bplib_cla_udp bplib_stor_vfs_ordered gnrc_ipv6_default gnrc_sock_udp netdev_default shell shell_cmd_gnrc_netif shell_cmd_ps vfs_default' -e 'USEPKG=bplib'  -w '/data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/' 'docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736' make
Makefile:33: REMOTE IPv6 address not set, defaulting to [::1]
Makefile:38: REMOTE_EID_NODE destination node number not set, defaulting to 100
Makefile:44: LOCAL_EID_NODE destination node number not set, defaulting to 100
Building application "bplib_cla_udp" for "stk3200" with CPU "efm32".

[INFO] Consider using git-cache-rs to speed up your build and reduce network traffic! See: https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs
[INFO] Consider using git-cache-rs to speed up your build and reduce network traffic! See: https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs
"make" -C /data/riotbuild/riotbase/pkg/bplib/
...
"make" -C /data/riotbuild/riotbase/sys/ztimer64
/opt/gcc-arm-none-eabi-10.3-2021.10/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld: /data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/bin/stk3200/bplib_cla_udp.elf section `.text' will not fit in region `rom'
/opt/gcc-arm-none-eabi-10.3-2021.10/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld: /data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/bin/stk3200/bplib_cla_udp.elf section `.bss' will not fit in region `ram'
/opt/gcc-arm-none-eabi-10.3-2021.10/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld: region `rom' overflowed by 51516 bytes
/opt/gcc-arm-none-eabi-10.3-2021.10/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld: region `ram' overflowed by 24980 bytes
collect2: error: ld returned 1 exit status
make: *** [/data/riotbuild/riotbase/Makefile.include:734: /data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/bin/stk3200/bplib_cla_udp.elf] Error 1
make: *** [/home/buechse/RIOTstuff/riot-vanilla/RIOT/makefiles/docker.inc.mk:395: ..in-docker-container] Error 2
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/examples/networking/dtn/bplib_cla_udp'



buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ BUILD_IN_DOCKER=1 BOARD=stk3600 make -C examples/networking/dtn/bplib_cla_udp/ -j
make: Entering directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/examples/networking/dtn/bplib_cla_udp'
Makefile:33: REMOTE IPv6 address not set, defaulting to [::1]
Makefile:38: REMOTE_EID_NODE destination node number not set, defaulting to 100
Makefile:44: LOCAL_EID_NODE destination node number not set, defaulting to 100
Launching build container using image "docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736".
docker run --rm --tty --user $(id -u) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-vanilla/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=stk3600' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=auto_init_gnrc_netif bplib_cla_udp bplib_stor_vfs_ordered gnrc_ipv6_default gnrc_sock_udp netdev_default shell shell_cmd_gnrc_netif shell_cmd_ps vfs_default' -e 'USEPKG=bplib'  -w '/data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/' 'docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736' make    -j
Makefile:33: REMOTE IPv6 address not set, defaulting to [::1]
Makefile:38: REMOTE_EID_NODE destination node number not set, defaulting to 100
Makefile:44: LOCAL_EID_NODE destination node number not set, defaulting to 100
Building application "bplib_cla_udp" for "stk3600" with CPU "efm32".

[INFO] Consider using git-cache-rs to speed up your build and reduce network traffic! See: https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs
[INFO] Consider using git-cache-rs to speed up your build and reduce network traffic! See: https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs
"make" -C /data/riotbuild/riotbase/pkg/bplib/
...
"make" -C /data/riotbuild/riotbase/pkg/bplib/storage/vfs/ordered
cc1: error: /data/riotbuild/riotbase/build/pkg/cmsis/CMSIS/DSP/Include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /data/riotbuild/riotbase/build/pkg/cmsis/CMSIS/DSP/Include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /data/riotbuild/riotbase/build/pkg/cmsis/CMSIS/DSP/Include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /data/riotbuild/riotbase/build/pkg/cmsis/CMSIS/DSP/Include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /data/riotbuild/riotbase/build/pkg/cmsis/CMSIS/DSP/Include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /data/riotbuild/riotbase/build/pkg/cmsis/CMSIS/DSP/Include: No such file or directory [-Werror=missing-include-dirs]
cc1: all warnings being treated as errors
make[2]: *** [/data/riotbuild/riotbase/Makefile.base:162: /data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/bin/stk3600/bplib_init/bplib_init.o] Error 1
make[1]: *** [Makefile:25: bplib_init] Error 2
make[1]: *** Waiting for unfinished jobs....
cc1: all warnings being treated as errors
make[2]: *** [/data/riotbuild/riotbase/Makefile.base:162: /data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/bin/stk3600/bplib_stor_vfs_ordered/cache.o] Error 1
make[2]: *** Waiting for unfinished jobs....
cc1: all warnings being treated as errors
make[2]: *** [/data/riotbuild/riotbase/Makefile.base:162: /data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/bin/stk3600/bplib_fwp/bplib_riot_fwp.o] Error 1
make[1]: *** [Makefile:19: bplib_fwp] Error 2
cc1: all warnings being treated as errors
make[2]: *** [/data/riotbuild/riotbase/Makefile.base:162: /data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/bin/stk3600/bplib_nc/bplib_riot_nc.o] Error 1
make[1]: *** [Makefile:22: bplib_nc] Error 2
cc1: all warnings being treated as errors
make[2]: *** [/data/riotbuild/riotbase/Makefile.base:162: /data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/bin/stk3600/bplib_cla_udp/bplib_cla_udp.o] Error 1
make[1]: *** [Makefile:42: bplib_cla_udp] Error 2
cc1: all warnings being treated as errors
make[2]: *** [/data/riotbuild/riotbase/Makefile.base:162: /data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/bin/stk3600/bplib_stor_vfs_ordered/storage.o] Error 1
make[1]: *** [Makefile:29: bplib_stor_vfs_ordered] Error 2
make: *** [/data/riotbuild/riotbase/Makefile.include:807: pkg-build] Error 2
make: *** [/home/buechse/RIOTstuff/riot-vanilla/RIOT/makefiles/docker.inc.mk:395: ..in-docker-container] Error 2
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/examples/networking/dtn/bplib_cla_udp'

```

With this PR:
```
buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ git rebase pr/efm32_arm_math
Successfully rebased and updated refs/heads/bplib-port.



buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ BUILD_IN_DOCKER=1 BOARD=stk3200 make -C examples/networking/dtn/bplib_cla_udp/ -j
make: Entering directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/examples/networking/dtn/bplib_cla_udp'
Makefile:33: REMOTE IPv6 address not set, defaulting to [::1]
Makefile:38: REMOTE_EID_NODE destination node number not set, defaulting to 100
Makefile:44: LOCAL_EID_NODE destination node number not set, defaulting to 100
Launching build container using image "docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736".
docker run --rm --tty --user $(id -u) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-vanilla/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=stk3200' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=auto_init_gnrc_netif bplib_cla_udp bplib_stor_vfs_ordered gnrc_ipv6_default gnrc_sock_udp netdev_default shell shell_cmd_gnrc_netif shell_cmd_ps vfs_default' -e 'USEPKG=bplib'  -w '/data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/' 'docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736' make    -j
Makefile:33: REMOTE IPv6 address not set, defaulting to [::1]
Makefile:38: REMOTE_EID_NODE destination node number not set, defaulting to 100
Makefile:44: LOCAL_EID_NODE destination node number not set, defaulting to 100
Building application "bplib_cla_udp" for "stk3200" with CPU "efm32".

[INFO] Consider using git-cache-rs to speed up your build and reduce network traffic! See: https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs
[INFO] Consider using git-cache-rs to speed up your build and reduce network traffic! See: https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs
"make" -C /data/riotbuild/riotbase/pkg/bplib/
...
"make" -C /data/riotbuild/riotbase/sys/ztimer64
/opt/gcc-arm-none-eabi-10.3-2021.10/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld: /data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/bin/stk3200/bplib_cla_udp.elf section `.text' will not fit in region `rom'
/opt/gcc-arm-none-eabi-10.3-2021.10/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld: /data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/bin/stk3200/bplib_cla_udp.elf section `.bss' will not fit in region `ram'
/opt/gcc-arm-none-eabi-10.3-2021.10/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld: region `rom' overflowed by 51516 bytes
/opt/gcc-arm-none-eabi-10.3-2021.10/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld: region `ram' overflowed by 24980 bytes
collect2: error: ld returned 1 exit status
make: *** [/data/riotbuild/riotbase/Makefile.include:734: /data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/bin/stk3200/bplib_cla_udp.elf] Error 1
make: *** [/home/buechse/RIOTstuff/riot-vanilla/RIOT/makefiles/docker.inc.mk:395: ..in-docker-container] Error 2
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/examples/networking/dtn/bplib_cla_udp'



buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ BUILD_IN_DOCKER=1 BOARD=stk3600 make -C examples/networking/dtn/bplib_cla_udp/ -j
make: Entering directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/examples/networking/dtn/bplib_cla_udp'
Makefile:33: REMOTE IPv6 address not set, defaulting to [::1]
Makefile:38: REMOTE_EID_NODE destination node number not set, defaulting to 100
Makefile:44: LOCAL_EID_NODE destination node number not set, defaulting to 100
Launching build container using image "docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736".
docker run --rm --tty --user $(id -u) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-vanilla/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=stk3600' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=auto_init_gnrc_netif bplib_cla_udp bplib_stor_vfs_ordered gnrc_ipv6_default gnrc_sock_udp netdev_default shell shell_cmd_gnrc_netif shell_cmd_ps vfs_default' -e 'USEPKG=bplib'  -w '/data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/' 'docker.io/riot/riotbuild@sha256:08fa7da2c702ac4db7cf57c23fc46c1971f3bffc4a6eff129793f853ec808736' make    -j
Makefile:33: REMOTE IPv6 address not set, defaulting to [::1]
Makefile:38: REMOTE_EID_NODE destination node number not set, defaulting to 100
Makefile:44: LOCAL_EID_NODE destination node number not set, defaulting to 100
Building application "bplib_cla_udp" for "stk3600" with CPU "efm32".

[INFO] Consider using git-cache-rs to speed up your build and reduce network traffic! See: https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs
[INFO] Consider using git-cache-rs to speed up your build and reduce network traffic! See: https://guides.riot-os.org/build-system/advanced_build_system_tricks/#speed-up-builds-with-git-cache-rs
"make" -C /data/riotbuild/riotbase/pkg/bplib/
...
"make" -C /data/riotbuild/riotbase/sys/net/gnrc/netif/init_devs
/opt/gcc-arm-none-eabi-10.3-2021.10/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld: /data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/bin/stk3600/bplib_cla_udp.elf section `.bss' will not fit in region `ram'
/opt/gcc-arm-none-eabi-10.3-2021.10/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld: region `ram' overflowed by 156 bytes
collect2: error: ld returned 1 exit status
make: *** [/data/riotbuild/riotbase/Makefile.include:734: /data/riotbuild/riotbase/examples/networking/dtn/bplib_cla_udp/bin/stk3600/bplib_cla_udp.elf] Error 1
make: *** [/home/buechse/RIOTstuff/riot-vanilla/RIOT/makefiles/docker.inc.mk:395: ..in-docker-container] Error 2
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/examples/networking/dtn/bplib_cla_udp'
```


### Issues/PRs references

Fix regression introduced in #18056, reverts 2467ff096182c1ea4c67b3dedd9d791e3f8115b6.

### Declaration of AI-Tools / LLMs usage:
AI-Tools / LLMs that were used are:
- none
