### PR TITLE
boards/waveshare-esp32s3-touch-lcd-128: add board support

### DIFF
--- a/boards/waveshare-esp32s3-touch-lcd-128/Kconfig
+++ b/boards/waveshare-esp32s3-touch-lcd-128/Kconfig
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
+
+config BOARD
+    default "waveshare-esp32s3-touch-lcd-128" if BOARD_WAVESHARE_ESP32S3_TOUCH_LCD_128
+
+config BOARD_WAVESHARE_ESP32S3_TOUCH_LCD_128
+    bool
+    default y
+    select BOARD_COMMON_ESP32S3
+    select CPU_MODEL_ESP32S3_R2
+
+source "$(RIOTBOARD)/common/esp32s3/Kconfig"

--- a/boards/waveshare-esp32s3-touch-lcd-128/Makefile
+++ b/boards/waveshare-esp32s3-touch-lcd-128/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/waveshare-esp32s3-touch-lcd-128/Makefile.dep
+++ b/boards/waveshare-esp32s3-touch-lcd-128/Makefile.dep
@@ -1,0 +1,16 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+ifneq (,$(filter disp_dev,$(USEMODULE)))
+  USEMODULE += gc9a01
+endif
+
+ifneq (,$(filter touch_dev,$(USEMODULE)))
+  USEMODULE += cst816s
+endif
+
+include $(RIOTBOARD)/common/esp32s3/stdio_esp32s3_default.dep.mk
+include $(RIOTBOARD)/common/esp32s3/Makefile.dep
+
+USEMODULE += boards_common_esp32s3

--- a/boards/waveshare-esp32s3-touch-lcd-128/Makefile.features
+++ b/boards/waveshare-esp32s3-touch-lcd-128/Makefile.features
@@ -1,0 +1,14 @@
+# the board uses an ESP32-S3R2 with 2 MB embedded SPI RAM.
+CPU_MODEL = esp32s3_r2
+
+# common board and CPU features
+include $(RIOTBOARD)/common/esp32s3/Makefile.features
+
+# peripherals provided by the board
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_usbdev
+
+# other features provided by the board
+FEATURES_PROVIDED += esp_spi_ram

--- a/boards/waveshare-esp32s3-touch-lcd-128/Makefile.include
+++ b/boards/waveshare-esp32s3-touch-lcd-128/Makefile.include
@@ -1,0 +1,3 @@
+PORT_LINUX ?= /dev/ttyACM0
+
+OPENOCD_CONFIG ?= board/esp32s3-builtin.cfg

--- a/boards/waveshare-esp32s3-touch-lcd-128/board.c
+++ b/boards/waveshare-esp32s3-touch-lcd-128/board.c
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     boards_waveshare-esp32s3-touch-lcd-128
+ * @{
+ *
+ * @file
+ * @brief       Board specific initializations for the Waveshare ESP32-S3
+ *              1.28-inch round display board (Touch version)
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include "board.h"
+
+void board_init(void)
+{
+#if MODULE_GC9A01
+    gpio_init(LCD_BACKLIGHT, GPIO_OUT);
+#endif
+}

--- a/boards/waveshare-esp32s3-touch-lcd-128/doc.md
+++ b/boards/waveshare-esp32s3-touch-lcd-128/doc.md
@@ -1,0 +1,103 @@
+<!--
+SPDX-FileCopyrightText: 2023 Gunar Schorcht
+SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+
+@defgroup   boards_waveshare-esp32s3-touch-lcd-128 Waveshare ESP32-S3-Touch-LCD-1.28
+@ingroup    boards_esp32s3
+@brief      Support for the Waveshare ESP32-S3-Touch-LCD-1.28 board
+@author     Gunar Schorcht <gunar@schorcht.net>
+@author     Yahia Abdella <yahia.abdella@tuhh.de>
+
+\section waveshare_esp32s3_touch_lcd_128 Waveshare ESP32-S3-Touch-LCD-1.28
+
+## Overview
+
+The Waveshare ESP32-S3-Touch-LCD-1.28 is a compact development board built around the
+ESP32-S3 microcontroller with an integrated 1.28-inch round TFT LCD display and
+capacitive touch panel.
+
+<img src="https://www.waveshare.net/photo/development-board/ESP32-S3-Touch-LCD-1.28/ESP32-S3-Touch-LCD-1.28-1.jpg" alt="Waveshare ESP32-S3-Touch-LCD-1.28" width="400" />
+
+The main features of the board are:
+
+- ESP32-S3-N8R2 SoC with 2.4 GHz WiFi (802.11 b/g/n) and Bluetooth 5, BLE
+- 16 MB Flash
+- 2 MB PSRAM
+- 1.28-inch 240x240 round IPS LCD (GC9A01 driver)
+- Capacitive touch panel (CST816S controller)
+- 6-axis IMU (QMI8658 accelerometer + gyroscope)
+- USB Type-C connector
+- Battery charging circuit with battery voltage monitoring
+- BOOT button (active low, directly usable as user button)
+
+## Hardware
+
+### MCU
+
+Most features of the board are provided by the ESP32-S3 SoC. For detailed
+information about the ESP32-S3 SoC variant (family) and ESP32x SoCs,
+see section \ref esp32_mcu_esp32 "ESP32 SoC Series".
+
+### Board Configuration
+
+The board integrates a 1.28-inch round IPS LCD driven by a GC9A01 display controller
+via SPI, a CST816S capacitive touch controller connected via I2C, and a QMI8658
+6-axis IMU also connected via I2C. A BOOT button on GPIO0 is directly usable
+as a user button.
+
+The default board configuration provides:
+
+- 1 x ADC channel (battery voltage monitoring)
+- 1 x SPI (display)
+- 1 x I2C (touch controller and IMU)
+- 1 x UART (console)
+
+The following table shows the default board configuration sorted by
+peripheral function. This configuration can be overridden by
+\ref esp32_application_specific_configurations
+"application-specific configurations".
+
+<center>
+Function        | GPIOs  | Remarks | Configuration
+:---------------|:-------|:--------|:----------------------------------
+BTN0            | GPIO0  | | |
+ADC_LINE(0)     | GPIO1  | Battery voltage | \ref esp32_adc_channels "ADC Channels"
+SPI_DEV(0) CLK  | GPIO10 | LCD SCLK, GC9A01 | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0) MOSI | GPIO11 | LCD SDA, GC9A01 | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0) MISO | GPIO12 | LCD SDO, GC9A01 | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0) CS0  | GPIO9  | LCD CS, GC9A01 | \ref esp32_spi_interfaces "SPI Interfaces"
+LCD DC          | GPIO8  | GC9A01 data/command | |
+LCD RST         | GPIO14 | GC9A01 reset | |
+LCD BL          | GPIO2  | Backlight control | |
+I2C_DEV(0) SCL  | GPIO7  | Touch + IMU | \ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(0) SDA  | GPIO6  | Touch + IMU | \ref esp32_i2c_interfaces "I2C Interfaces"
+Touch IRQ       | GPIO5  | CST816S interrupt | |
+Touch RST       | GPIO13 | CST816S reset | |
+UART_DEV(0) TxD | GPIO43 | Console (fixed) | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(0) RxD | GPIO44 | Console (fixed) | \ref esp32_uart_interfaces "UART interfaces"
+</center>
+<br>
+
+For detailed information about the peripheral configurations of ESP32-S3
+boards, see section \ref esp32_peripherals "Common Peripherals".
+
+### Board Pinout
+
+The following figures show the board hardware layout.
+
+<img src="https://docs.waveshare.com/assets/images/Esp32-s3-touch-lcd-1.28-003-c7bcf4bd1440b55a43abb060ad67d705.webp" alt="Waveshare ESP32-S3-Touch-LCD-1.28 Hardware Layout" width="600" />
+
+<img src="https://docs.waveshare.com/assets/images/ESP32-S3-Touch-LCD-1.28-pin-e2103bcf84f511752bbc41ceb86bbf56.webp" alt="Waveshare ESP32-S3-Touch-LCD-1.28 Hardware Layout" width="600" />
+
+The board schematic and additional documentation can be found on the
+[Waveshare Wiki](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-1.28).
+
+## Flashing the Device
+
+Flashing RIOT is quite easy. The board has a USB-C connector with
+reset/boot/flash logic. Just connect the board to your host computer
+and run:
+For detailed information about ESP32-S3 as well as configuring and compiling
+RIOT for ESP32-S3 boards, see \ref esp32_riot.

--- a/boards/waveshare-esp32s3-touch-lcd-128/include/board.h
+++ b/boards/waveshare-esp32s3-touch-lcd-128/include/board.h
@@ -1,0 +1,127 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_waveshare-esp32s3-touch-lcd-128
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Waveshare ESP32-S3 1.28-inch
+ *              round display board (Touch version)
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Yahia Abdella <yahia.abdella@tuhh.de>
+ */
+
+/**
+ * @name    Button pin definitions
+ * @{
+ */
+
+/**
+ * @brief   Default button GPIO pin definition
+ *
+ * The board has a BOOT button connected to GPIO0, which can be
+ * used as button during normal operation. Since the GPIO0 pin is pulled up,
+ * the button signal is inverted, i.e., pressing the button will give a
+ * low signal.
+ */
+#define BTN0_PIN        GPIO0
+
+/**
+ * @brief   Default button GPIO mode definition
+ */
+#define BTN0_MODE       GPIO_IN_PU
+
+/**
+ * @brief   Default interrupt flank definition for the button GPIO
+ */
+#ifndef BTN0_INT_FLANK
+#  define BTN0_INT_FLANK  GPIO_FALLING
+#endif
+
+/**
+ * @brief   Definition for compatibility with previous versions
+ */
+#define BUTTON0_PIN     BTN0_PIN
+
+/** @} */
+
+/**
+ * @name    LCD configuration
+ *
+ * The board features a 240x240 TFT display being driven by a GC9A01 LCD driver
+ * The display driver is connected via SPI
+ *
+ * @{
+ */
+#if MODULE_GC9A01
+#  define LCD_DC              GPIO8     /**< LCD DC signal */
+#  define LCD_CS              GPIO9     /**< LCD EN signal */
+#  define LCD_RST             GPIO14    /**< LCD RST signal */
+#  define LCD_BACKLIGHT       GPIO2     /**< LCD BL signal */
+
+#  define GC9A01_PARAM_CS               LCD_CS
+#  define GC9A01_PARAM_DCX              LCD_DC
+#  define GC9A01_PARAM_RST              LCD_RST
+#  define GC9A01_PARAM_NUM_LINES        240
+#  define GC9A01_PARAM_RGB_CHANNELS     240
+#  define GC9A01_PARAM_INVERTED         1
+#  define GC9A01_PARAM_RGB              0
+#  ifndef GC9A01_PARAM_ROTATION
+#    define GC9A01_PARAM_ROTATION       GC9A01_ROTATION_VERT
+#  endif
+#  ifndef GC9A01_PARAM_SPI_CLK
+#    define GC9A01_PARAM_SPI_CLK        SPI_CLK_10MHZ
+#  endif
+
+#  define BACKLIGHT_ON                gpio_set(LCD_BACKLIGHT)
+#  define BACKLIGHT_OFF               gpio_clear(LCD_BACKLIGHT)
+#endif
+/** @} */
+
+/**
+ * @name    Touch panel configuration
+ *
+ * The board features a CST816S touch display driver
+ * The touch chip is connected via I2C
+ *
+ * @{
+ */
+#if MODULE_CST816S
+#  define CST816S_PARAM_I2C_DEV       I2C_DEV(0)
+#  define CST816S_PARAM_IRQ           GPIO5
+#  define CST816S_PARAM_RESET         GPIO13
+#endif
+/** @} */
+
+/**
+ * @name    IMU configuration
+ *
+ * The board features a QMI8658 interial measurement unit
+ * The IMU is connected via I2C
+ *
+ * @{
+ */
+#if MODULE_QMI8658
+#  define QMI8658_PARAM_I2C       I2C_DEV(0)
+#endif
+/** @} */
+
+/* include common board definitions as last step */
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/waveshare-esp32s3-touch-lcd-128/include/gpio_params.h
+++ b/boards/waveshare-esp32s3-touch-lcd-128/include/gpio_params.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_waveshare-esp32s3-touch-lcd-128
+ * @brief       Board specific configuration of direct mapped GPIOs for the
+ *              Waveshare ESP32-S3 1.28-inch round display board (Touch
+ *              version)
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @{
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Boot button configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "BOOT",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/waveshare-esp32s3-touch-lcd-128/include/periph_conf.h
+++ b/boards/waveshare-esp32s3-touch-lcd-128/include/periph_conf.h
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_waveshare-esp32s3-touch-lcd-128
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for the Waveshare ESP32-S3
+ *              1.28-inch round display board (Touch version)
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Yahia Abdella <yahia.abdella@tuhh.de>
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    ADC channel configuration
+ * @{
+ */
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ *
+ * GPIO1 can be used for Battery voltage monitoring as ADC_LINE(0):
+ *  V_BAT = 3.3 / (1 << 12) * 3 * ADC_Value
+ */
+#ifndef ADC_GPIOS
+#  define ADC_GPIOS { GPIO1 }
+#endif
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * SPI_DEV(0) is used for the LCD display
+ *
+ * @note The GPIOs listed in the configuration are first initialized as SPI
+ *       signals when the corresponding SPI interface is used for the first
+ *       time by either calling the `spi_init_cs` function or the `spi_acquire`
+ *       function. Otherwise they are not allocated as SPI signals before and
+ *       can be used for other purposes as long as the SPI interface is not
+ *       used.
+ * @{
+ */
+#ifndef SPI0_CTRL
+#  define SPI0_CTRL   SPI2_HOST     /**< SPI2 (FSPI) is configured as SPI_DEV(0) */
+#endif
+#ifndef SPI0_SCK
+#  define SPI0_SCK    GPIO10        /**< LCD SCLK */
+#endif
+#ifndef SPI0_MOSI
+#  define SPI0_MOSI   GPIO11        /**< LCD SDA */
+#endif
+#ifndef SPI0_MISO
+#  define SPI0_MISO   GPIO12        /**< LCD SDO */
+#endif
+#ifndef SPI0_CS0
+#  define SPI0_CS0    GPIO9         /**< LCD CS */
+#endif
+/** @} */
+
+/**
+ * @name   I2C configuration
+ *
+ * I2C_DEV(0) is used for the IMU and the touch controller.
+ *
+ * @note The GPIOs listed in the configuration are only initialized as I2C
+ *       signals when module `periph_i2c` is used. Otherwise they are not
+ *       allocated and can be used for other purposes.
+ *
+ * @{
+ */
+#ifndef I2C0_SPEED
+#  define I2C0_SPEED      I2C_SPEED_FAST      /**< I2C bus speed of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SCL
+#  define I2C0_SCL        GPIO7               /**< SCL signal of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SDA
+#  define I2C0_SDA        GPIO6               /**< SDA signal of I2C_DEV(0) */
+#endif
+/** @} */
+
+/**
+ * @name   UART configuration
+ *
+ * ESP32-S3 provides 3 UART interfaces at maximum:
+ *
+ * UART_DEV(0) uses fixed standard configuration.<br>
+ * UART_DEV(1) is not used.<br>
+ *
+ * @{
+ */
+#define UART0_TXD   GPIO43  /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO44  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+/* include common peripheral definitions as last step */
+#include "periph_conf_common.h"
+
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR adds support for the [Waveshare ESP32-S3-Touch-LCD-1.28](https://docs.waveshare.com/ESP32-S3-Touch-LCD-1.28) board.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

The main features of the board can be tested using the driver tests e.g. `drivers/tests/gc9a01`, `drivers/tests/qmi8658`, `drivers/tests/cst816s`.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- Claude Opus for generating the first version of the `doc.md` which was then reviewed and fixed by me.