### PR TITLE
dist/tools/riotboot_gen_hdr: use $BUILD_DIR to build in

### DIFF
--- a/dist/tools/riotboot_gen_hdr/Makefile
+++ b/dist/tools/riotboot_gen_hdr/Makefile
@@ -1,4 +1,6 @@
 RIOTBASE       := ../../..
+BUILD_DIR      ?= $(RIOTBASE)/build
+GENHDR_BINDIR  := $(BUILD_DIR)/genhdr
 RIOT_INCLUDE   := $(RIOTBASE)/sys/include
 RIOT_CORE_INC  := $(RIOTBASE)/core/include
 NATIVE_INCLUDE := $(RIOTBASE)/cpu/native/include
@@ -26,16 +28,16 @@ else
   Q=
 endif
 
-all: bin/genhdr
+all: $(GENHDR_BINDIR)/genhdr
 
-bin/:
-	$(Q)mkdir -p bin
+$(GENHDR_BINDIR)/:
+	$(Q)mkdir -p "$@"
 
-bin/genhdr: $(GENHDR_HDR) $(GENHDR_SRC) Makefile | bin/
+$(GENHDR_BINDIR)/genhdr: $(GENHDR_HDR) $(GENHDR_SRC) Makefile | $(GENHDR_BINDIR)/
 	$(Q)$(CC) $(CFLAGS) -I$(RIOT_INCLUDE) -I$(RIOT_CORE_INC) \
 		-I$(NATIVE_INCLUDE) $(GENHDR_SRC) -o $@
 
 clean:
-	$(Q)rm -rf bin/
+	$(Q)rm -rf $(GENHDR_BINDIR)
 
 distclean: clean

--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -7,8 +7,8 @@ RIOTBOOT_DIR = $(RIOTBASE)/bootloaders/riotboot
 RIOTBOOT ?= $(RIOTBOOT_DIR)/bin/$(BOARD)/riotboot.elf
 CFLAGS += -I$(BINDIR)/riotbuild
 
-HEADER_TOOL_DIR = $(RIOTBASE)/dist/tools/riotboot_gen_hdr
-HEADER_TOOL ?= $(HEADER_TOOL_DIR)/bin/genhdr
+HEADER_TOOL_DIR = $(RIOTTOOLS)/riotboot_gen_hdr
+HEADER_TOOL ?= $(BUILD_DIR)/genhdr/genhdr
 BINDIR_RIOTBOOT = $(BINDIR)/riotboot_files
 
 $(BINDIR_RIOTBOOT): $(CLEAN)
@@ -58,6 +58,7 @@ $(HEADER_TOOL): FORCE
 	$(Q)/usr/bin/env -i \
 		QUIET=$(QUIET) \
 		PATH="$(PATH)" \
+		BUILD_DIR="$(BUILD_DIR)" \
 			$(MAKE) --no-print-directory -C $(HEADER_TOOL_DIR) all
 
 # Generate RIOT header and keep the original binary file


### PR DESCRIPTION
### Contribution description

When building both with `BUILD_IN_DOCKER=1` and with host tools, one can easily run in a state where the `genhdr` tool is not working, because the `genhdr` tool is build in the one environment but executed in a different. Reasons for incompatible binaries can be:

1. building the binary on `musl` and running it on `glibc` (or the other way round)
2. building the binary on a newer version of `glibc` and running it on an older version (newer versions of glibc are backward compatible with old binaries, but not forward compatible with future binaries)

A simple way to isolate incompatible environments is setting a different `BUILD_DIR`, which works just fine for packages. With this change, it will now also work for `riotboot_gen_hdr`.

### Testing procedure

```
$ make -C examples/advanced/suit_update
```

should still work and there should be a binary at `$(BUILD_DIR)/genhdr/genhdr`:

```
$ ./build/genhdr/genhdr 
usage:	genhdr generate [args]
	genhdr update <file> <new_version>
	genhdr show [--json] <file>
```

### Issues/PRs references

Fixes issues like

```
.../RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr: not found
make: *** [.../RIOT/makefiles/boot/riotboot.mk:67: <BINDIR>/bin/<BOARD>/riotboot_files/slot0.hdr] Error 127
```

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
