### PR TITLE
sys/clif: change use of `const` qualifier

### DIFF
--- a/sys/clif/clif.c
+++ b/sys/clif/clif.c
@@ -64,7 +64,7 @@ static const unsigned _attr_to_size[] = {
 #define ATTRS_NUMOF ARRAY_SIZE(_attr_to_str)
 
 ssize_t clif_decode_link(clif_t *link, clif_attr_t *attrs, unsigned attrs_len,
-                         const char *buf, size_t maxlen)
+                         char *buf, size_t maxlen)
 {
 
     assert(buf);
@@ -229,10 +229,10 @@ ssize_t clif_add_attr(clif_attr_t *attr, char *buf, size_t maxlen)
     return pos;
 }
 
-ssize_t clif_get_target(const char *input, size_t input_len, char **output)
+ssize_t clif_get_target_const(const char *input, size_t input_len, const char **output)
 {
     assert(input);
-    char *target_end;
+    const char *target_end;
 
     *output = memchr(input, LF_PATH_BEGIN_C, input_len);
     if (!*output) {

--- a/sys/include/clif.h
+++ b/sys/include/clif.h
@@ -183,7 +183,7 @@ ssize_t clif_encode_link(const clif_t *link, char *buf, size_t maxlen);
  * @return CLIF_NOT_FOUND if the string is malformed
  */
 ssize_t clif_decode_link(clif_t *link, clif_attr_t *attrs, unsigned attrs_len,
-                         const char *buf, size_t maxlen);
+                         char *buf, size_t maxlen);
 
 /**
  * @brief   Adds a given @p target to a given buffer @p buf using link format
@@ -270,9 +270,29 @@ ssize_t clif_add_link_separator(char *buf, size_t maxlen);
  *                          beginning of it
  *
  * @return length of the target if found
- * @return CLIF_NOT_FOUND if no valid target is found
+ * @retval CLIF_NOT_FOUND   no valid target is found
  */
-ssize_t clif_get_target(const char *input, size_t input_len, char **output);
+ssize_t clif_get_target_const(const char *input, size_t input_len, const char **output);
+
+/**
+ * @brief   Same as @ref clif_get_target_const but with non-`const` memory
+ *
+ * @pre `input != NULL`
+ *
+ * @param[in]  input        string where to look for the target. It should only
+ *                          be ONE link. Must not be NULL.
+ * @param[in]  input_len    length of @p input.
+ * @param[out] output       if a target is found this will point to the
+ *                          beginning of it
+ *
+ * @return length of the target if found
+ * @retval CLIF_NOT_FOUND   no valid target is found
+ */
+static inline ssize_t clif_get_target(char *input, size_t input_len, char **output)
+{
+    return clif_get_target_const(input, input_len, (const char **)output);
+}
+
 /**
  * @brief   Looks for the first attribute in a given link.
  *


### PR DESCRIPTION
### Contribution description

- change `clif_get_target()` to require a non-`const` input pointer, as it returns a non-`const` output pointer
- add `clif_get_target_const()` that does take a `const` input pointer, but returns a `const` output pointer
- change `clif_decode_link()` to require a non-`const` input pointer, as the pointer in `clif_t` is also non-`const`

This fixes the compilation on Ubuntu 26.04. Here the newg ibc headers changed the signature of `memchr()` to return `const void *` instead of `void *` if and only if the input was `const void *`. Previously, the call of `memchr()` allowed to silently discard the `const` qualifier, but that now fails with modern glibc.

This change not only improves the memory safety of the API, but also fixes compilation issues on Ubuntu 26.04.


### Testing procedure

#### `master`

```
make BOARD=native64 -C tests/unittests -j64
make: Entering directory '/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests'
Due to limitations in the gcoap API it is currently not possible to use a dual stack setup
Building application "tests_unittests" for "native64" with CPU "native".
[...]
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/clif/clif.c: In function ‘clif_get_target’:
/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/sys/clif/clif.c:237:13: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
  237 |     *output = memchr(input, LF_PATH_BEGIN_C, input_len);
      |             ^
cc1: all warnings being treated as errors
```

#### This PR

```
git:(sys/clif) ~/Repos/software/RIOT/master ➜ make BOARD=native64 -C tests/unittests -j64
make: Entering directory '/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests'
Due to limitations in the gcoap API it is currently not possible to use a dual stack setup
Building application "tests_unittests" for "native64" with CPU "native".
[...]
   text	   data	    bss	    dec	    hex	filename
1910803	 459592	 236496	2606891	 27c72b	/home/marian.buschsieweke@ml-pa.loc/Repos/software/RIOT/master/tests/unittests/bin/native64/tests_unittests.elf
```

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
