### PR TITLE
boards/common/native: expose mock saul GPIO pins

### DIFF
--- a/boards/common/native/Makefile.dep
+++ b/boards/common/native/Makefile.dep
@@ -26,3 +26,9 @@ ifneq (,$(filter lvgl,$(USEPKG)))
 endif
 
 USEMODULE += native_drivers
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  ifneq (,$(filter periph_gpio_mock,$(USEMODULE)))
+    USEMODULE += saul_gpio
+  endif
+endif

--- a/boards/common/native/include/gpio_params.h
+++ b/boards/common/native/include/gpio_params.h
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_common_native
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if IS_USED(MODULE_PERIPH_GPIO_MOCK)
+/**
+ * @brief    GPIO pin configuration
+ *
+ * This is only used when MODULE_PERIPH_GPIO_MOCK is enabled to support
+ * arbitrary GPIO pin configurations for testing purposes. Other GPIO drivers
+ * would rely on pre-defined GPIO pin configurations, which are more dynamic
+ * for the native board.
+ *
+ * There is no feedback when using this configuration because it is only used
+ * to provide some mock SAUL GPIO capabilities.
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED 0 (mock)",
+        .pin = GPIO_PIN(0, 0),
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED 1 (mock)",
+        .pin = GPIO_PIN(0, 1),
+        .mode = GPIO_OUT
+    }
+};
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */


### PR DESCRIPTION
### Contribution description

When `periph_gpio_mock` is included, expose two LEDs via `saul_gpio` for testing purposes. It is not enabled by default, so its use is limited. However, I do have a use-case that is only useful if there is something exposed via SAUL.

This does not work with `periph_gpio_linux` because the hard-coded pins are more dynamic for the native board.

Native defines macros for LED0 and LED1, and has the `native_drivers` module for providing _some_ console feedback. This change completely ignores that, just like `periph_gpio_mock` already does.

### Testing procedure

Compile using `USEMODULE=periph_gpio_mock BOARD=native make -C examples/basic/default`.

The run the example, and use the `saul` command:

```
RIOT native interrupts/signals initialized.
Native RTC initialized.
TZ not set, setting UTC
RIOT native64 board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2026.07-devel-121-ge4b21-feature/native_saul_gpio_mock)
Welcome to RIOT!

> saul
saul
ID      Class           Name
#0      ACT_SWITCH      LED 0 (mock)
#1      ACT_SWITCH      LED 1 (mock)

> saul write 0 1
saul write 0 1
Writing to device #0 - LED 0 (mock)
Data:                 1
data successfully written to device #0

> saul read 0
saul read 0
Reading from #0 (LED 0 (mock)|ACT_SWITCH)
Data:                 1
```

### Issues/PRs references
None

### Declaration of AI-Tools / LLMs usage:
None
