### PR TITLE
coding convention: break brace after multiline control statement

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -35,7 +35,7 @@ BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
   AfterClass: false
-  AfterControlStatement: false
+  AfterControlStatement: MultiLine
   AfterEnum: false
   AfterFunction: true
   AfterNamespace: true

--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -185,6 +185,19 @@ of recognised exceptions where we can (or even must) rely on extensions include:
     else {
         println("DEBUG ELSE");
     }
+
+    /* for multiline conditions: instead of: */
+    if (this_really_long_boolean_expression_it_barely_fits_in_a_single_line &&
+        this_is_another_very_long_expression) {
+        do_something();
+    }
+
+    /* write: */
+    if (this_really_long_boolean_expression_it_barely_fits_in_a_single_line &&
+        this_is_another_very_long_expression)
+    {
+        do_something();
+    }
 ```
 * Commas are always followed by a space.
 * For complex statements it is always good to use more parentheses - or split up

--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -173,6 +173,10 @@ of recognised exceptions where we can (or even must) rely on extensions include:
   `do`-statement, it goes into the same line.
 * Use curly braces even for one-line blocks. This improves debugging and later
   additions.
+* For long multiline conditions in `if-else`-statements, the opening bracket
+  should be placed in the next line to allow for a better distinction between
+  the conditions and the following code inside of the brackets, as they are
+  at the same or similar indentation levels. An example is given below.
 ```c
     /* instead of: */
     if (debug) println("DEBUG");


### PR DESCRIPTION
### Contribution description

We current do not wrap the brace after a control statement ever. This changes the behavior to still not break the line before the brace by default, but do break it on multiline statements.

E.g. before:

```c
if (boolean_expr1) {
    do_something();
}

if (boolean_expr2 &&
    boolean_expr3) {
    do_something();
}
```

With this change this now becomes:

```c
if (boolean_expr1) {
    do_something();
}

if (boolean_expr2 &&
    boolean_expr3)
{
    do_something();
}
```

Note that the behavior before suffered from poor readability of the code structure, as the indent does not make it obvious where the condition of the if statements ends and where the function body starts. With this change, the code becomes one line longer for the rare long boolean expressions, but the code structure is much easier to spot.

### Testing procedure

`clang-format` will not remove the line break in front of `{` if and only if the condition is split over multiple lines.

Sadly, `clang-format` will not add the line breaks ever unless a maximum line width is specified. But `clang-format` is relatively heavy-handing in filling lines up until the column limit, which doesn't match with the soft and hard column limit defined in our coding conventions. Hence, reflowing content has been disabled in clang-format so far.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none

### PR State

- [x] update `clang-format` to match the updated coding convention
- [ ] update `uncrustify` to match the updated coding convention