### PR TITLE
tools/uf2: allow UF2_MOUNTPOINT override

### DIFF
--- a/boards/common/adafruit-nrf52-bootloader/doc.md
+++ b/boards/common/adafruit-nrf52-bootloader/doc.md
@@ -58,6 +58,20 @@ for in common mounting locations. If the device is not mounted, the flashing
 process fails. Please configure automounting in this case or refer to the
 [`adafruit-nrfutil` Programmer](@ref ada-nrf52-adafruit-nrfutil).
 
+#### Set a Custom Mounting Point
+
+If the UF2 mass storage device cannot be detected automatically or if multiple
+UF2 devices are connected at the same time, you can explicitly specify the
+mountpoint by setting `UF2_MOUNTPOINT` to the path that contains
+`INFO_UF2.TXT`.
+
+Example:
+```sh
+make UF2_MOUNTPOINT=/media/$USER/FEATHER52840 BOARD=adafruit-feather-nrf52840-express -C examples/basic/hello-world flash
+```
+
+#### Handling the SoftDevice
+
 The board definitions with RIOT retain the SoftDevice firmware blob shipped with
 the original Adafruit nRF52 Bootloader that is used by i.a. Arduino and
 CircuitPython but not used by RIOT. If you want to override the SoftDevice

--- a/dist/tools/uf2/nrf52_softdevice_check.sh
+++ b/dist/tools/uf2/nrf52_softdevice_check.sh
@@ -16,8 +16,14 @@
 : "${RIOTBASE:=$(cd "$(dirname "$0")"/../../../ || exit; pwd)}"
 : "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
 
-# The uf2conv script lists all currently mounted devices with UF2 bootloader
-MOUNTPOINT=$("${RIOTTOOLS}"/uf2/uf2conv.py --list | cut -d ' ' -f1)
+# Allow overriding the UF2 mass storage mountpoint.
+# This is useful on systems where automatic mount detection is unreliable.
+if [ -n "${UF2_MOUNTPOINT}" ]; then
+    MOUNTPOINT="${UF2_MOUNTPOINT}"
+else
+    # The uf2conv script lists all currently mounted devices with UF2 bootloader
+    MOUNTPOINT=$("${RIOTTOOLS}"/uf2/uf2conv.py --list | cut -d ' ' -f1)
+fi
 
 if [ -z "${MOUNTPOINT}" ]; then
     echo "No device with UF2 bootloader found!"
@@ -27,7 +33,9 @@ fi
 if [ ! "$(echo "${MOUNTPOINT}" | wc -l)" -eq 1 ]; then
     echo "More than one device with UF2 bootloader found!"
     echo "RIOT cannot distinguish the correct device."\
-    "Please connect no more than one device at a time."
+    "Please connect no more than one device at a time"\
+    "or specify which device to use with the UF2_MOUNTPOINT environment"\
+    "variable."
     exit 1
 fi
 

--- a/makefiles/tools/uf2conv.inc.mk
+++ b/makefiles/tools/uf2conv.inc.mk
@@ -20,7 +20,7 @@ flashfile-format-check:
 # Execute the SoftDevice check. It verifies that the SoftDevice is present if
 # needed, that the versions match and that it is not accidentally overridden.
 uf2-softdevice-check:
-	@UF2_SOFTDEV=$(UF2_SOFTDEV) $(RIOTTOOLS)/uf2/nrf52_softdevice_check.sh
+	@UF2_SOFTDEV=$(UF2_SOFTDEV) UF2_MOUNTPOINT=$(UF2_MOUNTPOINT) $(RIOTTOOLS)/uf2/nrf52_softdevice_check.sh
 	@if [ $$? -ne 0 ]; then \
 		exit 1; \
   fi


### PR DESCRIPTION
## Problem
 
`make flash` for UF2-based nRF52 boards runs a SoftDevice sanity check via [dist/tools/uf2/nrf52_softdevice_check.sh](cci:7://file:///c:/Users/PAILFAC/Downloads/Clients/Mary/RIOT/dist/tools/uf2/nrf52_softdevice_check.sh:0:0-0:0).
That script relies on auto-detecting the UF2 mass-storage mountpoint using `uf2conv.py --list`.
 
On some host environments (notably Windows/MSYS2/Cygwin), mount/drive detection can be unreliable, causing the SoftDevice check to fail with:
- `No device with UF2 bootloader found!`
 
This blocks flashing even if the user can see the UF2 drive and knows its mount path.
 
## Solution
 
Add an explicit override:
- If `UF2_MOUNTPOINT` is set, [nrf52_softdevice_check.sh](cci:7://file:///c:/Users/PAILFAC/Downloads/Clients/Mary/RIOT/dist/tools/uf2/nrf52_softdevice_check.sh:0:0-0:0) uses it as the mountpoint instead of auto-detecting.
- When auto-detecting (default), the existing “more than one device found” safeguard remains unchanged.
 
Additionally, pass `UF2_MOUNTPOINT` through from `make` into the script for UF2 flashing flows.
 
## How to test
 
- Plug a UF2-capable nRF52 board in bootloader mode (mass-storage drive visible).
- Run:
  ```sh
  make -C <app> BOARD=<board> flash UF2_MOUNTPOINT=<path-to-UF2-drive>
