### PR TITLE
make: add tools-check target for host toolchain sanity checks

### DIFF
--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -20,6 +20,15 @@ get_cmd_version() {
     printf "%s" "$VERSION"
 }
 
+collect_issue() {
+    local issues_ref="$1"
+    local label="$2"
+    local version="$3"
+    if [ "$version" = "missing" ] || echo "$version" | grep -q '^error:'; then
+        eval "$issues_ref=\"${!issues_ref}\n- ${label}: ${version}\""
+    fi
+}
+
 get_define() {
     local cc="$1"
     local line=
@@ -199,5 +208,21 @@ for c in \
 done
 printf "%25s: %s\n" "flake8" "$(get_cmd_version "python3 -Wignore -m flake8")"
 printf "%25s: %s\n" "coccinelle" "$(get_cmd_version spatch)"
+
+ISSUES=""
+collect_issue ISSUES "python3" "$(get_cmd_version python3)"
+collect_issue ISSUES "git" "$(get_cmd_version git)"
+collect_issue ISSUES "make" "$(get_cmd_version ${MAKE})"
+collect_issue ISSUES "arm-none-eabi-gcc" "$(get_cmd_version arm-none-eabi-gcc)"
+collect_issue ISSUES "openocd" "$(get_cmd_version openocd)"
+
+if [ -n "$ISSUES" ]; then
+    printf "\n"
+    printf "%s\n" "Potential issues"
+    printf "%s\n" "----------------"
+    printf "%b\n" "$ISSUES" | sed '/^$/d'
+    printf "%s\n" ""
+    printf "%s\n" "Install the missing tools and re-run 'make print-versions' to verify."
+fi
 
 exit 0

--- a/makefiles/tools/targets.inc.mk
+++ b/makefiles/tools/targets.inc.mk
@@ -6,6 +6,32 @@
 
 .PHONY: mosquitto_rsmb
 
+.PHONY: tools-check
+
+tools-check:
+	@set -e; \
+	missing=0; \
+	check() { \
+		name="$$1"; \
+		hint="$$2"; \
+		if command -v "$$name" >/dev/null 2>&1; then \
+			printf "[OK] %s\n" "$$name"; \
+		else \
+			printf "[MISSING] %s\n" "$$name"; \
+			if [ -n "$$hint" ]; then printf "  hint: %s\n" "$$hint"; fi; \
+			missing=1; \
+		fi; \
+	}; \
+	check python3 "Install Python 3 and ensure it is in PATH."; \
+	check git "Install Git and ensure it is in PATH."; \
+	check make "Install GNU make (e.g., via your distro/MSYS2/WSL)."; \
+	check arm-none-eabi-gcc "Install the ARM embedded toolchain (arm-none-eabi-gcc)."; \
+	check openocd "Install OpenOCD if you flash using OpenOCD-based programmers."; \
+	check pyserial-miniterm "Install pyserial if you use serial terminal helpers: pip install pyserial"; \
+	if [ "$$missing" -ne 0 ]; then \
+		exit 1; \
+	fi
+
 # target for building the bossac binary
 $(RIOTTOOLS)/bossa-$(BOSSA_VERSION)/bossac:
 	@echo "[INFO] bossac $(BOSSA_VERSION) binary not found - building it from source"

--- a/makefiles/tools/targets.inc.mk
+++ b/makefiles/tools/targets.inc.mk
@@ -6,32 +6,6 @@
 
 .PHONY: mosquitto_rsmb
 
-.PHONY: tools-check
-
-tools-check:
-	@set -e; \
-	missing=0; \
-	check() { \
-		name="$$1"; \
-		hint="$$2"; \
-		if command -v "$$name" >/dev/null 2>&1; then \
-			printf "[OK] %s\n" "$$name"; \
-		else \
-			printf "[MISSING] %s\n" "$$name"; \
-			if [ -n "$$hint" ]; then printf "  hint: %s\n" "$$hint"; fi; \
-			missing=1; \
-		fi; \
-	}; \
-	check python3 "Install Python 3 and ensure it is in PATH."; \
-	check git "Install Git and ensure it is in PATH."; \
-	check make "Install GNU make (e.g., via your distro/MSYS2/WSL)."; \
-	check arm-none-eabi-gcc "Install the ARM embedded toolchain (arm-none-eabi-gcc)."; \
-	check openocd "Install OpenOCD if you flash using OpenOCD-based programmers."; \
-	check pyserial-miniterm "Install pyserial if you use serial terminal helpers: pip install pyserial"; \
-	if [ "$$missing" -ne 0 ]; then \
-		exit 1; \
-	fi
-
 # target for building the bossac binary
 $(RIOTTOOLS)/bossa-$(BOSSA_VERSION)/bossac:
 	@echo "[INFO] bossac $(BOSSA_VERSION) binary not found - building it from source"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

## Motivation
 
RIOT builds and flashing workflows commonly fail due to missing host-side tools (e.g., Python, git, ARM toolchain, OpenOCD, pyserial).
These failures often happen late and can be confusing for new contributors.
 
## Change
 
Add a new `make tools-check` target that:
- checks for common tools via `command -v`
- prints a clear `[OK]` / `[MISSING]` status line
- provides a short hint for installing missing tools
- exits non-zero if anything is missing
 
Tools checked:
- `python3`
- `git`
- `make`
- `arm-none-eabi-gcc`
- `openocd`
- `pyserial-miniterm`
 
## How to test
 
Run:
```sh
make tools-check
