### PR TITLE
pkg/radiolib: add RadioLib as external package

### DIFF
--- a/boards/b-l072z-lrwan1/board.c
+++ b/boards/b-l072z-lrwan1/board.c
@@ -20,7 +20,7 @@
 
 void board_init(void)
 {
-#if defined(MODULE_SX1276)
+#if defined(MODULE_SX1276) || defined(MODULE_RADIOLIB_SX127X)
     /* Enable TCXO */
     gpio_init(RADIO_TCXO_VCC_PIN, GPIO_OUT);
     gpio_set(RADIO_TCXO_VCC_PIN);

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -49,6 +49,7 @@ PSEUDOMODULES += auto_init_%
 NO_PSEUDOMODULES += auto_init_can
 NO_PSEUDOMODULES += auto_init_loramac
 NO_PSEUDOMODULES += auto_init_multimedia
+NO_PSEUDOMODULES += auto_init_radiolib
 NO_PSEUDOMODULES += auto_init_security
 NO_PSEUDOMODULES += auto_init_usbus
 NO_PSEUDOMODULES += auto_init_screen
@@ -384,6 +385,7 @@ PSEUDOMODULES += nrf24l01p_ng_diagnostics
 PSEUDOMODULES += od_string
 
 PSEUDOMODULES += opendsme
+PSEUDOMODULES += radiolib
 PSEUDOMODULES += openthread
 
 # declare periph submodules as pseudomodules, but exclude periph_common

--- a/pkg/radiolib/Makefile
+++ b/pkg/radiolib/Makefile
@@ -1,0 +1,28 @@
+PKG_NAME=radiolib
+PKG_URL=https://github.com/jgromes/RadioLib
+PKG_VERSION=f403b9c3d735bbd467ee92c1baf8ea216b608125 # v7.6.0
+PKG_LICENSE=MIT
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+RADIOLIB_MODULES =  radiolib_core \
+                    radiolib_utils \
+                    radiolib_physicallayer \
+                    radiolib_lr11x0 \
+                    radiolib_sx127x \
+					#
+
+CXXUWFLAGS += -Wcast-align -Wunused-parameter -Wdeprecated-copy
+
+DIR_radiolib_core          = src
+DIR_radiolib_utils         = src/utils
+DIR_radiolib_physicallayer = src/protocols/PhysicalLayer
+DIR_radiolib_lr11x0        = src/modules/LR11x0
+DIR_radiolib_sx127x        = src/modules/SX127x
+
+.PHONY: radiolib_%
+
+all: $(RADIOLIB_MODULES)
+
+radiolib_%:
+	$(QQ)RADIOLIB_MODULE=$@ "$(MAKE)" -C $(PKG_SOURCE_DIR)/$(DIR_$@) -f $(CURDIR)/Makefile.radiolib_module

--- a/pkg/radiolib/Makefile.dep
+++ b/pkg/radiolib/Makefile.dep
@@ -1,0 +1,32 @@
+# required features
+FEATURES_REQUIRED += cpp
+FEATURES_REQUIRED += libstdcpp
+FEATURES_REQUIRED += periph_spi
+FEATURES_REQUIRED += periph_gpio_irq
+
+# Contrib code of RadioLib
+USEMODULE += radiolib_riot_contrib
+
+# Internal RadioLib modules
+USEMODULE += radiolib_core
+USEMODULE += radiolib_utils
+USEMODULE += radiolib_physicallayer
+
+# timing
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
+USEMODULE += ztimer_usec
+
+USEMODULE += cpp11-compat
+CXXEXFLAGS += -Wno-unused-parameter
+CXXEXFLAGS += -Wno-pedantic
+CXXEXFLAGS += -Wno-missing-field-initializers
+CXXEXFLAGS += -Wno-unused-but-set-variable
+CXXEXFLAGS += -Wno-maybe-uninitialized
+CXXEXFLAGS += -Wno-unused-variable
+CXXEXFLAGS += -Wno-reorder
+CXXEXFLAGS += -Wno-address
+CXXEXFLAGS += -Wno-sign-compare
+CXXEXFLAGS += -Wno-unused-function
+CXXEXFLAGS += -Wno-missing-braces
+CXXEXFLAGS += -Wno-overloaded-virtual

--- a/pkg/radiolib/Makefile.include
+++ b/pkg/radiolib/Makefile.include
@@ -1,0 +1,4 @@
+INCLUDES += -isystem$(PKGDIRBASE)/radiolib/src
+INCLUDES += -I$(RIOTBASE)/pkg/radiolib/include
+
+DIRS += $(RIOTBASE)/pkg/radiolib/contrib

--- a/pkg/radiolib/Makefile.radiolib_module
+++ b/pkg/radiolib/Makefile.radiolib_module
@@ -1,0 +1,3 @@
+MODULE = $(RADIOLIB_MODULE)
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/radiolib/contrib/Makefile
+++ b/pkg/radiolib/contrib/Makefile
@@ -1,0 +1,3 @@
+MODULE = radiolib_riot_contrib
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/radiolib/contrib/radiolib_riotos.cpp
+++ b/pkg/radiolib/contrib/radiolib_riotos.cpp
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Baptiste Le Duc <baptiste.leduc@etik.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     pkg_radiolib
+ * @{
+ *
+ * @file
+ * @brief       RIOT hardware abstraction layer for RadioLib
+ *
+ * @author      Baptiste Le Duc <baptiste.leduc@etik.com>
+ */
+
+#include "radiolib_riotos.h"
+#include "ztimer.h"
+
+static void _irq_handler(void *arg)
+{
+    ((void (*)(void))arg)();
+}
+
+RiotHal::RiotHal(spi_t bus, spi_clk_t clk)
+    : RadioLibHal(GPIO_IN, GPIO_OUT, 0, 1, GPIO_RISING, GPIO_FALLING),
+      _bus(bus), _clk(clk) {}
+
+void RiotHal::pinMode(uint32_t pin, uint32_t mode)
+{
+    if (pin == RADIOLIB_NC) {
+        return;
+    }
+    gpio_init((gpio_t)pin, (gpio_mode_t)mode);
+}
+
+void RiotHal::digitalWrite(uint32_t pin, uint32_t value)
+{
+    if (pin == RADIOLIB_NC) {
+        return;
+    }
+    gpio_write((gpio_t)pin, (bool)value);
+}
+
+uint32_t RiotHal::digitalRead(uint32_t pin)
+{
+    if (pin == RADIOLIB_NC) {
+        return 0;
+    }
+    return gpio_read((gpio_t)pin);
+}
+
+void RiotHal::attachInterrupt(uint32_t interruptNum, void (*interruptCb)(void), uint32_t mode)
+{
+    if (interruptNum == RADIOLIB_NC) {
+        return;
+    }
+    gpio_init_int((gpio_t)interruptNum, GPIO_IN, (gpio_flank_t)mode,
+                  _irq_handler, (void *)interruptCb);
+}
+
+void RiotHal::detachInterrupt(uint32_t interruptNum)
+{
+    if (interruptNum == RADIOLIB_NC) {
+        return;
+    }
+    gpio_irq_disable((gpio_t)interruptNum);
+}
+
+void RiotHal::delay(RadioLibTime_t ms)
+{
+    ztimer_sleep(ZTIMER_MSEC, ms);
+}
+
+void RiotHal::delayMicroseconds(RadioLibTime_t us)
+{
+    ztimer_sleep(ZTIMER_USEC, us);
+}
+
+RadioLibTime_t RiotHal::millis(void)
+{
+    return ztimer_now(ZTIMER_MSEC);
+}
+
+RadioLibTime_t RiotHal::micros(void)
+{
+    return ztimer_now(ZTIMER_USEC);
+}
+
+long RiotHal::pulseIn(uint32_t pin, uint32_t state, RadioLibTime_t timeout)
+{
+    (void)pin;
+    (void)state;
+    (void)timeout;
+    return 0;
+}
+
+void RiotHal::spiBegin(void) {}
+
+void RiotHal::spiBeginTransaction(void)
+{
+    spi_acquire(_bus, SPI_CS_UNDEF, SPI_MODE_0, _clk);
+}
+
+void RiotHal::spiTransfer(uint8_t *out, size_t len, uint8_t *in)
+{
+    spi_transfer_bytes(_bus, SPI_CS_UNDEF, false, out, in, len);
+}
+
+void RiotHal::spiEndTransaction(void)
+{
+    spi_release(_bus);
+}
+
+void RiotHal::spiEnd(void) {}
+
+/** @} */

--- a/pkg/radiolib/doc.md
+++ b/pkg/radiolib/doc.md
@@ -1,0 +1,54 @@
+<!--
+SPDX-FileCopyrightText: 2026 Baptiste Le Duc <baptiste.leduc@etik.com>
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+@defgroup pkg_radiolib RadioLib
+@ingroup  pkg
+@brief    Universal wireless communication library for embedded devices
+@see      <https://github.com/jgromes/RadioLib>
+
+@warning RadioLib is a C++ library and this package exposes a C++-only API:
+`radiolib_radio` and `RiotHal` are only declared under `#ifdef __cplusplus`.
+Applications using this package must be built as C++ as plain C applications
+are not supported yet.
+
+## Introduction
+
+RadioLib provides a common API for a wide range of radio transceivers,
+modems and radio shields. This package provides the RIOT hardware
+abstraction layer (`RiotHal`) needed by RadioLib.
+
+## Usage
+
+Add the package, a transceiver driver module (e.g. `radiolib_sx127x`) and
+the auto-init module to the Makefile of your application:
+
+```makefile
+USEPKG += radiolib
+USEMODULE += radiolib_sx127x
+USEMODULE += auto_init_radiolib
+```
+
+`auto_init_radiolib` brings up the transceiver selected by the enabled
+driver module, using the pin/SPI configuration from
+`radiolib_riotos_params.h` (override the `RADIOLIB_RIOTOS_PARAM_*` macros
+from your board or application to match your wiring). The radio is then
+available through the global `radiolib_radio` handle, or `NULL` if
+auto-init failed:
+
+```cpp
+#include "radiolib_riotos.h"
+
+if (radiolib_radio != NULL) {
+    radiolib_radio->transmit("hello");
+}
+```
+
+## Limitations
+
+Only a subset of the transceiver families supported by RadioLib is compiled
+in, see `RADIOLIB_MODULES` in `pkg/radiolib/Makefile`.
+
+## License
+
+RadioLib is licensed under the MIT license.

--- a/pkg/radiolib/include/radiolib_riotos.h
+++ b/pkg/radiolib/include/radiolib_riotos.h
@@ -1,0 +1,180 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Baptiste Le Duc <baptiste.leduc@etik.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     pkg_radiolib
+ * @{
+ *
+ * @file
+ * @brief       RIOT hardware abstraction layer for RadioLib
+ *
+ * @author      Baptiste Le Duc <baptiste.leduc@etik.com>
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "periph/gpio.h"
+#include "periph/spi.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+
+#  include "Hal.h"
+
+class PhysicalLayer;
+
+/**
+ * @brief   Board's RadioLib transceiver, brought up by @ref auto_init_radiolib.
+ *
+ * The concrete transceiver class and pin mapping are selected at build time
+ * from the radiolib driver module in use  so applications stay board agnostic.
+ * NULL if auto-init failed.
+ */
+extern PhysicalLayer *radiolib_radio;
+
+/**
+ * @class RiotHal
+ * @brief RIOT-OS hardware abstraction class for RadioLib.
+ */
+class RiotHal : public RadioLibHal {
+public:
+    /**
+     * @brief Constructor.
+     *
+     * @param[in] bus  RIOT SPI bus (e.g. SPI_DEV(2)).
+     * @param[in] clk  SPI clock speed (e.g. SPI_CLK_5MHZ).
+     */
+    RiotHal(spi_t bus, spi_clk_t clk);
+
+    /**
+     * @brief Set pin mode (input/output).
+     *
+     * @param[in] pin   GPIO pin number.
+     * @param[in] mode  Pin mode (RadioLib constant).
+     */
+    void pinMode(uint32_t pin, uint32_t mode) override;
+
+    /**
+     * @brief Write digital value to pin.
+     *
+     * @param[in] pin    GPIO pin number.
+     * @param[in] value  Value to write (0 or 1).
+     */
+    void digitalWrite(uint32_t pin, uint32_t value) override;
+
+    /**
+     * @brief Read digital value from pin.
+     *
+     * @param[in] pin  GPIO pin number.
+     *
+     * @return Current pin level (0 or 1).
+     */
+    uint32_t digitalRead(uint32_t pin) override;
+
+    /**
+     * @brief Attach interrupt handler to pin.
+     *
+     * @param[in] interruptNum  GPIO pin number.
+     * @param[in] interruptCb   Callback invoked on interrupt.
+     * @param[in] mode          Trigger mode (RadioLib constant).
+     */
+    void attachInterrupt(uint32_t interruptNum, void (*interruptCb)(void), uint32_t mode) override;
+
+    /**
+     * @brief Detach interrupt handler from pin.
+     *
+     * @param[in] interruptNum  GPIO pin number.
+     */
+    void detachInterrupt(uint32_t interruptNum) override;
+
+    /**
+     * @brief Block for given number of milliseconds.
+     *
+     * @param[in] ms  Duration in milliseconds.
+     */
+    void delay(RadioLibTime_t ms) override;
+
+    /**
+     * @brief Block for given number of microseconds.
+     *
+     * @param[in] us  Duration in microseconds.
+     */
+    void delayMicroseconds(RadioLibTime_t us) override;
+
+    /**
+     * @brief Return elapsed time in milliseconds.
+     *
+     * @note The counter overflows after about 49 days, only differences of
+     *       two values are meaningful.
+     *
+     * @return Current milliseconds count.
+     */
+    RadioLibTime_t millis() override;
+
+    /**
+     * @brief Return elapsed time in microseconds.
+     *
+     * @note The counter overflows after about 71 minutes, only differences of
+     *       two values are meaningful.
+     *
+     * @return Current microseconds count.
+     */
+    RadioLibTime_t micros() override;
+
+    /**
+     * @brief Measure pulse length on pin (not supported, returns 0).
+     *
+     * @param[in] pin      GPIO pin number.
+     * @param[in] state    Pulse level to measure.
+     * @param[in] timeout  Maximum wait time in microseconds.
+     *
+     * @return Pulse duration in microseconds, or 0 if unsupported.
+     */
+    long pulseIn(uint32_t pin, uint32_t state, RadioLibTime_t timeout) override;
+
+    /**
+     * @brief Initialize SPI bus (no-op; bus initialized at board level).
+     */
+    void spiBegin() override;
+
+    /**
+     * @brief Acquire SPI bus for a transaction.
+     */
+    void spiBeginTransaction() override;
+
+    /**
+     * @brief Transfer bytes over SPI.
+     *
+     * @param[in]  out  TX buffer (may be NULL).
+     * @param[in]  len  Number of bytes to transfer.
+     * @param[out] in   RX buffer (may be NULL).
+     */
+    void spiTransfer(uint8_t *out, size_t len, uint8_t *in) override;
+
+    /**
+     * @brief Release SPI bus after a transaction.
+     */
+    void spiEndTransaction() override;
+
+    /**
+     * @brief De-initialize SPI bus (no-op).
+     */
+    void spiEnd() override;
+
+private:
+    spi_t _bus;
+    spi_clk_t _clk;
+};
+
+#endif /* __cplusplus */
+
+/** @} */

--- a/pkg/radiolib/include/radiolib_riotos_params.h
+++ b/pkg/radiolib/include/radiolib_riotos_params.h
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Baptiste Le Duc <baptiste.leduc@etik.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     pkg_radiolib
+ * @{
+ *
+ * @file
+ * @brief       Default configuration for the RadioLib RIOT HAL
+ *
+ * @author      Baptiste Le Duc <baptiste.leduc@etik.com>
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+#include "periph/spi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters for the RadioLib radio
+ * @{
+ */
+/**
+ * @brief   SPI bus the transceiver is connected to
+ */
+#ifndef CONFIG_RADIOLIB_SPI
+#  ifdef SX127X_PARAM_SPI
+#    define CONFIG_RADIOLIB_SPI SX127X_PARAM_SPI
+#  else
+#    define CONFIG_RADIOLIB_SPI SPI_UNDEF
+#  endif
+#endif
+
+/**
+ * @brief   SPI bus clock speed
+ */
+#ifndef CONFIG_RADIOLIB_SPI_CLK
+#  define CONFIG_RADIOLIB_SPI_CLK SPI_CLK_5MHZ
+#endif
+
+/**
+ * @brief   Chip select pin (NSS)
+ */
+#ifndef CONFIG_RADIOLIB_SPI_NSS
+#  ifdef SX127X_PARAM_SPI_NSS
+#    define CONFIG_RADIOLIB_SPI_NSS SX127X_PARAM_SPI_NSS
+#  else
+#    define CONFIG_RADIOLIB_SPI_NSS GPIO_UNDEF
+#  endif
+#endif
+
+/**
+ * @brief   Reset pin
+ */
+#ifndef CONFIG_RADIOLIB_RESET
+#  ifdef SX127X_PARAM_RESET
+#    define CONFIG_RADIOLIB_RESET SX127X_PARAM_RESET
+#  else
+#    define CONFIG_RADIOLIB_RESET GPIO_UNDEF
+#  endif
+#endif
+
+/**
+ * @brief   Interrupt pin
+ */
+#ifndef CONFIG_RADIOLIB_IRQ
+#  ifdef SX127X_PARAM_DIO0
+#    define CONFIG_RADIOLIB_IRQ SX127X_PARAM_DIO0
+#  else
+#    define CONFIG_RADIOLIB_IRQ GPIO_UNDEF
+#  endif
+#endif
+
+/**
+ * @brief   Auxiliary pin
+ */
+#ifndef CONFIG_RADIOLIB_GPIO
+#  ifdef SX127X_PARAM_DIO1
+#    define CONFIG_RADIOLIB_GPIO SX127X_PARAM_DIO1
+#  else
+#    define CONFIG_RADIOLIB_GPIO GPIO_UNDEF
+#  endif
+#endif
+
+/**
+ * @brief   Default carrier frequency in MHz
+ */
+#ifndef CONFIG_RADIOLIB_FREQ
+#  define CONFIG_RADIOLIB_FREQ (868.0)
+#endif
+/**@}*/
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/sys/auto_init/Makefile
+++ b/sys/auto_init/Makefile
@@ -14,6 +14,10 @@ ifneq (,$(filter auto_init_loramac,$(USEMODULE)))
   DIRS += loramac
 endif
 
+ifneq (,$(filter auto_init_radiolib,$(USEMODULE)))
+  DIRS += radiolib
+endif
+
 ifneq (,$(filter auto_init_multimedia,$(USEMODULE)))
   DIRS += multimedia
 endif

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -217,6 +217,11 @@ extern void auto_init_loramac(void);
 AUTO_INIT(auto_init_loramac,
           AUTO_INIT_PRIO_MOD_LORAMAC);
 #endif
+#if IS_USED(MODULE_AUTO_INIT_RADIOLIB)
+extern void auto_init_radiolib(void);
+AUTO_INIT(auto_init_radiolib,
+          AUTO_INIT_PRIO_MOD_RADIOLIB);
+#endif
 #if IS_USED(MODULE_DSM)
 extern void dsm_init(void);
 AUTO_INIT(dsm_init,

--- a/sys/auto_init/include/auto_init_priorities.h
+++ b/sys/auto_init/include/auto_init_priorities.h
@@ -253,6 +253,12 @@ extern "C" {
  */
 #define AUTO_INIT_PRIO_MOD_LORAMAC                      1330
 #endif
+#ifndef AUTO_INIT_PRIO_MOD_RADIOLIB
+/**
+ * @brief   RadioLib priority
+ */
+#define AUTO_INIT_PRIO_MOD_RADIOLIB                     1335
+#endif
 #ifndef AUTO_INIT_PRIO_MOD_DSM
 /**
  * @brief   DSM priority

--- a/sys/auto_init/radiolib/Makefile
+++ b/sys/auto_init/radiolib/Makefile
@@ -1,0 +1,3 @@
+MODULE = auto_init_radiolib
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/auto_init/radiolib/auto_init_radiolib.cpp
+++ b/sys/auto_init/radiolib/auto_init_radiolib.cpp
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Baptiste Le Duc <baptiste.leduc@etik.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     sys_auto_init
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization for RadioLib package
+ *
+ * @author      Baptiste Le Duc <baptiste.leduc@etik.com>
+ *
+ * @}
+ */
+
+#include "radiolib_riotos.h"
+#include "radiolib_riotos_params.h"
+
+#include <RadioLib.h>
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+static RiotHal _hal(CONFIG_RADIOLIB_SPI, CONFIG_RADIOLIB_SPI_CLK);
+
+static Module _mod(&_hal,
+                   CONFIG_RADIOLIB_SPI_NSS,
+                   CONFIG_RADIOLIB_IRQ,
+                   CONFIG_RADIOLIB_RESET,
+                   CONFIG_RADIOLIB_GPIO);
+
+#if IS_USED(MODULE_RADIOLIB_SX127X)
+static SX1276 _radio = &_mod;
+#elif IS_USED(MODULE_RADIOLIB_LR11X0)
+static LR1110 _radio = &_mod;
+#else
+#  error "radiolib: no transceiver driver module selected"
+#endif
+
+/**
+ * @brief   Board's RadioLib transceiver, ready to use after auto-init.
+ *
+ * NULL if @ref auto_init_radiolib failed to bring up the radio.
+ */
+PhysicalLayer *radiolib_radio = &_radio;
+
+extern "C" void auto_init_radiolib(void)
+{
+    int16_t state = _radio.begin();
+
+    if (state != RADIOLIB_ERR_NONE) {
+        DEBUG("[radiolib] begin failed: %d\n", state);
+        radiolib_radio = NULL;
+        return;
+    }
+
+    state = _radio.setFrequency(CONFIG_RADIOLIB_FREQ);
+    if (state != RADIOLIB_ERR_NONE) {
+        DEBUG("[radiolib] setFrequency failed: %d\n", state);
+        radiolib_radio = NULL;
+    }
+}

--- a/tests/pkg/radiolib/Makefile
+++ b/tests/pkg/radiolib/Makefile
@@ -1,0 +1,21 @@
+BOARD ?= b-l072z-lrwan1
+
+# Build with: make PING=1 for transmit mode
+# Default: receive mode
+
+ifdef PING
+	CFLAGS += -DPING
+endif
+
+include ../Makefile.pkg_common
+
+RADIOLIB_DRIVER ?= radiolib_sx127x
+
+USEPKG += radiolib
+USEMODULE += $(RADIOLIB_DRIVER)
+USEMODULE += auto_init_radiolib
+
+FEATURES_REQUIRED += periph_gpio periph_gpio_irq periph_spi
+USEMODULE += ztimer_msec ztimer_usec printf_float
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg/radiolib/Makefile.ci
+++ b/tests/pkg/radiolib/Makefile.ci
@@ -1,0 +1,10 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    stk3200 \
+    nucleo-c031c6 \
+    nucleo-f031k6 \
+    nucleo-f042k6 \
+    nucleo-l011k4 \
+    nucleo-l031k6 \
+    samd10-xmini \
+    stm32f030f4-demo \
+    #

--- a/tests/pkg/radiolib/README.md
+++ b/tests/pkg/radiolib/README.md
@@ -1,0 +1,71 @@
+<!--
+SPDX-FileCopyrightText: 2026 Baptiste Le Duc <baptiste.leduc@etik.com>
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+## RadioLib PingPong
+
+This test application verifies that the `radiolib` package works: the radio is
+brought up by `auto_init_radiolib` and used through the global `radiolib_radio`
+object
+
+Two boards are needed, one flashed as Ping (initiator), one as Pong
+(responder). Ping transmits `Ping`, waits 5 s for an answer and repeats every
+second; Pong waits for a packet and replies `Pong`.
+
+## Usage
+
+Board A (initiator):
+
+```
+make BOARD=<board> PING=1 -C tests/pkg/radiolib all flash term
+```
+
+Board B (responder):
+
+```
+make BOARD=<board> -C tests/pkg/radiolib all flash term
+```
+
+The default board is `b-l072z-lrwan1`, which carries an SX1276.
+
+Add `CFLAGS+=-DENABLE_DEBUG=1` to also print the TX/RX state, RSSI and SNR of
+each packet.
+
+## Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `RADIOLIB_DRIVER` | `radiolib_sx127x` | transceiver driver module |
+| `PING` | unset | build as Ping sender instead of Pong sender |
+
+Pins, SPI bus and carrier frequency come from the `CONFIG_RADIOLIB_*` macros
+in `pkg/radiolib/include/radiolib_riotos_params.h`, which default to the
+board's `SX127X_PARAM_*` definitions. Override them from the board header or
+via `CFLAGS` if your wiring differs:
+
+```
+make BOARD=<board> CFLAGS='-DCONFIG_RADIOLIB_FREQ=433.0' ...
+```
+
+## Expected results
+
+Both boards print `[radiolib] radio ready` on startup. Once the second board
+is running, Ping shows:
+
+```
+[radiolib] radio ready
+[radiolib] Received: Pong
+[radiolib] Received: Pong
+```
+
+and Pong shows:
+
+```
+[radiolib] radio ready
+[radiolib] Received: Ping
+[radiolib] Received: Ping
+```
+
+If `[radiolib] radio auto-init failed` is printed instead, the
+SPI or pin configuration does not match the wiring. You can see
+debug traces by setting `#define ENABLE_DEBUG=1` in `main.cpp`.

--- a/tests/pkg/radiolib/main.cpp
+++ b/tests/pkg/radiolib/main.cpp
@@ -1,0 +1,112 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Baptiste Le Duc <baptiste.leduc@etik.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Board independent RadioLib PingPong test
+ *
+ * The radio is brought up by the package auto-init and used through the
+ * global @ref radiolib_radio, so this application names no chip and no pins.
+ *
+ * Build as Ping sender (initiator): `make PING=1`
+ * Build as Pong sender (responder): `make`
+ * Enable debug output:      `make CFLAGS+=-DENABLE_DEBUG=1`
+ *
+ * @author      Baptiste Le Duc <baptiste.leduc@etik.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include "ztimer.h"
+#include "radiolib_riotos.h"
+#include <RadioLib.h>
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+#define RECV_TIMEOUT_MS 5000
+
+namespace {
+
+bool send(const char *msg)
+{
+    DEBUG("[radiolib] Sending: %s....", msg);
+    int state = radiolib_radio->transmit(msg);
+    if (state == RADIOLIB_ERR_NONE) {
+        DEBUG("done\n");
+        return true;
+    }
+    else if (state == RADIOLIB_ERR_PACKET_TOO_LONG) {
+        puts("packet too long!");
+    }
+    else if (state == RADIOLIB_ERR_TX_TIMEOUT) {
+        puts("TX timeout!");
+    }
+    else {
+        printf("failed, code %d\n", state);
+    }
+    return false;
+}
+
+bool recv(uint32_t timeout_ms)
+{
+    uint8_t buf[256];
+
+    int state = radiolib_radio->receive(buf, sizeof(buf) - 1, timeout_ms);
+    if (state == RADIOLIB_ERR_NONE) {
+        size_t len = radiolib_radio->getPacketLength();
+        if (len > sizeof(buf) - 1) {
+            len = sizeof(buf) - 1;
+        }
+        buf[len] = '\0';
+        printf("[radiolib] Received: %s\n", (char *)buf);
+        DEBUG("[radiolib] RSSI:      %.2f dBm\n", radiolib_radio->getRSSI());
+        DEBUG("[radiolib] SNR:       %.2f dB\n", radiolib_radio->getSNR());
+        return true;
+    }
+    else if (state == RADIOLIB_ERR_RX_TIMEOUT) {
+        DEBUG("[radiolib] RX timeout!\n");
+    }
+    else if (state == RADIOLIB_ERR_CRC_MISMATCH) {
+        puts("[radiolib] CRC error!");
+    }
+    else if (state == RADIOLIB_ERR_LORA_HEADER_DAMAGED) {
+        DEBUG("[radiolib] header damaged (noise/weak signal)\n");
+    }
+    else {
+        printf("[radiolib] RX failed, code %d\n", state);
+    }
+    return false;
+}
+
+} /* namespace */
+
+int main(void)
+{
+    if (radiolib_radio == NULL) {
+        puts("[radiolib] radio auto-init failed");
+        return -1;
+    }
+    puts("[radiolib] radio ready");
+
+    while (true) {
+#if defined(PING)
+        if (!send("Ping")) {
+            continue;
+        }
+        recv(RECV_TIMEOUT_MS);
+        ztimer_sleep(ZTIMER_MSEC, 1000);
+#else
+        if (!recv(RECV_TIMEOUT_MS)) {
+            continue;
+        }
+        send("Pong");
+#endif
+    }
+}


### PR DESCRIPTION
### Contribution description
 
This PR adds [RadioLib](https://github.com/jgromes/RadioLib) as an external package (`pkg/radiolib`), providing a universal radio transceiver library for RIOT applications. This is particularly useful for #22267, as the SeeedStudio T1000-E board carries a Semtech LR1110 LoRa transceiver not currently supported natively in RIOT.
 
The package integrates RadioLib via RIOT's standard `pkg/` mechanism and includes:
 
- A multi-module build structure mapping RadioLib source subdirectories to individual RIOT modules (`radiolib_core`, `radiolib_utils`, `radiolib_physicallayer`, `radiolib_lr11x0`)
- A RIOT HAL (`pkg/radiolib/contrib/radiolib_riotos.{h,cpp}`) implementing `RadioLibHal` using `periph/gpio`, `periph/spi`, and `ztimer`
### Testing procedure
 
Tested on the `b-l072z-lrwan1` (SX1276, supported by RadioLib) using the IoT-LAB testbed (Saclay site).
 
**Build:**
```sh
make -C tests/pkg/radiolib/ BOARD=b-l072z-lrwan1
```
 
**Hardware ([IoT-LAB](https://www.iot-lab.info/docs/boards/st-b-l072z-lrwan1/), 2× b-l072z-lrwan1, Saclay):**

The `tests/pkg/radiolib` application includes a SX1276 PingPong test. Flashed on two nodes; one transmits a Ping, the other receives and replies with a Pong. Both nodes exchanged packets successfully.

```sh
# Node 1 (TX → sends Ping)
make -C tests/pkg/radiolib/ BOARD=b-l072z-lrwan1 IOTLAB_NODE=<node1>.saclay.iot-lab.info PING=1 flash term

# Node 2 (RX → responds with Pong)
make -C tests/pkg/radiolib/ BOARD=b-l072z-lrwan1 IOTLAB_NODE=<node2>.saclay.iot-lab.info flash term
```
 
### Issues/PRs references
 
#22267
 
### Declaration of AI Tools / LLMs usage
- Claude Code for code review and guidance, with user authorship of the implementation