### PR TITLE
.github/workflows: update actions to be Node24 compliant

### DIFF
--- a/.github/workflows/deploy-guides.yml
+++ b/.github/workflows/deploy-guides.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: doc/starlight
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@main
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'merge_group'
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v6
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -44,7 +44,7 @@ env:
 # to hit Github Limit of 6h per job.
 jobs:
   check-secret:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       secret-configured: ${{ steps.secret-exists-check.outputs.defined }}
     steps:
@@ -87,7 +87,7 @@ jobs:
         echo '${{ secrets.IOTLABRC }}' > ~/.iotlabrc
     - name: Setup SSH agent
       if: ${{ matrix.pytest_mark == 'iotlab_creds' }}
-      uses: webfactory/ssh-agent@v0.9.0
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: ${{ secrets.IOTLAB_PRIVATE_KEY }}
     - name: Fetch host keys from IoT-LAB sites
@@ -115,7 +115,7 @@ jobs:
         fetch-depth: 1
         ref: ${{ github.event.inputs.riot_version }}
     - name: Set up Python 3.8
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.8
     - name: Install Python dependencies
@@ -190,7 +190,7 @@ jobs:
         mkdir test-reports/
         junit2html ${REPORT_XML} ${REPORT_NAME}.html
         cp ${REPORT_XML} ${REPORT_NAME}.xml
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: always()
       with:
         name: Test-Reports-${{ matrix.pytest_mark }}

--- a/.github/workflows/sync_codeberg.yml
+++ b/.github/workflows/sync_codeberg.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-secret:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       secret-configured: ${{ steps.secret-exists-check.outputs.defined }}
     steps:
@@ -29,7 +29,7 @@ jobs:
     if: needs.check-secret.outputs.secret-configured == 'true'
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
         with:
           fetch-depth: 0
       - name: "Sync repo"

--- a/.github/workflows/test-guides.yml
+++ b/.github/workflows/test-guides.yml
@@ -19,7 +19,7 @@ jobs:
         working-directory: doc/starlight
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@main
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test-on-iotlab.yml
+++ b/.github/workflows/test-on-iotlab.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   check-secret:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       secret-configured: ${{ steps.secret-exists-check.outputs.defined }}
     steps:
@@ -107,7 +107,7 @@ jobs:
       TEST_PERIPH_TIMER_PERIODIC_PRECISION: 0.30
     steps:
       - name: Set up Python 3.8
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.8
       - name: Install Python dependencies
@@ -117,7 +117,7 @@ jobs:
       - name: Configure credentials
         run: echo '${{ secrets.IOTLABRC }}' > ~/.iotlabrc
       - name: Setup SSH agent
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.IOTLAB_PRIVATE_KEY }}
       - name: Fetch host key from IoT-LAB ${{ matrix.boards.iotlab.site }} site
@@ -150,7 +150,7 @@ jobs:
       - name: Archive results
         if: always()
         # Store generated results-<riot board name> artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.boards.riot }}
           path: results-${{ matrix.boards.riot }}

--- a/.github/workflows/tools-test.yml
+++ b/.github/workflows/tools-test.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@main
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.8
     - name: Install dependencies


### PR DESCRIPTION
### Contribution description

While testing Workflow stuff, I noticed a slight warning, that NodeJS 20 based actions will be forced to run on NodeJS 24 by June 2026 and by September 2026, they will be disabled. See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

One thing that is of concern is the `tools-buildtest.yml` Workflow which uses `reactors/alls-green`, which has not been updated since 2022, but GitHub also doesn't complain about it:
<img width="947" height="687" alt="image" src="https://github.com/user-attachments/assets/62cea925-e8c9-461d-9cd5-5f4e366b24da" />

Likewise with `yesolutions/mirror-action` in Sync-to-Codeberg, but again, no complaints:

<img width="1514" height="597" alt="image" src="https://github.com/user-attachments/assets/c2bca871-66a5-4cee-a4cd-de7fb2ab09e1" />


### Testing procedure

I ran it in my local fork, but that does not cover all workflows (since I don't have configured and don't want to configure all credentials), so I guess YOLO? 🤣 


### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
