### PR TITLE
pkg/mpaland-printf: do not silently drop printing to stderr

### DIFF
--- a/pkg/mpaland-printf/patches/0001-Fix-parsing-of-int8_t.patch
+++ b/pkg/mpaland-printf/patches/0001-Fix-parsing-of-int8_t.patch
@@ -1,7 +1,7 @@
-From d864493f611c1435133b7b9c7cdce49d969b16b7 Mon Sep 17 00:00:00 2001
+From 4ccc61c95c8fa18d98c077cd87d0418df679763a Mon Sep 17 00:00:00 2001
 From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
 Date: Sat, 11 May 2024 22:42:21 +0200
-Subject: [PATCH 1/4] Fix parsing of `int8_t`
+Subject: [PATCH 1/6] Fix parsing of `int8_t`
 
 The code assumes that `char` is signed, but the C standard allows
 `char` to be either signed or unsigned. Instead, `singed char` and
@@ -11,7 +11,7 @@ The code assumes that `char` is signed, but the C standard allows
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/printf.c b/printf.c
-index 8a700ad..e6e18fa 100644
+index 8a700ad..f2357f4 100644
 --- a/printf.c
 +++ b/printf.c
 @@ -732,7 +732,7 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
@@ -24,5 +24,5 @@ index 8a700ad..e6e18fa 100644
            }
          }
 -- 
-2.43.0
+2.39.5
 

--- a/pkg/mpaland-printf/patches/0001-Fix-parsing-of-int8_t.patch
+++ b/pkg/mpaland-printf/patches/0001-Fix-parsing-of-int8_t.patch
@@ -1,7 +1,7 @@
 From 4ccc61c95c8fa18d98c077cd87d0418df679763a Mon Sep 17 00:00:00 2001
 From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
 Date: Sat, 11 May 2024 22:42:21 +0200
-Subject: [PATCH 1/6] Fix parsing of `int8_t`
+Subject: [PATCH 1/7] Fix parsing of `int8_t`
 
 The code assumes that `char` is signed, but the C standard allows
 `char` to be either signed or unsigned. Instead, `singed char` and

--- a/pkg/mpaland-printf/patches/0002-RIOT-integration.patch
+++ b/pkg/mpaland-printf/patches/0002-RIOT-integration.patch
@@ -1,7 +1,7 @@
 From a97c23e94ad0f0d69562921777ef797bab598b4b Mon Sep 17 00:00:00 2001
 From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
 Date: Sat, 11 May 2024 17:51:01 +0200
-Subject: [PATCH 2/6] RIOT integration
+Subject: [PATCH 2/7] RIOT integration
 
 Use stdio_write() from stdio_base.h for output
 ---

--- a/pkg/mpaland-printf/patches/0002-RIOT-integration.patch
+++ b/pkg/mpaland-printf/patches/0002-RIOT-integration.patch
@@ -1,7 +1,7 @@
-From ca5d3c2e0488b1888299ed7eb81c4dc16b7ac8c6 Mon Sep 17 00:00:00 2001
+From a97c23e94ad0f0d69562921777ef797bab598b4b Mon Sep 17 00:00:00 2001
 From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
 Date: Sat, 11 May 2024 17:51:01 +0200
-Subject: [PATCH 2/4] RIOT integration
+Subject: [PATCH 2/6] RIOT integration
 
 Use stdio_write() from stdio_base.h for output
 ---
@@ -10,7 +10,7 @@ Use stdio_write() from stdio_base.h for output
  2 files changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/printf.c b/printf.c
-index e6e18fa..d560d2b 100644
+index f2357f4..2133eb2 100644
 --- a/printf.c
 +++ b/printf.c
 @@ -34,6 +34,7 @@
@@ -46,5 +46,5 @@ index 6075bc2..154930a 100644
  
  /**
 -- 
-2.43.0
+2.39.5
 

--- a/pkg/mpaland-printf/patches/0003-RIOT-integration-Select-features-based-on-modules.patch
+++ b/pkg/mpaland-printf/patches/0003-RIOT-integration-Select-features-based-on-modules.patch
@@ -1,7 +1,7 @@
 From 811f4148888fdd11209c485a78212916eec96822 Mon Sep 17 00:00:00 2001
 From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
 Date: Sat, 11 May 2024 18:38:51 +0200
-Subject: [PATCH 3/6] RIOT integration: Select features based on modules
+Subject: [PATCH 3/7] RIOT integration: Select features based on modules
 
 Using module `printf_float` adds support for printing floats, using
 module `printf_long_long` adds support for printing `long long` or

--- a/pkg/mpaland-printf/patches/0003-RIOT-integration-Select-features-based-on-modules.patch
+++ b/pkg/mpaland-printf/patches/0003-RIOT-integration-Select-features-based-on-modules.patch
@@ -1,7 +1,7 @@
-From 4d6939143a251b93022980a472f2bcd9c42b8573 Mon Sep 17 00:00:00 2001
+From 811f4148888fdd11209c485a78212916eec96822 Mon Sep 17 00:00:00 2001
 From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
 Date: Sat, 11 May 2024 18:38:51 +0200
-Subject: [PATCH 3/4] RIOT integration: Select features based on modules
+Subject: [PATCH 3/6] RIOT integration: Select features based on modules
 
 Using module `printf_float` adds support for printing floats, using
 module `printf_long_long` adds support for printing `long long` or
@@ -11,7 +11,7 @@ module `printf_long_long` adds support for printing `long long` or
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/printf.c b/printf.c
-index d560d2b..6923fee 100644
+index 2133eb2..f43a500 100644
 --- a/printf.c
 +++ b/printf.c
 @@ -60,8 +60,8 @@
@@ -37,5 +37,5 @@ index d560d2b..6923fee 100644
  #endif
  
 -- 
-2.49.0
+2.39.5
 

--- a/pkg/mpaland-printf/patches/0004-Wrapper-targets-Add-endpoints-for-Wl-wrap.patch
+++ b/pkg/mpaland-printf/patches/0004-Wrapper-targets-Add-endpoints-for-Wl-wrap.patch
@@ -1,7 +1,7 @@
 From 92cd53951e322e8c300f5d799f46e660c978631b Mon Sep 17 00:00:00 2001
 From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
 Date: Sat, 11 May 2024 17:51:38 +0200
-Subject: [PATCH 4/6] Wrapper targets: Add endpoints for -Wl,wrap=...
+Subject: [PATCH 4/7] Wrapper targets: Add endpoints for -Wl,wrap=...
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/pkg/mpaland-printf/patches/0004-Wrapper-targets-Add-endpoints-for-Wl-wrap.patch
+++ b/pkg/mpaland-printf/patches/0004-Wrapper-targets-Add-endpoints-for-Wl-wrap.patch
@@ -1,4 +1,4 @@
-From 5c6c71c8d200cd9d4bb43b01184e08e09ff9c935 Mon Sep 17 00:00:00 2001
+From 92cd53951e322e8c300f5d799f46e660c978631b Mon Sep 17 00:00:00 2001
 From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
 Date: Sat, 11 May 2024 17:51:38 +0200
 Subject: [PATCH 4/6] Wrapper targets: Add endpoints for -Wl,wrap=...
@@ -16,7 +16,7 @@ Co-Authored-By: Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
  1 file changed, 123 insertions(+)
 
 diff --git a/printf.c b/printf.c
-index edf41d1..c55f066 100644
+index f43a500..3659477 100644
 --- a/printf.c
 +++ b/printf.c
 @@ -32,6 +32,9 @@

--- a/pkg/mpaland-printf/patches/0005-Change-p-formatting-to-match-glibc.patch
+++ b/pkg/mpaland-printf/patches/0005-Change-p-formatting-to-match-glibc.patch
@@ -1,7 +1,7 @@
 From 63de35a842b4d9c11ffc05f71027fa70d3292069 Mon Sep 17 00:00:00 2001
 From: Marian Buschsieweke <marian.buschsieweke@ml-pa.com>
 Date: Fri, 22 Aug 2025 10:32:04 +0200
-Subject: [PATCH 5/6] Change %p formatting to match glibc
+Subject: [PATCH 5/7] Change %p formatting to match glibc
 
 Taken from https://github.com/mpaland/printf/pull/90
 ---

--- a/pkg/mpaland-printf/patches/0005-Change-p-formatting-to-match-glibc.patch
+++ b/pkg/mpaland-printf/patches/0005-Change-p-formatting-to-match-glibc.patch
@@ -1,7 +1,7 @@
-From 101d684f1759aa8aef4d49bbb1e2eebdbaa41afb Mon Sep 17 00:00:00 2001
+From 63de35a842b4d9c11ffc05f71027fa70d3292069 Mon Sep 17 00:00:00 2001
 From: Marian Buschsieweke <marian.buschsieweke@ml-pa.com>
 Date: Fri, 22 Aug 2025 10:32:04 +0200
-Subject: [PATCH] Change %p formatting to match glibc
+Subject: [PATCH 5/6] Change %p formatting to match glibc
 
 Taken from https://github.com/mpaland/printf/pull/90
 ---
@@ -10,7 +10,7 @@ Taken from https://github.com/mpaland/printf/pull/90
  2 files changed, 26 insertions(+), 17 deletions(-)
 
 diff --git a/printf.c b/printf.c
-index efdee81..50a4ddf 100644
+index 3659477..be372d8 100644
 --- a/printf.c
 +++ b/printf.c
 @@ -824,19 +824,25 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
@@ -49,7 +49,7 @@ index efdee81..50a4ddf 100644
          break;
        }
 diff --git a/test/test_suite.cpp b/test/test_suite.cpp
-index 5507c3b..740771a 100644
+index 5507c3b..a198d56 100644
 --- a/test/test_suite.cpp
 +++ b/test/test_suite.cpp
 @@ -1361,36 +1361,39 @@ TEST_CASE("pointer", "[]" ) {
@@ -101,5 +101,5 @@ index 5507c3b..740771a 100644
  
  
 -- 
-2.43.0
+2.39.5
 

--- a/pkg/mpaland-printf/patches/0006-use-buffered-output.patch
+++ b/pkg/mpaland-printf/patches/0006-use-buffered-output.patch
@@ -1,14 +1,14 @@
-From 1070ce82390a7ca9bdaef52f106488ac7ef99645 Mon Sep 17 00:00:00 2001
+From 123962fa0ad5825ee483059ecb3eb537574db611 Mon Sep 17 00:00:00 2001
 From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
 Date: Sun, 19 Oct 2025 16:58:11 +0200
-Subject: [PATCH] use buffered output
+Subject: [PATCH 6/6] use buffered output
 
 ---
- printf.c | 63 +++++++++++++++++++++++++++++++++++++++++---------------
- 1 file changed, 46 insertions(+), 17 deletions(-)
+ printf.c | 55 ++++++++++++++++++++++++++++++++++++++++++-------------
+ 1 file changed, 42 insertions(+), 13 deletions(-)
 
 diff --git a/printf.c b/printf.c
-index 33fd8a6..756fd12 100644
+index be372d8..6604ee0 100644
 --- a/printf.c
 +++ b/printf.c
 @@ -133,6 +133,27 @@ typedef struct {
@@ -47,23 +47,19 @@ index 33fd8a6..756fd12 100644
 +static inline void _out_char(char character, void* _buffer, size_t idx, size_t maxlen)
  {
 -  (void)buffer; (void)idx; (void)maxlen;
--  if (character) {
--    _putchar(character);
--  }
--}
--
--
 +  (void)idx; (void)maxlen;
 +  output_buffer_type *buffer = _buffer;
 +  if (buffer->fill == sizeof(buffer->buf)) {
 +    write_all(buffer->buf, sizeof(buffer->buf));
 +    buffer->fill = 0;
 +  }
-+  if (character) {
+   if (character) {
+-    _putchar(character);
 +    buffer->buf[buffer->fill++] = character;
-+  }
-+}
-+
+   }
+ }
+ 
+-
  // internal output function wrapper
  static inline void _out_fct(char character, void* buffer, size_t idx, size_t maxlen)
  {
@@ -115,7 +111,7 @@ index 33fd8a6..756fd12 100644
  }
  
  
-@@ -962,8 +991,8 @@ int __wrap_putchar(int c)
+@@ -983,8 +1012,8 @@ __attribute__((used))
  int __wrap_puts(const char *s)
  {
    size_t len = strlen(s);
@@ -127,5 +123,5 @@ index 33fd8a6..756fd12 100644
  }
  
 -- 
-2.43.0
+2.39.5
 

--- a/pkg/mpaland-printf/patches/0006-use-buffered-output.patch
+++ b/pkg/mpaland-printf/patches/0006-use-buffered-output.patch
@@ -1,7 +1,7 @@
 From 123962fa0ad5825ee483059ecb3eb537574db611 Mon Sep 17 00:00:00 2001
 From: Marian Buschsieweke <marian.buschsieweke@posteo.net>
 Date: Sun, 19 Oct 2025 16:58:11 +0200
-Subject: [PATCH 6/6] use buffered output
+Subject: [PATCH 6/7] use buffered output
 
 ---
  printf.c | 55 ++++++++++++++++++++++++++++++++++++++++++-------------

--- a/pkg/mpaland-printf/patches/0007-Wrapper-targets-also-print-when-stderr-is-used.patch
+++ b/pkg/mpaland-printf/patches/0007-Wrapper-targets-also-print-when-stderr-is-used.patch
@@ -1,0 +1,63 @@
+From 5cbdcf0a951b79fa87a4473c47faed051580e3e3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mikolai=20G=C3=BCtschow?= <mikolai.guetschow@tu-dresden.de>
+Date: Tue, 12 May 2026 15:01:14 +0200
+Subject: [PATCH 7/7] Wrapper targets: also print when stderr is used
+
+Matching the behavior of the newlib and picolibc RIOT integration
+---
+ printf.c | 18 ++++++++++++------
+ 1 file changed, 12 insertions(+), 6 deletions(-)
+
+diff --git a/printf.c b/printf.c
+index 6604ee0..53a25db 100644
+--- a/printf.c
++++ b/printf.c
+@@ -997,7 +997,10 @@ int __wrap_putchar(int c)
+ __attribute__((used))
+ int __wrap_putc(int c, FILE *stream)
+ {
+-  (void)stream;
++  if (stream != stdout && stream != stderr) {
++    return EOF;
++  }
++
+   _putchar((char)c);
+   return 1;
+ }
+@@ -1021,7 +1024,10 @@ int __wrap_puts(const char *s)
+ __attribute__((used))
+ int __wrap_fputs(const char *s, FILE *stream)
+ {
+-  (void)stream;
++  if (stream != stdout && stream != stderr) {
++    return EOF;
++  }
++
+   size_t len = strlen(s);
+   write_all(s, len);
+   return len;
+@@ -1031,8 +1037,8 @@ int __wrap_fputs(const char *s, FILE *stream)
+ __attribute__((used))
+ int __wrap_vfprintf(FILE *stream, const char *format, va_list va)
+ {
+-  if (stream != stdout) {
+-    return 0;
++  if (stream != stdout && stream != stderr) {
++    return EOF;
+   }
+ 
+   return vprintf_(format, va);
+@@ -1053,8 +1059,8 @@ int __wrap_fprintf(FILE *stream, const char *format, ...)
+ __attribute__((used))
+ int __wrap_vdprintf(int fd, const char *format, va_list va)
+ {
+-  if (fd != STDOUT_FILENO) {
+-    return 0;
++  if (fd != STDOUT_FILENO && fd != STDERR_FILENO) {
++    return EOF;
+   }
+ 
+   return vprintf_(format, va);
+-- 
+2.39.5
+


### PR DESCRIPTION
### Contribution description

Instead print it using stdio_write. Now matching behavior of RIOT integration for newlib and picolibc.

### Testing procedure

Apply the following diff:

```diff
diff --git a/examples/basic/hello-world/main.c b/examples/basic/hello-world/main.c
index c1fe9bae12..5f248626e9 100644
--- a/examples/basic/hello-world/main.c
+++ b/examples/basic/hello-world/main.c
@@ -22,7 +22,7 @@ int main(void)
 {
     puts("Hello World!");
 
-    printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
+    fprintf(stderr, "You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s CPU.\n", RIOT_CPU);
 
     return 0;
```

Run on any board where mpaland-printf is selected by default (because newlib is used) since https://github.com/RIOT-OS/RIOT/pull/21438

```
make -C examples/basic/hello-world BOARD=nrf52840dk flash term -j
``` 

On `master` the second line is missing.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
