### PR TITLE
core/lib/rmutex: add recursion depth handling

### DIFF
--- a/core/lib/include/rmutex.h
+++ b/core/lib/include/rmutex.h
@@ -79,10 +79,10 @@ static inline void rmutex_init(rmutex_t *rmutex)
  * @brief Tries to get a recursive mutex, non-blocking.
  *
  * @param[in] rmutex Recursive mutex object to lock. Has to be
- *                  initialized first. Must not be NULL.
+ *                   initialized first. Must not be NULL.
  *
- * @return 1 if mutex was unlocked, now it is locked.
- * @return 0 if the mutex was locked.
+ * @retval 1 if the mutex was unlocked or locked by same thread, it is locked now.
+ * @retval 0 if the mutex was locked by another thread.
  */
 int rmutex_trylock(rmutex_t *rmutex);
 
@@ -90,9 +90,35 @@ int rmutex_trylock(rmutex_t *rmutex);
  * @brief Locks a recursive mutex, blocking.
  *
  * @param[in] rmutex Recursive mutex object to lock. Has to be
- *                 initialized first. Must not be NULL.
+ *                   initialized first. Must not be NULL.
  */
 void rmutex_lock(rmutex_t *rmutex);
+
+/**
+ * @brief Tries to get a recursive mutex without exceeding a maximum recursion depth,
+ *        non-blocking.
+ *
+ * @param[in] rmutex Recursive mutex object to lock. Has to be
+ *                   initialized first. Must not be NULL.
+ * @param[in] max    maximum recursion depth, must be > 0.
+ *
+ * @retval 1 if the mutex was unlocked, now it is locked.
+ * @retval 0 if the mutex was locked or the recursion depth has been exceeded.
+ */
+int rmutex_trylock_max(rmutex_t *rmutex, uint16_t max);
+
+/**
+ * @brief Tries to get a recursive mutex without exceeding a maximum recursion depth,
+ *        blocking.
+ *
+ * @param[in] rmutex Recursive mutex object to lock. Has to be
+ *                   initialized first. Must not be NULL.
+ * @param[in] max    maximum recursion depth.
+ *
+ * @retval 1 if the mutex was unlocked, now it is locked.
+ * @retval 0 if recursion depth was exceeded.
+ */
+int rmutex_lock_max(rmutex_t *rmutex, uint16_t max);
 
 /**
  * @brief Unlocks the recursive mutex.

--- a/core/lib/rmutex.c
+++ b/core/lib/rmutex.c
@@ -18,20 +18,35 @@
  *
  */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <inttypes.h>
 
 #include "assert.h"
 #include "atomic_utils.h"
+#include "panic.h"
 #include "rmutex.h"
 #include "thread.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-static int _lock(rmutex_t *rmutex, int trylock)
+/* default rmutex max value,
+ * might be reduced for debugging purposes*/
+#ifndef CONFIG_CORE_RMUTEX_MAX
+#define CONFIG_CORE_RMUTEX_MAX UINT16_MAX
+#endif
+
+static int _lock(rmutex_t *rmutex, uint16_t max, int trylock)
 {
     kernel_pid_t owner;
+
+    /* max == 0 capacity is always exceeded */
+    assert(max > 0);
+    if (max == 0) {
+        /* this is for NDEBUG handling of max == 0 */
+        return 0;
+    }
 
     /* try to lock the mutex */
     DEBUG("rmutex %" PRIi16 " : trylock\n", thread_getpid());
@@ -106,6 +121,15 @@ static int _lock(rmutex_t *rmutex, int trylock)
 
     DEBUG("rmutex %" PRIi16 " : increasing refs\n", thread_getpid());
 
+    /* due parameter max check we can be sure that max is always > 0 *
+     * -> refcount is > 0 at any of the following returns */
+
+    /* ensure we don't exceed refcount capacity */
+    if (rmutex->refcount >= max) {
+        /* refcount capacity reached or exceeded */
+        return 0;
+    }
+
     /* increase the refcount */
     rmutex->refcount++;
 
@@ -114,12 +138,24 @@ static int _lock(rmutex_t *rmutex, int trylock)
 
 void rmutex_lock(rmutex_t *rmutex)
 {
-    _lock(rmutex, 0);
+    if (!_lock(rmutex, CONFIG_CORE_RMUTEX_MAX, 0)) {
+        core_panic(PANIC_ASSERT_FAIL, "rmutex refcount overflow");
+    }
 }
 
 int rmutex_trylock(rmutex_t *rmutex)
 {
-    return _lock(rmutex, 1);
+    return _lock(rmutex, CONFIG_CORE_RMUTEX_MAX, 1);
+}
+
+int rmutex_lock_max(rmutex_t *rmutex, uint16_t max)
+{
+    return _lock(rmutex, max, 0);
+}
+
+int rmutex_trylock_max(rmutex_t *rmutex, uint16_t max)
+{
+    return _lock(rmutex, max, 1);
 }
 
 void rmutex_unlock(rmutex_t *rmutex)

--- a/tests/core/rmutex/main.c
+++ b/tests/core/rmutex/main.c
@@ -15,28 +15,29 @@
  * @}
  */
 
-#include <stdint.h>
 #include <inttypes.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "rmutex.h"
 #include "thread.h"
 
-#define THREAD_NUMOF            (5U)
+#define THREAD_NUMOF (5U)
 
 static char stacks[THREAD_NUMOF][THREAD_STACKSIZE_SMALL + THREAD_EXTRA_STACKSIZE_PRINTF];
 
-static const uint8_t prios[THREAD_NUMOF] = {THREAD_PRIORITY_MAIN - 1, 4, 5, 2, 4};
-static const uint8_t depth[THREAD_NUMOF] = {5, 3, 3, 4, 5};
+static const uint8_t prios[THREAD_NUMOF] = { THREAD_PRIORITY_MAIN - 1, 4, 5, 2, 4 };
+static const uint16_t depth[THREAD_NUMOF] = { 5, 3, 3, 4, 5 };
 
 static rmutex_t testlock;
 
-static void lock_recursive(uint8_t current_depth, uint8_t max_depth)
+static void lock_recursive(uint16_t current_depth, uint16_t max_depth)
 {
     thread_t *t = thread_get_active();
 
     printf("T%i (prio %i, depth %i): trying to lock rmutex now\n",
-        (int)t->pid, (int)t->priority, (int)current_depth);
+           (int)t->pid, (int)t->priority, (int)current_depth);
     rmutex_lock(&testlock);
 
     printf("T%i (prio %i, depth %i): locked rmutex now\n",
@@ -63,11 +64,44 @@ static void *lockme(void *arg)
     return NULL;
 }
 
+static void lock_recursive_max(uint16_t current_depth, uint16_t max_depth)
+{
+    thread_t *t = thread_get_active();
+
+    printf("T%i (prio %i, depth %i): trying to lock rmutex now\n",
+           (int)t->pid, (int)t->priority, (int)current_depth);
+
+    if (rmutex_lock_max(&testlock, max_depth)) {
+        printf("T%i (prio %i, depth %i): locked rmutex now\n",
+               (int)t->pid, (int)t->priority, (int)current_depth);
+
+        lock_recursive_max(current_depth + 1, max_depth);
+        thread_yield();
+        rmutex_unlock(&testlock);
+        printf("T%i (prio %i, depth %i): unlocked rmutex\n",
+               (int)t->pid, (int)t->priority, (int)current_depth);
+    }
+    else {
+        printf("T%i (prio %i, depth %i): did not lock rmutex\n",
+               (int)t->pid, (int)t->priority, (int)current_depth);
+    }
+}
+
+static void *lockme_max(void *arg)
+{
+    uintptr_t depth = (uintptr_t)arg;
+
+    lock_recursive_max(0, depth);
+
+    return NULL;
+}
+
 int main(void)
 {
-    puts("Recursive Mutex test");
+    puts("Recursive Mutex Test");
     puts("Please refer to the README.md for more information\n");
 
+    puts("Test 1 BEGIN");
     rmutex_init(&testlock);
 
     /* lock mutex, so that spawned threads have to wait */
@@ -75,7 +109,7 @@ int main(void)
     /* create threads */
     for (unsigned i = 0; i < THREAD_NUMOF; i++) {
         thread_create(stacks[i], sizeof(stacks[i]), prios[i], 0,
-                      lockme, (void*)(intptr_t)depth[i], "t");
+                      lockme, (void *)(intptr_t)depth[i], "t");
     }
     /* allow threads to lock the mutex */
     printf("main: unlocking recursive mutex\n");
@@ -83,7 +117,26 @@ int main(void)
     rmutex_unlock(&testlock);
 
     rmutex_lock(&testlock);
-    puts("\nTest END, check the order of priorities above.");
+    puts("\nTest 1 END, check the order of priorities above.");
+
+    /* After the first test the schedule entries and stacks are unused,
+     * so they will be reused. Ensure they are empty. */
+    memset(stacks, 0, sizeof(stacks));
+    puts("Rerunning the test using rmutex_lock_max(..)\n");
+
+    puts("Test 2 BEGIN");
+    /* create threads */
+    for (unsigned i = 0; i < THREAD_NUMOF; i++) {
+        thread_create(stacks[i], sizeof(stacks[i]), prios[i], 0,
+                      lockme_max, (void *)(intptr_t)depth[i], "t");
+    }
+    /* allow threads to lock the mutex */
+    printf("main: unlocking recursive mutex\n");
+
+    rmutex_unlock(&testlock);
+
+    rmutex_lock(&testlock);
+    puts("\nTest 2 END, check the order of priorities above.");
 
     return 0;
 }

--- a/tests/core/rmutex/tests/01-run.py
+++ b/tests/core/rmutex/tests/01-run.py
@@ -24,6 +24,7 @@ def testfunc(child):
     #  T4 (prio 6): waiting on condition variable now
     thread_prios = {}
     lock_depth = {}
+    child.expect("Test 1 BEGIN")
     for nr in range(NUM_THREADS):
         child.expect(r"T(\d+) \(prio (\d+), depth 0\): trying to lock rmutex now")
         thread_id = int(child.match.group(1))
@@ -36,6 +37,21 @@ def testfunc(child):
         for depth in range(lock_depth[T]):
             child.expect_exact("T{} (prio {}, depth {}): locked rmutex now"
                                .format(T, thread_prios[T], depth))
+    child.expect("Test 1 END")
+    child.expect("Test 2 BEGIN")
+    for nr in range(NUM_THREADS):
+        child.expect(r"T(\d+) \(prio (\d+), depth 0\): trying to lock rmutex now")
+        thread_id = int(child.match.group(1))
+        thread_prio = int(child.match.group(2))
+        thread_prios[thread_id] = thread_prio
+        lock_depth[thread_id] = expected_lock_depth[nr]
+
+    pri_sorted = sorted(thread_prios, key=lambda x: thread_prios[x] * 1000 + x)
+    for T in pri_sorted:
+        for depth in range(lock_depth[T]):
+            child.expect_exact("T{} (prio {}, depth {}): locked rmutex now"
+                               .format(T, thread_prios[T], depth))
+    child.expect("Test 2 END")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This adds recursion depth handling for rmutex (counting is limited to UINT16_MAX ( fail the lock if failable assert (using assume) if fail is not an option) 

adds recursion depth limited 
rmutex_lock_max( rmutex, max); 
rmutex_trylock_max( rmutex, max);

### Testing procedure

run `tests/core/rmutex` its expected to run twice now once 
Test 1 is previous in test depth limited rmutex_lock 
Test 2 the new in library depth limited rmutex_lock_max

`make -C tests/core/rmutex flash test`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- none
