### PR TITLE
doc/starlight: Add SPDX headers

### DIFF
--- a/doc/starlight/astro.config.ts
+++ b/doc/starlight/astro.config.ts
@@ -1,3 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Tom Hert <git@annsann.eu>
+ * SPDX-FileCopyrightText: 2026 Lasse Rosenow <Lasse.Rosenow@haw-hamburg.de>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 import rehypeGithubEmoji from "rehype-github-emoji";

--- a/doc/starlight/src/components/FileTree.astro
+++ b/doc/starlight/src/components/FileTree.astro
@@ -1,4 +1,10 @@
 ---
+/*
+ * SPDX-FileCopyrightText: 2026 Lasse Rosenow <Lasse.Rosenow@haw-hamburg.de>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 import { FileTree as StarlightFileTree } from "@astrojs/starlight/components";
 ---
 

--- a/doc/starlight/src/components/contact.astro
+++ b/doc/starlight/src/components/contact.astro
@@ -1,4 +1,10 @@
 ---
+/*
+ * SPDX-FileCopyrightText: 2026 Tom Hert <git@annsann.eu>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 import { Aside } from "@astrojs/starlight/components";
 ---
 

--- a/doc/starlight/src/components/gitsetup.mdx
+++ b/doc/starlight/src/components/gitsetup.mdx
@@ -1,3 +1,9 @@
+{/*
+ * SPDX-FileCopyrightText: 2025 Tom Hert <git@annsann.eu>
+ * SPDX-FileCopyrightText: 2025 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */}
+
 import FileTree from '@components/FileTree.astro';
 
 :::note

--- a/doc/starlight/src/content.config.ts
+++ b/doc/starlight/src/content.config.ts
@@ -1,3 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Lasse Rosenow <Lasse.Rosenow@haw-hamburg.de>
+ * SPDX-FileCopyrightText: 2026 Tom Hert <git@annsann.eu>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 import { defineCollection } from "astro:content";
 import { type Loader } from "astro/loaders";
 import { docsSchema } from "@astrojs/starlight/schema";

--- a/doc/starlight/src/fonts/font-face.css
+++ b/doc/starlight/src/fonts/font-face.css
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Lasse Rosenow <Lasse.Rosenow@haw-hamburg.de>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 @font-face {
   font-family: "Miso";
   src: url("../../../doxygen/src/fonts/miso.eot");

--- a/doc/starlight/src/lib/doxygen_filter.ts
+++ b/doc/starlight/src/lib/doxygen_filter.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Tom Hert <git@annsann.eu>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 /**
  * Clean up text by removing leading/trailing asterisks and quotes.
  * @param value The text to clean.

--- a/doc/starlight/src/pages/boards.astro
+++ b/doc/starlight/src/pages/boards.astro
@@ -1,4 +1,11 @@
 ---
+/*
+ * SPDX-FileCopyrightText: 2026 Tom Hert <git@annsann.eu>
+ * SPDX-FileCopyrightText: 2026 Lasse Rosenow <Lasse.Rosenow@haw-hamburg.de>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 import { getCollection } from "astro:content";

--- a/doc/starlight/src/pages/boards/[boardname].astro
+++ b/doc/starlight/src/pages/boards/[boardname].astro
@@ -1,4 +1,11 @@
 ---
+/*
+ * SPDX-FileCopyrightText: 2026 Tom Hert <git@annsann.eu>
+ * SPDX-FileCopyrightText: 2026 Lasse Rosenow <Lasse.Rosenow@haw-hamburg.de>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 import { LinkCard, Code, Aside, CardGrid } from "@astrojs/starlight/components";
 import { getCollection, render } from "astro:content";

--- a/doc/starlight/src/pages/changelog.astro
+++ b/doc/starlight/src/pages/changelog.astro
@@ -1,4 +1,10 @@
 ---
+/*
+ * SPDX-FileCopyrightText: 2026 Lasse Rosenow <Lasse.Rosenow@haw-hamburg.de>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 import { LinkButton, LinkCard } from "@astrojs/starlight/components";
 import { getCollection } from "astro:content";

--- a/doc/starlight/src/pages/changelog/[version].astro
+++ b/doc/starlight/src/pages/changelog/[version].astro
@@ -1,4 +1,11 @@
 ---
+/*
+ * SPDX-FileCopyrightText: 2026 Lasse Rosenow <Lasse.Rosenow@haw-hamburg.de>
+ * SPDX-FileCopyrightText: 2026 Tom Hert <git@annsann.eu>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 import { LinkCard } from "@astrojs/starlight/components";
 import { getCollection, render } from "astro:content";

--- a/doc/starlight/src/pages/changelog/rss.xml.js
+++ b/doc/starlight/src/pages/changelog/rss.xml.js
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Lasse Rosenow <Lasse.Rosenow@haw-hamburg.de>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 import rss from "@astrojs/rss";
 import { getCollection } from "astro:content";
 

--- a/doc/starlight/src/routeData.ts
+++ b/doc/starlight/src/routeData.ts
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Tom Hert <git@annsann.eu>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 import { defineRouteMiddleware } from "@astrojs/starlight/route-data";
 
 const generatedPath = "/doc/guides/generated/";

--- a/doc/starlight/src/styles/custom.css
+++ b/doc/starlight/src/styles/custom.css
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Lasse Rosenow <Lasse.Rosenow@haw-hamburg.de>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 /* Dark mode colors. */
 :root {
   --sl-color-accent-low: #002c1c;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

As part of my settlement for an approval by @crasbe, here is the PR to add SPDX headers to the starlight code.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`make doc-starlight`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- none
