### PR TITLE
.clang-format: sort headers alphabetically

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -69,11 +69,13 @@ DisableFormat: false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: false
 
-IncludeBlocks: Preserve
+IncludeBlocks: Regroup
 IncludeCategories:
-  - Regex: '.*'
+  - Regex: '^<.*>$'
     Priority: 1
-IncludeIsMainRegex: '(Test)?$'
+  - Regex: '^".*"'
+    Priority: 2
+IncludeIsMainRegex: '^$'
 IndentCaseLabels: false
 IndentGotoLabels: false
 IndentPPDirectives: AfterHash
@@ -99,7 +101,7 @@ PenaltyReturnTypeOnItsOwnLine: 60
 
 PointerAlignment: Right
 ReflowComments: false
-SortIncludes: false
+SortIncludes: true
 SortUsingDeclarations: false
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true


### PR DESCRIPTION
### Contribution description

- use `IncludeBlocks: Regroup` to sort headers in blocks
- use `IncludeCategories:` to manually force clang-format to put `#include <...>` before `#include "..."` to match the current practice in RIOT

### Testing procedure

#### This PR

```
$ clang-format drivers/xbee/xbee.c | head -n 35 | tail -n 16
#include <errno.h>
#include <string.h>

#include "assert.h"
#include "net/eui64.h"
#include "net/ieee802154.h"
#include "net/netdev.h"
#include "timex.h"
#include "xbee.h"
#include "ztimer.h"
#ifdef MODULE_GNRC
#  include "net/gnrc.h"
#endif

#define ENABLE_DEBUG 0
#include "debug.h"
```

(Note: `<errno.h>` is sorted in before `<string.h>`)


#### In `master`

```
clang-format drivers/xbee/xbee.c | head -n 35 | tail -n 16
#include <string.h>
#include <errno.h>

#include "assert.h"
#include "net/eui64.h"
#include "net/ieee802154.h"
#include "net/netdev.h"
#include "timex.h"
#include "xbee.h"
#include "ztimer.h"
#ifdef MODULE_GNRC
#  include "net/gnrc.h"
#endif

#define ENABLE_DEBUG 0
#include "debug.h"
```

(Note: `<errno.h> is not sorted correctly)

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
