### PR TITLE
examples: fix DEVELHELP settings in Makefiles

### DIFF
--- a/examples/basic/leds_shell/Makefile
+++ b/examples/basic/leds_shell/Makefile
@@ -10,7 +10,7 @@ RIOTBASE ?= $(CURDIR)/../../../
 # Uncomment this to enable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
-DEVELHELP = 1
+DEVELHELP ?= 1
 
 # Change this to 0 to show compiler invocation lines by default:
 QUIET ?= 1

--- a/examples/networking/ble/misc/skald_ibeacon/Makefile
+++ b/examples/networking/ble/misc/skald_ibeacon/Makefile
@@ -13,7 +13,7 @@ USEMODULE += skald_ibeacon
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
-# CFLAGS += -DDEVELHELP
+# DEVELHELP ?= 1
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1

--- a/examples/networking/coap/gcoap/Makefile.slip
+++ b/examples/networking/coap/gcoap/Makefile.slip
@@ -59,7 +59,7 @@ USEMODULE += ps
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
-CFLAGS += -DDEVELHELP
+DEVELHELP ?= 1
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1

--- a/examples/networking/misc/benchmark_udp/Makefile
+++ b/examples/networking/misc/benchmark_udp/Makefile
@@ -39,7 +39,7 @@ USEMODULE += benchmark_udp
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
-DEVELHELP ?= 0
+# DEVELHELP ?= 1
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1

--- a/examples/networking/misc/lwip_ipv4/Makefile
+++ b/examples/networking/misc/lwip_ipv4/Makefile
@@ -10,7 +10,7 @@ RIOTBASE ?= $(CURDIR)/../../../../
 # Uncomment this to enable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:
-DEVELHELP = 1
+DEVELHELP ?= 1
 
 # Change this to 0 to show compiler invocation lines by default:
 QUIET ?= 1


### PR DESCRIPTION
### Contribution description

Some examples still used the old style `CFLAGS += -DDEVELHELP`. This can cause unwanted side effects because in some parts of the code the condition `DEVELHELP == 1` is evaluated instead of the CFLAG.

Also, I changed `DEVELHELP = 1` to `DEVELHELP ?= 1` to make it changeable from the console.

### Testing procedure

Look at the changes 👀 

### Issues/PRs references

Noticed while fixing the RIOT Tutorials.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
