### PR TITLE
boards/stm32f030f4-demo: deprecate board

### DIFF
--- a/boards/stm32f030f4-demo/Makefile.include
+++ b/boards/stm32f030f4-demo/Makefile.include
@@ -1,4 +1,11 @@
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
+include $(RIOTBASE)/makefiles/utils/ansi.mk
+include $(RIOTBASE)/makefiles/color.inc.mk
+
+MSG="Warning: This board is deprecated and the support for it will be removed"\
+    "after the 2026.07 Release."
+$(shell $(COLOR_ECHO) "$(COLOR_YELLOW)$(MSG)$(COLOR_RESET)" 1>&2)
+
 # Setup of programmer and serial is shared between STM32 based boards
 include $(RIOTMAKE)/boards/stm32.inc.mk

--- a/boards/stm32f030f4-demo/doc.md
+++ b/boards/stm32f030f4-demo/doc.md
@@ -6,6 +6,9 @@
 
 The STM32F030F4 Demo Board is a very cheap breakout board for the STM32F030F4 MCU.
 
+\warning This board is deprecated and the support for it will be removed
+         after the 2026.07 Release!
+
 ## Hardware
 
 ![STM32F030F4 Demo Board](https://user-images.githubusercontent.com/20950920/48240567-e985c080-e3db-11e8-8775-68a216485b59.jpg)


### PR DESCRIPTION
### Contribution description

The `STM32F030F4 Demo` board was added in 2019 by @benpicco as a cheap board to run RIOT.
It can indeed be bought reasonably cheap for <2€, but it's also kind of obscure and the RIOT documentation is among the first results for it, which is not necessarily a sign that the board is widely used 😅 

Also the board has so little RAM, that it is excluded from many tests and examples anyways:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ grep -RnwI -i stm32f030f4-demo . | grep Makefile.ci | wc -l
293
```

These days it's not worth hassling with the Chinese STM32 boards which more often than not have fake STM32 chips on them, since the Nucleo boards have become so widely available and cheap and don't have fake chips, weird bootloaders and other stuff that makes the development experience annoying.


### Testing procedure

Execute `BOARD=stm32f030f4-demo make -C tests/sys/shell` and observe the wonderful yellow deprecation warning.

### Issues/PRs references

Support was added in #12433
Noticed in #22257 

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
