### PR TITLE
drivers/periph/dac: add dac_play API for async multi sample output

### DIFF
--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -376,7 +376,7 @@ static const adc_conf_chan_t adc_channels[] = {
 #define DAC_CLOCK           SAM0_GCLK_TIMER
 #ifndef DAC_VREF
                             /* Use analogue supply voltage as reference */
-#define DAC_VREF            DAC_CTRLB_REFSEL_VDDANA
+#  define DAC_VREF          DAC_CTRLB_REFSEL_VDDANA
 #endif
 /** @} */
 

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -375,8 +375,8 @@ static const adc_conf_chan_t adc_channels[] = {
                             /* Must not exceed 12 MHz */
 #define DAC_CLOCK           SAM0_GCLK_TIMER
 #ifndef DAC_VREF
-                            /* Internal reference only gives 1V */
-#define DAC_VREF            DAC_CTRLB_REFSEL_INTREF
+                            /* Use analogue supply voltage as reference */
+#define DAC_VREF            DAC_CTRLB_REFSEL_VDDANA
 #endif
 /** @} */
 

--- a/cpu/sam0_common/Makefile.dep
+++ b/cpu/sam0_common/Makefile.dep
@@ -1,3 +1,8 @@
+ifneq (,$(filter periph_dac_play,$(USEMODULE)))
+  USEMODULE += periph_dma
+  FEATURES_REQUIRED += periph_dac
+endif
+
 ifneq (,$(filter periph_uart_nonblocking,$(USEMODULE)))
   USEMODULE += tsrb
 endif

--- a/cpu/sam0_common/Makefile.features
+++ b/cpu/sam0_common/Makefile.features
@@ -8,6 +8,7 @@ ifeq (,$(filter $(CPU_MODELS_WITHOUT_DMA),$(CPU_MODEL)))
 endif
 
 FEATURES_PROVIDED += periph_adc_continuous
+FEATURES_PROVIDED += periph_dac_play
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_in_address_space
 FEATURES_PROVIDED += periph_flashpage_pagewise

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -1194,8 +1194,8 @@ void dma_setup(dma_t dma, unsigned trigger, uint8_t prio, dma_cb_t cb, void *ctx
 /**
  * @brief   Update the DMA Completion callback context
  *
- * @param   dma     DMA channel to release
- * @param   ctx     DMA complete callback context
+ * @param   dma[in] DMA channel to release
+ * @param   ctx[in] DMA complete callback context
  */
 void dma_set_cb_arg(dma_t dma, void *ctx);
 
@@ -1326,21 +1326,21 @@ void dma_append_dst(dma_t dma, DmacDescriptor *next, void *dst, size_t num,
 /**
  * @brief   Make the DMA transfer repeat indefinitely
  *
- * @param   dma     DMA channel reference
+ * @param   dma[in] DMA channel reference
  */
 void dma_enable_loop(dma_t dma);
 
 /**
  * @brief   Disable DMA transfer looping
  *
- * @param   dma     DMA channel reference
+ * @param   dma[in] DMA channel reference
  */
 void dma_disable_loop(dma_t dma);
 
 /**
  * @brief   Start a DMA transfer.
  *
- * @param   dma     DMA channel reference
+ * @param   dma[in] DMA channel reference
  */
 void dma_start(dma_t dma);
 

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -1150,6 +1150,13 @@ typedef enum {
 } dma_incr_t;
 
 /**
+ * @brief   Signature of event callback functions triggered from interrupts
+ *
+ * @param[in] arg       optional context for the callback
+ */
+typedef void (*dma_cb_t)(void *arg);
+
+/**
  * @brief   Initialize DMA
  */
 void dma_init(void);
@@ -1179,9 +1186,18 @@ void dma_release_channel(dma_t dma);
  * @param   dma     DMA channel reference
  * @param   trigger Trigger to use for this DMA channel
  * @param   prio    Channel priority
- * @param   irq     Whether to enable the interrupt handler for this channel
+ * @param   cb      Callback to call when DMA transfer is done, may be NULL
+ * @param   ctx     Callback context
  */
-void dma_setup(dma_t dma, unsigned trigger, uint8_t prio, bool irq);
+void dma_setup(dma_t dma, unsigned trigger, uint8_t prio, dma_cb_t cb, void *ctx);
+
+/**
+ * @brief   Update the DMA Completion callback context
+ *
+ * @param   dma     DMA channel to release
+ * @param   ctx     DMA complete callback context
+ */
+void dma_set_cb_arg(dma_t dma, void *ctx);
 
 /**
  * @brief   Prepare the DMA channel for an individual transfer.
@@ -1327,17 +1343,6 @@ void dma_disable_loop(dma_t dma);
  * @param   dma     DMA channel reference
  */
 void dma_start(dma_t dma);
-
-/**
- * @brief   Wait for a DMA channel to finish the transfer.
- *
- * This function uses a blocking mutex to wait for the transfer to finish
- *
- * @note Use only with DMA channels of which the interrupt is enabled
- *
- * @param   dma     DMA channel reference
- */
-void dma_wait(dma_t dma);
 
 /**
  * @brief   Cancel an active DMA transfer

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -1308,6 +1308,20 @@ void dma_append_dst(dma_t dma, DmacDescriptor *next, void *dst, size_t num,
                     bool incr);
 
 /**
+ * @brief   Make the DMA transfer repeat indefinitely
+ *
+ * @param   dma     DMA channel reference
+ */
+void dma_enable_loop(dma_t dma);
+
+/**
+ * @brief   Disable DMA transfer looping
+ *
+ * @param   dma     DMA channel reference
+ */
+void dma_disable_loop(dma_t dma);
+
+/**
  * @brief   Start a DMA transfer.
  *
  * @param   dma     DMA channel reference

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -1150,6 +1150,13 @@ typedef enum {
 } dma_incr_t;
 
 /**
+ * @brief   Signature of event callback functions triggered from interrupts
+ *
+ * @param[in] arg       optional context for the callback
+ */
+typedef void (*dma_cb_t)(void *arg);
+
+/**
  * @brief   Initialize DMA
  */
 void dma_init(void);
@@ -1179,9 +1186,18 @@ void dma_release_channel(dma_t dma);
  * @param   dma     DMA channel reference
  * @param   trigger Trigger to use for this DMA channel
  * @param   prio    Channel priority
- * @param   irq     Whether to enable the interrupt handler for this channel
+ * @param   cb      Callback to call when DMA transfer is done, may be NULL
+ * @param   ctx     Callback context
  */
-void dma_setup(dma_t dma, unsigned trigger, uint8_t prio, bool irq);
+void dma_setup(dma_t dma, unsigned trigger, uint8_t prio, dma_cb_t cb, void *ctx);
+
+/**
+ * @brief   Update the DMA Completion callback context
+ *
+ * @param[in]   dma DMA channel to release
+ * @param[in]   ctx DMA complete callback context
+ */
+void dma_set_cb_arg(dma_t dma, void *ctx);
 
 /**
  * @brief   Prepare the DMA channel for an individual transfer.
@@ -1310,34 +1326,23 @@ void dma_append_dst(dma_t dma, DmacDescriptor *next, void *dst, size_t num,
 /**
  * @brief   Make the DMA transfer repeat indefinitely
  *
- * @param   dma     DMA channel reference
+ * @param[in]   dma DMA channel reference
  */
 void dma_enable_loop(dma_t dma);
 
 /**
  * @brief   Disable DMA transfer looping
  *
- * @param   dma     DMA channel reference
+ * @param[in]   dma DMA channel reference
  */
 void dma_disable_loop(dma_t dma);
 
 /**
  * @brief   Start a DMA transfer.
  *
- * @param   dma     DMA channel reference
+ * @param[in]   dma DMA channel reference
  */
 void dma_start(dma_t dma);
-
-/**
- * @brief   Wait for a DMA channel to finish the transfer.
- *
- * This function uses a blocking mutex to wait for the transfer to finish
- *
- * @note Use only with DMA channels of which the interrupt is enabled
- *
- * @param   dma     DMA channel reference
- */
-void dma_wait(dma_t dma);
 
 /**
  * @brief   Cancel an active DMA transfer

--- a/cpu/sam0_common/periph/dac.c
+++ b/cpu/sam0_common/periph/dac.c
@@ -16,6 +16,7 @@
  */
 
 #include <assert.h>
+#include <errno.h>
 
 #include "cpu.h"
 #include "periph/dac.h"
@@ -32,6 +33,13 @@
 #define CONFIG_SAM0_DAC_RUN_ON_STANDBY 0
 #endif
 
+static dma_t tx_dma[DAC_NUMOF] = {
+    0xff,
+#if DAC_NUMOF == 2
+    0xff,
+#endif
+};
+
 static void _dac_init_clock(dac_t line)
 {
     sam0_gclk_enable(DAC_CLOCK);
@@ -47,6 +55,11 @@ static void _dac_init_clock(dac_t line)
 #endif
 
     dac_poweron(line);
+}
+
+uint32_t dac_get_freq(void)
+{
+    return sam0_gclk_freq(DAC_CLOCK) / 12;
 }
 
 static inline bool _ext_vref(void)
@@ -184,6 +197,63 @@ void dac_set(dac_t line, uint16_t value)
     _sync();
     DAC->DATA.reg = DAC_VAL(value);
 #endif
+}
+
+int dac_play_setup(dac_t line, dma_cb_t cb, void *arg)
+{
+    uint8_t dmac_id;
+#ifdef DAC_DMAC_ID_EMPTY_1
+    dmac_id = line
+            ? DAC_DMAC_ID_EMPTY_1
+            : DAC_DMAC_ID_EMPTY_0;
+#else
+    dmac_id = DAC_DMAC_ID_EMPTY;
+#endif
+
+    if (tx_dma[line] != UINT8_MAX) {
+        return -EEXIST;
+    }
+
+    tx_dma[line] = dma_acquire_channel();
+    if (tx_dma[line] == UINT8_MAX) {
+        return -ENOMEM;
+    }
+
+    dma_setup(tx_dma[line], dmac_id, 0, cb, arg);
+
+    return 0;
+}
+
+void dac_play_teardown(dac_t line)
+{
+    if (tx_dma[line] == UINT8_MAX) {
+        return;
+    }
+
+    dma_cancel(tx_dma[line]);
+    dma_disable_loop(tx_dma[line]);
+    dma_release_channel(tx_dma[line]);
+    tx_dma[line] = UINT8_MAX;
+}
+
+void dac_play(dac_t line, const uint16_t *buf, size_t len, uint8_t flags)
+{
+    void *dst;
+#ifdef DAC_SYNCBUSY_DATA1
+    dst = (void *)&DAC->DATA[line].reg;
+#else
+    dst = (void *)&DAC->DATA.reg;
+#endif
+
+    /* source buffer will be set by dac_play() */
+    dma_prepare(tx_dma[line], DMAC_BTCTRL_BEATSIZE_HWORD_Val,
+                buf + len, dst, len, DMA_INCR_SRC);
+
+    if (flags & DAC_PLAY_LOOPED) {
+        dma_enable_loop(tx_dma[line]);
+    }
+
+    dma_start(tx_dma[line]);
 }
 
 void dac_poweron(dac_t line)

--- a/cpu/sam0_common/periph/dac.c
+++ b/cpu/sam0_common/periph/dac.c
@@ -126,6 +126,9 @@ int8_t dac_init(dac_t line)
 #if CONFIG_SAM0_DAC_RUN_ON_STANDBY && defined(DAC_DACCTRL_RUNSTDBY)
                            | DAC_DACCTRL_RUNSTDBY
 #endif
+#ifdef DAC_DACCTRL_LEFTADJ
+                           | DAC_DACCTRL_LEFTADJ
+#endif
                            ;
 
 #ifdef DAC_DACCTRL_REFRESH
@@ -144,6 +147,9 @@ int8_t dac_init(dac_t line)
     DAC->CTRLB.reg = DAC_VREF
 #ifdef DAC_CTRLB_EOEN
                    | DAC_CTRLB_EOEN
+#endif
+#ifdef DAC_CTRLB_LEFTADJ
+                   | DAC_CTRLB_LEFTADJ
 #endif
                    ;
 

--- a/cpu/sam0_common/periph/dac.c
+++ b/cpu/sam0_common/periph/dac.c
@@ -203,9 +203,7 @@ int dac_play_setup(dac_t line, dma_cb_t cb, void *arg)
 {
     uint8_t dmac_id;
 #ifdef DAC_DMAC_ID_EMPTY_1
-    dmac_id = line
-            ? DAC_DMAC_ID_EMPTY_1
-            : DAC_DMAC_ID_EMPTY_0;
+    dmac_id = line ? DAC_DMAC_ID_EMPTY_1 : DAC_DMAC_ID_EMPTY_0;
 #else
     dmac_id = DAC_DMAC_ID_EMPTY;
 #endif

--- a/cpu/sam0_common/periph/dac.c
+++ b/cpu/sam0_common/periph/dac.c
@@ -16,6 +16,7 @@
  */
 
 #include <assert.h>
+#include <errno.h>
 
 #include "cpu.h"
 #include "periph/dac.h"
@@ -32,6 +33,13 @@
 #define CONFIG_SAM0_DAC_RUN_ON_STANDBY 0
 #endif
 
+static dma_t tx_dma[DAC_NUMOF] = {
+    0xff,
+#if DAC_NUMOF == 2
+    0xff,
+#endif
+};
+
 static void _dac_init_clock(dac_t line)
 {
     sam0_gclk_enable(DAC_CLOCK);
@@ -47,6 +55,11 @@ static void _dac_init_clock(dac_t line)
 #endif
 
     dac_poweron(line);
+}
+
+uint32_t dac_get_freq(void)
+{
+    return sam0_gclk_freq(DAC_CLOCK) / 12;
 }
 
 static inline bool _ext_vref(void)
@@ -184,6 +197,61 @@ void dac_set(dac_t line, uint16_t value)
     _sync();
     DAC->DATA.reg = DAC_VAL(value);
 #endif
+}
+
+int dac_play_setup(dac_t line, dma_cb_t cb, void *arg)
+{
+    uint8_t dmac_id;
+#ifdef DAC_DMAC_ID_EMPTY_1
+    dmac_id = line ? DAC_DMAC_ID_EMPTY_1 : DAC_DMAC_ID_EMPTY_0;
+#else
+    dmac_id = DAC_DMAC_ID_EMPTY;
+#endif
+
+    if (tx_dma[line] != UINT8_MAX) {
+        return -EEXIST;
+    }
+
+    tx_dma[line] = dma_acquire_channel();
+    if (tx_dma[line] == UINT8_MAX) {
+        return -ENOMEM;
+    }
+
+    dma_setup(tx_dma[line], dmac_id, 0, cb, arg);
+
+    return 0;
+}
+
+void dac_play_teardown(dac_t line)
+{
+    if (tx_dma[line] == UINT8_MAX) {
+        return;
+    }
+
+    dma_cancel(tx_dma[line]);
+    dma_disable_loop(tx_dma[line]);
+    dma_release_channel(tx_dma[line]);
+    tx_dma[line] = UINT8_MAX;
+}
+
+void dac_play(dac_t line, const uint16_t *buf, size_t len, uint8_t flags)
+{
+    void *dst;
+#ifdef DAC_SYNCBUSY_DATA1
+    dst = (void *)&DAC->DATA[line].reg;
+#else
+    dst = (void *)&DAC->DATA.reg;
+#endif
+
+    /* source buffer will be set by dac_play() */
+    dma_prepare(tx_dma[line], DMAC_BTCTRL_BEATSIZE_HWORD_Val,
+                buf + len, dst, len, DMA_INCR_SRC);
+
+    if (flags & DAC_PLAY_LOOPED) {
+        dma_enable_loop(tx_dma[line]);
+    }
+
+    dma_start(tx_dma[line]);
 }
 
 void dac_poweron(dac_t line)

--- a/cpu/sam0_common/periph/dma.c
+++ b/cpu/sam0_common/periph/dma.c
@@ -17,7 +17,6 @@
 
 #include "periph_cpu.h"
 #include "periph_conf.h"
-#include "mutex.h"
 #include "bitarithm.h"
 #include "pm_layered.h"
 #include "thread_flags.h"

--- a/cpu/sam0_common/periph/dma.c
+++ b/cpu/sam0_common/periph/dma.c
@@ -140,6 +140,11 @@ static inline void _set_next_descriptor(DmacDescriptor *descr, void *next)
     descr->DESCADDR.reg = (uint32_t)next;
 }
 
+static inline DmacDescriptor *_get_next_descriptor(const DmacDescriptor *descr)
+{
+    return (DmacDescriptor *)descr->DESCADDR.reg;
+}
+
 void dma_setup(dma_t dma, unsigned trigger, uint8_t prio, bool irq)
 {
 #ifdef REG_DMAC_CHID
@@ -202,8 +207,8 @@ void dma_prepare_dst(dma_t dma, void *dst, size_t num, bool incr)
     _set_next_descriptor(descr, NULL);
 }
 
-void _fmt_append(DmacDescriptor *descr, DmacDescriptor *next,
-                 const void *src, void *dst, size_t num)
+static void _fmt_append(DmacDescriptor *descr, DmacDescriptor *next,
+                        const void *src, void *dst, size_t num)
 {
     /* Configure the full descriptor besides the BTCTRL data */
     _set_next_descriptor(descr, next);
@@ -244,6 +249,34 @@ void dma_append_dst(dma_t dma, DmacDescriptor *next, void *dst, size_t num,
     next->BTCTRL.reg = (descr->BTCTRL.reg & ~DMAC_BTCTRL_DSTINC) |
                        (incr << DMAC_BTCTRL_DSTINC_Pos);
     _fmt_append(descr, next, (void *)descr->SRCADDR.reg, dst, num);
+}
+
+void dma_enable_loop(dma_t dma)
+{
+    DmacDescriptor *first = &descriptors[dma];
+    DmacDescriptor *last = first;
+    while (_get_next_descriptor(last)) {
+        last = _get_next_descriptor(last);
+        if (last == first) {
+            /* loop already exists */
+            return;
+        }
+    }
+    _set_next_descriptor(last, first);
+}
+
+void dma_disable_loop(dma_t dma)
+{
+    DmacDescriptor *first = &descriptors[dma];
+    DmacDescriptor *last = first;
+    while (_get_next_descriptor(last) != first) {
+        last = _get_next_descriptor(last);
+        if (last == NULL) {
+            /* loop already disabled */
+            return;
+        }
+    }
+    _set_next_descriptor(last, NULL);
 }
 
 void dma_start(dma_t dma)

--- a/cpu/sam0_common/periph/dma.c
+++ b/cpu/sam0_common/periph/dma.c
@@ -38,7 +38,8 @@ static DmacDescriptor DMA_DESCRIPTOR_ATTRS writeback[CONFIG_DMA_NUMOF];
 static uint32_t channels_free = (1LLU << CONFIG_DMA_NUMOF) - 1;
 
 struct dma_ctx {
-    mutex_t sync_lock;
+    dma_cb_t cb;
+    void *ctx;
 };
 
 struct dma_ctx dma_ctx[CONFIG_DMA_NUMOF];
@@ -56,9 +57,7 @@ static void _poweron(void)
 void dma_init(void)
 {
     _poweron();
-    for (unsigned i = 0; i < CONFIG_DMA_NUMOF; i++) {
-        mutex_init(&dma_ctx[i].sync_lock);
-    }
+
     /* Enable all priorities with RR scheduling */
     DMAC->CTRL.reg = DMAC_CTRL_LVLEN0 |
                      DMAC_CTRL_LVLEN1 |
@@ -99,8 +98,6 @@ dma_t dma_acquire_channel(void)
         channel = bitarithm_lsb(channels_free);
         /* Clear channel bit */
         channels_free &= ~(1 << channel);
-        /* ensure the sync lock is locked */
-        mutex_trylock(&dma_ctx[channel].sync_lock);
     }
     irq_restore(state);
     return channel;
@@ -145,7 +142,12 @@ static inline DmacDescriptor *_get_next_descriptor(const DmacDescriptor *descr)
     return (DmacDescriptor *)descr->DESCADDR.reg;
 }
 
-void dma_setup(dma_t dma, unsigned trigger, uint8_t prio, bool irq)
+void dma_set_cb_arg(dma_t dma, void *ctx)
+{
+    dma_ctx[dma].ctx = ctx;
+}
+
+void dma_setup(dma_t dma, unsigned trigger, uint8_t prio, dma_cb_t cb, void *ctx)
 {
 #ifdef REG_DMAC_CHID
     /* Ensure that this set of register writes is atomic */
@@ -156,7 +158,7 @@ void dma_setup(dma_t dma, unsigned trigger, uint8_t prio, bool irq)
                         (prio << DMAC_CHCTRLB_LVL_Pos);
     /* Clear everything in case a previous user left it configured */
     DMAC->CHINTENCLR.reg = 0xFF;
-    if (irq) {
+    if (cb) {
         DMAC->CHINTENSET.reg = DMAC_CHINTENSET_TCMPL;
     }
     irq_restore(state);
@@ -165,10 +167,13 @@ void dma_setup(dma_t dma, unsigned trigger, uint8_t prio, bool irq)
                                      (trigger << DMAC_CHCTRLA_TRIGSRC_Pos);
     DMAC->Channel[dma].CHPRILVL.reg = prio;
     DMAC->Channel[dma].CHINTENCLR.reg = 0xFF;
-    if (irq) {
+    if (cb) {
         DMAC->Channel[dma].CHINTENSET.reg = DMAC_CHINTENSET_TCMPL;
     }
 #endif
+
+    dma_ctx[dma].cb = cb;
+    dma_ctx[dma].ctx = ctx;
 }
 
 void dma_prepare(dma_t dma, uint8_t width, const void *src, void *dst,
@@ -293,12 +298,6 @@ void dma_start(dma_t dma)
 #endif
 }
 
-void dma_wait(dma_t dma)
-{
-    DEBUG("[DMA]: mutex lock: %u\n", dma);
-    mutex_lock(&dma_ctx[dma].sync_lock);
-}
-
 void dma_cancel(dma_t dma)
 {
     DEBUG("[DMA]: Cancelling active transfer: %u\n", dma);
@@ -326,8 +325,8 @@ void isr_dmac(void)
     /* Clear the pending interrupt flags for this channel by writing the
      * channel ID together with the flags to clear */
     DMAC->INTPEND.reg = status;
-    if (status & DMAC_INTPEND_TCMPL) {
-        mutex_unlock(&dma_ctx[dma].sync_lock);
+    if ((status & DMAC_INTPEND_TCMPL) && dma_ctx[dma].cb) {
+        dma_ctx[dma].cb(dma_ctx[dma].ctx);
     }
     DEBUG("[DMA] IRQ: %u: %x\n", dma, status);
     cortexm_isr_end();

--- a/cpu/sam0_common/periph/dma.c
+++ b/cpu/sam0_common/periph/dma.c
@@ -17,7 +17,6 @@
 
 #include "periph_cpu.h"
 #include "periph_conf.h"
-#include "mutex.h"
 #include "bitarithm.h"
 #include "pm_layered.h"
 #include "thread_flags.h"
@@ -38,7 +37,8 @@ static DmacDescriptor DMA_DESCRIPTOR_ATTRS writeback[CONFIG_DMA_NUMOF];
 static uint32_t channels_free = (1LLU << CONFIG_DMA_NUMOF) - 1;
 
 struct dma_ctx {
-    mutex_t sync_lock;
+    dma_cb_t cb;
+    void *ctx;
 };
 
 struct dma_ctx dma_ctx[CONFIG_DMA_NUMOF];
@@ -56,9 +56,7 @@ static void _poweron(void)
 void dma_init(void)
 {
     _poweron();
-    for (unsigned i = 0; i < CONFIG_DMA_NUMOF; i++) {
-        mutex_init(&dma_ctx[i].sync_lock);
-    }
+
     /* Enable all priorities with RR scheduling */
     DMAC->CTRL.reg = DMAC_CTRL_LVLEN0 |
                      DMAC_CTRL_LVLEN1 |
@@ -99,8 +97,6 @@ dma_t dma_acquire_channel(void)
         channel = bitarithm_lsb(channels_free);
         /* Clear channel bit */
         channels_free &= ~(1 << channel);
-        /* ensure the sync lock is locked */
-        mutex_trylock(&dma_ctx[channel].sync_lock);
     }
     irq_restore(state);
     return channel;
@@ -145,7 +141,12 @@ static inline DmacDescriptor *_get_next_descriptor(const DmacDescriptor *descr)
     return (DmacDescriptor *)descr->DESCADDR.reg;
 }
 
-void dma_setup(dma_t dma, unsigned trigger, uint8_t prio, bool irq)
+void dma_set_cb_arg(dma_t dma, void *ctx)
+{
+    dma_ctx[dma].ctx = ctx;
+}
+
+void dma_setup(dma_t dma, unsigned trigger, uint8_t prio, dma_cb_t cb, void *ctx)
 {
 #ifdef REG_DMAC_CHID
     /* Ensure that this set of register writes is atomic */
@@ -156,7 +157,7 @@ void dma_setup(dma_t dma, unsigned trigger, uint8_t prio, bool irq)
                         (prio << DMAC_CHCTRLB_LVL_Pos);
     /* Clear everything in case a previous user left it configured */
     DMAC->CHINTENCLR.reg = 0xFF;
-    if (irq) {
+    if (cb) {
         DMAC->CHINTENSET.reg = DMAC_CHINTENSET_TCMPL;
     }
     irq_restore(state);
@@ -165,10 +166,13 @@ void dma_setup(dma_t dma, unsigned trigger, uint8_t prio, bool irq)
                                      (trigger << DMAC_CHCTRLA_TRIGSRC_Pos);
     DMAC->Channel[dma].CHPRILVL.reg = prio;
     DMAC->Channel[dma].CHINTENCLR.reg = 0xFF;
-    if (irq) {
+    if (cb) {
         DMAC->Channel[dma].CHINTENSET.reg = DMAC_CHINTENSET_TCMPL;
     }
 #endif
+
+    dma_ctx[dma].cb = cb;
+    dma_ctx[dma].ctx = ctx;
 }
 
 void dma_prepare(dma_t dma, uint8_t width, const void *src, void *dst,
@@ -293,12 +297,6 @@ void dma_start(dma_t dma)
 #endif
 }
 
-void dma_wait(dma_t dma)
-{
-    DEBUG("[DMA]: mutex lock: %u\n", dma);
-    mutex_lock(&dma_ctx[dma].sync_lock);
-}
-
 void dma_cancel(dma_t dma)
 {
     DEBUG("[DMA]: Cancelling active transfer: %u\n", dma);
@@ -326,8 +324,8 @@ void isr_dmac(void)
     /* Clear the pending interrupt flags for this channel by writing the
      * channel ID together with the flags to clear */
     DMAC->INTPEND.reg = status;
-    if (status & DMAC_INTPEND_TCMPL) {
-        mutex_unlock(&dma_ctx[dma].sync_lock);
+    if ((status & DMAC_INTPEND_TCMPL) && dma_ctx[dma].cb) {
+        dma_ctx[dma].cb(dma_ctx[dma].ctx);
     }
     DEBUG("[DMA] IRQ: %u: %x\n", dma, status);
     cortexm_isr_end();

--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -149,6 +149,13 @@ static inline bool _use_dma(spi_t bus)
 #endif
 }
 
+#ifdef MODULE_PERIPH_DMA
+static void _unlock(void *ctx)
+{
+    mutex_unlock(ctx);
+}
+#endif
+
 static inline void _init_dma(spi_t bus, const volatile void *reg_rx, volatile void *reg_tx)
 {
     if (!_use_dma(bus)) {
@@ -160,9 +167,9 @@ static inline void _init_dma(spi_t bus, const volatile void *reg_rx, volatile vo
     _dma_state[bus].tx_dma = dma_acquire_channel();
 
     dma_setup(_dma_state[bus].tx_dma,
-              spi_config[bus].tx_trigger, 0, false);
+              spi_config[bus].tx_trigger, 0, NULL, NULL);
     dma_setup(_dma_state[bus].rx_dma,
-              spi_config[bus].rx_trigger, 1, true);
+              spi_config[bus].rx_trigger, 1, _unlock, NULL);
 
     dma_prepare(_dma_state[bus].rx_dma, DMAC_BTCTRL_BEATSIZE_BYTE_Val,
                 (void*)reg_rx, NULL, 1, 0);
@@ -468,10 +475,14 @@ static void _dma_execute(spi_t bus)
 #if IS_ACTIVE(MODULE_PM_LAYERED) && defined(SAM0_SPI_PM_BLOCK)
     pm_block(SAM0_SPI_PM_BLOCK);
 #endif
+
+    mutex_t lock = MUTEX_INIT_LOCKED;
+    dma_set_cb_arg(_dma_state[bus].rx_dma, &lock);
+
     dma_start(_dma_state[bus].rx_dma);
     dma_start(_dma_state[bus].tx_dma);
 
-    dma_wait(_dma_state[bus].rx_dma);
+    mutex_lock(&lock);
 #if IS_ACTIVE(MODULE_PM_LAYERED) && defined(SAM0_SPI_PM_BLOCK)
     pm_unblock(SAM0_SPI_PM_BLOCK);
 #endif

--- a/drivers/include/periph/dac.h
+++ b/drivers/include/periph/dac.h
@@ -128,6 +128,57 @@ void dac_poweron(dac_t line);
  */
 void dac_poweroff(dac_t line);
 
+/**
+ * @brief   Get the sample rate of the DAC in Hz
+ */
+uint32_t dac_get_freq(void);
+
+/**
+ * @brief   Options for @ref dac_play
+ * @{
+ */
+#define DAC_PLAY_LOOPED     (1 << 0)    /**< keep playing the sample buffer in a loop */
+/** @} */
+
+/**
+ * @brief   Signature of event callback functions triggered from interrupts
+ *
+ * @param[in] arg       optional context for the callback
+ */
+typedef void (*dma_cb_t)(void *arg);
+
+/**
+ * @brief   Configure DAC line for playing sample buffer
+ *
+ * @param[in]   line        DAC line to configure
+ * @param[in]   cb          Callback to be executed when the current sample buffer
+ *                          is done. Will be executed in interrupt context.
+ *                          May be NULL.
+ * @param[in]   arg         Callback argument
+ *
+ * @retval      0           Success
+ * @retval      -EEXIST     Line has already been configured
+ * @retval      -ENOMEM     Can't allocate resources for playback
+ */
+int dac_play_setup(dac_t line, dma_cb_t cb, void *arg);
+
+/**
+ * @brief   Start playing sample buffer
+ *
+ * @param[in]   line        DAC line to user for playing
+ * @param[in]   buf         Sample buffer to play
+ * @param[in]   len         Number of samples to play
+ * @param[in]   flags       Playback options
+ */
+void dac_play(dac_t line, const uint16_t *buf, size_t len, uint8_t flags);
+
+/**
+ * @brief   Release DAC line
+ *
+ * @param[in]   line        DAC line to release
+ */
+void dac_play_teardown(dac_t line);
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/periph/dac.h
+++ b/drivers/include/periph/dac.h
@@ -49,6 +49,7 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
+#include <stddef.h>
 #include <stdint.h>
 #include <limits.h>
 
@@ -130,6 +131,8 @@ void dac_poweroff(dac_t line);
 
 /**
  * @brief   Get the sample rate of the DAC in Hz
+ *
+ * @return  Sampling Rate in Hz
  */
 uint32_t dac_get_freq(void);
 

--- a/drivers/include/periph/dac.h
+++ b/drivers/include/periph/dac.h
@@ -49,6 +49,7 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
+#include <stddef.h>
 #include <stdint.h>
 #include <limits.h>
 
@@ -127,6 +128,71 @@ void dac_poweron(dac_t line);
  * @param[in] line          DAC line to power off
  */
 void dac_poweroff(dac_t line);
+
+/**
+ * @brief   Get the sample rate of the DAC in Hz
+ *
+ * @note this requires the `periph_dac_play` feature
+ *
+ * @return  Sampling Rate in Hz
+ */
+uint32_t dac_get_freq(void);
+
+/**
+ * @brief   Options for @ref dac_play
+ * @{
+ */
+#define DAC_PLAY_LOOPED     (1 << 0)    /**< keep playing the sample buffer in a loop */
+/** @} */
+
+/**
+ * @brief   Signature of event callback functions triggered from interrupts
+ *
+ * @param[in] arg       optional context for the callback
+ */
+typedef void (*dma_cb_t)(void *arg);
+
+/**
+ * @brief   Configure DAC line for playing sample buffer
+ *
+ * @note this requires the `periph_dac_play` feature
+ *
+ * @param[in]   line        DAC line to configure
+ * @param[in]   cb          Callback to be executed when the current sample buffer
+ *                          is done.
+ *                          If `DAC_PLAY_LOOPED` is set in `dac_play()`, the callback
+ *                          will not be executed, the current sample buffer will be
+ *                          played again.
+ *                          Will be executed in interrupt context.
+ *                          May be NULL.
+ * @param[in]   arg         Callback argument
+ *
+ * @retval      0           Success
+ * @retval      -EEXIST     Line has already been configured
+ * @retval      -ENOMEM     Can't allocate resources for playback
+ */
+int dac_play_setup(dac_t line, dma_cb_t cb, void *arg);
+
+/**
+ * @brief   Start playing sample buffer
+ *
+ * @note this requires the `periph_dac_play` feature
+ *
+ * @param[in]   line        DAC line to user for playing
+ * @param[in]   buf         Sample buffer to play
+ * @param[in]   len         Number of samples to play
+ * @param[in]   flags       Playback options
+ */
+void dac_play(dac_t line, const uint16_t *buf, size_t len, uint8_t flags);
+
+/**
+ * @brief   Release DAC line
+ *
+ * @note this requires the `periph_dac_play` feature
+ *
+ * @param[in]   line        DAC line to release
+ */
+void dac_play_teardown(dac_t line);
 
 #ifdef __cplusplus
 }

--- a/features.yaml
+++ b/features.yaml
@@ -665,6 +665,8 @@ groups:
       help: The ADC peripheral can be left on between measurements.
     - name: periph_dac
       help: A DAC peripheral is present.
+    - name: periph_dac_play
+      help: The DAC peripheral implements playing multiple samples in the background.
 
   - title: Integrated Connectivity
     help: Peripheral network and communication interfaces.

--- a/makefiles/features_existing.inc.mk
+++ b/makefiles/features_existing.inc.mk
@@ -152,6 +152,7 @@ FEATURES_EXISTING := \
     periph_cpuid \
     periph_cryptocell_310 \
     periph_dac \
+    periph_dac_play \
     periph_dma \
     periph_ecc_ed25519 \
     periph_ecc_p192r1 \

--- a/tests/periph/dac_play/Makefile
+++ b/tests/periph/dac_play/Makefile
@@ -1,0 +1,17 @@
+BOARD ?= same54-xpro
+
+include ../Makefile.periph_common
+
+USEMODULE += shell
+
+FEATURES_REQUIRED += periph_dac_play
+
+LOW_MEMORY_BOARDS := samd10-xmini
+
+# Disable the greeting sample if the board has too little memory
+# or flashing takes too long
+ifneq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
+  CFLAGS += -DCONIFG_DAC_BUF_SAMPLES=512
+endif
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph/dac_play/main.c
+++ b/tests/periph/dac_play/main.c
@@ -10,11 +10,9 @@
  * @file
  * @brief       DAC (audio) test application
  *
- *              Generates Sine, Square, Triangle and Sawtooth waves
- *              using a DAC.
- *              Connect a speaker or headphones to the DAC output
- *              pins of your board, you should be able to hear the
- *              generated sounds.
+ * Generates Sine, Square, Triangle and Sawtooth waves using a DAC.
+ * Connect a speaker or headphones to the DAC output pins of your board,
+ * you should be able to hear the generated sounds.
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  *
@@ -88,7 +86,7 @@ static uint16_t _fill_sine_samples(uint16_t *dst, uint16_t len)
     for (uint16_t i = 0; i < len; ++i) {
         dst[i] = fast_sini(i * step) - SINI_MIN;
         /* scale amplitude 12 -> 16 bit
-           fast_sini() would clip since it goes from -0x1000 to 0x1000 */
+         * fast_sini() would clip since it goes from -0x1000 to 0x1000 */
         dst[i] = ((dst[i] << 3) * 64) / 65;
     }
 
@@ -107,7 +105,8 @@ static void _play_cb(void *arg)
 
     if (--ctx->iterations) {
         dac_play(CONFIG_DAC_LINE, ctx->buf, ctx->num_samples, 0);
-    } else {
+    }
+    else {
         dac_play_teardown(CONFIG_DAC_LINE);
         /* restore idle level */
         dac_set(CONFIG_DAC_LINE, 1 << 15);
@@ -137,7 +136,8 @@ static void play_function(uint32_t freq, uint32_t secs, sample_gen_t fun) {
         ctx.iterations = (secs * sample_rate) / len;
 
         dac_play_setup(CONFIG_DAC_LINE, _play_cb, &ctx);
-    } else {
+    }
+    else {
         ctx.iterations = UINT32_MAX;
         flags |= DAC_PLAY_LOOPED;
 
@@ -166,6 +166,8 @@ static int cmd_saw(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(saw, "Play Sawtooth wave /|", cmd_saw);
+
 static int cmd_triang(int argc, char **argv)
 {
     if (argc < 3) {
@@ -180,6 +182,8 @@ static int cmd_triang(int argc, char **argv)
 
     return 0;
 }
+
+SHELL_COMMAND(triang, "Play Triangle wave /\\", cmd_triang);
 
 static int cmd_sine(int argc, char **argv)
 {
@@ -196,6 +200,8 @@ static int cmd_sine(int argc, char **argv)
     return 0;
 }
 
+SHELL_COMMAND(sine, "Play Sine wave     ~", cmd_sine);
+
 static int cmd_square(int argc, char **argv)
 {
     if (argc < 3) {
@@ -211,13 +217,7 @@ static int cmd_square(int argc, char **argv)
     return 0;
 }
 
-static const shell_command_t shell_commands[] = {
-    { "saw",    "Play Sawtooth wave /|", cmd_saw },
-    { "triang", "Play Triangle wave /\\", cmd_triang },
-    { "sine",   "Play Sine wave     ~", cmd_sine },
-    { "square", "Play Square wave   _–", cmd_square },
-    { NULL, NULL, NULL }
-};
+SHELL_COMMAND(square, "Play Square wave   _–", cmd_square);
 
 int main(void)
 {
@@ -227,7 +227,7 @@ int main(void)
 
     /* start the shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }

--- a/tests/periph/dac_play/main.c
+++ b/tests/periph/dac_play/main.c
@@ -1,0 +1,233 @@
+/*
+ * SPDX-FileCopyrightText: 2026 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       DAC (audio) test application
+ *
+ * Generates Sine, Square, Triangle and Sawtooth waves using a DAC.
+ * Connect a speaker or headphones to the DAC output pins of your board,
+ * you should be able to hear the generated sounds.
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "macros/math.h"
+#include "periph/dac.h"
+#include "imath.h"
+#include "shell.h"
+
+#ifndef CONFIG_DAC_LINE
+#  define CONFIG_DAC_LINE 0
+#endif
+
+#ifndef CONIFG_DAC_BUF_SAMPLES
+#  define CONIFG_DAC_BUF_SAMPLES 2048
+#endif
+
+/* simple function to fill buffer the size of one period */
+/* Sample period may get trimmed to align with wave period */
+typedef uint16_t (*sample_gen_t)(uint16_t *dst, uint16_t len);
+
+static uint16_t _fill_square_samples(uint16_t *dst, uint16_t len)
+{
+    uint8_t *buf = (void *)dst;
+
+    memset(buf, 0x00, len);
+    buf += len;
+    memset(buf, 0xff, len);
+
+    return len;
+}
+
+static uint16_t _fill_saw_samples(uint16_t *dst, uint16_t len)
+{
+    uint32_t delta = (0xffff << 8) / len;
+
+    for (uint16_t i = 0; i < len; ++i) {
+        dst[i] = (i * delta) >> 8;
+    }
+
+    return len;
+}
+
+static uint16_t _fill_triang_samples(uint16_t *dst, uint16_t len)
+{
+    uint32_t delta = (0xffff << 9) / len;
+
+    for (uint16_t i = 0; i < len / 2; ++i) {
+        dst[i] = (i * delta) >> 8;
+    }
+    dst += len / 2;
+    for (uint16_t i = 0; i < len / 2; ++i) {
+        dst[i] = 0xffff - ((i * delta) >> 8);
+    }
+
+    return len;
+}
+
+static uint16_t _fill_sine_samples(uint16_t *dst, uint16_t len)
+{
+    /* round up here to not exceed the supplied buffer */
+    unsigned step = DIV_ROUND_UP(SINI_PERIOD, len);
+    len = SINI_PERIOD / step;
+
+    for (uint16_t i = 0; i < len; ++i) {
+        dst[i] = fast_sini(i * step) - SINI_MIN;
+        /* scale amplitude 12 -> 16 bit
+         * fast_sini() would clip since it goes from -0x1000 to 0x1000 */
+        dst[i] = ((dst[i] << 3) * 64) / 65;
+    }
+
+    return len;
+}
+
+typedef struct {
+    uint16_t buf[CONIFG_DAC_BUF_SAMPLES];
+    uint32_t iterations;
+    uint16_t num_samples;
+} dac_play_ctx_t;
+
+static void _play_cb(void *arg)
+{
+    dac_play_ctx_t *ctx = arg;
+
+    if (--ctx->iterations) {
+        dac_play(CONFIG_DAC_LINE, ctx->buf, ctx->num_samples, 0);
+    }
+    else {
+        dac_play_teardown(CONFIG_DAC_LINE);
+        /* restore idle level */
+        dac_set(CONFIG_DAC_LINE, 1 << 15);
+    }
+}
+
+static void play_function(uint32_t freq, uint32_t secs, sample_gen_t fun) {
+    static dac_play_ctx_t ctx;
+
+    uint32_t sample_rate = dac_get_freq();
+    uint16_t len = sample_rate / freq;
+    uint8_t flags = 0;
+
+    if (len > ARRAY_SIZE(ctx.buf)) {
+        printf("sample buffer (%u samples) too small for single period (%u samples)\n",
+               ARRAY_SIZE(ctx.buf), len);
+        return;
+    }
+
+    /* stop ongoing playback */
+    if (ctx.iterations) {
+        dac_play_teardown(CONFIG_DAC_LINE);
+    }
+
+    /* use secs == 0 to signal infinite playback */
+    if (secs) {
+        ctx.iterations = (secs * sample_rate) / len;
+
+        dac_play_setup(CONFIG_DAC_LINE, _play_cb, &ctx);
+    }
+    else {
+        ctx.iterations = UINT32_MAX;
+        flags |= DAC_PLAY_LOOPED;
+
+        dac_play_setup(CONFIG_DAC_LINE, NULL, NULL);
+    }
+
+    /* generate samples */
+    ctx.num_samples = fun(ctx.buf, len);
+
+    /* play the sample */
+    dac_play(CONFIG_DAC_LINE, ctx.buf, ctx.num_samples, flags);
+}
+
+static int cmd_saw(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <freq> <secs>\n", argv[0]);
+        return 1;
+    }
+
+    unsigned freq = atoi(argv[1]);
+    unsigned secs = atoi(argv[2]);
+
+    play_function(freq, secs, _fill_saw_samples);
+
+    return 0;
+}
+
+SHELL_COMMAND(saw, "Play Sawtooth wave /|", cmd_saw);
+
+static int cmd_triang(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <freq> <secs>\n", argv[0]);
+        return 1;
+    }
+
+    unsigned freq = atoi(argv[1]);
+    unsigned secs = atoi(argv[2]);
+
+    play_function(freq, secs, _fill_triang_samples);
+
+    return 0;
+}
+
+SHELL_COMMAND(triang, "Play Triangle wave /\\", cmd_triang);
+
+static int cmd_sine(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <freq> <secs>\n", argv[0]);
+        return 1;
+    }
+
+    unsigned freq = atoi(argv[1]);
+    unsigned secs = atoi(argv[2]);
+
+    play_function(freq, secs, _fill_sine_samples);
+
+    return 0;
+}
+
+SHELL_COMMAND(sine, "Play Sine wave     ~", cmd_sine);
+
+static int cmd_square(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <freq> <secs>\n", argv[0]);
+        return 1;
+    }
+
+    unsigned freq = atoi(argv[1]);
+    unsigned secs = atoi(argv[2]);
+
+    play_function(freq, secs, _fill_square_samples);
+
+    return 0;
+}
+
+SHELL_COMMAND(square, "Play Square wave   _–", cmd_square);
+
+int main(void)
+{
+    dac_init(CONFIG_DAC_LINE);
+    /* Initialize to the idle level of 16bit audio */
+    dac_set(CONFIG_DAC_LINE, 1 << 15);
+
+    /* start the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/periph/dac_play/main.c
+++ b/tests/periph/dac_play/main.c
@@ -1,0 +1,233 @@
+/*
+ * SPDX-FileCopyrightText: 2026 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       DAC (audio) test application
+ *
+ *              Generates Sine, Square, Triangle and Sawtooth waves
+ *              using a DAC.
+ *              Connect a speaker or headphones to the DAC output
+ *              pins of your board, you should be able to hear the
+ *              generated sounds.
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "macros/math.h"
+#include "periph/dac.h"
+#include "imath.h"
+#include "shell.h"
+
+#ifndef CONFIG_DAC_LINE
+#  define CONFIG_DAC_LINE 0
+#endif
+
+#ifndef CONIFG_DAC_BUF_SAMPLES
+#  define CONIFG_DAC_BUF_SAMPLES 2048
+#endif
+
+/* simple function to fill buffer the size of one period */
+/* Sample period may get trimmed to align with wave period */
+typedef uint16_t (*sample_gen_t)(uint16_t *dst, uint16_t len);
+
+static uint16_t _fill_square_samples(uint16_t *dst, uint16_t len)
+{
+    uint8_t *buf = (void *)dst;
+
+    memset(buf, 0x00, len);
+    buf += len;
+    memset(buf, 0xff, len);
+
+    return len;
+}
+
+static uint16_t _fill_saw_samples(uint16_t *dst, uint16_t len)
+{
+    uint32_t delta = (0xffff << 8) / len;
+
+    for (uint16_t i = 0; i < len; ++i) {
+        dst[i] = (i * delta) >> 8;
+    }
+
+    return len;
+}
+
+static uint16_t _fill_triang_samples(uint16_t *dst, uint16_t len)
+{
+    uint32_t delta = (0xffff << 9) / len;
+
+    for (uint16_t i = 0; i < len / 2; ++i) {
+        dst[i] = (i * delta) >> 8;
+    }
+    dst += len / 2;
+    for (uint16_t i = 0; i < len / 2; ++i) {
+        dst[i] = 0xffff - ((i * delta) >> 8);
+    }
+
+    return len;
+}
+
+static uint16_t _fill_sine_samples(uint16_t *dst, uint16_t len)
+{
+    /* round up here to not exceed the supplied buffer */
+    unsigned step = DIV_ROUND_UP(SINI_PERIOD, len);
+    len = SINI_PERIOD / step;
+
+    for (uint16_t i = 0; i < len; ++i) {
+        dst[i] = fast_sini(i * step) - SINI_MIN;
+        /* scale amplitude 12 -> 16 bit
+           fast_sini() would clip since it goes from -0x1000 to 0x1000 */
+        dst[i] = ((dst[i] << 3) * 64) / 65;
+    }
+
+    return len;
+}
+
+typedef struct {
+    uint16_t buf[CONIFG_DAC_BUF_SAMPLES];
+    uint32_t iterations;
+    uint16_t num_samples;
+} dac_play_ctx_t;
+
+static void _play_cb(void *arg)
+{
+    dac_play_ctx_t *ctx = arg;
+
+    if (--ctx->iterations) {
+        dac_play(CONFIG_DAC_LINE, ctx->buf, ctx->num_samples, 0);
+    } else {
+        dac_play_teardown(CONFIG_DAC_LINE);
+        /* restore idle level */
+        dac_set(CONFIG_DAC_LINE, 1 << 15);
+    }
+}
+
+static void play_function(uint32_t freq, uint32_t secs, sample_gen_t fun) {
+    static dac_play_ctx_t ctx;
+
+    uint32_t sample_rate = dac_get_freq();
+    uint16_t len = sample_rate / freq;
+    uint8_t flags = 0;
+
+    if (len > ARRAY_SIZE(ctx.buf)) {
+        printf("sample buffer (%u samples) too small for single period (%u samples)\n",
+               ARRAY_SIZE(ctx.buf), len);
+        return;
+    }
+
+    /* stop ongoing playback */
+    if (ctx.iterations) {
+        dac_play_teardown(CONFIG_DAC_LINE);
+    }
+
+    /* use secs == 0 to signal infinite playback */
+    if (secs) {
+        ctx.iterations = (secs * sample_rate) / len;
+
+        dac_play_setup(CONFIG_DAC_LINE, _play_cb, &ctx);
+    } else {
+        ctx.iterations = UINT32_MAX;
+        flags |= DAC_PLAY_LOOPED;
+
+        dac_play_setup(CONFIG_DAC_LINE, NULL, NULL);
+    }
+
+    /* generate samples */
+    ctx.num_samples = fun(ctx.buf, len);
+
+    /* play the sample */
+    dac_play(CONFIG_DAC_LINE, ctx.buf, ctx.num_samples, flags);
+}
+
+static int cmd_saw(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <freq> <secs>\n", argv[0]);
+        return 1;
+    }
+
+    unsigned freq = atoi(argv[1]);
+    unsigned secs = atoi(argv[2]);
+
+    play_function(freq, secs, _fill_saw_samples);
+
+    return 0;
+}
+
+static int cmd_triang(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <freq> <secs>\n", argv[0]);
+        return 1;
+    }
+
+    unsigned freq = atoi(argv[1]);
+    unsigned secs = atoi(argv[2]);
+
+    play_function(freq, secs, _fill_triang_samples);
+
+    return 0;
+}
+
+static int cmd_sine(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <freq> <secs>\n", argv[0]);
+        return 1;
+    }
+
+    unsigned freq = atoi(argv[1]);
+    unsigned secs = atoi(argv[2]);
+
+    play_function(freq, secs, _fill_sine_samples);
+
+    return 0;
+}
+
+static int cmd_square(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <freq> <secs>\n", argv[0]);
+        return 1;
+    }
+
+    unsigned freq = atoi(argv[1]);
+    unsigned secs = atoi(argv[2]);
+
+    play_function(freq, secs, _fill_square_samples);
+
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "saw",    "Play Sawtooth wave /|", cmd_saw },
+    { "triang", "Play Triangle wave /\\", cmd_triang },
+    { "sine",   "Play Sine wave     ~", cmd_sine },
+    { "square", "Play Square wave   _–", cmd_square },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    dac_init(CONFIG_DAC_LINE);
+    /* Initialize to the idle level of 16bit audio */
+    dac_set(CONFIG_DAC_LINE, 1 << 15);
+
+    /* start the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `periph_dac` API only plays single samples. The `dac_dds` drives does exist, but it's interrupt based so it's prone to distortions when interrupts are disabled even for a brief time.

The proper solution is to use DMA to feed the DAC and since the DAC API is CPU specific, the only way to do this is by extending the DAC API with a new `dac_play()` function that allows to supply a buffer of samples that will then be played asynchronously.

Support for this is indicated by the `periph_dac_play` feature.

We can supply a completion callback to supply the next buffer or set it to loop mode where the same sample is played over and over again independent of the CPU (e.g. if we want to produce a constant sine wave).

⚠️ **This contains a change to the way `dac_set()` behaves on sam0** ⚠️

Previously the 12 bit DAC was not left-adjusted, that means `dac_set(0xfff)` would produce the highest amplitude while `dac_set(0x1000)` would be clipped to 0.

However our API doc says

> The value is always given as 16-bit value and is internally scaled to the
> actual resolution that the DAC unit provides (e.g. 12-bit).

Fix this by setting the `LEFTADJ` bit.
This however means that existing users will experience a lower amplitude when they supply 12 bit values.

### Testing procedure

Try out the different waveforms in `tests/periph/dac_play`:

```
sine 330 10
```

<img width="2352" height="1326" alt="image" src="https://github.com/user-attachments/assets/b7a9ea79-de19-4391-97ec-c7c09ffc5edb" />

```
triang 330 10
```

<img width="2352" height="1326" alt="image" src="https://github.com/user-attachments/assets/54f39f04-9a01-4898-96e1-4daec262f75e" />

```
square 330 10
```

<img width="2352" height="1326" alt="image" src="https://github.com/user-attachments/assets/3676f103-4817-42b4-a440-e772b36da29f" />

```
saw 330 10
```

<img width="2352" height="1326" alt="image" src="https://github.com/user-attachments/assets/55e857a7-8128-4511-9179-3c46eff3df33" />

(The overshooting for square and sawtooth waves are actually an artifact of the oscilloscope, the signal looks clean on the (more expensive) Tektronix scope)

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- none
