### PR TITLE
drivers/periph_common/flashpage: add offset and length to API

### DIFF
--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -288,8 +288,8 @@ void flashpage_read(unsigned page, void *data, size_t offset, size_t len);
  *
  * @pre     @p offset + @p len MUST be less than or equal to FLASHPAGE_SIZE.
  *
- * @return              FLASHPAGE_OK if data in the page is identical to @p data
- * @return              FLASHPAGE_NOMATCH if data and page content diverge
+ * @retval              FLASHPAGE_OK if data in the page is identical to @p data
+ * @retval              FLASHPAGE_NOMATCH if data and page content diverge
  */
 int flashpage_verify(unsigned page, const void *data, size_t offset, size_t len);
 
@@ -302,8 +302,8 @@ int flashpage_verify(unsigned page, const void *data, size_t offset, size_t len)
  * @param[in] data      data to write to the page, MUST be FLASHPAGE_SIZE
  *                      byte.
  *
- * @return              FLASHPAGE_OK on success
- * @return              FLASHPAGE_NOMATCH if data and page content diverge
+ * @retval              FLASHPAGE_OK on success
+ * @retval              FLASHPAGE_NOMATCH if data and page content diverge
  */
 int flashpage_write_and_verify(unsigned page, const void *data);
 
@@ -409,8 +409,8 @@ void flashpage_rwwee_read(unsigned page, void *data, size_t offset, size_t len);
  *
  * @pre     @p offset + @p len MUST be less than or equal to FLASHPAGE_SIZE.
  *
- * @return              FLASHPAGE_OK if data in the RWWEE page is identical to @p data
- * @return              FLASHPAGE_NOMATCH if data and RWWEE page content diverge
+ * @retval              FLASHPAGE_OK if data in the RWWEE page is identical to @p data
+ * @retval              FLASHPAGE_NOMATCH if data and RWWEE page content diverge
  */
 int flashpage_rwwee_verify(unsigned page, const void *data, size_t offset, size_t len);
 
@@ -424,8 +424,8 @@ int flashpage_rwwee_verify(unsigned page, const void *data, size_t offset, size_
  * @param[in] data      data to write to the RWWEE page, MUST be FLASHPAGE_SIZE
  *                      byte.
  *
- * @return              FLASHPAGE_OK on success
- * @return              FLASHPAGE_NOMATCH if data and RWWEE page content diverge
+ * @retval              FLASHPAGE_OK on success
+ * @retval              FLASHPAGE_NOMATCH if data and RWWEE page content diverge
  */
 int flashpage_rwwee_write_and_verify(unsigned page, const void *data);
 

--- a/drivers/include/periph/flashpage.h
+++ b/drivers/include/periph/flashpage.h
@@ -270,8 +270,12 @@ void flashpage_write(void *target_addr, const void *data, size_t len);
  * @param[in]  page     page to read
  * @param[out] data     memory to write the page to, MUST be FLASHPAGE_SIZE
  *                      byte
+ * @param[in] offset    offset in the page to start reading from
+ * @param[in] len       length of the data to be read.
+ *
+ * @pre     @p offset + @p len MUST be less than or equal to FLASHPAGE_SIZE.
  */
-void flashpage_read(unsigned page, void *data);
+void flashpage_read(unsigned page, void *data, size_t offset, size_t len);
 
 /**
  * @brief   Verify the given page against the given data
@@ -279,11 +283,15 @@ void flashpage_read(unsigned page, void *data);
  * @param[in] page      page to verify
  * @param[in] data      data to compare page against, MUST be FLASHPAGE_SIZE
  *                      byte of data
+ * @param[in] offset    offset in the page to start comparing from
+ * @param[in] len       length of the data to be verified.
+ *
+ * @pre     @p offset + @p len MUST be less than or equal to FLASHPAGE_SIZE.
  *
  * @return              FLASHPAGE_OK if data in the page is identical to @p data
  * @return              FLASHPAGE_NOMATCH if data and page content diverge
  */
-int flashpage_verify(unsigned page, const void *data);
+int flashpage_verify(unsigned page, const void *data, size_t offset, size_t len);
 
 /**
  * @brief   Write the given page and verify the results
@@ -383,8 +391,12 @@ void flashpage_rwwee_write(void *target_addr, const void *data, size_t len);
  * @param[in]  page     RWWEE page to read
  * @param[out] data     memory to write the RWWEE page to, MUST be FLASHPAGE_SIZE
  *                      byte
+ * @param[in] offset    offset in the RWWEE page to start reading from
+ * @param[in] len       length of the data to be read.
+ *
+ * @pre     @p offset + @p len MUST be less than or equal to FLASHPAGE_SIZE.
  */
-void flashpage_rwwee_read(unsigned page, void *data);
+void flashpage_rwwee_read(unsigned page, void *data, size_t offset, size_t len);
 
 /**
  * @brief   Verify the given RWWEE page against the given data
@@ -392,11 +404,15 @@ void flashpage_rwwee_read(unsigned page, void *data);
  * @param[in] page      RWWEE page to verify
  * @param[in] data      data to compare RWWEE page against, MUST be FLASHPAGE_SIZE
  *                      byte of data
+ * @param[in] offset    offset in the RWWEE page to start comparing from
+ * @param[in] len       length of the data to be verified.
+ *
+ * @pre     @p offset + @p len MUST be less than or equal to FLASHPAGE_SIZE.
  *
  * @return              FLASHPAGE_OK if data in the RWWEE page is identical to @p data
  * @return              FLASHPAGE_NOMATCH if data and RWWEE page content diverge
  */
-int flashpage_rwwee_verify(unsigned page, const void *data);
+int flashpage_rwwee_verify(unsigned page, const void *data, size_t offset, size_t len);
 
 /**
  * @brief   Write the given RWWEE page and verify the results

--- a/drivers/periph_common/flashpage.c
+++ b/drivers/periph_common/flashpage.c
@@ -21,28 +21,30 @@
 
 #include "periph/flashpage.h"
 
-void flashpage_read(unsigned page, void *data)
+void flashpage_read(unsigned page, void *data, size_t offset, size_t len)
 {
     assert(page < FLASHPAGE_NUMOF);
+    assert(offset + len <= flashpage_size(page) && offset + len > offset);
 
 #if defined(CPU_FAM_STM32WB) || (defined(CPU_FAM_STM32WL) && \
                                  !defined(CPU_LINE_STM32WLE5xx))
     assert(page < (FLASH->SFR & FLASH_SFR_SFSA));
 #endif
 
-    memcpy(data, flashpage_addr(page), flashpage_size(page));
+    memcpy(data, (uint8_t *)flashpage_addr(page) + offset, len);
 }
 
-int flashpage_verify(unsigned page, const void *data)
+int flashpage_verify(unsigned page, const void *data, size_t offset, size_t len)
 {
     assert(page < (int)FLASHPAGE_NUMOF);
+    assert(offset + len <= flashpage_size(page) && offset + len > offset);
 
 #if defined(CPU_FAM_STM32WB) || (defined(CPU_FAM_STM32WL) && \
                                  !defined(CPU_LINE_STM32WLE5xx))
     assert(page < (int)(FLASH->SFR & FLASH_SFR_SFSA));
 #endif
 
-    if (memcmp(flashpage_addr(page), data, flashpage_size(page)) == 0) {
+    if (memcmp((uint8_t *)flashpage_addr(page) + offset, data, len) == 0) {
         return FLASHPAGE_OK;
     }
     else {
@@ -53,7 +55,7 @@ int flashpage_verify(unsigned page, const void *data)
 int flashpage_write_and_verify(unsigned page, const void *data)
 {
     flashpage_write_page(page, data);
-    return flashpage_verify(page, data);
+    return flashpage_verify(page, data, 0, flashpage_size(page));
 }
 
 #ifdef FLASHPAGE_SIZE
@@ -70,18 +72,20 @@ void flashpage_write_page(unsigned page, const void *data)
 #endif
 
 #if defined(FLASHPAGE_RWWEE_NUMOF)
-void flashpage_rwwee_read(unsigned page, void *data)
+void flashpage_rwwee_read(unsigned page, void *data, size_t offset, size_t len)
 {
     assert(page < (int)FLASHPAGE_RWWEE_NUMOF);
+    assert(offset + len <= FLASHPAGE_SIZE && offset + len > offset);
 
-    memcpy(data, flashpage_rwwee_addr(page), FLASHPAGE_SIZE);
+    memcpy(data, (uint8_t *)flashpage_rwwee_addr(page) + offset, len);
 }
 
-int flashpage_rwwee_verify(unsigned page, const void *data)
+int flashpage_rwwee_verify(unsigned page, const void *data, size_t offset, size_t len)
 {
     assert(page < (int)FLASHPAGE_RWWEE_NUMOF);
+    assert(offset + len <= FLASHPAGE_SIZE && offset + len > offset);
 
-    if (memcmp(flashpage_rwwee_addr(page), data, FLASHPAGE_SIZE) == 0) {
+    if (memcmp((uint8_t *)flashpage_rwwee_addr(page) + offset, data, len) == 0) {
         return FLASHPAGE_OK;
     }
     else {
@@ -92,7 +96,7 @@ int flashpage_rwwee_verify(unsigned page, const void *data)
 int flashpage_rwwee_write_and_verify(unsigned page, const void *data)
 {
     flashpage_rwwee_write_page(page, data);
-    return flashpage_rwwee_verify(page, data);
+    return flashpage_rwwee_verify(page, data, 0, FLASHPAGE_SIZE);
 }
 #endif /* FLASHPAGE_RWWEE_NUMOF */
 

--- a/tests/periph/flashpage/Makefile
+++ b/tests/periph/flashpage/Makefile
@@ -8,6 +8,7 @@ FEATURES_OPTIONAL += periph_flashpage_rwee
 
 USEMODULE += od
 USEMODULE += od_string
+USEMODULE += random
 USEMODULE += shell
 
 # avoid running Kconfig by default

--- a/tests/periph/flashpage/main.c
+++ b/tests/periph/flashpage/main.c
@@ -91,7 +91,7 @@ static int getpage(const char *str)
 #ifdef MODULE_PERIPH_FLASHPAGE_PAGEWISE
 static void memdump(void *addr, size_t len)
 {
-    od_hex_dump	(addr, len, LINE_LEN);
+    od_hex_dump(addr, len, LINE_LEN);
 }
 
 static void dump_local(void)
@@ -520,7 +520,8 @@ static int cmd_test_rwwee(int argc, char **argv)
         return 1;
     }
 
-    fill += (page % ('z' - 'a')); // Make each page slightly different by changing starting char for easier comparison by eye
+    /* Make each page slightly different by changing starting char for easier comparison by eye */
+    fill += (page % ('z' - 'a'));
 
     for (unsigned i = 0; i < sizeof(page_mem); i++) {
         page_mem[i] = (uint8_t)fill++;

--- a/tests/periph/flashpage/main.c
+++ b/tests/periph/flashpage/main.c
@@ -23,6 +23,7 @@
 
 #include "architecture.h"
 #include "od.h"
+#include "random.h"
 #include "shell.h"
 #include "periph/flashpage.h"
 #include "unaligned.h"
@@ -177,6 +178,35 @@ static int cmd_read(int argc, char **argv)
     flashpage_read(page, page_mem, 0, sizeof(page_mem));
     printf("Read flash page %i into local page buffer\n", page);
     dump_local();
+
+    return 0;
+}
+
+static int cmd_test_read(int argc, char **argv)
+{
+    int page;
+
+    if (argc < 2) {
+        printf("usage: %s <page>\n", argv[0]);
+        return 1;
+    }
+
+    page = getpage(argv[1]);
+    if (page < 0) {
+        return 1;
+    }
+
+    flashpage_read(page, page_mem, 0, sizeof(page_mem));
+    printf("Read flash page %i into local page buffer\n", page);
+    for (size_t offset = 0; offset < sizeof(page_mem); offset += sizeof(raw_buf)) {
+        random_bytes(raw_buf, sizeof(raw_buf));
+        flashpage_read(page, raw_buf, offset, sizeof(raw_buf));
+        if (memcmp(page_mem + offset, raw_buf, sizeof(raw_buf))) {
+            printf("error: partially read data does not match previously read data\n");
+            return 1;
+        }
+    }
+    printf("Successfully verified flash page content by reading it in chunks\n");
 
     return 0;
 }
@@ -481,6 +511,35 @@ static int cmd_read_rwwee(int argc, char **argv)
     return 0;
 }
 
+static int cmd_test_read_rwwee(int argc, char **argv)
+{
+    int page;
+
+    if (argc < 2) {
+        printf("usage: %s <page>\n", argv[0]);
+        return 1;
+    }
+
+    page = getpage_rwwee(argv[1]);
+    if (page < 0) {
+        return 1;
+    }
+
+    flashpage_rwwee_read(page, page_mem);
+    printf("Read RWWEE flash page %i into local page buffer\n", page);
+    for (size_t offset = 0; offset < sizeof(page_mem); offset += sizeof(raw_buf)) {
+        random_bytes(raw_buf, sizeof(raw_buf));
+        flashpage_rwwee_read(page, raw_buf, offset, sizeof(raw_buf));
+        if (memcmp(page_mem + offset, raw_buf, sizeof(raw_buf))) {
+            printf("error: RWWEE partially read data does not match previously read data\n");
+            return 1;
+        }
+    }
+    printf("Successfully verified flash page content by reading it in chunks\n");
+
+    return 0;
+}
+
 static int cmd_write_rwwee(int argc, char **argv)
 {
     int page;
@@ -684,6 +743,8 @@ static const shell_command_t shell_commands[] = {
     { "dump_local", "Dump the local page buffer to STDOUT", cmd_dump_local },
     { "read", "Copy the given page to the local page buffer and dump to STDOUT", cmd_read },
     { "write", "Write the local page buffer to the given page", cmd_write },
+    { "test_read", "Read the given page in chunks "
+                   "and verify the read content matches the local page buffer", cmd_test_read },
 #endif
     { "write_raw", "Write raw bytes (max 64B) to the given address", cmd_write_raw },
     { "erase", "Erase the given page buffer", cmd_erase },
@@ -702,6 +763,8 @@ static const shell_command_t shell_commands[] = {
     { "test_rwwee", "Write and verify test pattern to RWWEE", cmd_test_rwwee },
     { "test_last_rwwee", "Write and verify test pattern on last RWWEE page available", cmd_test_last_rwwee },
     { "test_last_rwwee_raw", "Write and verify raw short write on last RWWEE page available", cmd_test_last_rwwee_raw },
+    { "test_read_rwwee", "Read the given RWWEE page in chunks "
+                         "and verify the read content matches the local page buffer", cmd_test_read_rwwee },
 #endif
 #ifdef NVMCTRL_USER
     { "dump_config_page", "Dump the content of the MCU configuration page", cmd_dump_config },

--- a/tests/periph/flashpage/main.c
+++ b/tests/periph/flashpage/main.c
@@ -174,7 +174,7 @@ static int cmd_read(int argc, char **argv)
         return 1;
     }
 
-    flashpage_read(page, page_mem);
+    flashpage_read(page, page_mem, 0, sizeof(page_mem));
     printf("Read flash page %i into local page buffer\n", page);
     dump_local();
 
@@ -377,7 +377,7 @@ static int cmd_test_reserved(int argc, char **argv)
 
     printf("Reserved page num: %u \n", page);
 
-    flashpage_read(page, page_mem);
+    flashpage_read(page, page_mem, 0, sizeof(page_mem));
 
     /* test is running for the first time so initialize flash */
     if (memcmp(sig, &page_mem[1], sizeof(sig)) != 0) {

--- a/tests/periph/flashpage/tests/01-run.py
+++ b/tests/periph/flashpage/tests/01-run.py
@@ -20,6 +20,15 @@ def testfunc(child):
     child.expect_exact('wrote raw short buffer to last flash page')
     child.expect('>')
 
+    # check if board has pagewise write capability and if so test read and partial read
+    # capability is deduced from help contents
+    child.sendline("help")
+    index = child.expect(['test_read', '>'])
+    if index == 0:
+        child.sendline("test_read 0")
+        child.expect_exact('Successfully verified flash page content by reading it in chunks')
+        child.expect('>')
+
     # check if board has pagewise write capability and if so test that as well
     # capability is deduced from help contents
     child.sendline("help")
@@ -45,6 +54,15 @@ def testfunc(child):
     if index == 0:
         child.sendline("test_last_rwwee")
         child.expect_exact('wrote local page buffer to last RWWEE flash page')
+        child.expect('>')
+
+    # check if board has RWWEE capability and if so test chunkwise read
+    # capability is deduced from help contents
+    child.sendline("help")
+    index = child.expect(['test_read_rwwee', '>'])
+    if index == 0:
+        child.sendline("test_read_rwwee 0")
+        child.expect_exact('Successfully verified flash page content by reading it in chunks')
         child.expect('>')
 
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Adds `offset` and `length` parameters to `flashpage_read()` and `flashpage_verify()` API.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
`BOARD=same54-xpro make -C tests/periph/flashpage flash term`
```
Type '/exit' to exit.
help
2026-05-06 15:59:08,235 # help
2026-05-06 15:59:08,237 # Command              Description
2026-05-06 15:59:08,241 # ---------------------------------------
2026-05-06 15:59:08,245 # info                 Show information about pages
2026-05-06 15:59:08,250 # dump                 Dump the selected page to STDOUT
2026-05-06 15:59:08,255 # dump_local           Dump the local page buffer to STDOUT
2026-05-06 15:59:08,263 # read                 Copy the given page to the local page buffer and dump to STDOUT
2026-05-06 15:59:08,268 # write                Write the local page buffer to the given page
2026-05-06 15:59:08,274 # write_raw            Write raw bytes (max 64B) to the given address
2026-05-06 15:59:08,279 # erase                Erase the given page buffer
2026-05-06 15:59:08,284 # edit                 Write bytes to the local page buffer
2026-05-06 15:59:08,288 # test                 Write and verify test pattern
2026-05-06 15:59:08,295 # test_last_pagewise   Write and verify test pattern on last page available
2026-05-06 15:59:08,301 # test_reserved_pagewise Write and verify short write on reserved page
2026-05-06 15:59:08,307 # test_last_raw        Write and verify raw short write on last page available
2026-05-06 15:59:08,313 # dump_config_page     Dump the content of the MCU configuration page
2026-05-06 15:59:08,319 # test_config_page     Test writing config page. (!DANGER ZONE!)
> test
2026-05-06 15:59:18,311 # test
2026-05-06 15:59:18,313 # usage: test <page>
> test 22
2026-05-06 15:59:24,975 # test 22
2026-05-06 15:59:25,031 # wrote local page buffer to flash page 22 at addr 0x0002c000
> test_last_pagewise
2026-05-06 15:59:40,386 # test_last_pagewise
2026-05-06 15:59:40,456 # wrote local page buffer to last flash page
> test_reserved_pagewise
2026-05-06 15:59:54,033 # test_reserved_pagewise
2026-05-06 15:59:54,035 # Reserved page num: 4 
2026-05-06 15:59:54,041 # Since the last firmware update this test has been run 2 times 
2026-05-06 15:59:54,109 # wrote local page buffer to reserved flash page
2026-05-06 15:59:54,109 # 
2026-05-06 15:59:54,120 # When running on a bootloader, as an extra check, try restarting the board and check whether this application still comes up.
> test_last_raw
2026-05-06 16:00:13,445 # test_last_raw
2026-05-06 16:00:13,491 # wrote raw short buffer to last flash page
```
### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- none
