### PR TITLE
.clang-tidy: disable warning about magic numbers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,9 +39,23 @@
 # Fine Tuning
 # -----------
 #
-# - readability-function-cognitive-complexity.IgnoreMacros: 'true':
-#       Otherwise the use of `DEBUG()...` will be penalized, even though it
-#       helps both in debugging and to document the code.
+# - readability-function-cognitive-complexity.IgnoreMacros: `true`:
+#       Otherwise the use of `DEBUG()` will be penalized, even though it
+#       helps both with debugging and with documenting the code.
+# - readability-identifier-length:
+#       Disabled because of too many false positives.. E.g., `fd` for file
+#       descriptors or `id` for IDs will be flagged, but are sensible variables
+#       names when the scope is the function body
+# - readability-magic-numbers:
+#       Disabled because of too many false positives. E.g. in
+#       ```
+#       size_t byte_pos = bitpos / 8;
+#       size_t byte_mask = 1U << (bitpos & 7);
+#       ```
+#       the numbers `8` and `7` are considered to be magic, but the code is
+#       still self-explanatory. Adding `#define BITS_PER_BYTE 8` and
+#       `#define BIT_POS_IN_BYTE_MASK 7` to silence the warning would not
+#       improve the readability here, but instead reduce it.
 #
 # Warning
 # -------
@@ -60,6 +74,7 @@ Checks: "clang-analyzer-*,
          -bugprone-reserved-identifier,
          -bugprone-easily-swappable-parameters,
          -readability-identifier-length,
+         -readability-magic-numbers
         "
 WarningsAsErrors: "bugprone-*,
                    portability-*,

--- a/dist/tools/ci/can_fast_ci_run.py
+++ b/dist/tools/ci/can_fast_ci_run.py
@@ -22,10 +22,10 @@ OTHER_CLASSIFIERS = [
     [re.compile(r"^(drivers\/include\/.*|sys\/include\/.*)$"), "public-headers"],
     [re.compile(r"^(Kconfig|kconfigs\/.*|pkg\/Kconfig|sys\/Kconfig|drivers\/Kconfig)$"), "kconfig"],
     [re.compile(r"^(.*\.cff|doc\/.*|.*\.md|.*\.txt)$"), "doc"],
-    [re.compile(r"^(CODEOWNERS|.mailmap|.gitignore|.github\/.*)$"), "git"],
+    [re.compile(r"^(CODEOWNERS|\.mailmap|\.gitignore|\.github|\.gitattributes)$"), "git"],
     [re.compile(r"^(\.murdock|dist\/ls\/.*|\.drone.yml)$"), "ci-murdock"],
     [re.compile(r"^(\.bandit|\.drone.yml)$"), "ci-other"],
-    [re.compile(r"^(dist\/.*|Vagrantfile)$"), "tools"],
+    [re.compile(r"^(dist\/.*|Vagrantfile|\.clang-format|\.clang-tidy)$"), "tools"],
 ]
 
 REGEX_MODULE = re.compile(r"^(boards\/common|core|cpu|drivers|sys)\/")


### PR DESCRIPTION
### Contribution description

Citing the comment in the script:

> Disabled because of too many false positives. E.g. in
> ```
> size_t byte_pos = bitpos / 8;
> size_t byte_mask = 1U << (bitpos & 7);
> ```
> the numbers `8` and `7` are considered to be magic, but the code is
> still self-explanatory. Adding `#define BITS_PER_BYTE 8` and
> `#define BIT_POS_IN_BYTE_MASK 7` to silence the warning would not
> improve the readability here, but instead reduce it.

In addition, the missing documentation of the reasoning for disabling the `readability-identifier-length` has been added as well.

### Testing procedure

Open a random file in RIOT with an editor/IDE that supports LSP and `clangd` installed. In `master`, the viewing the file is impossible due to the ridiculous amount of warnings. With this PR, the amount of annotations will be a lot more reasonable.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- LLM to review the wording in the comments for spelling, grammar and readability
