### PR TITLE
sys/include/atomic_utils: Fixed atomic bit "narrowing conversion" compile error

### DIFF
--- a/sys/include/atomic_utils.h
+++ b/sys/include/atomic_utils.h
@@ -1358,25 +1358,25 @@ ATOMIC_FETCH_OP_IMPL(and, &, u64, uint64_t)
 static inline atomic_bit_u8_t atomic_bit_u8(volatile uint8_t *dest,
                                             uint8_t bit)
 {
-    atomic_bit_u8_t result = { .dest = dest, .mask = 1U << bit };
+    atomic_bit_u8_t result = { .dest = dest, .mask = (uint8_t)(1U << bit) };
     return result;
 }
 static inline atomic_bit_u16_t atomic_bit_u16(volatile uint16_t *dest,
                                               uint8_t bit)
 {
-    atomic_bit_u16_t result = { .dest = dest, .mask = 1U << bit };
+    atomic_bit_u16_t result = { .dest = dest, .mask = (uint16_t)(1U << bit) };
     return result;
 }
 static inline atomic_bit_u32_t atomic_bit_u32(volatile uint32_t *dest,
                                               uint8_t bit)
 {
-    atomic_bit_u32_t result = { .dest = dest, .mask = 1UL << bit };
+    atomic_bit_u32_t result = { .dest = dest, .mask = (uint32_t)(1UL << bit) };
     return result;
 }
 static inline atomic_bit_u64_t atomic_bit_u64(volatile uint64_t *dest,
                                               uint8_t bit)
 {
-    atomic_bit_u64_t result = { .dest = dest, .mask = 1ULL << bit };
+    atomic_bit_u64_t result = { .dest = dest, .mask = (uint64_t)(1ULL << bit) };
     return result;
 }
 static inline void atomic_set_bit_u8(atomic_bit_u8_t bit)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

With `-Werror=narrowing` enabled, a compiler error will be thrown on `atomic_bit_u8` ... `atomic_bit_u64` . Example:

```bash
sys/include/atomic_utils.h:1361:57: error: narrowing conversion of '(1 << ((int)bit))' from 'unsigned int' to 'uint8_t' {aka 'unsigned char'} [-Werror=narrowing]
 1361 |     atomic_bit_u8_t result = { .dest = dest, .mask = 1U << bit };
      |                                                      ~~~^~~~~~
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This PR wraps the bit shift with a typecast to the correct type.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- none
