### PR TITLE
cpu/native/fs: fix stale errno reading in mount()

### DIFF
--- a/cpu/native/fs/native_fs.c
+++ b/cpu/native/fs/native_fs.c
@@ -85,8 +85,10 @@ static int _mount(vfs_mount_t *mountp)
         real_mkdir(parent, 0777);
     }
 
-    real_mkdir(_prefix_path(mountp, ""), 0777);
-    res = errno == EEXIST ? 0 : -errno;
+    res = real_mkdir(_prefix_path(mountp, ""), 0777);
+    if (res < 0) {
+        res = (errno == EEXIST) ? 0 : -errno;
+    }
 
     mutex_unlock(&_lock);
     return res;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

On `native` `_mount`, `errno` is read also success case and value is falsely interpreted as an error.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`BOARD=native make -C tests/sys/shell_scripting`

`nvm0` folder is created but test fails because `errno` is falsely interpreted.
On second attempt, the test succeeds because `nvm0` already was created.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Issue noted in CI of #22158 

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- none
