### PR TITLE
.github/workflows: only run Guide Deployment if Secret is configured

### DIFF
--- a/.github/workflows/deploy-guides.yml
+++ b/.github/workflows/deploy-guides.yml
@@ -1,4 +1,4 @@
-name: Build Docs
+name: Deploy Guides to RIOT-OS.org Server
 
 on:
   push:
@@ -32,7 +32,7 @@ jobs:
             echo "defined=false" >> $GITHUB_OUTPUT;
           fi
 
-  deploy-docs:
+  deploy-guide:
     runs-on: ubuntu-latest
     needs: [check-secret]
     if: needs.check-secret.outputs.secret-configured == 'true'

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,41 +1,41 @@
 name: Build Docs
 
 on:
-    push:
-        branches:
-            - master
-        paths:
-            - 'doc/guides/**'
-            - 'doc/starlight/**'
-            - 'CODE_OF_CONDUCT.md'
-            - 'GOVERNANCE.md'
-            - 'CONTRIBUTING.md'
-            - 'CODING_CONVENTIONS*.md'
-            - 'SECURITY.md'
-            - 'release-notes.txt'
+  push:
+    branches:
+      - master
+    paths:
+      - 'doc/guides/**'
+      - 'doc/starlight/**'
+      - 'CODE_OF_CONDUCT.md'
+      - 'GOVERNANCE.md'
+      - 'CONTRIBUTING.md'
+      - 'CODING_CONVENTIONS*.md'
+      - 'SECURITY.md'
+      - 'release-notes.txt'
 
 jobs:
-    build-docs:
-        runs-on: ubuntu-latest
-        defaults:
-            run:
-                working-directory: doc/starlight
-        steps:
-          - name: Checkout repository
-            uses: actions/checkout@v4
-          - name: Set up Node.js
-            uses: actions/setup-node@v6
-            with:
-                node-version: '25.x'
-          - name: Build documentation
-            run: make build
-          - name: Deploy to riot-os.org server
-            uses: burnett01/rsync-deployments@v8
-            with:
-              switches: -avzr --delete
-              path: doc/starlight/dist/
-              remote_path: /
-              remote_host: ${{ secrets.SSH_GUIDES_REMOTE_HOST }}
-              remote_port: ${{ secrets.SSH_GUIDES_REMOTE_PORT }}
-              remote_user: ${{ secrets.SSH_GUIDES_REMOTE_USER }}
-              remote_key: ${{ secrets.SSH_GUIDES_PRIVATE_KEY }}
+  build-docs:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: doc/starlight
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+            node-version: '25.x'
+      - name: Build documentation
+        run: make build
+      - name: Deploy to riot-os.org server
+        uses: burnett01/rsync-deployments@v8
+        with:
+          switches: -avzr --delete
+          path: doc/starlight/dist/
+          remote_path: /
+          remote_host: ${{ secrets.SSH_GUIDES_REMOTE_HOST }}
+          remote_port: ${{ secrets.SSH_GUIDES_REMOTE_PORT }}
+          remote_user: ${{ secrets.SSH_GUIDES_REMOTE_USER }}
+          remote_key: ${{ secrets.SSH_GUIDES_PRIVATE_KEY }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -15,8 +15,27 @@ on:
       - 'release-notes.txt'
 
 jobs:
-  build-docs:
+  check-secret:
     runs-on: ubuntu-latest
+    outputs:
+      secret-configured: ${{ steps.secret-exists-check.outputs.defined }}
+    steps:
+      - name: Check if Secret is configured
+        id: secret-exists-check
+        # check if the secrets are configured before running the tasks
+        # see: https://stackoverflow.com/a/70249520
+        shell: bash
+        run: |
+          if [ "${{ secrets.SSH_GUIDES_PRIVATE_KEY }}" != '' ]; then
+            echo "defined=true" >> $GITHUB_OUTPUT;
+          else
+            echo "defined=false" >> $GITHUB_OUTPUT;
+          fi
+
+  deploy-docs:
+    runs-on: ubuntu-latest
+    needs: [check-secret]
+    if: needs.check-secret.outputs.secret-configured == 'true'
     defaults:
       run:
         working-directory: doc/starlight

--- a/.github/workflows/test-guides.yml
+++ b/.github/workflows/test-guides.yml
@@ -1,4 +1,4 @@
-name: Guide Docs Build Test
+name: Guide Build Test
 
 on:
   pull_request:
@@ -12,7 +12,7 @@ on:
       - 'release-notes.txt'
 
 jobs:
-  build-docs:
+  build-guide:
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -1,28 +1,28 @@
 name: Guide Docs Build Test
 
 on:
-    pull_request:
-        paths:
-            - 'doc/guides/**'
-            - 'doc/starlight/**'
-            - 'CODE_OF_CONDUCT.md'
-            - 'GOVERNANCE.md'
-            - 'CONTRIBUTING.md'
-            - 'CODING_CONVENTIONS*.md'
-            - 'release-notes.txt'
+  pull_request:
+    paths:
+      - 'doc/guides/**'
+      - 'doc/starlight/**'
+      - 'CODE_OF_CONDUCT.md'
+      - 'GOVERNANCE.md'
+      - 'CONTRIBUTING.md'
+      - 'CODING_CONVENTIONS*.md'
+      - 'release-notes.txt'
 
 jobs:
-    build-docs:
-        runs-on: ubuntu-latest
-        defaults:
-            run:
-                working-directory: doc/starlight
-        steps:
-          - name: Checkout repository
-            uses: actions/checkout@v4
-          - name: Set up Node.js
-            uses: actions/setup-node@v6
-            with:
-                node-version: '25.x'
-          - name: Build documentation
-            run: make build
+  build-docs:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: doc/starlight
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+            node-version: '25.x'
+      - name: Build documentation
+        run: make build


### PR DESCRIPTION
### Contribution description

This is a follow up for #22085 that adds the conditional execution for the Guide Deployment workflow.

Also I fixed the indentation for two workflows and renamed the titles from `test_docs` and `deploy_docs` to `test-guides` and `deploy-guides` and also gave the workflows the `guides` name.

At least for me, `docs` is still connected to Doxygen, so I was properly confused when getting mails about failed doc workflows 😅 

### Testing procedure

Not sure?

### Issues/PRs references

Follow up for #22085.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
