### PR TITLE
cpu/rp2350_common: add periph_timer driver for TIMER0

### DIFF
--- a/boards/common/rpi-pico-2/include/periph_conf.h
+++ b/boards/common/rpi-pico-2/include/periph_conf.h
@@ -55,6 +55,57 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_NUMOF      ARRAY_SIZE(uart_config)
 
+/**
+ * @name    Timer configuration
+ *
+ * The RP2350 provides two independent 64-bit microsecond timers (TIMER0,
+ * TIMER1). Each has four compare channels (ALARM0..3) wired to separate
+ * NVIC IRQs. We expose only TIMER0 here; alarm matches are on the lower
+ * 32 bits of the counter, so timer_read() / timer_set_absolute() use a
+ * 32-bit wraparound window of ~71 minutes at 1 MHz.
+ * @{
+ */
+#define PERIPH_TIMER_PROVIDES_SET   /**< use the driver-provided timer_set */
+
+/**
+ * @brief   Per-channel timer configuration (one IRQ per ALARM)
+ */
+typedef struct {
+    IRQn_Type irqn;                 /**< NVIC IRQ for this alarm channel */
+} timer_channel_conf_t;
+
+/**
+ * @brief   Timer device configuration
+ */
+typedef struct {
+    TIMER0_Type *dev;               /**< pointer to TIMER register block */
+    const timer_channel_conf_t *ch; /**< per-channel configuration array */
+    uint8_t ch_numof;               /**< number of compare channels */
+} timer_conf_t;
+
+static const timer_channel_conf_t timer0_channel_config[] = {
+    { .irqn = TIMER0_IRQ_0_IRQn },
+    { .irqn = TIMER0_IRQ_1_IRQn },
+    { .irqn = TIMER0_IRQ_2_IRQn },
+    { .irqn = TIMER0_IRQ_3_IRQn },
+};
+
+static const timer_conf_t timer_config[] = {
+    {
+        .dev = TIMER0,
+        .ch = timer0_channel_config,
+        .ch_numof = ARRAY_SIZE(timer0_channel_config),
+    },
+};
+
+#define TIMER_0_ISRA    isr_timer0_0
+#define TIMER_0_ISRB    isr_timer0_1
+#define TIMER_0_ISRC    isr_timer0_2
+#define TIMER_0_ISRD    isr_timer0_3
+
+#define TIMER_NUMOF     ARRAY_SIZE(timer_config)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/rp2350_common/Makefile.features
+++ b/cpu/rp2350_common/Makefile.features
@@ -1,2 +1,3 @@
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/cpu/rp2350_common/periph/timer.c
+++ b/cpu/rp2350_common/periph/timer.c
@@ -225,36 +225,34 @@ void timer_stop(tim_t dev)
     DEV(dev)->PAUSE = 1;
 }
 
-/* Indices passed to _isr() by the four per-channel ISR thunks below.
- * TIMER_DEV_0 is the tim_t device index (only TIMER0 is currently
- * exposed). ALARM_CH_0..3 are the alarm channel indices, mapping 1:1
- * onto the hardware's ALARM0..ALARM3 registers. These are function-
- * call indices, not register bit positions; the picosdk
- * TIMER_INTE_ALARM_x_BITS macros (1 << x) are bit masks for writes
- * to the INTE register and are a different concept. */
-#define TIMER_DEV_0     0
-#define ALARM_CH_0      0
-#define ALARM_CH_1      1
-#define ALARM_CH_2      2
-#define ALARM_CH_3      3
+/* RP2350 TIMER0 has four independent IRQ lines (one per alarm channel).
+ * The two integer args to _isr() are runtime function-call indices,
+ * not register bit positions: the first is the tim_t device index
+ * (always 0 here since only TIMER0 is exposed, TIMER_NUMOF == 1), and
+ * the second is the alarm channel index 0..3 (mapping 1:1 onto the
+ * hardware's ALARM0..ALARM3 registers). Same pattern as the rpx0xx
+ * (RP2040) timer driver. */
 
-/* RP2350 TIMER0 has four independent IRQ lines (one per alarm channel). */
+/* timer 0 IRQ0 */
 void TIMER_0_ISRA(void)
 {
-    _isr(TIMER_DEV_0, ALARM_CH_0);
+    _isr(0, 0);
 }
 
+/* timer 0 IRQ1 */
 void TIMER_0_ISRB(void)
 {
-    _isr(TIMER_DEV_0, ALARM_CH_1);
+    _isr(0, 1);
 }
 
+/* timer 0 IRQ2 */
 void TIMER_0_ISRC(void)
 {
-    _isr(TIMER_DEV_0, ALARM_CH_2);
+    _isr(0, 2);
 }
 
+/* timer 0 IRQ3 */
 void TIMER_0_ISRD(void)
 {
-    _isr(TIMER_DEV_0, ALARM_CH_3);
+    _isr(0, 3);
 }

--- a/cpu/rp2350_common/periph/timer.c
+++ b/cpu/rp2350_common/periph/timer.c
@@ -1,0 +1,260 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Mert Cakir
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     cpu_rp2350
+ * @ingroup     drivers_periph_timer
+ * @{
+ *
+ * @file
+ * @brief       Timer (TIMER0) implementation for the RP2350
+ *
+ * The RP2350 has a 64-bit microsecond timer driven by a 1 MHz tick from the
+ * TICKS block (set up at 1 us by the boot ROM). Alarms compare against the
+ * low 32 bits of the counter, so the alarm window is a 32-bit wraparound
+ * (~71 minutes at 1 MHz).
+ *
+ * @author      Mert Cakir
+ *
+ * @}
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "compat_layer.h"
+#include "irq.h"
+#include "periph_cpu.h"
+#include "periph/timer.h"
+
+#include "regs/timer.h"
+
+#define DEV(d)          (timer_config[d].dev)
+#define ALARM(d, a)     ((&(DEV(d)->ALARM0)) + (a))
+
+static timer_cb_t   _ctx_cb[TIMER_NUMOF];
+static void        *_ctx_arg[TIMER_NUMOF];
+static unsigned     _flag_periodic[TIMER_NUMOF];
+static unsigned     _flag_reset[TIMER_NUMOF];
+
+static inline void _timer_reset_count(tim_t dev)
+{
+    /* Always write TIMELW before TIMEHW; writes only commit when TIMEHW
+     * is written (see RP2350 datasheet section 12.8.2 Counter). */
+    unsigned state = irq_disable();
+    DEV(dev)->TIMELW = 0;
+    DEV(dev)->TIMEHW = 0;
+    irq_restore(state);
+}
+
+static inline bool _is_periodic(tim_t dev, int channel)
+{
+    return !!(_flag_periodic[dev] & (1U << channel));
+}
+
+static inline bool _reset_on_match(tim_t dev, int channel)
+{
+    return !!(_flag_reset[dev] & (1U << channel));
+}
+
+static void _isr(tim_t dev, int channel)
+{
+    /* INTR is W1C: writing 1 clears the latched interrupt for that alarm */
+    DEV(dev)->INTR = 1U << channel;
+
+    if (_is_periodic(dev, channel)) {
+        if (_reset_on_match(dev, channel)) {
+            _timer_reset_count(dev);
+        }
+        /* Re-arm by re-writing the same compare value */
+        *ALARM(dev, channel) = *ALARM(dev, channel);
+    }
+
+    if (_ctx_cb[dev]) {
+        _ctx_cb[dev](_ctx_arg[dev], channel);
+    }
+
+    rp_end_isr();
+}
+
+int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
+{
+    if (dev >= TIMER_NUMOF) {
+        return -ENODEV;
+    }
+    /* Currently only TIMER0 is exposed (TIMER_NUMOF == 1). It is driven
+     * by the 1 us tick from the TICKS block, so 1 MHz is its only
+     * supported frequency. A future TIMER1 implementation may relax
+     * this check; for now, gate it on dev == 0. */
+    if (dev == 0 && freq != 1000000U) {
+        return -1;
+    }
+
+    _ctx_cb[dev] = cb;
+    _ctx_arg[dev] = arg;
+    _flag_periodic[dev] = 0;
+    _flag_reset[dev] = 0;
+
+    /* Disarm any leftover alarms, mask all alarm interrupts, clear pending */
+    DEV(dev)->ARMED = TIMER_ARMED_BITS;          /* W1C: write 1 to disarm */
+    atomic_clear(&DEV(dev)->INTE, TIMER_INTE_BITS);
+    DEV(dev)->INTR = TIMER_INTR_BITS;            /* W1C: clear all latched IRQs */
+
+    /* Make sure the timer is running */
+    DEV(dev)->PAUSE = 0;
+
+    /* Enable each per-channel NVIC line and unmask the alarm in INTE */
+    for (uint8_t i = 0; i < timer_config[dev].ch_numof; i++) {
+        rp_irq_enable(timer_config[dev].ch[i].irqn);
+        atomic_set(&DEV(dev)->INTE, 1U << i);
+    }
+
+    return 0;
+}
+
+int timer_set(tim_t dev, int channel, unsigned int timeout)
+{
+    if (dev >= TIMER_NUMOF) {
+        return -ENODEV;
+    }
+    if (channel < 0 || channel >= timer_config[dev].ch_numof) {
+        return -EINVAL;
+    }
+
+    if (!timeout) {
+        /* Avoid the corner case where a tick happens between sampling
+         * TIMERAWL and writing the alarm (would arm a full 32-bit period
+         * away). Invoke the callback directly. */
+        if (_ctx_cb[dev]) {
+            _ctx_cb[dev](_ctx_arg[dev], channel);
+        }
+        return 0;
+    }
+
+    unsigned state = irq_disable();
+    _flag_periodic[dev] &= ~(1U << channel);
+    /* Alarm match is on the low 32 bits of the 64-bit counter */
+    uint32_t target = DEV(dev)->TIMERAWL + timeout;
+    *ALARM(dev, channel) = target;     /* writing ALARM_x arms the alarm */
+    irq_restore(state);
+    return 0;
+}
+
+int timer_set_absolute(tim_t dev, int channel, unsigned int value)
+{
+    if (dev >= TIMER_NUMOF) {
+        return -ENODEV;
+    }
+    if (channel < 0 || channel >= timer_config[dev].ch_numof) {
+        return -EINVAL;
+    }
+
+    unsigned state = irq_disable();
+    _flag_periodic[dev] &= ~(1U << channel);
+    *ALARM(dev, channel) = (uint32_t)value;
+    irq_restore(state);
+    return 0;
+}
+
+int timer_set_periodic(tim_t dev, int channel, unsigned int value, uint8_t flags)
+{
+    if (dev >= TIMER_NUMOF) {
+        return -ENODEV;
+    }
+    if (channel < 0 || channel >= timer_config[dev].ch_numof) {
+        return -EINVAL;
+    }
+
+    if (flags & TIM_FLAG_SET_STOPPED) {
+        timer_stop(dev);
+    }
+    if (flags & TIM_FLAG_RESET_ON_SET) {
+        _timer_reset_count(dev);
+    }
+
+    unsigned state = irq_disable();
+    _flag_periodic[dev] |= (1U << channel);
+    if (flags & TIM_FLAG_RESET_ON_MATCH) {
+        _flag_reset[dev] |= (1U << channel);
+    } else {
+        _flag_reset[dev] &= ~(1U << channel);
+    }
+    *ALARM(dev, channel) = (uint32_t)value;
+    irq_restore(state);
+    return 0;
+}
+
+int timer_clear(tim_t dev, int channel)
+{
+    if (dev >= TIMER_NUMOF) {
+        return -ENODEV;
+    }
+    if (channel < 0 || channel >= timer_config[dev].ch_numof) {
+        return -EINVAL;
+    }
+
+    /* ARMED is W1C: write 1 to disarm the channel */
+    DEV(dev)->ARMED = 1U << channel;
+    unsigned state = irq_disable();
+    _flag_periodic[dev] &= ~(1U << channel);
+    irq_restore(state);
+    return 0;
+}
+
+unsigned int timer_read(tim_t dev)
+{
+    assert(dev < TIMER_NUMOF);
+    /* TIMERAWL is the raw low 32 bits with no latching */
+    return DEV(dev)->TIMERAWL;
+}
+
+void timer_start(tim_t dev)
+{
+    assert(dev < TIMER_NUMOF);
+    DEV(dev)->PAUSE = 0;
+}
+
+void timer_stop(tim_t dev)
+{
+    assert(dev < TIMER_NUMOF);
+    DEV(dev)->PAUSE = 1;
+}
+
+/* Indices passed to _isr() by the four per-channel ISR thunks below.
+ * TIMER_DEV_0 is the tim_t device index (only TIMER0 is currently
+ * exposed). ALARM_CH_0..3 are the alarm channel indices, mapping 1:1
+ * onto the hardware's ALARM0..ALARM3 registers. These are function-
+ * call indices, not register bit positions; the picosdk
+ * TIMER_INTE_ALARM_x_BITS macros (1 << x) are bit masks for writes
+ * to the INTE register and are a different concept. */
+#define TIMER_DEV_0     0
+#define ALARM_CH_0      0
+#define ALARM_CH_1      1
+#define ALARM_CH_2      2
+#define ALARM_CH_3      3
+
+/* RP2350 TIMER0 has four independent IRQ lines (one per alarm channel). */
+void TIMER_0_ISRA(void)
+{
+    _isr(TIMER_DEV_0, ALARM_CH_0);
+}
+
+void TIMER_0_ISRB(void)
+{
+    _isr(TIMER_DEV_0, ALARM_CH_1);
+}
+
+void TIMER_0_ISRC(void)
+{
+    _isr(TIMER_DEV_0, ALARM_CH_2);
+}
+
+void TIMER_0_ISRD(void)
+{
+    _isr(TIMER_DEV_0, ALARM_CH_3);
+}


### PR DESCRIPTION
### Contribution description

Adds the `periph_timer` driver for the RP2350 BSP using TIMER0,
plus the matching `timer_conf_t` typedef and `timer_config[]` array
in the shared rpi-pico-2 board header. With this PR,
`BOARD=rpi-pico-2-arm` now provides the `periph_timer` feature,
which unblocks `ztimer_msec` and any RIOT module / test that
depends on it (including `tests/periph/timer`,
`tests/periph/uart`, the shell read-timeout path, and so on).

Hardware notes:

- The RP2350 has two independent 64-bit microsecond timers
  (TIMER0, TIMER1), each with four ALARM compare channels
  (`ALARM0..3`). Unlike the RP2040 (rpx0xx BSP), each ALARM has
  its own NVIC IRQ line (`TIMERx_IRQ_0..3`), so the ISR routing
  is one-to-one, with no shared-IRQ demux needed.
- This PR exposes only TIMER0 (`tim_t = 0`) with all four
  channels. A second device for TIMER1 can be added later.
- Alarms compare against the low 32 bits of the 64-bit counter,
  giving a ~71-minute wraparound at 1 MHz. `timer_set()` computes
  the target as `TIMERAWL + timeout` to keep the alarm in the
  correct 32-bit window, the same idiom as
  `cpu/rpx0xx/periph/timer.c`.
- The 1 us tick is generated by the RP2350 TICKS block, set up by
  the boot ROM. No additional clock plumbing is required in
  `timer_init()`.

What is intentionally **not** included:

- TIMER1 (trivial follow-up if needed).
- Sub-microsecond / non-1-MHz frequencies (`timer_init()` returns
  `-1` for any `freq != 1000000`). Supporting other frequencies
  would require reconfiguring the TICKS block, which is out of
  scope here.
- `periph_timer_query_freqs` (only one supported frequency).

Files touched:

- `cpu/rp2350_common/periph/timer.c`: the driver (~210 lines)
- `boards/common/rpi-pico-2/include/periph_conf.h`: `timer_conf_t`,
  `timer_channel_conf_t`, `timer_config[]`, `TIMER_0_ISRA..D`
- `cpu/rp2350_common/Makefile.features`: declares `periph_timer`

### Testing procedure

Build and run RIOT's stock periph_timer test on a Pi Pico 2 H:

```
BOARD=rpi-pico-2-arm make -C tests/periph/timer flash term
```

On master this fails with
`There are unsatisfied feature requirements: periph_timer`. With
this PR applied, the test builds, flashes, and prints (the `[A]`
prefix below is added by an external multi-board UART aggregator,
not the firmware):

```
main(): This is RIOT! (Version: 2026.07-devel-161-g15a5b)
[A] Test for peripheral TIMERs
[A] Available timers: 1
[A] TIMER 0
[A] =======
[A]   - feature periph_timer_query_freqs unsupported
[A]   - Calling timer_init(0, 1000000)
[A]     initialization successful
[A]   - timer_stop(0): stopped
[A]   - timer_set(0, 0, 5000)    Successfully set timeout 5000 for channel 0
[A]   - timer_set(0, 1, 10000)   Successfully set timeout 10000 for channel 1
[A]   - timer_set(0, 2, 15000)   Successfully set timeout 15000 for channel 2
[A]   - timer_set(0, 3, 20000)   Successfully set timeout 20000 for channel 3
[A]   - timer_set(0, 4, 25000)   ERROR: Couldn't set timeout 25000 for channel 4
[A]   - timer_start(0)
[A]   - Results:
[A]     - channel 0 fired at SW count   122979   - init:   122979
[A]     - channel 1 fired at SW count   245799   - diff:   122820
[A]     - channel 2 fired at SW count   368814   - diff:   123015
[A]     - channel 3 fired at SW count   491837   - diff:   123023
[A]   - Validating no spurious IRQs are triggered:
[A]     [OK] (no spurious IRQs)
[A] TEST SUCCEEDED
```

All four ALARM channels fire at the expected offsets, the
out-of-range channel is correctly rejected, and no spurious IRQs
are triggered.

Before this PR is applied: on `rpi-pico-2-arm`, the
`periph_timer` feature is missing, so any RIOT application or test
that selects `ztimer_msec` (directly or via `ztimer_sec`, the
shell read-timeout path, network stack timers, etc.) fails at
feature-resolution. With the PR applied:

- `tests/periph/timer` builds and passes (output above);
- `tests/periph/uart` builds (its `ztimer_msec` dependency is
  satisfied; that is the original motivation for this PR);
- the broader `ztimer` chain (`ztimer_msec`, `ztimer_sec`,
  `ztimer_periodic`) becomes selectable for any RP2350 application;
- `cpu/rp2350_common/Makefile.features` declares
  `periph_timer`, so feature-gated `USEMODULE` rules across the
  tree resolve correctly on RP2350.

### Issues/PRs references

Companion PRs from the same investigation, independent merge order:
- #22268: `pkg/pqm4`: ML-DSA-44 (FIPS 204) package
- #22269: `cpu/rp2350_common/periph/uart`: PL011 FIFO/ISR fixes.
  Once **this** PR lands, RIOT's stock `tests/periph/uart` builds
  for `BOARD=rpi-pico-2-arm`, providing an additional validation
  route for those UART fixes.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- Claude Code (Anthropic, claude-opus-4-7): agent mode with user
  review for code drafting (the driver structure mirrors
  `cpu/rpx0xx/periph/timer.c`, adapted for RP2350's per-alarm IRQ
  routing and the local `atomic_set/clear` helpers in the BSP),
  PR description authoring, and hardware test orchestration. All
  commits are authored by me; every code change was reviewed
  before commit; the driver was hardware-verified on a Pi Pico 2 H
  using `tests/periph/timer` (full output above) before opening
  the PR.