### PR TITLE
doc/starlight: Improve boards search style

### DIFF
--- a/doc/starlight/src/pages/boards.astro
+++ b/doc/starlight/src/pages/boards.astro
@@ -29,7 +29,14 @@ const sortedBoards = boards.sort((a, b) =>
     id="riot-boards-search"
     type="search"
     placeholder="Type to filter boards (e.g. arduino, stm32, nrf)"
-    style={{ width: "100%", margin: "0.5rem 0 1rem 0", padding: "0.5rem" }}
+    style={{
+      width: "100%",
+      margin: "0.5rem 0 1rem 0",
+      padding: "0.5rem 0.8rem",
+      background: "transparent",
+      border: "1px solid var(--sl-color-text-accent)",
+      borderRadius: "8px",
+    }}
   />
   <p id="riot-boards-no-results" hidden>No board entries match this filter.</p>
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Right now the input field to search for boards is unstyled. This PR aligns the style to the documentations aesthetics.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="1878" height="1016" alt="image" src="https://github.com/user-attachments/assets/84024ad3-363e-44da-88b5-4a7a5c6d2167" />
</td>
<td>
<img width="1878" height="1016" alt="image" src="https://github.com/user-attachments/assets/3cc03421-df69-4242-9188-13a27929d77e" />
</td>
</tr>
<tr>
<td>
<img width="1878" height="1016" alt="image" src="https://github.com/user-attachments/assets/f698454f-6e6a-4746-9b98-f2bbf40ee86b" />
</td>
<td>
<img width="1878" height="1016" alt="image" src="https://github.com/user-attachments/assets/531094a9-eedb-48ee-b32e-516852c80e57" />
</td>
</tr>
</table>

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- none
