### PR TITLE
boards: add seeedstudio sensecap t1000e support

### DIFF
--- a/boards/seeedstudio-sensecap-t1000e/Kconfig
+++ b/boards/seeedstudio-sensecap-t1000e/Kconfig
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2026 Baptiste Le Duc <baptiste.leduc@etik.com>
+# SPDX-License-Identifier: LGPL-2.1-only
+
+config BOARD
+    default "seeedstudio-sensecap-t1000e" if BOARD_SEEEDSTUDIO_T1000E
+
+config BOARD_SEEEDSTUDIO_T1000E
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52840XXAA
+
+config T1000E_ENABLE_3V3
+    bool "Enable 3.3V rail"
+    default y
+    help
+        Drive the main 3.3V load switch at boot. Required by most
+        on-board peripherals. Disable to save power if all peripherals
+        are managed at runtime.
+
+config T1000E_ENABLE_SENSOR
+    bool "Enable sensor power rail"
+    default y
+    help
+        Drive the sensor load switch at boot, powering the light sensor
+        and NTC thermistor. Disable if neither sensor is used.
+
+config T1000E_ENABLE_ACC
+    bool "Enable accelerometer power rail"
+    default y
+    help
+        Drive the accelerometer load switch at boot, powering the
+        QMA6100P. Disable if the accelerometer is not used.
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/seeedstudio-sensecap-t1000e/Makefile
+++ b/boards/seeedstudio-sensecap-t1000e/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/seeedstudio-sensecap-t1000e/Makefile.dep
+++ b/boards/seeedstudio-sensecap-t1000e/Makefile.dep
@@ -1,0 +1,8 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_adc
+  USEMODULE += saul_gpio
+endif
+
+USEMODULE += boards_common_adafruit-nrf52-bootloader
+
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/seeedstudio-sensecap-t1000e/Makefile.features
+++ b/boards/seeedstudio-sensecap-t1000e/Makefile.features
@@ -1,0 +1,14 @@
+CPU_MODEL = nrf52840xxaa
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# Other features provided by the board (in alphabetical order)
+FEATURES_PROVIDED += highlevel_stdio
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/seeedstudio-sensecap-t1000e/Makefile.include
+++ b/boards/seeedstudio-sensecap-t1000e/Makefile.include
@@ -1,0 +1,3 @@
+# UART_DEV(0) is reserved for the GNSS module
+STDIO_UART_DEV ?= 1
+UF2_SOFTDEV ?= SD730

--- a/boards/seeedstudio-sensecap-t1000e/board.c
+++ b/boards/seeedstudio-sensecap-t1000e/board.c
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Baptiste Le Duc <baptiste.leduc@etik.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     boards_seeedstudio-sensecap-t1000e
+ * @{
+ *
+ * @file
+ * @brief       Board initialization for the SeeedStudio SenseCAP T1000-E
+ *
+ * @author      Baptiste Le Duc <baptiste.leduc@etik.com>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "kernel_defines.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    if (IS_ACTIVE(CONFIG_T1000E_ENABLE_3V3)) {
+        gpio_init(T1000E_3V3_EN_PIN, GPIO_OUT);
+        gpio_set(T1000E_3V3_EN_PIN);
+    }
+
+    if (IS_ACTIVE(CONFIG_T1000E_ENABLE_SENSOR)) {
+        gpio_init(T1000E_SENSOR_EN_PIN, GPIO_OUT);
+        gpio_set(T1000E_SENSOR_EN_PIN);
+    }
+
+    if (IS_ACTIVE(CONFIG_T1000E_ENABLE_ACC)) {
+        gpio_init(T1000E_3V3_ACC_EN_PIN, GPIO_OUT);
+        gpio_set(T1000E_3V3_ACC_EN_PIN);
+    }
+}

--- a/boards/seeedstudio-sensecap-t1000e/doc.md
+++ b/boards/seeedstudio-sensecap-t1000e/doc.md
@@ -1,0 +1,112 @@
+@defgroup   boards_seeedstudio-sensecap-t1000e SeeedStudio SenseCAP T1000-E
+@ingroup    boards
+@brief      Support for the SeeedStudio SenseCAP T1000-E
+@author     Baptiste Le Duc <baptiste.leduc@etik.com>
+
+Pin configuration is based on the
+[Meshtastic firmware variant](https://github.com/meshtastic/firmware/blob/develop/variants/nrf52840/tracker-t1000-e/variant.h)
+for this board.
+
+## Overview
+
+The [SenseCAP T1000-E](https://wiki.seeedstudio.com/sensecap_t1000_e/) is a
+compact LoRaWAN tracker based on the nRF52840 MCU with the following
+on-board components:
+
+- Nordic nRF52840 SoC @64MHz, 1MB Flash, 256KB RAM
+- Semtech LR1110 LoRa transceiver
+- Mediatek AG3335 GNSS module
+- QMA6100P 3-axis accelerometer
+- NTC temperature sensor
+- Light sensor
+- Buzzer
+- 1 user button
+- 1 LED
+- LiPo battery support with charging detection
+
+## Hardware
+
+| MCU         | nRF52840                               | Supported |
+|:----------- |:-------------------------------------- |:---------:|
+| Family      | ARM Cortex-M4 with FPU                 |           |
+| Vendor      | Nordic Semiconductor                   |           |
+| RAM         | 256 KByte                              |           |
+| Flash       | 1 MByte                                |           |
+| Frequency   | 64 MHz                                 |           |
+| FPU         | yes                                    |   yes     |
+| Timers      | 5 (32-bit)                             |   yes     |
+| RTC         | 3                                      |   yes     |
+| ADC         | 12-bit SAADC, 8 channels               |   yes     |
+| UART        | 2 x UARTE                              |   yes     |
+| SPI         | 3 x SPIM                               |   yes     |
+| I2C         | 2 x TWIM                               |   yes     |
+| PWM         | 4 x PWM (4 ch each)                    |   yes     |
+| USB         | 1 x Full Speed                         |   yes     |
+| BLE         | Bluetooth 5.0                          |   yes     |
+| IEEE 802.15.4 | yes                                  |   yes     |
+| Vcc         | 1.7V - 3.6V                            |           |
+| Datasheet   | [nRF52840 Product Specification](https://docs.nordicsemi.com/bundle/ps_nrf52840/page/keyfeatures_html5.html) | |
+| Board Manual | [SenseCAP T1000-E Wiki](https://wiki.seeedstudio.com/sensecap_t1000_e/) | |
+
+## Pin Layout / Configuration
+
+| RIOT Peripheral      | MCU Pin | Board Function              | Remark                        |
+|:---------------------|:--------|:----------------------------|:------------------------------|
+| BTN0                 | P0.06   | User button                 | pull-down, active high        |
+| LED0                 | P0.24   | LED                         |                               |
+| UART_DEV(0) RX       | P0.14   | GNSS (AG3335) RX            |                               |
+| UART_DEV(0) TX       | P0.13   | GNSS (AG3335) TX            |                               |
+| UART_DEV(1) RX       | P0.17   | spare / debug RX            |                               |
+| UART_DEV(1) TX       | P0.16   | spare / debug TX            |                               |
+| SPI_DEV(0) SCLK      | P0.11   | LR1110 SCLK                 |                               |
+| SPI_DEV(0) MOSI      | P1.09   | LR1110 MOSI                 |                               |
+| SPI_DEV(0) MISO      | P1.08   | LR1110 MISO                 |                               |
+| I2C_DEV(0) SCL       | P0.27   | QMA6100P SCL                |                               |
+| I2C_DEV(0) SDA       | P0.26   | QMA6100P SDA                |                               |
+| PWM_DEV(0) CH0       | P0.25   | Buzzer                      |                               |
+| NRF52_AIN0           | P0.02   | Battery voltage ADC         |                               |
+| NRF52_AIN5           | P0.29   | Light sensor ADC            |                               |
+| NRF52_AIN7           | P0.31   | NTC temperature ADC         |                               |
+| T1000E_LORA_NSS_PIN  | P0.12   | LR1110 chip select          |                               |
+| T1000E_LORA_RESET_PIN| P1.10   | LR1110 reset                |                               |
+| T1000E_LORA_IRQ_PIN  | P1.01   | LR1110 IRQ (DIO1)           |                               |
+| T1000E_LORA_BUSY_PIN | P0.07   | LR1110 busy (DIO2)          |                               |
+| T1000E_GPS_EN_PIN    | P1.11   | GNSS power enable           |                               |
+| T1000E_GPS_RESET_PIN | P1.15   | GNSS reset                  |                               |
+| T1000E_3V3_EN_PIN    | P1.06   | Sensor 3V3 power enable     |                               |
+| T1000E_3V3_ACC_EN_PIN| P1.07   | Accelerometer power enable  |                               |
+| T1000E_ACC_INT_PIN   | P1.02   | QMA6100P interrupt          |                               |
+| T1000E_CHRG_DETECT_PIN| P1.03  | Charging status             |                               |
+| T1000E_EXT_PWR_DETECT_PIN| P0.05| External power detect      |                               |
+
+## Flashing the Device
+
+The T1000-E ships with the
+[Adafruit nRF52 Bootloader](https://github.com/adafruit/Adafruit_nRF52_Bootloader),
+you can find flashing instructions
+[Adafruit nRF52 Bootloader](@ref boards_common_adafruit-nrf52-bootloader) section.
+
+DFU mode must be entered manually before flashing. Follow the
+[SeeedStudio instructions](https://files.seeedstudio.com/wiki/SenseCAP/Meshtastic/dfu-mode2.gif)
+to put the device in DFU mode, then run:
+
+```shell
+BOARD=seeedstudio-sensecap-t1000e make -C examples/basic/hello-world flash
+```
+
+@note Accessing the SWD pads requires opening the device enclosure. Overwriting
+the bootloader via SWD would make UF2 flashing unavailable and is not recommended
+for normal use.
+
+## Accessing STDIO
+
+By default, `stdio` uses `UART_DEV(1)` (P0.16/P0.17).
+`UART_DEV(0)` is reserved for the GNSS module. Connect a USB-to-UART adapter
+to P0.16 (TX) and P0.17 (RX) to access the terminal.
+
+To use USB CDC ACM (virtual serial port over the existing USB cable) instead,
+you can add `USEMODULE+=stdio_cdc_acm` to your application's Makefile or to
+the compiler call:
+```shell
+USEMODULE=stdio_cdc_acm BOARD=seeedstudio-sensecap-t1000e make -C examples/basic/hello-world flash term
+```

--- a/boards/seeedstudio-sensecap-t1000e/include/adc_params.h
+++ b/boards/seeedstudio-sensecap-t1000e/include/adc_params.h
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Baptiste Le Duc <baptiste.leduc@etik.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_seeedstudio-sensecap-t1000e
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped ADC lines
+ *
+ * @author      Baptiste Le Duc <baptiste.leduc@etik.com>
+ */
+
+#include "periph/adc.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   ADC SAUL configuration
+ *
+ * @note    NTC_THERMISTOR exposes a raw ADC reading, not degrees Celsius.
+ *          NTC curve conversion must be done at the application level.
+ */
+static const saul_adc_params_t saul_adc_params[] =
+{
+    {
+        .name = "LIGHT",
+        .line = ADC_LINE(NRF52_AIN5),   /* P0.29 */
+        .res  = ADC_RES_10BIT,
+    },
+    {
+        .name = "NTC_THERMISTOR",
+        .line = ADC_LINE(NRF52_AIN7),   /* P0.31 */
+        .res  = ADC_RES_10BIT,
+    },
+    {
+        .name = "BAT",
+        .line = ADC_LINE(NRF52_AIN0),   /* P0.02 */
+        .res  = ADC_RES_10BIT,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/seeedstudio-sensecap-t1000e/include/board.h
+++ b/boards/seeedstudio-sensecap-t1000e/include/board.h
@@ -1,0 +1,117 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Baptiste Le Duc <baptiste.leduc@etik.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_seeedstudio-sensecap-t1000e
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the SeeedStudio SenseCAP T1000-E
+ *
+ * @author      Baptiste Le Duc <baptiste.leduc@etik.com>
+ */
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Default board power-rail configuration
+ * @{
+ */
+#ifndef CONFIG_T1000E_ENABLE_3V3
+#  define CONFIG_T1000E_ENABLE_3V3        1     /**< enable 3.3V rail at boot */
+#endif
+#ifndef CONFIG_T1000E_ENABLE_SENSOR
+#  define CONFIG_T1000E_ENABLE_SENSOR     1     /**< enable sensor power rail at boot */
+#endif
+#ifndef CONFIG_T1000E_ENABLE_ACC
+#  define CONFIG_T1000E_ENABLE_ACC        1     /**< enable accelerometer power rail at boot */
+#endif
+/** @} */
+
+/**
+ * @name    Button pin definitions
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(0, 6)
+#define BTN0_MODE           GPIO_IN_PD
+#define BTN0_INT_FLANK      GPIO_RISING
+/** @} */
+
+/**
+ * @name    LED (on-board) configuration
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 24)
+#define LED0_ON             gpio_set(LED0_PIN)
+#define LED0_OFF            gpio_clear(LED0_PIN)
+#define LED0_TOGGLE         gpio_toggle(LED0_PIN)
+/** @} */
+
+/**
+ * @name    Buzzer configuration
+ * @{
+ */
+#define BUZZER_EN_PIN       GPIO_PIN(1, 5)    /**< Buzzer power enable pin */
+#define BUZZER_PIN          GPIO_PIN(0, 25)   /**< Buzzer PWM signal pin */
+/** @} */
+
+/**
+ * @name    Power enable pins
+ * @{
+ */
+#define T1000E_SENSOR_EN_PIN        GPIO_PIN(0, 4)  /**< Sensor power enable pin */
+#define T1000E_3V3_EN_PIN           GPIO_PIN(1, 6)  /**< 3.3V rail enable pin */
+#define T1000E_3V3_ACC_EN_PIN       GPIO_PIN(1, 7)  /**< 3.3V accelerometer rail enable pin */
+/** @} */
+
+/**
+ * @name    LR1110 LoRa transceiver control pins
+ * @{
+ */
+#define T1000E_LORA_NSS_PIN         GPIO_PIN(0, 12) /**< LR1110 SPI chip select pin */
+#define T1000E_LORA_RESET_PIN       GPIO_PIN(1, 10) /**< LR1110 reset pin */
+#define T1000E_LORA_IRQ_PIN         GPIO_PIN(1, 1)  /**< LR1110 interrupt request pin */
+#define T1000E_LORA_BUSY_PIN        GPIO_PIN(0, 7)  /**< LR1110 busy pin */
+/** @} */
+
+/**
+ * @name    GNSS (AG3335) control pins
+ * @{
+ */
+#define T1000E_GPS_EN_PIN           GPIO_PIN(1, 11) /**< GNSS module power enable pin */
+#define T1000E_GPS_RESET_PIN        GPIO_PIN(1, 15) /**< GNSS module reset pin */
+#define T1000E_GPS_VRTC_EN_PIN      GPIO_PIN(0, 8)  /**< GNSS RTC backup voltage enable pin */
+#define T1000E_GPS_SLEEP_INT_PIN    GPIO_PIN(1, 12) /**< GNSS sleep interrupt pin */
+#define T1000E_GPS_RTC_INT_PIN      GPIO_PIN(0, 15) /**< GNSS RTC interrupt pin */
+#define T1000E_GPS_RESETB_OUT_PIN   GPIO_PIN(1, 14) /**< GNSS reset-B output pin */
+/** @} */
+
+/**
+ * @name    Battery and charging detection pins
+ * @{
+ */
+#define T1000E_BAT_ADC_PIN          GPIO_PIN(0, 2)  /**< Battery voltage ADC input pin */
+#define T1000E_CHRG_DETECT_PIN      GPIO_PIN(1, 3)  /**< Charger connected detection pin */
+#define T1000E_EXT_PWR_DETECT_PIN   GPIO_PIN(0, 5)  /**< External power detection pin */
+/** @} */
+
+/**
+ * @name    Accelerometer (QMA6100P) interrupt pin
+ * @{
+ */
+#define T1000E_ACC_INT_PIN          GPIO_PIN(1, 2)  /**< Accelerometer interrupt pin */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/seeedstudio-sensecap-t1000e/include/gpio_params.h
+++ b/boards/seeedstudio-sensecap-t1000e/include/gpio_params.h
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Baptiste Le Duc <baptiste.leduc@etik.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_seeedstudio-sensecap-t1000e
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Baptiste Le Duc <baptiste.leduc@etik.com>
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   GPIO SAUL configuration
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "LED0",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = SAUL_GPIO_INIT_CLEAR,
+    },
+    {
+        .name  = "BTN0",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/seeedstudio-sensecap-t1000e/include/periph_conf.h
+++ b/boards/seeedstudio-sensecap-t1000e/include/periph_conf.h
@@ -1,0 +1,139 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Baptiste Le Duc <baptiste.leduc@etik.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_seeedstudio-sensecap-t1000e
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the SeeedStudio SenseCAP T1000-E
+ *
+ * @author      Baptiste Le Duc <baptiste.leduc@etik.com>
+ */
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ *
+ * UART_DEV(0): GNSS module (AG3335)
+ * UART_DEV(1): spare / debug
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(0, 14),
+        .tx_pin     = GPIO_PIN(0, 13),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin    = GPIO_UNDEF,
+        .cts_pin    = GPIO_UNDEF,
+#endif
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+    {
+        .dev        = NRF_UARTE1,
+        .rx_pin     = GPIO_PIN(0, 17),
+        .tx_pin     = GPIO_PIN(0, 16),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin    = GPIO_UNDEF,
+        .cts_pin    = GPIO_UNDEF,
+#endif
+        .irqn       = UARTE1_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_uart0)
+#define UART_1_ISR          (isr_uarte1)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * SPI_DEV(0): LR1110 LoRa transceiver
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPIM2,
+        .sclk = GPIO_PIN(0, 11),
+        .mosi = GPIO_PIN(1, 9),
+        .miso = GPIO_PIN(1, 8),
+    },
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ *
+ * I2C_DEV(0): QMA6100P accelerometer
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev   = NRF_TWIM0,
+        .scl   = GPIO_PIN(0, 27),
+        .sda   = GPIO_PIN(0, 26),
+        .speed = I2C_SPEED_FAST,
+    },
+};
+
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**
+ * @name    PWM configuration
+ *
+ * PWM_DEV(0) CH0: buzzer (P0.25)
+ *
+ * @note    Unused channels must be set to GPIO_UNDEF.
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev = NRF_PWM0,
+        .pin = {
+            GPIO_PIN(0, 25),
+            GPIO_UNDEF,
+            GPIO_UNDEF,
+            GPIO_UNDEF,
+        },
+    },
+};
+
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
+/**
+ * @name    ADC configuration
+ *
+ * ADC_NUMOF is fixed by the nRF52 CPU (9 or 10 channels).
+ * Relevant lines for this board:
+ *   NRF52_AIN0 (P0.02): battery voltage
+ *   NRF52_AIN5 (P0.29): light sensor
+ *   NRF52_AIN7 (P0.31): NTC temperature sensor
+ * @{
+ */
+/* ADC_NUMOF defined in cpu/nrf52/include/periph_cpu.h */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */


### PR DESCRIPTION
Add board support for the SenseCAP T1000-E LoRaWAN tracker, based on the Nordic nRF52840 (Cortex-M4F, 1MB Flash, 256KB RAM).
 
#### Hardware
 
| Peripheral | Part | Interface |
|---|---|---|
| LoRa transceiver | Semtech LR1110 | SPI_DEV(0), NRF_SPIM2 |
| GNSS | Mediatek AG3335 | UART_DEV(0), NRF_UARTE0 |
| Accelerometer | QMA6100P | I2C_DEV(0), NRF_TWIM0 |
| Temperature | NTC | NRF52_AIN7 (P0.31) |
| Light sensor | — | NRF52_AIN5 (P0.29) |
| Buzzer | PWM | PWM_DEV(0), NRF_PWM0 |
| Button | 1× user (active-high, pull-down) | P0.06 |
| LED | 1× | P0.24 |
| Power | LiPo + charge detection | — |
 
#### What's included
 
- `Kconfig`, `Makefile.*`, `board.h`, `periph_conf.h`, `doc.md`, `board.c`

## Notes

- LR1110 support will be added by #22271
- QMA6100P driver is not yet available in RIOT: a separate PR will be needed

## Testing

**Blinky**: works out of the box:
```
BOARD=seeedstudio-sensecap-t1000e make -C examples/basic/blinky flash
```

**Hello world over USB CDC ACM** : requires `stdio_cdc_acm`:
```
USEMODULE="stdio_cdc_acm" BOARD=seeedstudio-sensecap-t1000e make -C examples/basic/hello-world flash term
```
`hello-world` does not work out of the box over USB CDC: the single `puts()` fires at boot before pyterm finishes connecting, so output is lost. The intended workaround is to reset the board after pyterm is open, but pressing the user button does not appear to trigger a reset on this board. Applications that print continuously (e.g. `while(1){ puts("Hello World!"); }`) work correctly.


## References
 **Issues/PRs** 
 The board figures in the board wishlist #22172 because of #[22161](https://github.com/RIOT-OS/RIOT/issues/22161)
 
 **Useful links**
- [SenseCAP T1000-E Wiki](https://wiki.seeedstudio.com/sensecap_t1000_e/)
- [nRF52840 Product Spec](https://docs.nordicsemi.com/bundle/ps_nrf52840/page/keyfeatures_html5.html)
- [Meshtastic reference](https://github.com/meshtastic/firmware/blob/develop/variants/nrf52840/tracker-t1000-e)
 
### Declaration of AI Tools / LLMs usage
- Claude Code for code review and guidance, with user authorship of the implementation

## Roadmap
- [x] Builds successfully
- [x] Tested on hardware
- [x] Add saul support
- [x] Test saul support
