### PR TITLE
boards: fix static tests warnings from github actions

### DIFF
--- a/boards/arduino-nano-33-iot/include/periph_conf.h
+++ b/boards/arduino-nano-33-iot/include/periph_conf.h
@@ -115,8 +115,8 @@ static const tc32_conf_t timer_config[] = {
 static const uart_conf_t uart_config[] = {
     {
         .dev      = &SERCOM5->USART,
-        .rx_pin   = GPIO_PIN(PB,23),
-        .tx_pin   = GPIO_PIN(PB,22),
+        .rx_pin   = GPIO_PIN(PB, 23),
+        .tx_pin   = GPIO_PIN(PB, 22),
 #ifdef MODULE_SAM0_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,

--- a/boards/avsextrem/board_init.c
+++ b/boards/avsextrem/board_init.c
@@ -126,7 +126,7 @@ void board_init(void)
     PINSEL3 &= ~(BIT12 | BIT13 | BIT18 | BIT19);
 
     //SD
-    FIO0DIR &= ~(BIT19 | BIT20 | BIT21 | BIT22) ; //0.19 0.20 0.21 0.22 as input
+    FIO0DIR &= ~(BIT19 | BIT20 | BIT21 | BIT22); //0.19 0.20 0.21 0.22 as input
     PINMODE1 |= (BIT7) | (BIT9) | (BIT11) | (BIT13); // no resistors
     FIO2DIR &= ~(BIT11 + BIT12 + BIT13); //2.11 2.12 2.13 as input
     PINMODE4 |= (BIT23) | (BIT25) | (BIT27); // no resistors

--- a/boards/b-l072z-lrwan1/include/periph_conf.h
+++ b/boards/b-l072z-lrwan1/include/periph_conf.h
@@ -46,7 +46,10 @@ static const dma_conf_t dma_config[] = {
 #define DMA_SHARED_ISR_0            isr_dma1_channel2_3
 #define DMA_SHARED_ISR_0_STREAMS    { 0, 1 } /* Indexes 0 and 1 of dma_config share the same isr */
 #define DMA_SHARED_ISR_1            isr_dma1_channel4_5_6_7
-#define DMA_SHARED_ISR_1_STREAMS    { 2, 3, 4 } /* Indexes 2, 3 and 4 of dma_config share the same isr */
+/*
+ * @brief Indexes 2, 3 and 4 of dma_config share the same isr
+ */
+#define DMA_SHARED_ISR_1_STREAMS    { 2, 3, 4 }
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
 /** @} */

--- a/boards/common/arduino-mkr/include/periph_conf.h
+++ b/boards/common/arduino-mkr/include/periph_conf.h
@@ -34,8 +34,8 @@ extern "C" {
 static const uart_conf_t uart_config[] = {
     {
         .dev      = &SERCOM5->USART,
-        .rx_pin   = GPIO_PIN(PB,23),  /* ARDUINO_PIN_13, RX Pin */
-        .tx_pin   = GPIO_PIN(PB,22),  /* ARDUINO_PIN_14, TX Pin */
+        .rx_pin   = GPIO_PIN(PB, 23),  /* ARDUINO_PIN_13, RX Pin */
+        .tx_pin   = GPIO_PIN(PB, 22),  /* ARDUINO_PIN_14, TX Pin */
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,

--- a/boards/common/arduino-zero/include/periph_conf.h
+++ b/boards/common/arduino-zero/include/periph_conf.h
@@ -123,8 +123,8 @@ static const tc32_conf_t timer_config[] = {
 static const uart_conf_t uart_config[] = {
     {
         .dev      = &SERCOM5->USART,
-        .rx_pin   = GPIO_PIN(PB,23),
-        .tx_pin   = GPIO_PIN(PB,22),
+        .rx_pin   = GPIO_PIN(PB, 23),
+        .tx_pin   = GPIO_PIN(PB, 22),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
@@ -137,8 +137,8 @@ static const uart_conf_t uart_config[] = {
     },
     {
         .dev      = &SERCOM0->USART,
-        .rx_pin   = GPIO_PIN(PA,11),
-        .tx_pin   = GPIO_PIN(PA,10),
+        .rx_pin   = GPIO_PIN(PA, 11),
+        .tx_pin   = GPIO_PIN(PA, 10),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,

--- a/boards/common/blxxxpill/include/board_common.h
+++ b/boards/common/blxxxpill/include/board_common.h
@@ -30,10 +30,10 @@ extern "C" {
  */
 #ifndef LED0_PORT_NUM
 #define LED0_PORT           GPIO_PORT_C /**< GPIO port of LED 0 */
-#define LED0_PORT_NUM       PORT_C                                  /**< GPIO Port number the LED is connected to */
+#define LED0_PORT_NUM       PORT_C      /**< GPIO Port number the LED is connected to */
 #endif
 #ifndef LED0_PIN_NUM
-#define LED0_PIN_NUM        (13)                                    /**< Pin number the LED is connected to */
+#define LED0_PIN_NUM        (13)        /**< Pin number the LED is connected to */
 #endif
 #ifndef LED0_IS_INVERTED
 #define LED0_IS_INVERTED    1

--- a/boards/common/iotlab/include/periph_conf_common.h
+++ b/boards/common/iotlab/include/periph_conf_common.h
@@ -42,9 +42,9 @@ extern "C" {
  * @{
  */
 static const adc_conf_t adc_config[] = {
-    { GPIO_PIN(PORT_A,3), 0, 3  },
-    { GPIO_UNDEF        , 0, 16 },
-    { GPIO_UNDEF        , 0, 17 }
+    { GPIO_PIN(PORT_A, 3), 0, 3 },
+    { GPIO_UNDEF, 0, 16 },
+    { GPIO_UNDEF, 0, 17 }
 };
 
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)

--- a/boards/common/msp430/include/cfg_timer_a_smclk_b_aclk.h
+++ b/boards/common/msp430/include/cfg_timer_a_smclk_b_aclk.h
@@ -41,12 +41,12 @@ static const timer_conf_t timer_conf[] = {
         .clock_source = TIMER_CLOCK_SOURCE_AUXILIARY_CLOCK,
     }
 };
-#define TIMER_NUMOF         ARRAY_SIZE(timer_conf)  /**< Number of timers available */
+#define TIMER_NUMOF       ARRAY_SIZE(timer_conf)  /**< Number of timers available */
 
-#define TIMER0_ISR_CC0      (TIMERA0_VECTOR)        /**< IRQ vector for channel 0 of TIMER_DEV(0) */
-#define TIMER0_ISR_CCX      (TIMERA1_VECTOR)        /**< IRQ vector for channels !=0 of TIMER_DEV(0) */
-#define TIMER1_ISR_CC0      (TIMERB0_VECTOR)        /**< IRQ vector for channel 0 of TIMER_DEV(0) */
-#define TIMER1_ISR_CCX      (TIMERB1_VECTOR)        /**< IRQ vector for channels !=0 of TIMER_DEV(1) */
+#define TIMER0_ISR_CC0    (TIMERA0_VECTOR)    /**< IRQ vector for channel 0 of TIMER_DEV(0) */
+#define TIMER0_ISR_CCX    (TIMERA1_VECTOR)    /**< IRQ vector for channels !=0 of TIMER_DEV(0) */
+#define TIMER1_ISR_CC0    (TIMERB0_VECTOR)    /**< IRQ vector for channel 0 of TIMER_DEV(0) */
+#define TIMER1_ISR_CCX    (TIMERB1_VECTOR)    /**< IRQ vector for channels !=0 of TIMER_DEV(1) */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/remote/include/fancy_leds.h
+++ b/boards/common/remote/include/fancy_leds.h
@@ -33,21 +33,21 @@
   LED_FADE_EXPAND(led)
 
 #define LED_FADE_EXPAND(led)                  \
-  for(k = 0; k < 800; ++k) {                  \
+  for (k = 0; k < 800; ++k) {                 \
     j = k > 400 ? 800 - k : k;                \
     led##_ON;                                 \
-    for(i = 0; i < j; ++i) {                  \
-      __asm__("nop");                             \
+    for (i = 0; i < j; ++i) {                 \
+      __asm__("nop");                         \
     }                                         \
     led##_OFF;                                \
-    for(i = 0; i < 400 - j; ++i) {            \
-      __asm__("nop");                             \
+    for (i = 0; i < 400 - j; ++i) {           \
+      __asm__("nop");                         \
     }                                         \
   }
 
 #define LED_RAINBOW()                         \
   volatile int i;                             \
-  int k,j;                                    \
+  int k, j;                                   \
   LED_FADE_EXPAND(LED3);                      \
   LED_FADE_EXPAND(LED0);                      \
   LED_FADE_EXPAND(LED4);                      \

--- a/boards/esp32-ttgo-t-beam/include/board.h
+++ b/boards/esp32-ttgo-t-beam/include/board.h
@@ -80,12 +80,12 @@
  * SX127X configuration.
  * @{
  */
-#define SX127X_PARAM_SPI_NSS            GPIO18
-#define SX127X_PARAM_RESET              GPIO23
-#define SX127X_PARAM_DIO0               GPIO26
-#define SX127X_PARAM_DIO1               GPIO_UNDEF /* Pin is not connected to the LoRa chip directly */
-#define SX127X_PARAM_DIO2               GPIO_UNDEF /* Pin is not connected to the LoRa chip directly */
-#define SX127X_PARAM_DIO3               GPIO_UNDEF
+#define SX127X_PARAM_SPI_NSS     GPIO18
+#define SX127X_PARAM_RESET       GPIO23
+#define SX127X_PARAM_DIO0        GPIO26
+#define SX127X_PARAM_DIO1        GPIO_UNDEF /* Pin is not connected to the LoRa chip directly */
+#define SX127X_PARAM_DIO2        GPIO_UNDEF /* Pin is not connected to the LoRa chip directly */
+#define SX127X_PARAM_DIO3        GPIO_UNDEF
 /** @} */
 
 /* include common board definitions as last step */

--- a/boards/esp32-wroom-32/include/periph_conf.h
+++ b/boards/esp32-wroom-32/include/periph_conf.h
@@ -48,7 +48,7 @@ extern "C" {
  * purposes.
  */
 #ifndef ADC_GPIOS
-#define ADC_GPIOS   { GPIO0 , GPIO2 , GPIO4 , GPIO12, GPIO13, GPIO14, \
+#define ADC_GPIOS   { GPIO0, GPIO2, GPIO4, GPIO12, GPIO13, GPIO14, \
                       GPIO15, GPIO25, GPIO26, GPIO27, GPIO32, GPIO33, \
                       GPIO34, GPIO35, GPIO36, GPIO39 }
 #endif

--- a/boards/generic-cc2538-cc2592-dk/include/board.h
+++ b/boards/generic-cc2538-cc2592-dk/include/board.h
@@ -28,28 +28,40 @@ extern "C" {
  * @{
  */
 #define LED_GREEN_PIN       GPIO_PIN(PORT_C, 0) /**< GPIO pin for green LED */
-#define LED_GREEN_PORT      GPIO_C              /**< GPIO port register to used to control green LED */
+/**
+ * @brief GPIO port register to used to control green LED
+ */
+#define LED_GREEN_PORT      GPIO_C
 #define LED_GREEN_BIT       (1U << 0)           /**< Bitmask to write to @ref LED_GREEN_PORT */
 #define LED0_PIN            LED_GREEN_PIN       /**< Alias for LED_GREEN_PIN */
 #define LED0_PORT           LED_GREEN_PORT      /**< Alias for LED_GREEN_PORT */
 #define LED0_BIT            LED_GREEN_BIT       /**< Alias for LED_GREEN_BIT */
 
 #define LED_RED_PIN         GPIO_PIN(PORT_C, 1) /**< GPIO pin for red LED */
-#define LED_RED_PORT        GPIO_C              /**< GPIO port register to used to control red LED */
+/**
+ * @brief GPIO port register to used to control red LED
+ */
+#define LED_RED_PORT        GPIO_C
 #define LED_RED_BIT         (1U << 1)           /**< Bitmask to write to @ref LED_RED_PORT */
 #define LED1_PIN            LED_RED_PIN         /**< Alias for LED_RED_PIN */
 #define LED1_PORT           LED_RED_PORT        /**< Alias for LED_RED_PORT */
 #define LED1_BIT            LED_RED_BIT         /**< Alias for LED_RED_BIT */
 
 #define LED_YELLOW_PIN      GPIO_PIN(PORT_B, 1) /**< GPIO pin for yellow LED */
-#define LED_YELLOW_PORT     GPIO_B              /**< GPIO port register to used to control yellow LED */
+/**
+ * @brief GPIO port register to used to control yellow LED
+ */
+#define LED_YELLOW_PORT     GPIO_B
 #define LED_YELLOW_BIT      (1U << 1)           /**< Bitmask to write to @ref LED_YELLOW_PORT */
 #define LED2_PIN            LED_YELLOW_PIN      /**< Alias for LED_YELLOW_PIN */
 #define LED2_PORT           LED_YELLOW_PORT     /**< Alias for LED_YELLOW_PORT */
 #define LED2_BIT            LED_YELLOW_BIT      /**< Alias for LED_YELLOW_BIT */
 
 #define LED_BLUE_PIN        GPIO_PIN(PORT_B, 0) /**< GPIO pin for blue LED */
-#define LED_BLUE_PORT       GPIO_B              /**< GPIO port register to used to control blue LED */
+/**
+ * @brief GPIO port register to used to control blue LED
+ */
+#define LED_BLUE_PORT       GPIO_B
 #define LED_BLUE_BIT        (1U << 0)           /**< Bitmask to write to @ref LED_BLUE_PORT */
 #define LED3_PIN            LED_BLUE_PIN        /**< Alias for LED_BLUE_PIN */
 #define LED3_PORT           LED_BLUE_PORT       /**< Alias for LED_BLUE_PORT */

--- a/boards/lora-e5-dev/board.c
+++ b/boards/lora-e5-dev/board.c
@@ -27,12 +27,12 @@
 
 void board_init(void)
 {
-    if(IS_ACTIVE(CONFIG_LORA_E5_DEV_ENABLE_3P3V)) {
+    if (IS_ACTIVE(CONFIG_LORA_E5_DEV_ENABLE_3P3V)) {
         gpio_init(LORA_E5_DEV_3P3V_ENABLE_PIN, GPIO_OUT);
         gpio_set(LORA_E5_DEV_3P3V_ENABLE_PIN);
     }
 
-    if(IS_ACTIVE(CONFIG_LORA_E5_DEV_ENABLE_5V)) {
+    if (IS_ACTIVE(CONFIG_LORA_E5_DEV_ENABLE_5V)) {
         gpio_init(LORA_E5_DEV_5V_ENABLE_PIN, GPIO_OUT);
         gpio_set(LORA_E5_DEV_5V_ENABLE_PIN);
     }

--- a/boards/lsn50/include/periph_conf.h
+++ b/boards/lsn50/include/periph_conf.h
@@ -44,7 +44,10 @@ static const dma_conf_t dma_config[] = {
 #define DMA_SHARED_ISR_0            isr_dma1_channel2_3
 #define DMA_SHARED_ISR_0_STREAMS    { 0, 1 } /* Indexes 0 and 1 of dma_config share the same isr */
 #define DMA_SHARED_ISR_1            isr_dma1_channel4_5_6_7
-#define DMA_SHARED_ISR_1_STREAMS    { 2, 3, 4 } /* Indexes 2, 3 and 4 of dma_config share the same isr */
+/*
+ * @brief Indexes 2, 3 and 4 of dma_config share the same isr
+ */
+#define DMA_SHARED_ISR_1_STREAMS    { 2, 3, 4 }
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
 /** @} */

--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -30,7 +30,7 @@ extern "C" {
 #define CC110X_PARAM_CS         GPIO_PIN(PORT_B, 12)    /**< CS pin of CC1101 */
 #define CC110X_PARAM_GDO0       GPIO_PIN(PORT_C, 4)     /**< GDO0 pin of CC1101 */
 #define CC110X_PARAM_GDO2       GPIO_PIN(PORT_C, 5)     /**< GDO2 pin of CC1101 */
-/*
+/**
  * @brief SPI clock (reduced to work around hw bug)
  */
 #define CC110X_PARAM_SPI_CLOCK  SPI_CLK_1MHZ

--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -30,7 +30,10 @@ extern "C" {
 #define CC110X_PARAM_CS         GPIO_PIN(PORT_B, 12)    /**< CS pin of CC1101 */
 #define CC110X_PARAM_GDO0       GPIO_PIN(PORT_C, 4)     /**< GDO0 pin of CC1101 */
 #define CC110X_PARAM_GDO2       GPIO_PIN(PORT_C, 5)     /**< GDO2 pin of CC1101 */
-#define CC110X_PARAM_SPI_CLOCK  SPI_CLK_1MHZ            /**< SPI clock (reduced to work around hw bug) */
+/*
+ * @brief SPI clock (reduced to work around hw bug)
+ */
+#define CC110X_PARAM_SPI_CLOCK  SPI_CLK_1MHZ
 /** @} */
 
 /**

--- a/boards/mulle/board.c
+++ b/boards/mulle/board.c
@@ -90,7 +90,6 @@ void board_init(void)
 {
     int status;
 
-
     /* Initialize power control pins */
     power_pins_init();
 
@@ -105,7 +104,6 @@ void board_init(void)
 
     /* Turn on AVDD for reading voltages */
     gpio_set(MULLE_POWER_AVDD);
-
 
     /* NVRAM requires xtimer for timing */
     ztimer_init();

--- a/boards/nucleo-f072rb/include/periph_conf.h
+++ b/boards/nucleo-f072rb/include/periph_conf.h
@@ -107,7 +107,7 @@ static const pwm_conf_t pwm_config[] = {
         .rcc_mask = RCC_APB1ENR_TIM2EN,
         .chan     = { { .pin = GPIO_PIN(PORT_B, 3)  /* D3 */, .cc_chan = 1 },
                       { .pin = GPIO_PIN(PORT_B, 10) /* D6 */, .cc_chan = 2 },
-                      { .pin = GPIO_PIN(PORT_B, 11)         , .cc_chan = 3 },
+                      { .pin = GPIO_PIN(PORT_B, 11),          .cc_chan = 3 },
                       { .pin = GPIO_UNDEF,                    .cc_chan = 0 } },
         .af       = GPIO_AF2,
         .bus      = APB1

--- a/boards/nucleo-f091rc/include/periph_conf.h
+++ b/boards/nucleo-f091rc/include/periph_conf.h
@@ -162,7 +162,7 @@ static const pwm_conf_t pwm_config[] = {
         .rcc_mask = RCC_APB1ENR_TIM2EN,
         .chan     = { { .pin = GPIO_PIN(PORT_B, 3)  /* D3 */, .cc_chan = 1 },
                       { .pin = GPIO_PIN(PORT_B, 10) /* D6 */, .cc_chan = 2 },
-                      { .pin = GPIO_PIN(PORT_B, 11)         , .cc_chan = 3 },
+                      { .pin = GPIO_PIN(PORT_B, 11),          .cc_chan = 3 },
                       { .pin = GPIO_UNDEF,                    .cc_chan = 0 } },
         .af       = GPIO_AF2,
         .bus      = APB1

--- a/boards/nucleo-f401re/include/periph_conf.h
+++ b/boards/nucleo-f401re/include/periph_conf.h
@@ -121,7 +121,7 @@ static const pwm_conf_t pwm_config[] = {
     {
         .dev      = TIM2,
         .rcc_mask = RCC_APB1ENR_TIM2EN,
-        .chan     = { { .pin = GPIO_PIN(PORT_A, 15)         , .cc_chan = 0 },
+        .chan     = { { .pin = GPIO_PIN(PORT_A, 15),          .cc_chan = 0 },
                       { .pin = GPIO_PIN(PORT_B, 3)  /* D3 */, .cc_chan = 1 },
                       { .pin = GPIO_PIN(PORT_B, 10) /* D6 */, .cc_chan = 2 },
                       { .pin = GPIO_UNDEF,                    .cc_chan = 0 } },

--- a/boards/nucleo-f411re/include/periph_conf.h
+++ b/boards/nucleo-f411re/include/periph_conf.h
@@ -57,8 +57,8 @@ static const uart_conf_t uart_config[] = {
     {
         .dev        = USART2,
         .rcc_mask   = RCC_APB1ENR_USART2EN,
-        .rx_pin     = GPIO_PIN(PORT_A,3),
-        .tx_pin     = GPIO_PIN(PORT_A,2),
+        .rx_pin     = GPIO_PIN(PORT_A, 3),
+        .tx_pin     = GPIO_PIN(PORT_A, 2),
         .rx_af      = GPIO_AF7,
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
@@ -114,7 +114,7 @@ static const pwm_conf_t pwm_config[] = {
     {
         .dev      = TIM2,
         .rcc_mask = RCC_APB1ENR_TIM2EN,
-        .chan     = { { .pin = GPIO_PIN(PORT_A, 15)         , .cc_chan = 0 },
+        .chan     = { { .pin = GPIO_PIN(PORT_A, 15),          .cc_chan = 0 },
                       { .pin = GPIO_PIN(PORT_B, 3)  /* D3 */, .cc_chan = 1 },
                       { .pin = GPIO_PIN(PORT_B, 10) /* D6 */, .cc_chan = 2 },
                       { .pin = GPIO_UNDEF,                    .cc_chan = 0 } },

--- a/boards/nucleo-f446ze/include/periph_conf.h
+++ b/boards/nucleo-f446ze/include/periph_conf.h
@@ -193,7 +193,7 @@ static const adc_conf_t adc_config[] = {
     { .pin = GPIO_PIN(PORT_B, 0), .dev = 2, .chan =  9 }, /* ADC123_IN9   */
     { .pin = GPIO_PIN(PORT_C, 1), .dev = 2, .chan = 15 }, /* ADC3_IN15    */
     { .pin = GPIO_PIN(PORT_C, 0), .dev = 2, .chan =  8 }, /* ADC3_IN8     */
-    { .pin = GPIO_UNDEF, 	  .dev = 0, .chan = 18 }, /* VBAT */
+    { .pin = GPIO_UNDEF,          .dev = 0, .chan = 18 }, /* VBAT */
 };
 
 /**

--- a/boards/nucleo-l073rz/include/periph_conf.h
+++ b/boards/nucleo-l073rz/include/periph_conf.h
@@ -96,7 +96,7 @@ static const pwm_conf_t pwm_config[] = {
         .rcc_mask = RCC_APB1ENR_TIM3EN,
         .chan     = { { .pin = GPIO_PIN(PORT_B, 4) /* D5 */, .cc_chan = 0 },
                       { .pin = GPIO_PIN(PORT_C, 7) /* D9 */, .cc_chan = 1 },
-                      { .pin = GPIO_PIN(PORT_C, 8)         , .cc_chan = 2 },
+                      { .pin = GPIO_PIN(PORT_C, 8),          .cc_chan = 2 },
                       { .pin = GPIO_UNDEF,                   .cc_chan = 0 } },
         .af       = GPIO_AF2,
         .bus      = APB1

--- a/boards/pba-d-01-kw2x/board.c
+++ b/boards/pba-d-01-kw2x/board.c
@@ -48,7 +48,7 @@ static inline void modem_clock_init(void)
     KW2XDRF_GPIO->PSOR = (1 << KW2XDRF_RST_PIN);
 
     /* wait for modem IRQ_B interrupt request */
-    while (KW2XDRF_GPIO->PDIR & (1 << KW2XDRF_IRQ_PIN));
+    while (KW2XDRF_GPIO->PDIR & (1 << KW2XDRF_IRQ_PIN)) { };
 }
 
 void post_startup(void)

--- a/boards/remote-pa/include/periph_conf.h
+++ b/boards/remote-pa/include/periph_conf.h
@@ -60,7 +60,7 @@ static const spi_conf_t spi_config[] = {
         .num      = 1,
         .mosi_pin = GPIO_PIN(2, 7),
         .miso_pin = GPIO_PIN(0, 4),
-        .sck_pin  = GPIO_PIN(1 ,5),
+        .sck_pin  = GPIO_PIN(1, 5),
         .cs_pin   = SPI_CS_UNDEF,
     }
 };

--- a/boards/samd20-xpro/include/periph_conf.h
+++ b/boards/samd20-xpro/include/periph_conf.h
@@ -134,8 +134,8 @@ static const tc32_conf_t timer_config[] = {
 static const uart_conf_t uart_config[] = {
     {    /* Virtual COM Port */
         .dev      = &SERCOM3->USART,
-        .rx_pin   = GPIO_PIN(PA,25),
-        .tx_pin   = GPIO_PIN(PA,24),
+        .rx_pin   = GPIO_PIN(PA, 25),
+        .tx_pin   = GPIO_PIN(PA, 24),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
@@ -148,8 +148,8 @@ static const uart_conf_t uart_config[] = {
     },
     {    /* EXT1 */
         .dev      = &SERCOM4->USART,
-        .rx_pin   = GPIO_PIN(PB,9),
-        .tx_pin   = GPIO_PIN(PB,8),
+        .rx_pin   = GPIO_PIN(PB, 9),
+        .tx_pin   = GPIO_PIN(PB, 8),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
@@ -162,8 +162,8 @@ static const uart_conf_t uart_config[] = {
     },
     {    /* EXT2 */
         .dev      = &SERCOM0->USART,
-        .rx_pin   = GPIO_PIN(PA,9),
-        .tx_pin   = GPIO_PIN(PA,8),
+        .rx_pin   = GPIO_PIN(PA, 9),
+        .tx_pin   = GPIO_PIN(PA, 8),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -136,8 +136,8 @@ static const tc32_conf_t timer_config[] = {
 static const uart_conf_t uart_config[] = {
     {    /* Virtual COM Port */
         .dev      = &SERCOM3->USART,
-        .rx_pin   = GPIO_PIN(PA,23),
-        .tx_pin   = GPIO_PIN(PA,22),
+        .rx_pin   = GPIO_PIN(PA, 23),
+        .tx_pin   = GPIO_PIN(PA, 22),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
@@ -150,8 +150,8 @@ static const uart_conf_t uart_config[] = {
     },
     {    /* EXT1 */
         .dev      = &SERCOM4->USART,
-        .rx_pin   = GPIO_PIN(PB,9),
-        .tx_pin   = GPIO_PIN(PB,8),
+        .rx_pin   = GPIO_PIN(PB, 9),
+        .tx_pin   = GPIO_PIN(PB, 8),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
@@ -164,8 +164,8 @@ static const uart_conf_t uart_config[] = {
     },
     {    /* EXT2/3 */
         .dev      = &SERCOM4->USART,
-        .rx_pin   = GPIO_PIN(PB,11),
-        .tx_pin   = GPIO_PIN(PB,10),
+        .rx_pin   = GPIO_PIN(PB, 11),
+        .tx_pin   = GPIO_PIN(PB, 10),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -65,8 +65,8 @@ static const tc32_conf_t timer_config[] = {
 static const uart_conf_t uart_config[] = {
     {    /* Virtual COM Port */
         .dev      = &SERCOM3->USART,
-        .rx_pin   = GPIO_PIN(PA,23),
-        .tx_pin   = GPIO_PIN(PA,22),
+        .rx_pin   = GPIO_PIN(PA, 23),
+        .tx_pin   = GPIO_PIN(PA, 22),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -136,11 +136,11 @@ static const tc32_conf_t timer_config[] = {
 static const uart_conf_t uart_config[] = {
     {
         .dev      = &SERCOM0->USART,
-        .rx_pin   = GPIO_PIN(PA,5),
-        .tx_pin   = GPIO_PIN(PA,4),
+        .rx_pin   = GPIO_PIN(PA, 5),
+        .tx_pin   = GPIO_PIN(PA, 4),
 #ifdef MODULE_PERIPH_UART_HW_FC
-        .rts_pin  = GPIO_PIN(PA,6),
-        .cts_pin  = GPIO_PIN(PA,7),
+        .rts_pin  = GPIO_PIN(PA, 6),
+        .cts_pin  = GPIO_PIN(PA, 7),
 #endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_1,
@@ -154,11 +154,11 @@ static const uart_conf_t uart_config[] = {
     },
     {
         .dev      = &SERCOM5->USART,
-        .rx_pin   = GPIO_PIN(PA,23),
-        .tx_pin   = GPIO_PIN(PA,22),
+        .rx_pin   = GPIO_PIN(PA, 23),
+        .tx_pin   = GPIO_PIN(PA, 22),
 #ifdef MODULE_PERIPH_UART_HW_FC
-        .rts_pin  = GPIO_PIN(PB,22),
-        .cts_pin  = GPIO_PIN(PB,23),
+        .rts_pin  = GPIO_PIN(PB, 22),
+        .cts_pin  = GPIO_PIN(PB, 23),
 #endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_1,

--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -55,8 +55,8 @@ static const tc32_conf_t timer_config[] = {
 static const uart_conf_t uart_config[] = {
     {    /* Virtual COM Port */
         .dev      = &SERCOM0->USART,
-        .rx_pin   = GPIO_PIN(PA,5),
-        .tx_pin   = GPIO_PIN(PA,4),
+        .rx_pin   = GPIO_PIN(PA, 5),
+        .tx_pin   = GPIO_PIN(PA, 4),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,

--- a/boards/samr34-xpro/include/board.h
+++ b/boards/samr34-xpro/include/board.h
@@ -41,8 +41,8 @@ extern "C" {
  * @name Board specific configuration
  *  @{
  */
-#define TCXO_PWR_PIN                        GPIO_PIN(PA, 9)     /**< 32 MHz oscillator for radio enable */
-#define TX_OUTPUT_SEL_PIN                   GPIO_PIN(PA, 13)    /**< BAND_SEL */
+#define TCXO_PWR_PIN                GPIO_PIN(PA, 9)     /**< 32 MHz oscillator for radio enable */
+#define TX_OUTPUT_SEL_PIN           GPIO_PIN(PA, 13)    /**< BAND_SEL */
 /** @}*/
 
 /**

--- a/boards/sodaq-autonomo/include/periph_conf.h
+++ b/boards/sodaq-autonomo/include/periph_conf.h
@@ -38,8 +38,8 @@ extern "C" {
 static const uart_conf_t uart_config[] = {
     {
         .dev      = &SERCOM0->USART,
-        .rx_pin   = GPIO_PIN(PA,9),
-        .tx_pin   = GPIO_PIN(PA,10),
+        .rx_pin   = GPIO_PIN(PA, 9),
+        .tx_pin   = GPIO_PIN(PA, 10),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
@@ -52,8 +52,8 @@ static const uart_conf_t uart_config[] = {
     },
     {
         .dev      = &SERCOM5->USART,
-        .rx_pin   = GPIO_PIN(PB,31),
-        .tx_pin   = GPIO_PIN(PB,30),
+        .rx_pin   = GPIO_PIN(PB, 31),
+        .tx_pin   = GPIO_PIN(PB, 30),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
@@ -66,8 +66,8 @@ static const uart_conf_t uart_config[] = {
     },
     {
         .dev      = &SERCOM4->USART,
-        .rx_pin   = GPIO_PIN(PB,13),
-        .tx_pin   = GPIO_PIN(PB,14),
+        .rx_pin   = GPIO_PIN(PB, 13),
+        .tx_pin   = GPIO_PIN(PB, 14),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
@@ -80,8 +80,8 @@ static const uart_conf_t uart_config[] = {
     },
     {
         .dev      = &SERCOM1->USART,
-        .rx_pin   = GPIO_PIN(PA,17),
-        .tx_pin   = GPIO_PIN(PA,18),
+        .rx_pin   = GPIO_PIN(PA, 17),
+        .tx_pin   = GPIO_PIN(PA, 18),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,

--- a/boards/sodaq-explorer/include/periph_conf.h
+++ b/boards/sodaq-explorer/include/periph_conf.h
@@ -34,8 +34,8 @@ extern "C" {
 static const uart_conf_t uart_config[] = {
     {
         .dev      = &SERCOM5->USART,
-        .rx_pin   = GPIO_PIN(PB,31),  /* D0, RX Pin */
-        .tx_pin   = GPIO_PIN(PB,30),  /* D1, TX Pin */
+        .rx_pin   = GPIO_PIN(PB, 31),  /* D0, RX Pin */
+        .tx_pin   = GPIO_PIN(PB, 30),  /* D1, TX Pin */
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
@@ -48,8 +48,8 @@ static const uart_conf_t uart_config[] = {
     },
     {
         .dev      = &SERCOM4->USART,
-        .rx_pin   = GPIO_PIN(PB,13),
-        .tx_pin   = GPIO_PIN(PB,14),
+        .rx_pin   = GPIO_PIN(PB, 13),
+        .tx_pin   = GPIO_PIN(PB, 14),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
@@ -62,8 +62,8 @@ static const uart_conf_t uart_config[] = {
     },
     { /* Connected to RN2483 */
         .dev      = &SERCOM0->USART,
-        .rx_pin   = GPIO_PIN(PA,5),
-        .tx_pin   = GPIO_PIN(PA,6),
+        .rx_pin   = GPIO_PIN(PA, 5),
+        .tx_pin   = GPIO_PIN(PA, 6),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,

--- a/boards/sodaq-one/include/periph_conf.h
+++ b/boards/sodaq-one/include/periph_conf.h
@@ -37,8 +37,8 @@ extern "C" {
 static const uart_conf_t uart_config[] = {
     {
         .dev      = &SERCOM5->USART,
-        .rx_pin   = GPIO_PIN(PB,3),  /* D0, RX Pin */
-        .tx_pin   = GPIO_PIN(PB,2),  /* D1, TX Pin */
+        .rx_pin   = GPIO_PIN(PB, 3),  /* D0, RX Pin */
+        .tx_pin   = GPIO_PIN(PB, 2),  /* D1, TX Pin */
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,
@@ -51,8 +51,8 @@ static const uart_conf_t uart_config[] = {
     },
     {
         .dev      = &SERCOM2->USART,
-        .rx_pin   = GPIO_PIN(PA,13),
-        .tx_pin   = GPIO_PIN(PA,12),
+        .rx_pin   = GPIO_PIN(PA, 13),
+        .tx_pin   = GPIO_PIN(PA, 12),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,

--- a/boards/sodaq-sara-aff/include/periph_conf.h
+++ b/boards/sodaq-sara-aff/include/periph_conf.h
@@ -54,8 +54,8 @@ static const uart_conf_t uart_config[] = {
     },
     {
         .dev      = &SERCOM0->USART,
-        .rx_pin   = GPIO_PIN(PA,5),
-        .tx_pin   = GPIO_PIN(PA,6),
+        .rx_pin   = GPIO_PIN(PA, 5),
+        .tx_pin   = GPIO_PIN(PA, 6),
 #ifdef MODULE_PERIPH_UART_HW_FC
         .rts_pin  = GPIO_UNDEF,
         .cts_pin  = GPIO_UNDEF,

--- a/boards/spark-core/include/board.h
+++ b/boards/spark-core/include/board.h
@@ -54,7 +54,7 @@
  * @name User button configuration
  * @{
  */
-#define BUTTON1             GPIO_PIN(PORT_B,2)
+#define BUTTON1             GPIO_PIN(PORT_B, 2)
 /** @} */
 
 /**
@@ -62,9 +62,9 @@
  * @{
  */
 #define CC3000_SPI          SPI_DEV(0)
-#define CC3000_CS           GPIO_PIN(PORT_B,12)
-#define CC3000_EN           GPIO_PIN(PORT_B,8)
-#define CC3000_INT          GPIO_PIN(PORT_B,11)
+#define CC3000_CS           GPIO_PIN(PORT_B, 12)
+#define CC3000_EN           GPIO_PIN(PORT_B, 8)
+#define CC3000_INT          GPIO_PIN(PORT_B, 11)
 /** @} */
 
 /**
@@ -72,7 +72,7 @@
  * @{
  */
 #define EXTFLASH_SPI        SPI_DEV(0)
-#define EXTFLASH            GPIO_PIN(PORT_B,9)
+#define EXTFLASH            GPIO_PIN(PORT_B, 9)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/stm32f469i-disco/include/gpio_params.h
+++ b/boards/stm32f469i-disco/include/gpio_params.h
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2021 luisan00
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 #pragma once
 
 #include "board.h"


### PR DESCRIPTION
### Contribution description

PR #22183 fix 10 visible in Github Action page static-test warnings concerning boards. When I run `make static-test` locally, more warning concerning code issues are found. This PR fix them (more than 100 warnings). 

_Question to community._

Should we start process of fixing remaining static-test warnings. When I run `make static-test`, except those fixed, there are more than 3700 remaining warnings. If Community give green light - I could set up tracking PR (like PR #21515 for SPDX), and start fixing them in spare time, but help will be needed.

### Testing procedure

Green Murdock and lack of this warnings concerning boards in Github Actions.

### Issues/PRs references

PR #22183

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
