### PR TITLE
.gitattributes: mark generated files as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,10 @@
 *.a binary
-*.patch binary
-Cargo.lock binary
+*.patch linguist-generated
+Cargo.lock linguist-generated
 # Default conflict marker size is 7 which causes some of the headings in
 # release-notes.txt to trigger git diff --check: 'leftover conflict marker'
 # when the heading is exactly 7 characters long.
 *.md conflict-marker-size=100
 *.txt conflict-marker-size=100
-*.svg binary
-package-lock.json binary
+*.svg linguist-generated
+package-lock.json linguist-generated


### PR DESCRIPTION
### Contribution description

Github uses [linguist][1] to classify files. Using the [`linguist-generated`][2] attribute disables those files from statistics and hides the diff by default. This is attribute also supported by Codeberg/forgejo and results in those files showing up as generated there as well.

[1]: https://github.com/github-linguist/linguist
[2]: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

### Testing procedure

Not sure if possible until merged... But the documentation can be read and manual review of the `.gitattributes` file should be possible.

### Issues/PRs references

None
### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
