### PR TITLE
.cargo: Revert to branch reference for riot-wrappers

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,4 +6,4 @@
 
 [patch.crates-io]
 riot-sys = { git = "https://github.com/RIOT-OS/rust-riot-sys" }
-riot-wrappers = { git = "https://github.com/RIOT-OS/rust-riot-wrappers", rev = "d9b05bb2523ebed899f9b55a0dadd4b26c8576c4" }
+riot-wrappers = { git = "https://github.com/RIOT-OS/rust-riot-wrappers" }

--- a/examples/lang_support/official/rust-async/Cargo.lock
+++ b/examples/lang_support/official/rust-async/Cargo.lock
@@ -568,7 +568,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.9.2"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#833f7688461277f0c2f959f3491069f26df3b18d"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#6258817d4f32e07a3c2bfff3de538d0123eabc3e"
 dependencies = [
  "bare-metal",
  "coap-handler",

--- a/examples/lang_support/official/rust-gcoap/Cargo.lock
+++ b/examples/lang_support/official/rust-gcoap/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.9.2"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#833f7688461277f0c2f959f3491069f26df3b18d"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#6258817d4f32e07a3c2bfff3de538d0123eabc3e"
 dependencies = [
  "bare-metal",
  "coap-handler",

--- a/examples/lang_support/official/rust-hello-world/Cargo.lock
+++ b/examples/lang_support/official/rust-hello-world/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.9.2"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#833f7688461277f0c2f959f3491069f26df3b18d"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#6258817d4f32e07a3c2bfff3de538d0123eabc3e"
 dependencies = [
  "bare-metal",
  "coap-handler",

--- a/tests/rust_minimal/Cargo.lock
+++ b/tests/rust_minimal/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "riot-wrappers"
 version = "0.9.2"
-source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#833f7688461277f0c2f959f3491069f26df3b18d"
+source = "git+https://github.com/RIOT-OS/rust-riot-wrappers#6258817d4f32e07a3c2bfff3de538d0123eabc3e"
 dependencies = [
  "bare-metal",
  "coap-handler",


### PR DESCRIPTION
### Contribution description

The explicit reference given in .cargo/config.toml is not part of the main branch, and thus not available to all users -- and the fix that was needed for [1] is now already in main.

It updates the riot-wrappers for consistency:

* ws281x adjustments to changed RIOT inline-ness
* eh-personality is exported as a symbol rather than a (nightly-only) Rust feature


[1]: https://github.com/RIOT-OS/RIOT/pull/22036#issuecomment-4344275072


### Testing procedure

@crasbe / @fabian18, was the trouble that this worked around for in #22036 only build related? Then CI should suffice.

### Issues/PRs references

Reverts some of #22036.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
