### PR TITLE
makefiles/tools: select correct TTY by serial

### DIFF
--- a/makefiles/tools/openocd-adapters/ftdi.inc.mk
+++ b/makefiles/tools/openocd-adapters/ftdi.inc.mk
@@ -29,6 +29,6 @@ ifeq (tigard,$(OPENOCD_FTDI_ADAPTER))
   # If the user provided a programmer serial, we also use that to detect the
   # TTY.
   ifneq (,$(SERIAL))
-    TTY_SELECT_CMD += --serial "$(SERIAL)"
+    TTY_BOARD_FILTER += --serial "$(SERIAL)"
   endif
 endif


### PR DESCRIPTION
### Contribution description

The serial filter needs to be added to the `TTY_BOARD_FILTER` rather than to the `TTY_SELECT_CMD`. The latter is still empty and setting the serial will result in `--serial <SERIAL>` being executed instead of the python script selecting the TTY.

### Testing procedure

Run `make BOARD=<some-board> PROGRAMMER=openocd OPENOCD_DEBUG_ADAPTER=ftdi SERIAL=<FTDI_SERIAL> -C <APP> term`

With `master`, this will result in `/bin/sh: 0: Illegal option --`, with this PR, it will select the /dev/ttyUSB<NUM> matching to the serial instead.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
