### PR TITLE
pkg/mpaland-printf: mark wrapper functions as used to fix LTO

### DIFF
--- a/pkg/mpaland-printf/patches/0004-Wrapper-targets-Add-endpoints-for-Wl-wrap.patch
+++ b/pkg/mpaland-printf/patches/0004-Wrapper-targets-Add-endpoints-for-Wl-wrap.patch
@@ -1,15 +1,22 @@
-From b1ee169d8cfd6e37817ad267736aa1f92f1a2076 Mon Sep 17 00:00:00 2001
+From 5c6c71c8d200cd9d4bb43b01184e08e09ff9c935 Mon Sep 17 00:00:00 2001
 From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
 Date: Sat, 11 May 2024 17:51:38 +0200
 Subject: [PATCH 4/6] Wrapper targets: Add endpoints for -Wl,wrap=...
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 This adds aliases needed to wrap printf() and friends.
+
+Marked them as used to fix LTO.
+
+Co-Authored-By: Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
 ---
- printf.c | 108 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 108 insertions(+)
+ printf.c | 123 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 123 insertions(+)
 
 diff --git a/printf.c b/printf.c
-index edf41d1..ed7f72b 100644
+index edf41d1..c55f066 100644
 --- a/printf.c
 +++ b/printf.c
 @@ -32,6 +32,9 @@
@@ -22,7 +29,7 @@ index edf41d1..ed7f72b 100644
  
  #include "printf.h"
  #include "stdio_base.h"
-@@ -920,3 +923,108 @@ static void _putchar(char character)
+@@ -920,3 +923,123 @@ static void _putchar(char character)
  {
    stdio_write(&character, sizeof(character));
  }
@@ -30,25 +37,31 @@ index edf41d1..ed7f72b 100644
 +
 +/* provide entry points for linker to redirect stdio */
 +__attribute__((alias("printf_")))
++__attribute__((used))
 +int __wrap_printf(const char* format, ...);
 +
 +
 +__attribute__((alias("sprintf_")))
++__attribute__((used))
 +int __wrap_sprintf(char* buffer, const char* format, ...);
 +
 +
 +__attribute__((alias("snprintf_")))
++__attribute__((used))
 +int __wrap_snprintf(char* buffer, size_t count, const char* format, ...);
 +
 +
 +__attribute__((alias("vprintf_")))
++__attribute__((used))
 +int __wrap_vprintf(const char* format, va_list va);
 +
 +
 +__attribute__((alias("vsnprintf_")))
++__attribute__((used))
 +int __wrap_vsnprintf(char* buffer, size_t count, const char* format, va_list va);
 +
 +
++__attribute__((used))
 +int __wrap_putchar(int c)
 +{
 +  _putchar((char)c);
@@ -56,6 +69,7 @@ index edf41d1..ed7f72b 100644
 +}
 +
 +
++__attribute__((used))
 +int __wrap_putc(int c, FILE *stream)
 +{
 +  (void)stream;
@@ -65,9 +79,11 @@ index edf41d1..ed7f72b 100644
 +
 +
 +__attribute__((alias("__wrap_putc")))
++__attribute__((used))
 +int __wrap_fputc(int c, FILE *stream);
 +
 +
++__attribute__((used))
 +int __wrap_puts(const char *s)
 +{
 +  size_t len = strlen(s);
@@ -77,6 +93,7 @@ index edf41d1..ed7f72b 100644
 +}
 +
 +
++__attribute__((used))
 +int __wrap_fputs(const char *s, FILE *stream)
 +{
 +  (void)stream;
@@ -86,6 +103,7 @@ index edf41d1..ed7f72b 100644
 +}
 +
 +
++__attribute__((used))
 +int __wrap_vfprintf(FILE *stream, const char *format, va_list va)
 +{
 +  if (stream != stdout) {
@@ -96,6 +114,7 @@ index edf41d1..ed7f72b 100644
 +}
 +
 +
++__attribute__((used))
 +int __wrap_fprintf(FILE *stream, const char *format, ...)
 +{
 +  va_list va;
@@ -106,6 +125,7 @@ index edf41d1..ed7f72b 100644
 +}
 +
 +
++__attribute__((used))
 +int __wrap_vdprintf(int fd, const char *format, va_list va)
 +{
 +  if (fd != STDOUT_FILENO) {
@@ -116,12 +136,14 @@ index edf41d1..ed7f72b 100644
 +}
 +
 +
++__attribute__((used))
 +int __wrap_vsprintf(char* buffer, const char* format, va_list va)
 +{
 +  return __wrap_vsnprintf(buffer, (size_t)-1, format, va);
 +}
 +
 +
++__attribute__((used))
 +int __wrap_dprintf(int fd, const char *format, ...)
 +{
 +  va_list va;
@@ -132,5 +154,5 @@ index edf41d1..ed7f72b 100644
 +  
 +}
 -- 
-2.43.0
+2.39.5
 


### PR DESCRIPTION
### Contribution description

LTO is currently broken when using mpaland/printf as printf wrapper, at least on some GCC versions. Probably related to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88643

Similar fix as in https://github.com/RIOT-OS/RIOT/pull/16789/changes/812b2738452f856490e8e776371c68991cfdc95f


### Testing procedure

```
make -C examples/basic/hello-world BOARD=nrf52840dk LTO=1 all
```

Fails on `master` with linker errors (also reproducible in current riotdocker):

<details>

```
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /tmp/ccn57hXP.ltrans0.ltrans.o: in function `main_trampoline':
/home/mikolai/TUD/Code/RIOT-build/core/lib/init.c:57: undefined reference to `__wrap_puts'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /tmp/ccn57hXP.ltrans0.ltrans.o: in function `main_trampoline':
/home/mikolai/TUD/Code/RIOT-build/examples/basic/hello-world/main.c:23: undefined reference to `__wrap_puts'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /tmp/ccn57hXP.ltrans0.ltrans.o:/home/mikolai/TUD/Code/RIOT-build/examples/basic/hello-world/main.c:25: undefined reference to `__wrap_printf'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /tmp/ccn57hXP.ltrans0.ltrans.o:/home/mikolai/TUD/Code/RIOT-build/examples/basic/hello-world/main.c:26: undefined reference to `__wrap_printf'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /tmp/ccn57hXP.ltrans0.ltrans.o: in function `core_panic.isra.0':
/home/mikolai/TUD/Code/RIOT-build/core/lib/panic.c:64: undefined reference to `__wrap_printf'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/core/lib/panic.c:71: undefined reference to `__wrap_puts'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /tmp/ccn57hXP.ltrans0.ltrans.o: in function `core_panic.isra.0':
/home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/panic.c:31: undefined reference to `__wrap_printf'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /tmp/ccn57hXP.ltrans0.ltrans.o: in function `_unschedule':
/home/mikolai/TUD/Code/RIOT-build/core/sched.c:131: undefined reference to `__wrap_printf'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /tmp/ccn57hXP.ltrans0.ltrans.o: in function `hard_fault_handler':
/home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:351: undefined reference to `__wrap_puts'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:355: undefined reference to `__wrap_puts'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:356: undefined reference to `__wrap_printf'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:391: undefined reference to `__wrap_puts'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:392: undefined reference to `__wrap_printf'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:393: undefined reference to `__wrap_printf'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:394: undefined reference to `__wrap_printf'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:395: undefined reference to `__wrap_printf'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:398: undefined reference to `__wrap_printf'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /tmp/ccn57hXP.ltrans0.ltrans.o:/home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:402: more undefined references to `__wrap_printf' follow
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /tmp/ccn57hXP.ltrans0.ltrans.o: in function `hard_fault_handler':
/home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:405: undefined reference to `__wrap_puts'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:406: undefined reference to `__wrap_printf'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:413: undefined reference to `__wrap_printf'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:423: undefined reference to `__wrap_puts'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:424: undefined reference to `__wrap_printf'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:427: undefined reference to `__wrap_printf'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:376: undefined reference to `__wrap_puts'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:379: undefined reference to `__wrap_printf'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:384: undefined reference to `__wrap_printf'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /home/mikolai/TUD/Code/RIOT-build/cpu/cortexm_common/vectors_cortexm.c:420: undefined reference to `__wrap_printf'
```

</details>

With this PR, builds as expected.


### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
