### PR TITLE
dist/tools/benchmark_udp: fix macOS compatibility

### DIFF
--- a/dist/tools/benchmark_udp/main.c
+++ b/dist/tools/benchmark_udp/main.c
@@ -235,7 +235,10 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    while (getrandom(&cookie, sizeof(cookie), 0) != sizeof(cookie)) {}
+    if (getentropy(&cookie, sizeof(cookie)) != 0) {
+        perror("getentropy() failed");
+        exit(1);
+    }
     cookie &= BENCH_MASK_COOKIE;
 
     struct addrinfo hint = {
@@ -249,7 +252,7 @@ int main(int argc, char **argv)
     int res = getaddrinfo(argv[0], argv[1],
                           &hint, &server_addr);
     if (res != 0) {
-        perror("getaddrinfo()");
+        perror("getaddrinfo() failed");
         exit(1);
     }
 


### PR DESCRIPTION
### Contribution description

The `getrandom(..)` method is not available under macOS, but `getentropy(..)` is (and under Linux too). On macOS, this fails with the following error under GCC:

```
main.c:238:12: error: call to undeclared function 'getrandom'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  238 |     while (getrandom(&cookie, sizeof(cookie), 0) != sizeof(cookie)) {}
      |            ^
```

Because [`getrandom(..)`](https://www.man7.org/linux/man-pages/man2/getrandom.2.html) was invoked in blocking mode (flag=0), there is no difference, because [`getentropy(..)`](https://www.man7.org/linux/man-pages/man3/getentropy.3.html) will always be blocking.

macOS compatibility isn't a major concern, but the fix is small and makes it a bit more usable for me :-)

### Testing procedure

Using macOS (26.x), I was able to compile and use the benchmark tool. The screenshots below shows it is working.

<img width="1962" height="1205" alt="Scherm­afbeelding 2026-05-08 om 16 55 17" src="https://github.com/user-attachments/assets/96544d43-102d-408b-9a91-8eb44a918dee" />

<img width="1962" height="1205" alt="Scherm­afbeelding 2026-05-08 om 16 54 47" src="https://github.com/user-attachments/assets/e713f608-6700-4aff-9337-7812eaac746a" />

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- None
