### PR TITLE
pkg: Use cargo home environment variable when set

### DIFF
--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -51,9 +51,12 @@ endif
 
 PKG_SOURCE_LOCAL ?= $(PKG_SOURCE_LOCAL_$(shell echo $(PKG_NAME) | tr a-z- A-Z_))
 
-# Check if git-cache-rs is installed in the local default directory and if so,
-# set the `GIT_CACHE_RS` variable to use it.
-DEFAULT_GIT_CACHE_RS ?= $(HOME)/.cargo/bin/git-cache
+# If CARGO_HOME is set, use it to search for `git-cache-rs` (git-cache),
+# otherwise try the local default directory. The git-cache can also be set
+# directly with GIT_CACHE_RS.
+CARGO_HOME ?= $(HOME)/.cargo
+
+DEFAULT_GIT_CACHE_RS ?= $(CARGO_HOME)/bin/git-cache
 ifeq ($(DEFAULT_GIT_CACHE_RS),$(wildcard $(DEFAULT_GIT_CACHE_RS)))
   GIT_CACHE_RS ?= $(DEFAULT_GIT_CACHE_RS)
 endif


### PR DESCRIPTION
…o's default directory

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This change to `pkg/pkg.mk` allows the cargo home directory to be set from the environment using `CARGO_HOME`. This variable is also used by cargo to specify the cargo home location.

This allows for example to set the directory to system directory (e.g. `/usr/local/cargo`) inside a docker container instead of a user directory

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- none
