### PR TITLE
boards/*: fix (some) Starlight build issues in doc.md files

### DIFF
--- a/boards/adafruit-feather-nrf52840-express/doc.md
+++ b/boards/adafruit-feather-nrf52840-express/doc.md
@@ -30,13 +30,13 @@ This lets you access the Feather directly over USB.
 You have several alternative possibilities to connect to the board.
 
 1. With
-   ~~~~~~~~~~~~~~~~~~~~~ {.mk}
+   ```makefile
    USEMODULE += stdio_uart
-   ~~~~~~~~~~~~~~~~~~~~~
+   ```
    and an FTDI adapter connected to the Feather's RX and TX ports you can use
    UART-based terminals to connect to the feather
 2. With
-   ~~~~~~~~~~~~~~~~~~~~~ {.mk}
+   ```makefile
    USEMODULE += stdio_rtt
-   ~~~~~~~~~~~~~~~~~~~~~
+   ```
    you can use the Segger J-Link Programmer as a serial interface to the device.

--- a/boards/esp32-heltec-lora32-v2/doc.md
+++ b/boards/esp32-heltec-lora32-v2/doc.md
@@ -95,27 +95,25 @@ according to the defined functionality of GPIOs. This configuration can be
 overridden by \ref esp32_application_specific_configurations
 "application-specific configurations".
 
-<center>
-Function        | GPIOs  | Remarks |Configuration
-:---------------|:-------|:--------|:----------------------------------
-BTN0            | GPIO0  | low active  | |
-LED0            | GPIO25 | high active | |
-ADC             | GPIO36, GPIO39, GPIO37, GPIO38,\n GPIO0, GPIO2, GPIO12, GPIO13,\n GPIO4, GPIO15 | | \ref esp32_adc_channels "ADC Channels"
-DAC             | | | \ref esp32_dac_channels "DAC Channels"
-PWM_DEV(0)      | GPIO25, GPIO2, GPIO17 | | \ref esp32_pwm_channels "PWM Channels"
-PWM_DEV(1)      | GPIO22, GPIO23 | | \ref esp32_pwm_channels "PWM Channels"
-I2C_DEV(0):SDA  | GPIO4 | | \ref esp32_i2c_interfaces "I2C Interfaces"
-I2C_DEV(0):SCL  | GPIO15 | I2C_SPEED_FAST is used | \ref esp32_i2c_interfaces "I2C Interfaces"
-SPI_DEV(0):CLK  | GPIO5 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
-SPI_DEV(0):MISO | GPIO19 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
-SPI_DEV(0):MOSI | GPIO27 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
-SPI_DEV(0):CS0  | GPIO18 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
-UART_DEV(0):TxD | GPIO1  | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
-UART_DEV(0):RxD | GPIO3  | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
-UART_DEV(1):TxD | GPIO10 | not available in **qout** and **qio** flash mode | \ref esp32_uart_interfaces "UART interfaces"
-UART_DEV(1):RxD | GPIO9  | not available in **qout** and **qio** flash mode | \ref esp32_uart_interfaces "UART interfaces"
-OLED RESET      | GPIO16 | | |
-</center>
+| Function        | GPIOs  | Remarks | Configuration |
+|:----------------|:-------|:--------|:--------------|
+| BTN0            | GPIO0  | low active  | |
+| LED0            | GPIO25 | high active | |
+| ADC             | GPIO36, GPIO39, GPIO37, GPIO38,\n GPIO0, GPIO2, GPIO12, GPIO13,\n GPIO4, GPIO15 | | \ref esp32_adc_channels "ADC Channels" |
+| DAC             | | | \ref esp32_dac_channels "DAC Channels" |
+| PWM_DEV(0)      | GPIO25, GPIO2, GPIO17 | | \ref esp32_pwm_channels "PWM Channels" |
+| PWM_DEV(1)      | GPIO22, GPIO23 | | \ref esp32_pwm_channels "PWM Channels" |
+| I2C_DEV(0):SDA  | GPIO4 | | \ref esp32_i2c_interfaces "I2C Interfaces" |
+| I2C_DEV(0):SCL  | GPIO15 | I2C_SPEED_FAST is used | \ref esp32_i2c_interfaces "I2C Interfaces" |
+| SPI_DEV(0):CLK  | GPIO5 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces" |
+| SPI_DEV(0):MISO | GPIO19 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces" |
+| SPI_DEV(0):MOSI | GPIO27 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces" |
+| SPI_DEV(0):CS0  | GPIO18 | VSPI is used | \ref esp32_spi_interfaces "SPI Interfaces" |
+| UART_DEV(0):TxD | GPIO1  | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces" |
+| UART_DEV(0):RxD | GPIO3  | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces" |
+| UART_DEV(1):TxD | GPIO10 | not available in **qout** and **qio** flash mode | \ref esp32_uart_interfaces "UART interfaces" |
+| UART_DEV(1):RxD | GPIO9  | not available in **qout** and **qio** flash mode | \ref esp32_uart_interfaces "UART interfaces" |
+| OLED RESET      | GPIO16 | | |
 \n
 @note
 - The configuration of ADC channels contains all ESP32 GPIOs that can be used
@@ -134,12 +132,12 @@ The 0.96-inch OLED display with 128x64 pixels uses the widely used SSD1306
 controller. It is connected via `I2C_DEV(0)`. It can be used with the `pkg/u8g2`
 package. For this purpose, the `pkg/u8g2` package has to be used in the
 application Makefile
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```makefile
 USEPKG += u8g2
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 and function `u8g2_Setup_ssd1306_i2c_128x64_noname_f` has to be called to
 setup the right driver, for example:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+```c
 #include "u8g2.h"
 #include "u8x8_riotos.h"
 
@@ -159,14 +157,14 @@ u8g2_SetUserPtr(&u8g2, &user_data);
 u8g2_SetI2CAddress(&u8g2, SSD1306_I2C_ADDR);
 u8g2_InitDisplay(&u8g2);
 u8g2_SetPowerSave(&u8g2, 0);
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 The `tests/pkg/u8g2` test application is a good example of how to use the
 `pkg/u8g2` package. It can be compiled for the board with the following command:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```shell
 TEST_OUTPUT=4 TEST_I2C=0 TEST_ADDR=0x3c TEST_PIN_RESET=GPIO16 \
 TEST_DISPLAY=u8g2_Setup_ssd1306_i2c_128x64_noname_f \
 BOARD=esp32-heltec-lora32-v2 make -C tests/pkg/u8g2/ flash
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
 [Back to table of contents](#esp32_heltec_lora32_v2_toc)
 
@@ -177,23 +175,23 @@ network interface modules have been tested with the board. You could use
 the following code in your \ref esp32_application_specific_configurations
 "application-specific configuration" to use such modules:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+```c
 #ifdef BOARD_ESP32_HELTEC_LORA32_V2
 
-#if MODULE_MRF24J40
-#define MRF24J40_PARAM_CS       GPIO12      /* MRF24J40 CS signal    */
-#define MRF24J40_PARAM_RESET    GPIO22      /* MRF24J40 RESET signal */
-#define MRF24J40_PARAM_INT      GPIO23      /* MRF24J40 INT signal   */
-#endif
+#  if MODULE_MRF24J40
+#    define MRF24J40_PARAM_CS       GPIO12  /* MRF24J40 CS signal    */
+#    define MRF24J40_PARAM_RESET    GPIO22  /* MRF24J40 RESET signal */
+#    define MRF24J40_PARAM_INT      GPIO23  /* MRF24J40 INT signal   */
+#  endif
 
-#if MODULE_ENC28J80
-#define ENC28J80_PARAM_CS       GPIO12      /* ENC28J80 CS signal    */
-#define ENC28J80_PARAM_RESET    GPIO22      /* ENC28J80 RESET signal */
-#define ENC28J80_PARAM_INT      GPIO23      /* ENC28J80 INT signal   */
-#endif
+#  if MODULE_ENC28J80
+#    define ENC28J80_PARAM_CS       GPIO12  /* ENC28J80 CS signal    */
+#    define ENC28J80_PARAM_RESET    GPIO22  /* ENC28J80 RESET signal */
+#    define ENC28J80_PARAM_INT      GPIO23  /* ENC28J80 INT signal   */
+#  endif
 
 #endif
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 For other parameters, the default values defined by the drivers can be used.
 
 @note The **RESET** signal of MRF24J40 and ENC28J60 based modules can also
@@ -225,9 +223,9 @@ and [here for SX1278 version](https://resource.heltec.cn/download/WiFi_LoRa_32/V
 Flashing RIOT is quite easy. The board has a Micro-USB connector with
 reset/boot/flash logic. Just connect the board to your host computer and
 type using the programming port:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```shell
 make flash BOARD=esp32-heltec-lora32-v2 ...
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 For detailed information about ESP32 as well as configuring and compiling RIOT
 for ESP32 boards, see \ref esp32_riot.
 

--- a/boards/esp32-mh-et-live-minikit/doc.md
+++ b/boards/esp32-mh-et-live-minikit/doc.md
@@ -134,13 +134,13 @@ board. You could use the following code in your
 \ref esp32_application_specific_configurations
 "application-specific configuration" to use such a module:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+```c
 #if MODULE_ENC28J80 && BOARD_ESP32_MH_ET_LIVE_MINIKIT
-#define ENC28J80_PARAM_CS       GPIO14      /* ENC28J80 CS signal    */
-#define ENC28J80_PARAM_INT      GPIO33      /* ENC28J80 INT signal   */
-#define ENC28J80_PARAM_RESET    GPIO12      /* ENC28J80 RESET signal */
+#  define ENC28J80_PARAM_CS       GPIO14    /* ENC28J80 CS signal    */
+#  define ENC28J80_PARAM_INT      GPIO33    /* ENC28J80 INT signal   */
+#  define ENC28J80_PARAM_RESET    GPIO12    /* ENC28J80 RESET signal */
 #endif
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 For **ENC28J80_PARAM_SPI** the default parameter defined by the driver can
 be used.
 
@@ -172,9 +172,9 @@ The corresponding board schematic can be found
 Flashing RIOT is quite easy. The board has a Micro-USB connector with a
 reset/boot/flash logic. Just connect the board to your host computer using
 the programming port and type:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```shell
 make flash BOARD=esp32-mh-et-live-minikit ...
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 For detailed information about ESP32 as well as configuring and compiling
 RIOT for ESP32 boards, see \ref esp32_riot.
 

--- a/boards/esp32-olimex-evb/doc.md
+++ b/boards/esp32-olimex-evb/doc.md
@@ -41,9 +41,9 @@ for soldering iron or breadboards.
 Because of the differences in the on-board hardware, it is necessary to
 add the following line to the makefile of the application to use the
 according configuration for Olimex ESP32-GATEWAY:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```makefile
 USEMODULE += olimex_esp32_gateway
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
 @image html "https://gitlab.com/gschorcht/RIOT.wiki-Images/raw/master/esp32/Olimex_ESP32-EVB_GATEWAY.png" "Olimex ESP32-EVB (left) and Olimex ESP32-GATEWAY (right)"
 
@@ -123,9 +123,9 @@ GPIO27 | EMAC_RMII:RX_DV   | EMAC_RMII:RX_DV  | LAN interface | \ref esp32_ether
 To use the board configuration for Olimex-ESP32-GATEWAY, it is necessary
 to add the following line to makefile of the application:
 \n
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```makefile
 USEMODULE += olimex_esp32_gateway
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 - GPIO9 and GIOP10 can only be used in **dout** and **dio**
   \ref esp32_flash_modes "flash modes".
 - It might be necessary to remove the SD card or the peripheral hardware
@@ -145,17 +145,17 @@ You could use the following code in your
 \ref esp32_application_specific_configurations
 "application-specific configuration" to use such modules:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+```c
 #ifdef BOARD_ESP32_OLIMEX_EVB && !MODULE_ESP32_OLIMEX_GATEWAY
 
-#if MODULE_MRF24J40
-#define MRF24J40_PARAM_CS       GPIO9       /* MRF24J40 CS signal    */
-#define MRF24J40_PARAM_RESET    GPIO10      /* MRF24J40 RESET signal */
-#define MRF24J40_PARAM_INT      GPIO34      /* MRF24J40 INT signal   */
-#endif
+#  if MODULE_MRF24J40
+#    define MRF24J40_PARAM_CS       GPIO9   /* MRF24J40 CS signal    */
+#    define MRF24J40_PARAM_RESET    GPIO10  /* MRF24J40 RESET signal */
+#    define MRF24J40_PARAM_INT      GPIO34  /* MRF24J40 INT signal   */
+#  endif
 
 #endif
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 For other parameters, the default values defined by the drivers can be used.
 
 @note
@@ -194,9 +194,9 @@ The corresponding board schematics can be found on GitHub for
 Flashing RIOT is quite easy. The board has a Micro-USB connector with
 reset/boot/flash logic. Just connect the board to your host computer and
 type using the programming port:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```shell
 make flash BOARD=esp32-olimex-evb ...
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 For detailed information about ESP32 as well as configuring and compiling
 RIOT for ESP32 boards, see \ref esp32_riot.
 

--- a/boards/esp32-wemos-lolin-d32-pro/doc.md
+++ b/boards/esp32-wemos-lolin-d32-pro/doc.md
@@ -105,9 +105,9 @@ GPIO32 is used as **TFT_LED** signal and ADC_LINE(4) is not available.
 makefile of the application to enable the according default board and
 peripheral configuration:
 \n
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```makefile
 USEMODULE += esp_lolin_tft
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
 For detailed information about the configuration of ESP32 boards, see section \ref esp32_peripherals "Common Peripherals".
 
@@ -120,23 +120,23 @@ network interface modules have been tested with the board. You could use
 the following code in your \ref esp32_application_specific_configurations
 "application-specific configuration" to use such modules:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+```c
 #ifdef BOARD_ESP32_WEMOS_LOLIN_D32_PRO
 
-#if MODULE_MRF24J40
-#define MRF24J40_PARAM_CS       GPIO15      /* MRF24J40 CS signal    */
-#define MRF24J40_PARAM_RESET    GPIO2       /* MRF24J40 RESET signal */
-#define MRF24J40_PARAM_INT      GPIO13      /* MRF24J40 INT signal   */
-#endif
+#  if MODULE_MRF24J40
+#    define MRF24J40_PARAM_CS       GPIO15  /* MRF24J40 CS signal    */
+#    define MRF24J40_PARAM_RESET    GPIO2   /* MRF24J40 RESET signal */
+#    define MRF24J40_PARAM_INT      GPIO13  /* MRF24J40 INT signal   */
+#  endif
 
-#if MODULE_ENC28J80
-#define ENC28J80_PARAM_CS       GPIO15      /* ENC28J80 CS signal    */
-#define ENC28J80_PARAM_RESET    GPIO2       /* ENC28J80 RESET signal */
-#define ENC28J80_PARAM_INT      GPIO13      /* ENC28J80 INT signal   */
-#endif
+#  if MODULE_ENC28J80
+#    define ENC28J80_PARAM_CS       GPIO15  /* ENC28J80 CS signal    */
+#    define ENC28J80_PARAM_RESET    GPIO2   /* ENC28J80 RESET signal */
+#    define ENC28J80_PARAM_INT      GPIO13  /* ENC28J80 INT signal   */
+#  endif
 
 #endif
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 For other parameters, the default values defined by the drivers can be used.
 
 @note
@@ -172,9 +172,9 @@ The corresponding board schematic can be found
 Flashing RIOT is quite easy. The board has a Micro-USB connector with
 reset/boot/flash logic. Just connect the board to your host computer
 using the programming port and type:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```shell
 make flash BOARD=esp32-wemos-lolin-d32-pro ...
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 For detailed information about ESP32 as well as configuring and compiling
 RIOT for ESP32 boards, see \ref esp32_riot.
 

--- a/boards/esp32-wroom-32/doc.md
+++ b/boards/esp32-wroom-32/doc.md
@@ -131,24 +131,24 @@ network interface modules have been tested with the board. You could use
 the following code in your \ref esp32_application_specific_configurations
 "application-specific configuration" to use such modules:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+```c
 #ifdef BOARD_ESP32_WROOM-32
 
-#if MODULE_MRF24J40
-#define MRF24J40_PARAM_CS       GPIO16       /* MRF24J40 CS signal    */
-#define MRF24J40_PARAM_RESET    GPIO17       /* MRF24J40 RESET signal */
-#define MRF24J40_PARAM_INT      GPIO34       /* MRF24J40 INT signal   */
-#define MRF24J40_PARAM_SPI_CLK  SPI_CLK_1MHZ /* SPI clock frequency */
-#endif
+#  if MODULE_MRF24J40
+#    define MRF24J40_PARAM_CS       GPIO16       /* MRF24J40 CS signal    */
+#    define MRF24J40_PARAM_RESET    GPIO17       /* MRF24J40 RESET signal */
+#    define MRF24J40_PARAM_INT      GPIO34       /* MRF24J40 INT signal   */
+#    define MRF24J40_PARAM_SPI_CLK  SPI_CLK_1MHZ /* SPI clock frequency */
+#  endif
 
-#if MODULE_ENC28J80
-#define ENC28J80_PARAM_CS       GPIO32      /* ENC28J80 CS signal    */
-#define ENC28J80_PARAM_RESET    GPIO33      /* ENC28J80 RESET signal */
-#define ENC28J80_PARAM_INT      GPIO35      /* ENC28J80 INT signal   */
-#endif
+#  if MODULE_ENC28J80
+#    define ENC28J80_PARAM_CS       GPIO32      /* ENC28J80 CS signal    */
+#    define ENC28J80_PARAM_RESET    GPIO33      /* ENC28J80 RESET signal */
+#    define ENC28J80_PARAM_INT      GPIO35      /* ENC28J80 INT signal   */
+#  endif
 
 #endif
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 For other parameters, the default values defined by the drivers can be used.
 
 @note The **RESET** signal of MRF24J40 and ENC28J60 based modules can also
@@ -178,9 +178,9 @@ The corresponding board schematics can be found
 Flashing RIOT is quite easy. The board has a Micro-USB connector with
 reset/boot/flash logic. Just connect the board to your host computer
 and type using the programming port:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```shell
 make flash BOARD=esp32-wroom-32 ...
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 For detailed information about ESP32 as well as configuring and compiling
 RIOT for ESP32 boards, see \ref esp32_riot.
 

--- a/boards/esp32-wrover-kit/doc.md
+++ b/boards/esp32-wrover-kit/doc.md
@@ -212,23 +212,23 @@ interface modules have been tested with the board. You could use the following
 code in your \ref esp32_application_specific_configurations
 "application-specific configuration" to use such modules:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+```c
 #ifdef BOARD_ESP32_WROVER_KIT
 
-#if MODULE_MRF24J40
-#define MRF24J40_PARAM_CS       GPIO9       /* MRF24J40 CS signal    */
-#define MRF24J40_PARAM_INT      GPIO10      /* MRF24J40 INT signal   */
-#define MRF24J40_PARAM_RESET    GPIO12      /* MRF24J40 RESET signal */
-#endif
+#  if MODULE_MRF24J40
+#    define MRF24J40_PARAM_CS       GPIO9   /* MRF24J40 CS signal    */
+#    define MRF24J40_PARAM_INT      GPIO10  /* MRF24J40 INT signal   */
+#    define MRF24J40_PARAM_RESET    GPIO12  /* MRF24J40 RESET signal */
+#  endif
 
-#if MODULE_ENC28J80
-#define ENC28J80_PARAM_CS       GPIO9       /* ENC28J80 CS signal    */
-#define ENC28J80_PARAM_INT      GPIO10      /* ENC28J80 INT signal   */
-#define ENC28J80_PARAM_RESET    GPIO12      /* ENC28J80 RESET signal */
-#endif
+#  if MODULE_ENC28J80
+#    define ENC28J80_PARAM_CS       GPIO9   /* ENC28J80 CS signal    */
+#    define ENC28J80_PARAM_INT      GPIO10  /* ENC28J80 INT signal   */
+#    define ENC28J80_PARAM_RESET    GPIO12  /* ENC28J80 RESET signal */
+#  endif
 
 #endif
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 For other parameters, the default values defined by the drivers can be used.
 
 @note
@@ -261,9 +261,9 @@ Flashing RIOT is quite straight forward. The board has a Micro-USB connector
 with reset/boot/flash logic. Just connect the board using the programming port
 to your host computer and type:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```shell
 make flash BOARD=esp32-wrover-kit ...
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
 The USB bridge is based on FDI FT2232HL and offers two USB interfaces:
 
@@ -275,9 +275,9 @@ Therefore, you have to declare the USB interface in the make command. For
 example, if the ESP32-WROVER-KIT is connected to the host computer through the
 USB interfaces `/dev/ttyUSB0` and `/dev/ttyUSB1`, the make command would be
 used as following:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```shell
 make flash BOARD=esp32-wrover-kit PORT=/dev/ttyUSB1 ...
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
 For detailed information about ESP32 as well as configuring and compiling RIOT
 for ESP32 boards, see \ref esp32_riot.
@@ -294,35 +294,35 @@ for details on how to setup and how to use ESP-WROVER-Kit V3 and OpenOCD.
 
 To use the JTAG interface, the `esp_jtag` module has to be enabled for
 compilation.
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```shell
 USEMODULE=esp_jtag make flash BOARD=esp32-wrover-kit ...
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
 To flash and debug using OpenOCD, the precompiled version of OpenOCD for
 ESP32 has to be installed using the install script while being in RIOT's
 root directory, see also section
 [Using Local Toolchain Installation](#esp32_local_toolchain_installation).
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```shell
 dist/tools/esptool/install.sh openocd
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
 Before OpenOCD can then be used, the `PATH` variable has to be set correctly
 and the `OPENOCD` variable has to be exported using the following command.
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```shell
 . dist/tools/esptool/export.sh openocd
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
 Once the `PATH` variable and the `OPENOCD` variable are set, OpenOCD can be used
 
 - to flash the application using command
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ```shell
   PROGRAMMER=openocd USEMODULE=esp_jtag make flash BOARD=esp32-wrover-kit ...
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ```
 - to start a debugging session (the board will be reset, but not flashed)
   using command
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ```shell
   PROGRAMMER=openocd USEMODULE=esp_jtag make debug BOARD=esp32-wrover-kit ...
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ```
 
 by setting the `PROGRAMMER` variable to `openocd`.
 

--- a/boards/feather-m0/doc.md
+++ b/boards/feather-m0/doc.md
@@ -28,13 +28,13 @@ SAMD21 mcu.
 `AIN7` can be used to [measure the voltage of a connected Lipoly battery][battery].
 It is mapped to ADC_LINE(6) in RIOT.
 
-~~~~~~~~~~~~~~~~ {.c}
+```c
 int vbat = adc_sample(ADC_LINE(6), ADC_RES_10BIT);
 vbat *= 2;      /* voltage was divided by 2, so multiply it back */
 vbat *= 33;     /* reference voltage 3.3V * 10 */
 vbat /= 10240;  /* resolution * 10 (because we multiplied 3.3V by 10) */
 printf("Bat: %dV\n", vbat);
-~~~~~~~~~~~~~~~~
+```
 
 [battery]: https://learn.adafruit.com/adafruit-feather-m0-basic-proto/power-management#measuring-battery-4-9
 
@@ -42,8 +42,8 @@ printf("Bat: %dV\n", vbat);
 
 Use `BOARD=feather-m0` with the `make` command.<br/>
 Example with `hello-world` application:
-```
-     make BOARD=feather-m0 -C examples/basic/hello-world flash
+```shell
+make BOARD=feather-m0 -C examples/basic/hello-world flash
 ```
 
 @note     If the application crashes, automatic reflashing via USB, as explained
@@ -64,9 +64,9 @@ Example with `hello-world` application:
 To enable the WiFi interface of the Feather M0 WiFi variant of the board
 automatically for networking applications, use `feather-m0-wifi` as board
 and define the required WiFi parameters, for example:
-```
-     CFLAGS='-DWIFI_SSID=\"<ssid>\" -DWIFI_PASS=\"<pass>\"' \
-     make BOARD=feather-m0-wifi -C examples/networking/gnrc/networking
+```shell
+CFLAGS='-DWIFI_SSID=\"<ssid>\" -DWIFI_PASS=\"<pass>\"' \
+make BOARD=feather-m0-wifi -C examples/networking/gnrc/networking
 ```
 
 For detailed information about the parameters, see section
@@ -79,7 +79,7 @@ To enable the LoRa module available on the
 variant of the board automatically for LoRa applications,
 use `feather-m0-lora` as board:
 
-```
+```shell
 make BOARD=feather-m0-lora -C examples/networking/gnrc/lorawan
 ```
 


### PR DESCRIPTION
### Contribution description

Starlight is not able to interpret `~~~{.mk}` as syntax highlighting for Makefiles, therefore it was replaced with the backtick style.

Also tables are not parsed correctly when they are inside of `<center>` tags, which was fixed for one table as an example.

Some code was modified to include the preprocessor indentation.

This is just a small drop on the hot stone, I wanted to explore the mitigation rather than completing the herculean cleanup task.

Also ping @LasseRosenow :)

### Testing procedure

Look at the generated docs in Doxygen and Starlight 👀 

Running `make doc-starlight` after a `make -C doc/starlight clean` should run without errors about syntax highlighting now.

### Issues/PRs references

Progress for #22203.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
