### PR TITLE
.github/workflows: rebase before running static test

### DIFF
--- a/.github/workflows/static-test.yml
+++ b/.github/workflows/static-test.yml
@@ -22,26 +22,40 @@ jobs:
     - uses: actions/checkout@main
       with:
         fetch-depth: 0
-    - name: set CI_BASE_BRANCH
+    - name: Set CI_BASE_BRANCH
       run: |
-          if [ -n "${{ github.base_ref }}" ]; then
-              echo "CI_BASE_BRANCH=${{ github.base_ref }}" >> $GITHUB_ENV
-          elif [ -n "${{ github.event.merge_group.base_ref }}" ]; then
-              echo "CI_BASE_BRANCH=${{ github.event.merge_group.base_ref }}" | sed s.=refs/heads/.=. >> $GITHUB_ENV
-          fi
+        # Figure out the correct base branch to work on...
+
+        if [ -n "${{ github.base_ref }}" ]; then
+          echo "CI_BASE_BRANCH=${{ github.base_ref }}" >> $GITHUB_ENV
+        elif [ -n "${{ github.event.merge_group.base_ref }}" ]; then
+          echo "CI_BASE_BRANCH=${{ github.event.merge_group.base_ref }}" | sed s.=refs/heads/.=. >> $GITHUB_ENV
+        fi
+
+        echo "Base Branch: origin/$(grep '^CI_BASE_BRANCH=' $GITHUB_ENV | cut -d= -f2-)"
     - name: Setup git
       run: |
+        # Configuring and rebasing the repository...
+
+        # Name and E-Mail required for rebasing
+        git config user.name "statictester"
+        git config user.email "statictester@riot.invalid"
+
         # Note: CI_BASE_BRANCH is empty when not in a PR
         if [ -n "${CI_BASE_BRANCH}" ]; then
           git fetch origin ${CI_BASE_BRANCH}:${CI_BASE_BRANCH} --no-tags
+          echo "Rebasing PR branch onto origin/${CI_BASE_BRANCH}..."
+          git rebase origin/${CI_BASE_BRANCH}
         else
           git config diff.renameLimit 16384
         fi
         git config apply.whitespace nowarn
     - name: Fetch riot/static-test-tools Docker image
       run: docker pull riot/static-test-tools:latest
-    - name: Run static-tests
+    - name: Run static-tests on `riot/static-test-tools`
       run: |
+        # Start docker container and run tests...
+
         # Note: ${CI_BASE_BRANCH} is empty when not in a PR
         docker run --rm                             \
           -e CI_BASE_BRANCH                         \


### PR DESCRIPTION
### Contribution description

The `static-test` workflow has a tendency to fail when the PR is not up to date with the `master` branch anymore, for example for the `buildsystem_sanity_check` when the Docker image was updated, `doccheck` when documentation has been fixed elsewhere or `codespell` when typos have been fixed elsewhere.

This forces contributors to rebase their PR, which sometimes leads to issues (especially for people who are not super experienced with git yet).

Also it is annoying and somewhat unnecessary because Murdock rebases the PR before running the static tests again anyways.

### Testing procedure

I guess we should see that this PR does not fail the `static-tests` workflow.
I deliberately dropped the last Riotdocker bump commit from the history of this branch, so the `buildsystem_sanity_check` should fail without the changes. Let's see how this goes :D

### Issues/PRs references

As discussed in #22250.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- ChatGPT for explaining what all the git commands do 😅 