### PR TITLE
boards/arduino* & adafruit*: fix static tests warnings from github actions

### DIFF
--- a/boards/adafruit-clue/include/board.h
+++ b/boards/adafruit-clue/include/board.h
@@ -104,7 +104,11 @@ extern "C" {
 #define ILI9341_PARAM_RGB       (1)                             /**< RGB configuration */
 #define ILI9341_PARAM_INVERTED  (1)                             /**< Inversion configuration */
 #define ILI9341_PARAM_ROTATION  (ILI9341_ROTATION_VERT)         /**< Rotation mode */
-#define ILI9341_PARAM_OFFSET_X  (80)                            /**< Vertical rotation requires a 80 pixel offset */
+
+/**
+ * @brief Vertical rotation requires a 80 pixel offset
+ */
+#define ILI9341_PARAM_OFFSET_X  (80)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/adafruit-pybadge/include/board.h
+++ b/boards/adafruit-pybadge/include/board.h
@@ -51,11 +51,11 @@ extern "C" {
  * @name    Backlight control
  * @{
  */
-#define BACKLIGHT_PIN          GPIO_PIN(PA, 1)                  /**< Backlight pin */
-#define BACKLIGHT_PORT         PORT->Group[PA]                  /**< Backlight pin port */
-#define BACKLIGHT_MASK         (1 << 1)                         /**< Backlight pin mask */
-#define BACKLIGHT_ON           (BACKLIGHT_PORT.OUTSET.reg = BACKLIGHT_MASK) /**< Turn backlight on */
-#define BACKLIGHT_OFF          (BACKLIGHT_PORT.OUTCLR.reg = BACKLIGHT_MASK) /**< Turn backlight off */
+#define BACKLIGHT_PIN     GPIO_PIN(PA, 1)                  /**< Backlight pin */
+#define BACKLIGHT_PORT    PORT->Group[PA]                  /**< Backlight pin port */
+#define BACKLIGHT_MASK    (1 << 1)                         /**< Backlight pin mask */
+#define BACKLIGHT_ON      (BACKLIGHT_PORT.OUTSET.reg = BACKLIGHT_MASK) /**< Turn backlight on */
+#define BACKLIGHT_OFF     (BACKLIGHT_PORT.OUTCLR.reg = BACKLIGHT_MASK) /**< Turn backlight off */
 /** @} */
 
 /**
@@ -68,7 +68,11 @@ extern "C" {
 #define ST77XX_PARAM_DCX        GPIO_PIN(PB, 5)                 /**< DCX pin */
 #define ST77XX_PARAM_RST        GPIO_PIN(PA, 0)                 /**< Reset pin */
 #define ST77XX_PARAM_NUM_LINES  (160U)                          /**< Number of screen lines */
-#define ST77XX_PARAM_RGB_CHANNELS   (128U)                      /**< Number of screen rgb channel (height) */
+
+/**
+ * @brief Number of screen rgb channel (height)
+ */
+#define ST77XX_PARAM_RGB_CHANNELS   (128U)
 #define ST77XX_PARAM_RGB        (1)                             /**< RGB configuration */
 #define ST77XX_PARAM_INVERTED   (0)                             /**< Inversion configuration */
 #define ST77XX_PARAM_ROTATION   ST77XX_ROTATION_90              /**< Rotation mode */
@@ -80,8 +84,13 @@ extern "C" {
  * @name    Neopixel LEDs (not supported yet)
  * @{
  */
-#define WS281X_PARAM_PIN        (GPIO_PIN(PA, 15))              /**< GPIO pin connected to the data pin of the first LED */
+
+/**
+ * @brief GPIO pin connected to the data pin of the first LED
+ */
+#define WS281X_PARAM_PIN        (GPIO_PIN(PA, 15))
 #define WS281X_PARAM_NUMOF      (5U)                            /**< Number of LEDs chained */
+
 /** @} */
 
 /**

--- a/boards/arduino-mega2560/include/atmega_pcint.h
+++ b/boards/arduino-mega2560/include/atmega_pcint.h
@@ -1,12 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 #pragma once
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define ATMEGA_PCINT_MAP_PCINT0 GPIO_PIN(PORT_B, 0), GPIO_PIN(PORT_B, 1), GPIO_PIN(PORT_B, 2), GPIO_PIN(PORT_B, 3), GPIO_PIN(PORT_B, 4), GPIO_PIN(PORT_B, 5), GPIO_PIN(PORT_B, 6), GPIO_PIN(PORT_B, 7)
-#define ATMEGA_PCINT_MAP_PCINT1 GPIO_PIN(PORT_E, 0), GPIO_PIN(PORT_J, 0), GPIO_PIN(PORT_J, 1), GPIO_UNDEF, GPIO_UNDEF, GPIO_UNDEF, GPIO_UNDEF, GPIO_UNDEF
-#define ATMEGA_PCINT_MAP_PCINT2 GPIO_PIN(PORT_K, 0), GPIO_PIN(PORT_K, 1), GPIO_PIN(PORT_K, 2), GPIO_PIN(PORT_K, 3), GPIO_PIN(PORT_K, 4), GPIO_PIN(PORT_K, 5), GPIO_PIN(PORT_K, 6), GPIO_PIN(PORT_K, 7)
+#define ATMEGA_PCINT_MAP_PCINT0 GPIO_PIN(PORT_B, 0), GPIO_PIN(PORT_B, 1), GPIO_PIN(PORT_B, 2),\
+                                GPIO_PIN(PORT_B, 3), GPIO_PIN(PORT_B, 4), GPIO_PIN(PORT_B, 5),\
+                                GPIO_PIN(PORT_B, 6), GPIO_PIN(PORT_B, 7)
+
+#define ATMEGA_PCINT_MAP_PCINT1 GPIO_PIN(PORT_E, 0), GPIO_PIN(PORT_J, 0), GPIO_PIN(PORT_J, 1),\
+                                GPIO_UNDEF, GPIO_UNDEF, GPIO_UNDEF, GPIO_UNDEF, GPIO_UNDEF
+
+#define ATMEGA_PCINT_MAP_PCINT2 GPIO_PIN(PORT_K, 0), GPIO_PIN(PORT_K, 1), GPIO_PIN(PORT_K, 2),\
+                                GPIO_PIN(PORT_K, 3), GPIO_PIN(PORT_K, 4), GPIO_PIN(PORT_K, 5),\
+                                GPIO_PIN(PORT_K, 6), GPIO_PIN(PORT_K, 7)
 
 #ifdef __cplusplus
 }

--- a/boards/arduino-mkrwan1300/include/periph_conf.h
+++ b/boards/arduino-mkrwan1300/include/periph_conf.h
@@ -34,8 +34,8 @@ extern "C" {
 static const uart_conf_t uart_config[] = {
     {
         .dev      = &SERCOM5->USART,
-        .rx_pin   = GPIO_PIN(PB,23),  /* ARDUINO_PIN_13, RX Pin */
-        .tx_pin   = GPIO_PIN(PB,22),  /* ARDUINO_PIN_14, TX Pin */
+        .rx_pin   = GPIO_PIN(PB, 23), /* ARDUINO_PIN_13, RX Pin */
+        .tx_pin   = GPIO_PIN(PB, 22), /* ARDUINO_PIN_14, TX Pin */
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
@@ -48,8 +48,8 @@ static const uart_conf_t uart_config[] = {
     },
     { /* LoRa module */
         .dev      = &SERCOM4->USART,
-        .rx_pin   = GPIO_PIN(PA,15),
-        .tx_pin   = GPIO_PIN(PA,12),
+        .rx_pin   = GPIO_PIN(PA, 15),
+        .tx_pin   = GPIO_PIN(PA, 12),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,


### PR DESCRIPTION
### Contribution description

Static tests from Github actions on branch `master` shows some errors and warnings.

This PR fix warnings associated with boards:
- arduino-mkrwan1300,
- arduino-mega2560,
- adafruit-pybadge,
- adafruit-clue.

### Testing procedure

Green Murdock and lack of this warnings in Github Actions.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
