### PR TITLE
sys/net/nanocoap: concretize debug message on malformed hdr

### DIFF
--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -128,18 +128,18 @@ ssize_t coap_parse_udp(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     pkt->buf = buf;
     coap_udp_hdr_t *hdr = (coap_udp_hdr_t *)buf;
 
-    uint8_t *pkt_pos = coap_hdr_data_ptr(hdr);
-    uint8_t *pkt_end = buf + len;
-
     pkt->payload = NULL;
     pkt->payload_len = 0;
     memset(pkt->opt_crit, 0, sizeof(pkt->opt_crit));
     pkt->snips = NULL;
 
     if (!coap_is_hdr_in_bounds(pkt, len)) {
-        DEBUG("msg too short\n");
+        DEBUG("msg malformed\n");
         return -EBADMSG;
     }
+
+    uint8_t *pkt_pos = coap_hdr_data_ptr(hdr);
+    uint8_t *pkt_end = buf + len;
 
     if ((coap_get_code_raw(pkt) == 0) && (len > sizeof(coap_udp_hdr_t))) {
         DEBUG("empty msg too long\n");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hello :horse: 

the `coap_is_hdr_in_bounds` does not only check for bounds length but also if the extended token length field has a valid value as in RFC 8974. This PR hence adjusts the wording in the debug message to reflect that.


### Testing procedure

CI should be sufficient as well as good review.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
