### PR TITLE
dist/tools: update doc of `can_fast_ci_run.py` and add `VERSION` file to fast-run list

### DIFF
--- a/dist/tools/ci/can_fast_ci_run.py
+++ b/dist/tools/ci/can_fast_ci_run.py
@@ -21,7 +21,7 @@ OTHER_CLASSIFIERS = [
     [re.compile(r"^(Makefile.*|sys\/Makefile.*|drivers\/Makefile.*|makefiles\/.*)$"), "build-system"],
     [re.compile(r"^(drivers\/include\/.*|sys\/include\/.*)$"), "public-headers"],
     [re.compile(r"^(Kconfig|kconfigs\/.*|pkg\/Kconfig|sys\/Kconfig|drivers\/Kconfig)$"), "kconfig"],
-    [re.compile(r"^(.*\.cff|doc\/.*|.*\.md|.*\.txt)$"), "doc"],
+    [re.compile(r"^(.*\.cff|doc\/.*|.*\.md|.*\.txt|VERSION)$"), "doc"],
     [re.compile(r"^(CODEOWNERS|\.mailmap|\.gitignore|\.gitattributes)$"), "git"],
     [re.compile(r"^\.github/.*$"), "github"],
     [re.compile(r"^(\.murdock|dist\/ls\/.*|\.drone.yml)$"), "ci-murdock"],

--- a/dist/tools/ci/can_fast_ci_run.py
+++ b/dist/tools/ci/can_fast_ci_run.py
@@ -135,10 +135,8 @@ def classify_changes(riotbase=None, upstream_branch="master"):
     Runs the given compiler with -v -E on an no-op compilation unit and parses the built-in
     include search directories and the GCC version from the output
 
-    :param args: parse command line arguments
-    :type args: dict
-    :param pr_branch: name of the PR branch
-    :type pr_branch: str
+    :param riotbase: path of the RIOT base directory
+    :type riotbase: str
     :param upstream_branch: name of the main upstream branch the PR should be merged into
     :type upstream_branch: str
 


### PR DESCRIPTION
### Contribution description

The documentation for the `classify_changes` function was outdated, so I updated it.

Also, the addition of a `VERSION` file should probably not cause a full build?
I don't think our build system even uses the file, RIOT derives it's version from the `GIT_VERSION`


### Testing procedure

Clone a fresh copy of the mothership `git clone https://github.com/RIOT-OS/RIOT`, checkout the `2026.04-branch`, checkout the #22244 PR (I use `gh pr checkout 22244`, you can use something else too I guess?), run the following command:

```
buechse@skyleaf:~/RIOTstuff/riot-upstream$ gh repo clone RIOT-OS/RIOT
Cloning into 'RIOT'...
remote: Enumerating objects: 401023, done.
remote: Counting objects: 100% (191/191), done.
remote: Compressing objects: 100% (145/145), done.
remote: Total 401023 (delta 106), reused 53 (delta 44), pack-reused 400832 (from 2)
Receiving objects: 100% (401023/401023), 177.40 MiB | 39.73 MiB/s, done.
Resolving deltas: 100% (276472/276472), done.
Updating files: 100% (15811/15811), done.

buechse@skyleaf:~/RIOTstuff/riot-upstream$ cd RIOT/

buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ git checkout 2026.04-branch
branch '2026.04-branch' set up to track 'origin/2026.04-branch'.
Switched to a new branch '2026.04-branch'

buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ gh pr checkout 22244
From https://github.com/RIOT-OS/RIOT
 * [new ref]               refs/pull/22244/head -> final_release_pr
Switched to branch 'final_release_pr'

buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ dist/tools/ci/can_fast_ci_run.py --upstreambranch 2026.04-branch --explain --debug
Couldn't classify changes: File "VERSION" doesn't match any known category
```

Checkout this PR in the same repository, checkout `final_release_pr` again, cherry pick this PR (and the other changes to `can_fast_ci_run.py`) onto it and run the command again.

```
buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ gh pr checkout 22247
remote: Enumerating objects: 17, done.
remote: Counting objects: 100% (17/17), done.
remote: Compressing objects: 100% (2/2), done.
remote: Total 12 (delta 10), reused 12 (delta 10), pack-reused 0 (from 0)
Unpacking objects: 100% (12/12), 1024 bytes | 341.00 KiB/s, done.
From https://github.com/RIOT-OS/RIOT
 * [new ref]               refs/pull/22247/head -> pr/VERSION_fast_run
Switched to branch 'pr/VERSION_fast_run'

buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ git checkout final_release_pr
Switched to branch 'final_release_pr'

buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ git cherry-pick 8d6b1ba f5e327d0c9 b6d632467e 2fd4ffe8da
[final_release_pr 134591029b] dist/tools/ci: update classification
 Author: Marian Buschsieweke <marian.buschsieweke@ml-pa.com>
 Date: Fri Apr 17 13:06:23 2026 +0200
 1 file changed, 2 insertions(+), 2 deletions(-)
[final_release_pr 75357673c1] dist/tools: add GitHub workflows to can_fast_ci_run
 Date: Tue May 5 17:18:16 2026 +0200
 1 file changed, 2 insertions(+), 1 deletion(-)
[final_release_pr fe7ee53cb5] dist/tools: fix documentation of can_fast_ci_run.py
 Date: Wed May 6 13:59:04 2026 +0200
 1 file changed, 2 insertions(+), 4 deletions(-)
[final_release_pr ec4c54cf41] dist/tools: add VERSION file as fast-runnable to can_fast_ci_run.py
 Date: Wed May 6 13:59:59 2026 +0200
 1 file changed, 1 insertion(+), 1 deletion(-)

buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ dist/tools/ci/can_fast_ci_run.py --upstreambranch 2026.04-branch --explain --debug
Other
=====

doc
---

- VERSION
- release-notes.txt

tools
-----

- dist/tools/ci/can_fast_ci_run.py

buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ echo $?
0
```


### Issues/PRs references

Noticed in #22244.

### Declaration of AI-Tools / LLMs usage:


AI-Tools / LLMs that were used are:
- none
