### PR TITLE
makefiles/docker: bump riotdocker version

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -5,7 +5,7 @@
 # When the docker image is updated, checks at
 # dist/tools/buildsystem_sanity_check/check.sh start complaining in CI, and
 # provide the latest values to verify and fill in.
-DOCKER_TESTED_IMAGE_REPO_DIGEST := 028d9267e715e992d9b47bb8738685c6cc96b1a3bc3924489e7e543a333e8486
+DOCKER_TESTED_IMAGE_REPO_DIGEST := 84778c8f1d4bba5cd6cb0097e3291731f293e7afffd30a94689aa5ad34015830
 
 DOCKER_PULL_IDENTIFIER := docker.io/riot/riotbuild@sha256:$(DOCKER_TESTED_IMAGE_REPO_DIGEST)
 export DOCKER_IMAGE ?= $(DOCKER_PULL_IDENTIFIER)


### PR DESCRIPTION
### Contribution description

Just the usual image hash bump.

### Testing procedure

The `buildsystem sanity check` should pass again.

### Issues/PRs references

Necessary after merging https://github.com/RIOT-OS/riotdocker/pull/267 and https://github.com/RIOT-OS/riotdocker/pull/263

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
