### PR TITLE
examples: migrate schedstatistics CFLAG to USEMODULE

### DIFF
--- a/examples/advanced/opendsme/Makefile
+++ b/examples/advanced/opendsme/Makefile
@@ -18,7 +18,7 @@ RIOTBASE ?= $(CURDIR)/../../..
 #EXTERNAL_BOARD_DIRS ?= $(CURDIR)/../../../thirdparty_boards
 
 # Uncomment this to enable scheduler statistics for ps:
-#CFLAGS += -DSCHEDSTATISTICS
+#USEMODULE += schedstatistics
 
 # If you want to use native with valgrind, you should recompile native
 # with the target all-valgrind instead of all:

--- a/examples/lang_support/official/riot_and_cpp/Makefile
+++ b/examples/lang_support/official/riot_and_cpp/Makefile
@@ -13,7 +13,7 @@ RIOTBASE ?= $(CURDIR)/../../../..
 #EXTERNAL_BOARD_DIRS ?= $(CURDIR)/../../../thirdparty_boards
 
 # Uncomment this to enable scheduler statistics for ps:
-#CFLAGS += -DSCHEDSTATISTICS
+#USEMODULE += schedstatistics
 
 # If you want to use native with valgrind, you should recompile native
 # with the target all-valgrind instead of all:


### PR DESCRIPTION
### Contribution description

When updating our tutorials, I found that some makefiles had `CFLAGS += -DSCHEDSTATISTICS` which I've never seen before. It turns out, that two examples in the main repo have that too. There is no mechanism to evaluate that in the CFLAGS though, it has do be a module.

### Testing procedure

You can verify my claim with essentially any application. Setting the CFLAGS will not invoke a make of `sys/schedstatistics` and `ps` is missing the functionality.

```
buechse@skyleaf:~/RIOTstuff/riot-vanillaice/RIOT$ CFLAGS=-DSCHEDSTATISTICS make -C tests/sys/shell all term
make: Entering directory '/home/buechse/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell'
using BOARD="native64" as "native" on a 64-bit system
Building application "tests_shell" for "native64" with CPU "native".

"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/boards
...
"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/sys
"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/sys/app_metadata
"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/sys/auto_init
"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/sys/frac
"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/sys/isrpipe
"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/sys/libc
"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/sys/preprocessor
"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/sys/ps
"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/sys/shell
"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/sys/shell/cmds
"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/sys/stdio
"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/sys/test_utils/print_stack_usage
"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/sys/tsrb
"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/sys/ztimer
/usr/bin/ld: warning: /home/buechse/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell/bin/native64/tests_shell.elf has a LOAD segment with RWX permissions
   text    data     bss     dec     hex filename
  38150    1800   59440   99390   1843e /home/buechse/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell/bin/native64/tests_shell.elf
/home/buechse/RIOTstuff/riot-vanillaice/RIOT/dist/tools/pyterm/pyterm -ps /home/buechse/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell/bin/native64/tests_shell.elf --process-args tap0
Welcome to pyterm!
Type '/exit' to exit.
2026-04-23 14:10:56,873 # RIOT native interrupts/signals initialized.
2026-04-23 14:10:56,873 # TZ not set, setting UTC
2026-04-23 14:10:56,873 # RIOT native64 board initialized.
2026-04-23 14:10:56,873 # RIOT native hardware initialization complete.
2026-04-23 14:10:56,873 #
2026-04-23 14:10:56,874 # main(): This is RIOT! (Version: 2026.07-devel-86-gdf174-pr/schedstatistics)
2026-04-23 14:10:56,874 # test_shell.
> ps
2026-04-23 14:10:58,251 # ps
2026-04-23 14:10:58,251 #       pid | state    Q | pri
2026-04-23 14:10:58,251 #         1 | pending  Q |  15
2026-04-23 14:10:58,252 #         2 | running  Q |   7
>
```

```
buechse@skyleaf:~/RIOTstuff/riot-vanillaice/RIOT$ USEMODULE=schedstatistics make -C tests/sys/shell all term
make: Entering directory '/home/buechse/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell'
using BOARD="native64" as "native" on a 64-bit system
Building application "tests_shell" for "native64" with CPU "native".

"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/boards
...
"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/sys/schedstatistics
...
"make" -C /home/buechse/RIOTstuff/riot-vanillaice/RIOT/sys/ztimer
/usr/bin/ld: warning: /home/buechse/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell/bin/native64/tests_shell.elf has a LOAD segment with RWX permissions
   text    data     bss     dec     hex filename
  38863    1808   59984  100655   1892f /home/buechse/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell/bin/native64/tests_shell.elf
/home/buechse/RIOTstuff/riot-vanillaice/RIOT/dist/tools/pyterm/pyterm -ps /home/buechse/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell/bin/native64/tests_shell.elf --process-args tap0
Welcome to pyterm!
Type '/exit' to exit.
2026-04-23 14:11:15,063 # RIOT native interrupts/signals initialized.
2026-04-23 14:11:15,064 # TZ not set, setting UTC
2026-04-23 14:11:15,064 # RIOT native64 board initialized.
2026-04-23 14:11:15,064 # RIOT native hardware initialization complete.
2026-04-23 14:11:15,064 #
2026-04-23 14:11:15,064 # main(): This is RIOT! (Version: 2026.07-devel-86-gdf174-pr/schedstatistics)
2026-04-23 14:11:15,064 # test_shell.
> ps
2026-04-23 14:11:16,134 # ps
2026-04-23 14:11:16,134 #       pid | state    Q | pri | runtime  | switches  | runtime_usec
2026-04-23 14:11:16,134 #         1 | pending  Q |  15 | 99.993% |         1  |    2070036
2026-04-23 14:11:16,135 #         2 | running  Q |   7 |  0.006% |         2  |        142
>
```


### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
