### PR TITLE
drivers/at86rf215: always disable ACK filter when ending TX

### DIFF
--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -224,6 +224,12 @@ void at86rf215_tx_done(at86rf215_t *dev)
 
     at86rf215_reg_write(dev, dev->BBC->RG_AMCS, amcs);
 
+    /* listen to non-ACK packets again */
+    if (dev->flags & AT86RF215_OPT_ACK_REQUESTED) {
+        dev->flags &= ~AT86RF215_OPT_ACK_REQUESTED;
+        at86rf215_filter_ack(dev, false);
+    }
+
     /* re-enable reduced power consumption */
     at86rf215_enable_rpc(dev);
 }

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -856,12 +856,6 @@ static void _tx_end(at86rf215_t *dev)
 {
     netdev_t *netdev = &dev->netdev.netdev;
 
-    /* listen to non-ACK packets again */
-    if (dev->flags & AT86RF215_OPT_ACK_REQUESTED) {
-        dev->flags &= ~AT86RF215_OPT_ACK_REQUESTED;
-        at86rf215_filter_ack(dev, false);
-    }
-
     at86rf215_tx_done(dev);
 
     if (netdev->event_callback) {
@@ -1011,7 +1005,6 @@ static void _handle_edc(at86rf215_t *dev)
         dev->state = AT86RF215_STATE_IDLE;
 
         at86rf215_enable_baseband(dev);
-        at86rf215_enable_rpc(dev);
         at86rf215_tx_done(dev);
 
         /* signal error to confirm_send */


### PR DESCRIPTION
### Contribution description

This fixes an issue in the radio driver where the ACK filter would stay enabled when CSMA timed out. The code to disable the ACK filter has now been placed centrally in `at86rf215_tx_done`, such that in every case, e.g. also when calling `at86rf215_tx_abort`, the ACK filter really gets disabled. Otherwise we won't receive any more data other than ACKs, which we don't expect at this point.


### Testing procedure

For actually testing this you probably need a lot of devices communicating with a central node in order to trigger the bug. I used a star network topology with one central node and 16 leaf nodes that are constantly sending data via CoAP to the central node. Prior to this fix the bug triggered within 2 minutes most of the time. With the fix I could not observe the driver getting stuck within 15 minutes of massive communication.


### Issues/PRs references

There is issue #21685 that describes a similar scenario. I'm not 100% certain it's actually the exact same bug, but it's rather likely in my opinion.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
