### PR TITLE
makefiles/docker: add user group ID to user command

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -145,7 +145,7 @@ _docker_is_podman = $(shell $(DOCKER) --version | grep podman 2>/dev/null)
 # - allocate a pseudo-tty
 # - remove container on exit
 # - set username/UID to executor
-DOCKER_USER ?= $$(id -u)
+DOCKER_USER ?= $$(id -u):$$(id -g)
 DOCKER_USER_OPT = $(if $(_docker_is_podman),--userns keep-id,--user $(DOCKER_USER))
 DOCKER_RUN_FLAGS ?= --rm --tty $(DOCKER_USER_OPT)
 


### PR DESCRIPTION
### Contribution description

This is the counterpart to RIOT-OS/riotdocker#266 and sets the user group ID for the user inside of the `riotbuild` docker container. This avoids having files with the wrong group (`root` group) on the file system for shared folders (such as `.gitcache`).

More details can be found in RIOT-OS/riotdocker#266.

### Testing procedure

See RIOT-OS/riotdocker#266.

### Issues/PRs references

Depends on RIOT-OS/riotdocker#266.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
