### PR TITLE
makefiles/tools: enhance miniterm path finding in serial.inc.mk [backport 2026.04]

### DIFF
--- a/cpu/esp8266/doc.md
+++ b/cpu/esp8266/doc.md
@@ -1200,10 +1200,8 @@ following.
 1. Start in first terminal window a terminal program which connects to the
 port of the ESP8266 module as console window:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-term1> python -m serial.tools.miniterm &lt;port&gt; 115200
+make BOARD=esp8266-esp-12x term
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-where `&lt;port&gt;` is the serial interface to which the ESP8266 module is connected,
-e.g., `/dev/ttyUSB0`.
 
 2. Start GDB with the application in a second terminal window:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/guides/misc/terminal_config.md
+++ b/doc/guides/misc/terminal_config.md
@@ -1,5 +1,5 @@
 ---
-title: Terminal Programs Configuration
+title: Terminal Program Configuration
 description: How to configure popular terminal programs for correct display of newlines
 ---
 
@@ -40,6 +40,13 @@ that will make them correctly display newlines.
     - Start with `--eol CR` parameter.
 - Via RIOT build system:
     - `RIOT_TERMINAL=miniterm make term`
+
+:::note
+You can install miniterm by installing `pyserial`. The preferred method
+for most Linux distributions is to install `python3-serial` with your
+package manager. If that is not possible or desired, you can also install
+`pyserial` with `pipx`.
+:::
 
 ## picocom
 

--- a/examples/lang_support/community/lua_REPL/README.md
+++ b/examples/lang_support/community/lua_REPL/README.md
@@ -12,12 +12,13 @@ system's default lua installation.
 Type `make all flash` to program your board. The lua interpreter communicates
 via UART (like the shell).
 
-It is not recommended to use `make term` because the default RIOT terminal messes
+It is not recommended to use the default RIOT terminal from `make term` because it
 up the input and output and the REPL needs multi-line input. Instead, use something
-like `miniterm.py` from pyserial:
+like `miniterm` from `pyserial` by setting the `RIOT_TERMINAL` environment
+variable:
 
 ```
-miniterm.py --eol LF --echo /dev/ttyACM0 115200
+RIOT_TERMINAL=miniterm BOARD=... make term
 ```
 
 By default only some of the builtin modules are loaded, to preserve RAM. See

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -73,13 +73,21 @@ else ifeq ($(RIOT_TERMINAL),picocom)
   TERMPROG  ?= picocom
   TERMFLAGS ?= --nolock --imap lfcrlf --baud "$(BAUD)" "$(PORT)"
 else ifeq ($(RIOT_TERMINAL),miniterm)
-  # Check if miniterm.py is available in the path, if not use just miniterm
-  # since new versions will only have miniterm and not miniterm.py
-  ifeq (,$(shell command -v miniterm.py 2>/dev/null))
+  # The executable for miniterm depends on the version and the way it was
+  # installed. Check for all (currently) known possibilities and select
+  # the correct one.
+  ifneq (,$(shell command -v pyserial-miniterm.py 2>/dev/null))
+    TERMPROG ?= pyserial-miniterm.py
+  else ifneq (,$(shell command -v pyserial-miniterm 2>/dev/null))
+    TERMPROG ?= pyserial-miniterm
+  else ifneq (,$(shell command -v miniterm.py 2>/dev/null))
+    TERMPROG ?= miniterm.py
+  else ifneq (,$(shell command -v miniterm 2>/dev/null))
     TERMPROG ?= miniterm
   else
-    TERMPROG ?= miniterm.py
+    $(error The pyserial miniterm was not found! Check if pyserial is installed.)
   endif
+
   # The RIOT shell will still transmit back a CRLF, but at least with --eol LF
   # we avoid sending two lines on every "enter".
   TERMFLAGS ?= --eol LF "$(PORT)" "$(BAUD)" $(MINITERMFLAGS)

--- a/tests/pkg/tinyusb_cdc_msc/README.md
+++ b/tests/pkg/tinyusb_cdc_msc/README.md
@@ -35,7 +35,7 @@ It should then be possible
    of the operating system
 2. to connect to the serial interface of the device with a terminal program, e.g.
    ```
-   python -m serial.tools.miniterm /dev/ttyACM0 115200
+   BOARD=... make term
    ```
    and get the entered characters sent back.
 


### PR DESCRIPTION
# Backport of #22208

### Contribution description

Apparently `miniterm` likes to change the executable name. In very old versions it was `miniterm.py`, then it was `miniterm` and now (version 3.5 and higher) it is `pyserial-miniterm`.

This change enhances the path discovery to select the right one.


### Testing procedure

Make sure you have (a recent version of) pyserial installed:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ pip show pyserial
Name: pyserial
Version: 3.5
Summary: Python Serial Port Extension
Home-page: https://github.com/pyserial/pyserial
Author: Chris Liechti
Author-email: cliechti@gmx.net
License: BSD
Location: /usr/lib/python3/dist-packages
Requires: 
Required-by: adafruit-nrfutil
```

Run your favorite application with `RIOT_TERMINAL=miniterm`.

Behavior on `master`:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ RIOT_TERMINAL=miniterm BOARD=nrf52840dk make -C tests/sys/shell flash term -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell'
Building application "tests_shell" for "nrf52840dk" with CPU "nrf52".

"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/pkg/cmsis/ 
...
J-Link>exit

Script processing completed.

Terminal program miniterm is required but not found in PATH.  Aborting.
make: *** [/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell/../../../Makefile.include:869: term] Error 1
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell'
```

Behavior with this PR:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ RIOT_TERMINAL=miniterm BOARD=nrf52840dk make -C tests/sys/shell flash term -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell'
Building application "tests_shell" for "nrf52840dk" with CPU "nrf52".

"make" -C /home/cbuec/RIOTstuff/riot-vanilla/RIOT/pkg/cmsis/ 
...
J-Link>exit

Script processing completed.

pyserial-miniterm --eol LF "/dev/ttyACM0" "115200"  
--- Miniterm on /dev/ttyACM0  115200,8,N,1 ---
--- Quit: Ctrl+] | Menu: Ctrl+T | Help: Ctrl+T followed by Ctrl+H ---
main(): This is RIOT! (Version: 2026.04-devel-410-gecc128-pr/miniterm)
test_shell.
>
```


### Issues/PRs references

Found while testing #22207.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
