### PR TITLE
doc/guides: add remarks about other repos in Release Tutorial

### DIFF
--- a/doc/guides/misc/managing-a-release.md
+++ b/doc/guides/misc/managing-a-release.md
@@ -18,6 +18,11 @@ Steps marked with a :scroll: icon can also be automated with the release manager
 - [ ] Gather features to push from contributors, and apply milestone label
 - [ ] Go through list of deprecated features and make sure pending removals are applied
 - [ ] Familiarise with release specs and tests, incl open issues, deprecations, api changes, and PRs
+- [ ] Check if the release will impact other repositories such as the
+      the [Tutorial](https://github.com/RIOT-OS/Tutorials),
+      the [RIOT Course](https://github.com/RIOT-OS/riot-course),
+      the [RIOT Exercises](https://github.com/netd-tud/riot-exercises) or
+      the [HAW Hamburg INET RIOT Exercises](https://github.com/inetrg/exercises).
 
 **Soft Feature Freeze**
 - [ ] Post about soft feature freeze to the forum
@@ -25,7 +30,6 @@ Steps marked with a :scroll: icon can also be automated with the release manager
 - [ ] Familiarise with nearly-merged, high impact PRs, and contact the contributors to ask them to hold
 
 **Hard Feature Freeze**
-
 Do the below actions iteratively, generating new release candidates, until all release specs tests pass.
 - [ ] Generate branch and tag for release candidate :scroll:
 - [ ] Add [branch protection rules](https://github.com/RIOT-OS/RIOT/settings/branches) for the release branch (if you don't have permissions ask an [admin](https://github.com/orgs/RIOT-OS/teams/admin) or [owner](https://github.com/orgs/RIOT-OS/teams/owners)). :warning: A new rule has to be added manually for each release, since the Github Merge Queue cannot be enabled for branches that are protected with a wildcard rule for some reason. You might need to ask for help from one of the RIOT-OS GitHub admins for that.
@@ -44,6 +48,10 @@ Do the below actions iteratively, generating new release candidates, until all r
 - [ ] Release either manually or using the release manager script :scroll:
 - [ ] Inform about the release on the forum
 - [ ] Update the [release statistics](https://github.com/RIOT-OS/RIOT/wiki/release-statistics)
+- [ ] Bump the RIOT version in the [Tutorial](https://github.com/RIOT-OS/Tutorials),
+      the [RIOT Course](https://github.com/RIOT-OS/riot-course),
+      the [RIOT Exercises](https://github.com/netd-tud/riot-exercises) and
+      the [RIOT Build Container](https://github.com/RIOT-OS/riotdocker/blob/master/.github/workflows/build.yml).
 
 ## 2. Preparation
 


### PR DESCRIPTION
### Contribution description

Unfortunately many repositories associated with RIOT are having bitrot issues, for example when the big documentation migration happened, links with `doc.riot-os.org` are now dead.

Also the Makefiles of Tasks reference modules that don't exist anymore etc.

The `riotbuild` container version tag is also often forgotten to update after a new release.

=> Therefore I've added some remarks to the Release Tutorial Checklist so hopefully that'll happen less in the future?

Since I have never managed a release, this is also a RFC from more experienced maintainers.

### Testing procedure

Read the docs 👀 


### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
