### PR TITLE
dist/tools: add static check for missing board doc.md files

### DIFF
--- a/dist/tools/board_doc_check/check.sh
+++ b/dist/tools/board_doc_check/check.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# SPDX-FileCopyrightText: 2026 Evgeniy Kuznetsov <evvykuznetsov@edu.hse.ru>
+# SPDX-License-Identifier: LGPL-2.1-only
+
+: "${RIOTBASE:=$(cd "$(dirname "$0")"/../../../ || exit; pwd)}"
+: "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
+
+# not running shellcheck with -x in the CI --> disable SC1091
+# shellcheck disable=SC1091
+. "${RIOTTOOLS}"/ci/github_annotate.sh
+
+github_annotate_setup
+
+EXIT_CODE=0
+
+for board_dir in "${RIOTBASE}"/boards/*/; do
+    board=$(basename "${board_dir}")
+
+    [ "${board}" = "common" ] && continue
+
+    if [ ! -f "${board_dir}/doc.md" ]; then
+        MSG="boards/${board}/doc.md is missing"
+        if github_annotate_is_on; then
+            github_annotate_error_no_file "${MSG}"
+        else
+            echo "ERROR: ${MSG}"
+        fi
+        EXIT_CODE=1
+    fi
+done
+
+github_annotate_teardown
+
+exit "${EXIT_CODE}"

--- a/dist/tools/ci/static_tests.sh
+++ b/dist/tools/ci/static_tests.sh
@@ -127,6 +127,7 @@ run ./dist/tools/headerguards/check.sh
 run ./dist/tools/buildsystem_sanity_check/check.sh
 run ./dist/tools/feature_resolution/check.sh
 run ./dist/tools/boards_supported/check.sh
+run ./dist/tools/board_doc_check/check.sh
 run ./dist/tools/codespell/check.sh
 run ./dist/tools/cargo-checks/check.sh
 run ./dist/tools/examples_check/check_has_readme.sh

--- a/doc/guides/advanced_tutorials/porting_boards.mdx
+++ b/doc/guides/advanced_tutorials/porting_boards.mdx
@@ -197,9 +197,13 @@ PROGRAMMER ?= openocd
 
 ### doc.md
 
-Although not explicitly needed, if upstreamed and as a general good
-practice, this file holds all `BOARD` documentation. This can include
-datasheet reference, documentation on how to flash, etc.
+This file holds all `BOARD` documentation and is mandatory for every
+newly ported board. It can (and should) include datasheet references,
+documentation on how to flash the board, etc.
+
+Proper documentation about your board makes it easier for others to use it
+to its full potential. Remember to also mention any features that are not
+supported yet!
 
 The documentation must be under the proper doxygen group, you can compile the
 documentation by calling `make doc` and then open the generated html file on


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
This PR adds a static test (.sh script) that checks whether every ported board has a mandatory doc.md file. \
The "common" directory is skipped as it's not a standalone ported board.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

./dist/tools/board_doc_check/check.sh
or make static-test

If all boards contain the required doc.md file, the test passes silently. Otherwise, it fails and reports the directories where the required file is missing.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Closes #22224. See also #22221.

Depends on #22221.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- none
