### PR TITLE
sys/net/unicoap: properly handle options with value zero

### DIFF
--- a/sys/net/application_layer/unicoap/options.c
+++ b/sys/net/application_layer/unicoap/options.c
@@ -546,6 +546,11 @@ ssize_t unicoap_options_copy_value(const unicoap_options_t* options, unicoap_opt
     if (size < 0) {
         return size;
     }
+    if (size == 0) {
+        /* value 0 SHOULD have been encoded as zero-length value, see RFC7252, Section 3.2 */
+        *dest = 0;
+        return size;
+    }
     if ((size_t)size > capacity) {
         return -ENOBUFS;
     }
@@ -921,6 +926,11 @@ ssize_t _unicoap_options_get_variable_uint(const unicoap_options_t* options,
     const uint8_t* src = NULL;
     ssize_t size = unicoap_options_get(options, number, &src);
     if (size < 0) {
+        return size;
+    }
+    if (size == 0) {
+        /* value 0 SHOULD have been encoded as zero-length value, see RFC7252, Section 3.2 */
+        *uint = 0;
         return size;
     }
     if ((size_t)size > max_size) {

--- a/tests/unittests/tests-unicoap/tests-unicoap-options.c
+++ b/tests/unittests/tests-unicoap/tests-unicoap-options.c
@@ -383,6 +383,27 @@ static void test_remove_multiple(void)
     _TEST_ASSERT_EQUAL_BYTES(options_blob, unicoap_options_data(&options), sizeof(options_blob));
 }
 
+static void test_option_value_uses_shortest_possible_representation(void)
+{
+    static const uint8_t options_blob[] = { 0x00 };
+    const unicoap_option_number_t OPTION_NUMBER = 0; // RESERVED
+    const uint32_t OPTION_VALUE = 0;
+    UNICOAP_OPTIONS_ALLOC_STATIC(options, 10);
+    TEST_ASSERT_EQUAL_INT(0, unicoap_options_add_uint(&options, OPTION_NUMBER, OPTION_VALUE));
+    TEST_ASSERT_EQUAL_INT(sizeof(options_blob), unicoap_options_size(&options));
+    _TEST_ASSERT_EQUAL_BYTES(options_blob, unicoap_options_data(&options), sizeof(options_blob));
+
+    uint8_t uint8_val = 42;
+    TEST_ASSERT_EQUAL_INT(0, unicoap_options_get_uint8(&options, OPTION_NUMBER, &uint8_val));
+    TEST_ASSERT_EQUAL_INT(OPTION_VALUE, uint8_val);
+    uint16_t uint16_val = 42;
+    TEST_ASSERT_EQUAL_INT(0, unicoap_options_get_uint16(&options, OPTION_NUMBER, &uint16_val));
+    TEST_ASSERT_EQUAL_INT(OPTION_VALUE, uint16_val);
+    uint32_t uint32_val = 42;
+    TEST_ASSERT_EQUAL_INT(0, unicoap_options_get_uint32(&options, OPTION_NUMBER, &uint32_val));
+    TEST_ASSERT_EQUAL_INT(OPTION_VALUE, uint32_val);
+}
+
 Test* tests_unicoap_options(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures){
@@ -393,6 +414,7 @@ Test* tests_unicoap_options(void)
         new_TestFixture(test_remove_leading),
         new_TestFixture(test_remove_trailing),
         new_TestFixture(test_remove_multiple),
+        new_TestFixture(test_option_value_uses_shortest_possible_representation),
     };
 
     EMB_UNIT_TESTCALLER(test_unicoap, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description

CoAP options carrying the value 0 may have been encoded as with value-length zero (this is actually [recommended by the RFC](https://www.rfc-editor.org/rfc/rfc7252.html#section-3.2)). `unicoap` would not have treated such encodings correctly while retrieving the option value.

While setting the option, `unicoap` already behaved as recommended.


### Testing procedure

```
make -C tests/unittests tests-unicoap test
```

with an added test case should still pass with this PR (and wouldn't without).


### Issues/PRs references

Encountered while working on experimental Uri-Path-Abbrev support based on #21582 in https://github.com/mguetschow/RIOT/tree/unicoap-uri-path-abbrev

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
