### PR TITLE
cpu/stm32u5: Fix LSI initialization

### DIFF
--- a/cpu/stm32/stmclk/stmclk_common.c
+++ b/cpu/stm32/stmclk/stmclk_common.c
@@ -65,11 +65,6 @@
 #define RCC_CSR_LSIRDY          RCC_CSR_LSI1RDY
 #endif
 
-#if defined (CPU_FAM_STM32U5)
-#define RCC_CSR_LSION           RCC_BDCR_LSION
-#define RCC_CSR_LSIRDY          RCC_BDCR_LSIRDY
-#endif
-
 #if defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5)
 #define RCC_CFGR_SWS_HSI        RCC_CFGR_SWS_0
 #endif
@@ -105,6 +100,9 @@ void stmclk_enable_lfclk(void)
 #if defined(CPU_FAM_STM32C0)
         RCC->CSR2 |= RCC_CSR2_LSION;
         while (!(RCC->CSR2 & RCC_CSR2_LSIRDY)) {}
+#elif defined(CPU_FAM_STM32U5)
+        RCC->BDCR |= RCC_BDCR_LSION;
+        while (!(RCC->BDCR & RCC_BDCR_LSIRDY)) {}
 #else
         RCC->CSR |= RCC_CSR_LSION;
         while (!(RCC->CSR & RCC_CSR_LSIRDY)) {}
@@ -123,6 +121,8 @@ void stmclk_disable_lfclk(void)
     else {
 #if defined(CPU_FAM_STM32C0)
         RCC->CSR2 &= ~(RCC_CSR2_LSION);
+#elif defined(CPU_FAM_STM32U5)
+        RCC->BDCR &= ~(RCC_BDCR_LSION);
 #else
         RCC->CSR &= ~(RCC_CSR_LSION);
 #endif


### PR DESCRIPTION
To enable the LSI oscillator on STM32U5, RCC_CSR was used instead of RCC_BDCR, which is the correct register.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
After clearing the reset status flags, the program got stuck in the LSIRDY loop on the next restart. After checking the reference manual, I identified that the wrong register was being used. Once the register was corrected, the program ran as expected.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

I wrote a simple watchdog code where the watchdog triggers a reset.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

None

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- none
