### PR TITLE
treewide: fix codespell typos

### DIFF
--- a/drivers/tm1637/tm1637.c
+++ b/drivers/tm1637/tm1637.c
@@ -194,7 +194,7 @@ static int _tm1637_transmit_segments(const tm1637_t *dev,
         return -1;
     }
 
-    /* transmit each byte indiviudally */
+    /* transmit each byte individually */
     for (int i = 0; i < DIGIT_COUNT; ++i) {
         res = _tm1637_transmit_byte(dev, segments[i]);
         if (res < 0) {

--- a/sys/net/gnrc/netapi/gnrc_netapi.c
+++ b/sys/net/gnrc/netapi/gnrc_netapi.c
@@ -133,7 +133,7 @@ int gnrc_netapi_dispatch(gnrc_nettype_t type, uint32_t demux_ctx,
     if (numof != 0) {
         gnrc_netreg_entry_t *sendto = gnrc_netreg_lookup(type, demux_ctx);
 
-        /* the packet is replicated over all interfaces that is's being sent on */
+        /* the packet is replicated over all interfaces that it's being sent on */
         gnrc_pktbuf_hold(pkt, numof - 1);
 
         while (sendto) {

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -700,7 +700,7 @@ static void _send_multicast(gnrc_pktsnip_t *pkt, bool prep_hdr,
     if (!gnrc_netif_highlander()) {
         /* interface not given: send over all interfaces */
         if (netif == NULL) {
-            /* the packet is replicated over all interfaces that is's being sent on */
+            /* the packet is replicated over all interfaces that it's being sent on */
             gnrc_pktbuf_hold(pkt, ifnum - 1);
 
             while ((netif = gnrc_netif_iter(netif))) {
@@ -1042,7 +1042,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
 
 #else  /* MODULE_GNRC_IPV6_ROUTER */
         DEBUG("ipv6: dropping packet\n");
-        /* non rounting hosts just drop the packet */
+        /* non-routing hosts just drop the packet */
         gnrc_pktbuf_release(pkt);
         return;
 #endif /* MODULE_GNRC_IPV6_ROUTER */


### PR DESCRIPTION
### Contribution description

Fix for Codespell typos found by version 2.4.2

After the release we might consider pinning the codespell version as suggested in https://github.com/RIOT-OS/riotdocker/pull/258

I'm on the fence about it. On one hand it's annoying on the other hand it's good because IMO nobody would remember to regularly update Codespell and _if_ someone did, it would be a huge mess to clean up all the typos it's finding now.

### Testing procedure

Static Test should succeed.


### Issues/PRs references

Progress for Tracking Issue #22216 I guess?

### Declaration of AI-Tools / LLMs usage:


AI-Tools / LLMs that were used are:
- none
