### PR TITLE
tests/net/ieee802154_hal: fix issues on native64

### DIFF
--- a/tests/net/ieee802154_hal/Makefile
+++ b/tests/net/ieee802154_hal/Makefile
@@ -1,9 +1,12 @@
 include ../Makefile.net_common
 
 ifneq (,$(filter native native32 native64,$(BOARD)))
+  USE_ZEP := 1
   ZEP_PORT_BASE ?= 17754
-  TERMFLAGS += -z [::1]:$(ZEP_PORT_BASE)
   USEMODULE += socket_zep
+else
+  # on non-native boards, we need to bump the event thread's stack
+  CFLAGS += -DEVENT_THREAD_MEDIUM_STACKSIZE=1024
 endif
 
 USEMODULE += od
@@ -17,8 +20,6 @@ USEMODULE += event_thread
 USEMODULE += event_callback
 USEMODULE += xtimer
 USEMODULE += netdev_default
-
-CFLAGS += -DEVENT_THREAD_MEDIUM_STACKSIZE=1024
 
 include $(RIOTBASE)/Makefile.include
 


### PR DESCRIPTION
### Contribution description

- align ZEP setup with examples/networking/gnrc/networking
    - boards/common/native/Makefile.include does handle ZEP config if and only if `USE_ZEP=1` is set
    - the ZEP port needs to be provided as `ZEP_PORT_BASE`
- do not provide a custom event thread size on native
    - at least on native64, 1 KiB of RAM will cause stack overflows, while the default is large enough

### Testing procedure

#### On `master`

```
$ make BOARD=native64 -C tests/net/ieee802154_hal flash term -j32
make: Entering directory '/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/net/ieee802154_hal'
Building application "tests_ieee802154_hal" for "native64" with CPU "native".
[...]
   text	   data	    bss	    dec	    hex	filename
  69344	   2248	  61056	 132648	  20628	/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/net/ieee802154_hal/bin/native64/tests_ieee802154_hal.elf
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/dist/tools/pyterm/pyterm -z [::1]:17754 -ps /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/net/ieee802154_hal/bin/native64/tests_ieee802154_hal.elf --process-args tap0 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
usage: pyterm [-h] [-p PORT] [-ts TCP_SERIAL] [-ps PROCESS] [-pa [PROCESS_ARGS ...]] [-b BAUDRATE] [-tg] [-sr SET_RTS]
              [-sd SET_DTR] [-d DIRECTORY] [-c CONFIG] [-f FORMAT] [-np] [-s SERVER] [-P TCP_PORT] [-H HOST] [-rn RUN_NAME]
              [-ln LOG_DIR_NAME] [-nl NEWLINE] [-pr PROMPT] [--repeat-command-on-empty-line]
              [--no-repeat-command-on-empty-line] [--reconnect] [--no-reconnect]
```

and even with manually setting the terminal to `native`:

```
$ make RIOT_TERMINAL=native BOARD=native64 -C tests/net/ieee802154_hal flash term -j32 
make: Entering directory '/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/net/ieee802154_hal'
Building application "tests_ieee802154_hal" for "native64" with CPU "native".
[...]
   text	   data	    bss	    dec	    hex	filename
  69344	   2248	  61056	 132648	  20628	/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/net/ieee802154_hal/bin/native64/tests_ieee802154_hal.elf
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/net/ieee802154_hal/bin/native64/tests_ieee802154_hal.elf -z [::1]:17754  tap0 
RIOT native interrupts/signals initialized.
TZ not set, setting UTC
RIOT native64 board initialized.
RIOT native hardware initialization complete.

*** stack smashing detected ***: terminated
Aborted
```

#### This PR

```
$ make BOARD=native64 -C tests/net/ieee802154_hal flash term -j32
[...]
   text	   data	    bss	    dec	    hex	filename
  69408	   2248	  76416	 148072	  24268	/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/net/ieee802154_hal/bin/native64/tests_ieee802154_hal.elf
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/dist/tools/pyterm/pyterm -ps /home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/net/ieee802154_hal/bin/native64/tests_ieee802154_hal.elf --process-args '-z [::1]:17754' --process-args tap0 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Welcome to pyterm!
Type '/exit' to exit.
2026-04-13 07:07:56,339 # RIOT native interrupts/signals initialized.
2026-04-13 07:07:56,339 # TZ not set, setting UTC
2026-04-13 07:07:56,339 # RIOT native64 board initialized.
2026-04-13 07:07:56,339 # RIOT native hardware initialization complete.
2026-04-13 07:07:56,340 # 
2026-04-13 07:07:56,340 # main(): This is RIOT! (Version: 2026.04-devel-365-g84f8a-tests/net/ieee802154_hal/native-fixes)
2026-04-13 07:07:56,340 # Trying to register socket_zep.
2026-04-13 07:07:56,340 # Success
2026-04-13 07:07:56,340 # Initialization successful - starting the shell now
>
```

Note that now indeed pyterm works, as `boards/common/native/Makefile.include` does correctly set it up.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
