### PR TITLE
nimble/netif: add rssi to netif header

### DIFF
--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -290,6 +290,8 @@ static netdev_t _nimble_netdev_dummy = {
 
 static void _on_data(nimble_netif_conn_t *conn, struct ble_l2cap_event *event)
 {
+    int res;
+
     struct os_mbuf *rxb = event->receive.sdu_rx;
     size_t rx_len = (size_t)OS_MBUF_PKTLEN(rxb);
 
@@ -301,8 +303,16 @@ static void _on_data(nimble_netif_conn_t *conn, struct ble_l2cap_event *event)
         goto end;
     }
 
+    gnrc_netif_hdr_t *netif_hdr = if_snip->data;
     /* we need to add the device PID to the netif header */
-    gnrc_netif_hdr_set_netif(if_snip->data, &_netif);
+    gnrc_netif_hdr_set_netif(netif_hdr, &_netif);
+
+    /* add RSSI to netif header */
+    int8_t rssi;
+    res = ble_gap_conn_rssi(conn->gaphandle, &rssi);
+    if (res == 0) {
+        netif_hdr->rssi = rssi;
+    }
 
     /* allocate space in the pktbuf to store the packet */
     gnrc_pktsnip_t *payload = gnrc_pktbuf_add(if_snip, NULL, rx_len, _nettype);
@@ -312,7 +322,7 @@ static void _on_data(nimble_netif_conn_t *conn, struct ble_l2cap_event *event)
     }
 
     /* copy payload from mbuf into pktbuffer */
-    int res = os_mbuf_copydata(rxb, 0, rx_len, payload->data);
+    res = os_mbuf_copydata(rxb, 0, rx_len, payload->data);
     if (res != 0) {
         gnrc_pktbuf_release(payload);
         goto end;


### PR DESCRIPTION
### Contribution description

Add RSSI to the netif header for ble packets using nimble's [`ble_gap_conn_rssi`](https://mynewt.apache.org/latest/network/ble_hs/ble_gap.html#c.ble_gap_conn_rssi), which returns the most recently read RSSI on the connection.
The RSSI is updated each time a data channel PDU is received, so it should be correct for the packet that the header is build for. cc @BOZHENG001

### Testing procedure

Tested with the `gnrc_networking` example:
- Connect two BLE nodes
- Pinging between the two nodes prints reasonable RSSI values (between -40 and -70)

### Issues/PRs references

### Declaration of AI-Tools / LLMs usage:


AI-Tools / LLMs that were used are:
- none
