### PR TITLE
pkg/pqm4: add ML-DSA-44 (FIPS 204) post-quantum signature package

### DIFF
--- a/pkg/pqm4/Makefile
+++ b/pkg/pqm4/Makefile
@@ -1,0 +1,22 @@
+PKG_NAME    = pqm4
+PKG_URL     = https://github.com/mupq/pqm4
+# pqm4 master, 2025-05-22 (Merge PR #392 - Update uov to round2)
+PKG_VERSION = a24bb4b662016968c19f5e6a0719c9ad530f0286
+PKG_LICENSE = CC0-1.0
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+# Build the pqm4 ML-DSA-44 m4f module via our custom Makefile.pqm4.
+all: prepare
+	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(CURDIR)/Makefile.pqm4
+
+# pqm4 has git submodules (mupq + nested pqclean) that pkg.mk does not init.
+# Hook submodule init before $(PKG_PATCHED) so patches can target submodule
+# contents if ever needed.
+SUBMODULES_DONE := $(PKG_SOURCE_DIR)/.submodules-initialized
+
+$(PKG_PATCHED): $(SUBMODULES_DONE)
+
+$(SUBMODULES_DONE): $(PKG_DOWNLOADED)
+	cd $(PKG_SOURCE_DIR) && git submodule update --init --recursive mupq
+	touch $@

--- a/pkg/pqm4/Makefile.dep
+++ b/pkg/pqm4/Makefile.dep
@@ -1,0 +1,4 @@
+USEMODULE += random
+
+# pqm4's m4f variant is used for this package, which requires an FPU
+FEATURES_REQUIRED += cortexm_fpu

--- a/pkg/pqm4/Makefile.include
+++ b/pkg/pqm4/Makefile.include
@@ -1,0 +1,7 @@
+# Headers consumed by the application (api.h, params.h, randombytes.h, hal.h)
+INCLUDES += -I$(PKGDIRBASE)/pqm4/crypto_sign/ml-dsa-44/m4f
+INCLUDES += -I$(PKGDIRBASE)/pqm4/mupq/common
+INCLUDES += -I$(PKGDIRBASE)/pqm4/mupq/pqclean/common
+INCLUDES += -I$(PKGDIRBASE)/pqm4/common
+
+CFLAGS += -DPQM4

--- a/pkg/pqm4/Makefile.pqm4
+++ b/pkg/pqm4/Makefile.pqm4
@@ -1,0 +1,45 @@
+# Build the ML-DSA-44 m4f variant + supporting Keccak/SHAKE files as a single
+# RIOT module named "pqm4". Source paths are relative to pqm4 root
+# ($(PKG_SOURCE_DIR)). The two RIOT-side glue source files live in
+# pkg/pqm4/ and are pulled in via vpath.
+
+NO_AUTO_SRC := 1
+MODULE      := pqm4
+
+# ML-DSA-44 m4f variant - C source
+SRC := \
+    crypto_sign/ml-dsa-44/m4f/packing.c \
+    crypto_sign/ml-dsa-44/m4f/poly.c \
+    crypto_sign/ml-dsa-44/m4f/polyvec.c \
+    crypto_sign/ml-dsa-44/m4f/rounding.c \
+    crypto_sign/ml-dsa-44/m4f/sign.c \
+    crypto_sign/ml-dsa-44/m4f/smallpoly.c \
+    crypto_sign/ml-dsa-44/m4f/symmetric-shake.c \
+    mupq/common/fips202.c
+
+# Preprocessed assembly (.S) - includes macros.i via cpp
+ASSMSRC := \
+    crypto_sign/ml-dsa-44/m4f/ntt.S \
+    crypto_sign/ml-dsa-44/m4f/smallntt_769.S \
+    common/keccakf1600.S
+
+# Plain GAS (.s) - no cpp, only inline .macro/.endm
+ASMSRC := \
+    crypto_sign/ml-dsa-44/m4f/pointwise_mont.s \
+    crypto_sign/ml-dsa-44/m4f/vector.s
+
+# RIOT-side glue compiled into the same pqm4 module
+SRC += riot-hal.c riot-randombytes.c
+vpath riot-hal.c $(RIOTPKG)/pqm4
+vpath riot-randombytes.c $(RIOTPKG)/pqm4
+
+# pqm4 sources expect this define (matches mupq/mk/config.mk default)
+CFLAGS += -DPQM4
+
+# disable warnings for `pqm4` sources
+CFLAGS += -Wno-unused-parameter
+CFLAGS += -Wno-unused-but-set-variable
+CFLAGS += -Wno-sign-compare
+CFLAGS += -Wno-shift-count-overflow
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/pqm4/doc.md
+++ b/pkg/pqm4/doc.md
@@ -1,0 +1,42 @@
+@defgroup pkg_pqm4 pqm4 - Post-Quantum Cryptography for ARM Cortex-M
+@ingroup  pkg
+@brief    pqm4 ML-DSA-44 (FIPS 204) reference for Cortex-M targets
+@author   Mert Cakir <mert-cakir@outlook.com>
+
+pqm4 is a benchmarking framework and library of post-quantum cryptographic
+primitives optimised for ARM Cortex-M microcontrollers. This RIOT package
+exposes the ML-DSA-44 (FIPS 204) signing scheme via pqm4's m4f speed
+variant.
+
+The same Cortex-M4F-targeted assembly runs unmodified on Cortex-M33 and
+later cores (ARMv8-M Mainline + DSP + FPv5 is a strict superset of
+ARMv7E-M + DSP + FPv4). The package thus brings ML-DSA-44 to any
+RIOT-supported Cortex-M >= M4F target.
+
+## Usage
+
+Add to your application Makefile:
+
+```makefile
+USEPKG += pqm4
+```
+
+Then in your code:
+
+```c
+#include "api.h"
+
+uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+uint8_t sk[CRYPTO_SECRETKEYBYTES];
+uint8_t sig[CRYPTO_BYTES];
+
+crypto_sign_keypair(pk, sk);
+crypto_sign(sm, &smlen, msg, msglen, sk);
+crypto_sign_open(m, &mlen, sm, smlen, pk);
+```
+
+## References
+
+@see https://github.com/mupq/pqm4
+@see https://csrc.nist.gov/pubs/fips/204/final
+@see https://tches.iacr.org/index.php/TCHES/article/view/8989

--- a/pkg/pqm4/riot-hal.c
+++ b/pkg/pqm4/riot-hal.c
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Mert Cakir <mert-cakir@outlook.com>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * @ingroup pkg_pqm4
+ * @{
+ *
+ * @file
+ * @brief   RIOT-side adapter for pqm4's mupq/common/hal.h contract.
+ *
+ * @author  Mert Cakir <mert-cakir@outlook.com>
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "thread.h"
+
+enum clock_mode {
+    CLOCK_FAST,
+    CLOCK_BENCHMARK
+};
+
+void hal_setup(const enum clock_mode clock)
+{
+    (void)clock;
+    /* RIOT board init has already set the system clock via cpu_init(). */
+}
+
+void hal_send_str(const char *in)
+{
+    puts(in);
+}
+
+uint64_t hal_get_time(void)
+{
+    /* Stub. The pqm4 crypto code does not call this; only the pqm4
+     * benchmark harness does, which is not linked into RIOT
+     * applications. */
+    return 0;
+}
+
+size_t hal_get_stack_size(void)
+{
+    return thread_get_stacksize(thread_get_active());
+}
+
+void hal_spraystack(void)
+{
+    /* Intentional stub. Use RIOT's thread_measure_stack_free() if you
+     * need actual peak-stack measurement. */
+}
+
+size_t hal_checkstack(void)
+{
+    return 0;
+}
+
+/** @} */

--- a/pkg/pqm4/riot-randombytes.c
+++ b/pkg/pqm4/riot-randombytes.c
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Mert Cakir <mert-cakir@outlook.com>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * @ingroup pkg_pqm4
+ * @{
+ *
+ * @file
+ * @brief   Linker-side randombytes() for pqm4 backed by RIOT's RNG.
+ *
+ * pqm4 (via pqclean) calls randombytes(), which is `#define`d to
+ * PQCLEAN_randombytes() in pqclean/common/randombytes.h. We provide
+ * that symbol here, backed by RIOT's @ref random_bytes(). This
+ * replaces pqm4's default randombytes implementation (which falls
+ * back to an insecure stub on most platforms).
+ *
+ * @author  Mert Cakir <mert-cakir@outlook.com>
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "random.h"
+
+/**
+ * @brief   pqclean-style RNG entry point.
+ *
+ * Called by pqm4 internals (post-`#define` rewrite of randombytes() ->
+ * PQCLEAN_randombytes()). Routes to RIOT's @ref random_bytes().
+ *
+ * Marked **weak** so applications that need deterministic randomness
+ * (for example NIST FIPS 204 KAT vector replay) can provide their own
+ * non-weak override at link time.
+ *
+ * @param[out] output   Bytes to fill.
+ * @param[in]  n        Number of bytes.
+ *
+ * @return Always 0 (success); RIOT @ref random_bytes() does not fail.
+ */
+__attribute__((weak)) int PQCLEAN_randombytes(uint8_t *output, size_t n)
+{
+    random_bytes(output, n);
+    return 0;
+}
+
+/** @} */

--- a/tests/pkg/pqm4/Makefile
+++ b/tests/pkg/pqm4/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.pkg_common
+
+USEPKG += pqm4
+
+USEMODULE += random
+USEMODULE += fmt
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg/pqm4/README.md
+++ b/tests/pkg/pqm4/README.md
@@ -1,0 +1,27 @@
+# pqm4 ML-DSA-44 self-test
+
+Exercises the `pkg/pqm4` package: keygen, sign, verify round-trip
+for ML-DSA-44 (FIPS 204).
+
+## Expected output
+
+```
+pqm4 ML-DSA-44 self-test
+========================
+  pk size: 1312 B
+  sk size: 2560 B
+  sig size: 2420 B
+[1/3] crypto_sign_keypair ...
+  OK
+[2/3] crypto_sign ...
+  OK (sm = 2453 B)
+[3/3] crypto_sign_open ...
+  OK (message recovered and verified)
+
+ALL TESTS PASSED
+```
+
+## Tested on
+
+- Raspberry Pi Pico 2 H (RP2350, Cortex-M33 @ 125 MHz)
+- RIOT-OS 2026.04

--- a/tests/pkg/pqm4/main.c
+++ b/tests/pkg/pqm4/main.c
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Mert Cakir <mert-cakir@outlook.com>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief   pqm4 ML-DSA-44 self-test: keygen, sign, verify round-trip.
+ *
+ * @author  Mert Cakir <mert-cakir@outlook.com>
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "api.h"
+#include "fmt.h"
+
+static uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+static uint8_t sk[CRYPTO_SECRETKEYBYTES];
+
+static const uint8_t msg[] = "pqm4 self-test message";
+#define MSG_LEN (sizeof(msg) - 1)
+
+static uint8_t sm[MSG_LEN + CRYPTO_BYTES];
+static uint8_t m_out[MSG_LEN + CRYPTO_BYTES];
+
+int main(void)
+{
+    puts("pqm4 ML-DSA-44 self-test");
+    puts("========================");
+
+    printf("  pk size: %u B\n", CRYPTO_PUBLICKEYBYTES);
+    printf("  sk size: %u B\n", CRYPTO_SECRETKEYBYTES);
+    printf("  sig size: %u B\n", CRYPTO_BYTES);
+
+    /* keygen */
+    puts("[1/3] crypto_sign_keypair ...");
+    if (crypto_sign_keypair(pk, sk) != 0) {
+        puts("  FAIL: keygen returned non-zero");
+        return 1;
+    }
+    puts("  OK");
+
+    /* sign */
+    puts("[2/3] crypto_sign ...");
+    size_t smlen = 0;
+    if (crypto_sign(sm, &smlen, msg, MSG_LEN, sk) != 0) {
+        puts("  FAIL: sign returned non-zero");
+        return 1;
+    }
+    printf("  OK (sm = %u B)\n", (unsigned)smlen);
+
+    /* verify */
+    puts("[3/3] crypto_sign_open ...");
+    size_t mlen = 0;
+    if (crypto_sign_open(m_out, &mlen, sm, smlen, pk) != 0) {
+        puts("  FAIL: verify returned non-zero");
+        return 1;
+    }
+    if (mlen != MSG_LEN || memcmp(m_out, msg, MSG_LEN) != 0) {
+        puts("  FAIL: recovered message mismatch");
+        return 1;
+    }
+    puts("  OK (message recovered and verified)");
+
+    puts("");
+    puts("ALL TESTS PASSED");
+    return 0;
+}

--- a/tests/pkg/pqm4/tests/01-run.py
+++ b/tests/pkg/pqm4/tests/01-run.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2026 Mert Cakir <mert-cakir@outlook.com>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact("pqm4 ML-DSA-44 self-test")
+    child.expect_exact("[1/3] crypto_sign_keypair ...")
+    child.expect_exact("  OK")
+    child.expect_exact("[2/3] crypto_sign ...")
+    child.expect_exact("  OK", timeout=30)
+    child.expect_exact("[3/3] crypto_sign_open ...")
+    child.expect_exact("  OK (message recovered and verified)")
+    child.expect_exact("ALL TESTS PASSED")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc, timeout=60))

--- a/tests/pkg/pqm4/tests/01-run.py
+++ b/tests/pkg/pqm4/tests/01-run.py
@@ -1,14 +1,10 @@
 #!/usr/bin/env python3
-
-# Copyright (C) 2026 Mert Cakir <mert-cakir@outlook.com>
 #
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2026 Mert Cakir <mert-cakir@outlook.com>
+# SPDX-License-Identifier: LGPL-2.1-only
 
 import sys
 from testrunner import run
-
 
 def testfunc(child):
     child.expect_exact("pqm4 ML-DSA-44 self-test")
@@ -19,7 +15,6 @@ def testfunc(child):
     child.expect_exact("[3/3] crypto_sign_open ...")
     child.expect_exact("  OK (message recovered and verified)")
     child.expect_exact("ALL TESTS PASSED")
-
 
 if __name__ == "__main__":
     sys.exit(run(testfunc, timeout=60))


### PR DESCRIPTION
### Contribution description

Adds `pkg/pqm4` as a new RIOT external package, exposing the
ML-DSA-44 (FIPS 204) post-quantum signature scheme via the upstream
[pqm4 library](https://github.com/mupq/pqm4) (Kannwischer, Rijneveld,
Schwabe, Stoffelen et al.).

The upstream pqm4 sources are unmodified. The package consists of:

- `Makefile`: fetches pqm4 at a pinned commit, hooks
  `git submodule update --init mupq` into `PKG_PREPARED` so the
  `mupq/pqclean` submodule is in place before consumers build
- `Makefile.pqm4`: explicit SRC list for the m4f (speed-optimised)
  variant; the m4fstack (memory-optimised, ~7 KiB signing stack)
  variant is a one-line edit away
- `Makefile.include`: exports header search paths and CFLAGS
- `Makefile.dep`: gates the package on the `cortexm_fpu` feature
  (provided by Cortex-M4F / Cortex-M7 / Cortex-M33 with FPU), so
  pre-Thumb-2 ARM (e.g. msba2 / LPC23xx) and Cortex-M0/M3/M23 are
  skipped at feature-resolution rather than failing in the assembler
- `glue/riot-hal.c`: implements pqm4's `mupq/common/hal.h` contract
  (six functions) over RIOT primitives, replacing upstream
  `hal-opencm3` / `hal-mps2`
- `glue/riot-randombytes.c`: implements `PQCLEAN_randombytes()`
  over RIOT's `random_bytes()`

The Cortex-M4F assembly in pqm4 runs unmodified on Cortex-M33
(ARMv8-M Mainline + DSP is a strict superset of ARMv7E-M + DSP).

A previous attempt at integrating pqm4 was made in PR #9897 (closed
unmerged in 2019, on the policy concern that ML-DSA was experimental
at the time). ML-DSA was standardised by NIST as FIPS 204 in
August 2024; this PR is the post-standardisation revisit.

### Testing procedure

`tests/pkg/pqm4` performs a keygen / sign / verify round-trip on a
fixed message. Build and run on a Cortex-M4F-or-later board:

```
BOARD=rpi-pico-2-arm make -C tests/pkg/pqm4 flash term
```

Expected serial output:

```
pqm4 ML-DSA-44 self-test
========================
  pk size: 1312 B
  sk size: 2560 B
  sig size: 2420 B
[1/3] crypto_sign_keypair ...
  OK
[2/3] crypto_sign ...
  OK (sm = 2442 B)
[3/3] crypto_sign_open ...
  OK (message recovered and verified)

ALL TESTS PASSED
```

Before this PR is applied, `tests/pkg/pqm4` does not exist in the
tree and no pqm4 integration is available at all. With the PR
applied:

- on Cortex-M4F / Cortex-M7 / Cortex-M33-with-FPU boards,
  `tests/pkg/pqm4` builds, flashes, and prints the output above;
  the package becomes available to any RIOT application via
  `USEPKG += pqm4` (then `#include "api.h"` to access
  `crypto_sign_keypair()`, `crypto_sign()`, `crypto_sign_open()`,
  and the matching ML-DSA-44 size constants);
- on boards without `cortexm_fpu` (msba2, Cortex-M0/M3/M23 etc.),
  the build skips at feature-resolution time, reporting
  `There are unsatisfied feature requirements: cortexm_fpu`.

Hardware-tested on Raspberry Pi Pico 2 H (RP2350, Cortex-M33 @ 125 MHz).

### Issues/PRs references

Supersedes the long-stale PR #9897 (2019 pqm4 integration attempt,
closed because ML-DSA was experimental, but that policy concern is
now obsolete with FIPS 204).

Companion PRs from the same investigation, independent merge order:
- #22269: `cpu/rp2350_common/periph/uart`: PL011 FIFO/ISR fixes
- #22270: `cpu/rp2350_common`: `periph_timer` driver

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- Claude Code (Anthropic, claude-opus-4-7): agent mode with user
  review for code drafting, package layout, PR description authoring,
  debugging assistance, and hardware test orchestration. All commits
  are authored by me; every code change was reviewed before commit;
  the `cortexm_fpu` gate, the `hal.h` glue layout, and the test
  Makefile path were iteratively adjusted in response to maintainer
  feedback and CI errors.