### PR TITLE
rust: Follow moves from GitLab to Codeberg

### DIFF
--- a/doc/guides/rust_tutorials/rust_in_riot.md
+++ b/doc/guides/rust_tutorials/rust_in_riot.md
@@ -40,9 +40,9 @@ Two examples are provided:
 There are [additional examples] available on GitLab,
 maintained in coordination with the riot-wrappers crate.
 
-[coap-message-demos]: https://gitlab.com/chrysn/coap-message-demos
-[riot-module-examples]: https://gitlab.com/etonomy/riot-module-examples
-[additional examples]: https://gitlab.com/etonomy/riot-examples/
+[coap-message-demos]: https://codeberg.org/chrysn/coap-tools
+[riot-module-examples]: https://codeberg.org/RIOT/rust-module-examples
+[additional examples]: https://codeberg.org/RIOT/rust-examples
 
 ## IDE / Editor Setup
 

--- a/examples/lang_support/official/rust-async/Cargo.lock
+++ b/examples/lang_support/official/rust-async/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor-riot"
 version = "0.1.0"
-source = "git+https://gitlab.com/etonomy/riot-module-examples#09fa2d45e92ca4e46da7f18af3db3d1bcec238d3"
+source = "git+https://codeberg.org/RIOT/rust-module-examples#934940b60df9177d60e9bd9b062546a20d48182d"
 dependencies = [
  "embassy-executor",
  "riot-sys",

--- a/examples/lang_support/official/rust-async/Cargo.toml
+++ b/examples/lang_support/official/rust-async/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["staticlib"]
 [dependencies]
 riot-wrappers = { version = "0.9", features = [ "set_panic_handler", "provide_critical_section_1_0", "panic_handler_format" ] }
 
-embassy-executor-riot = { git = "https://gitlab.com/etonomy/riot-module-examples" }
+embassy-executor-riot = { git = "https://codeberg.org/RIOT/rust-module-examples" }
 embassy-executor = "0.5"
 embassy-futures = "0.1.1"
 static_cell = "2.0.0"

--- a/examples/lang_support/official/rust-gcoap/Cargo.lock
+++ b/examples/lang_support/official/rust-gcoap/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
 [[package]]
 name = "coap-message-demos"
 version = "0.4.0"
-source = "git+https://gitlab.com/chrysn/coap-message-demos/#c5b883e198a0cf6d0239ca26393e09321887a446"
+source = "git+https://codeberg.org/chrysn/coap-tools#c5b883e198a0cf6d0239ca26393e09321887a446"
 dependencies = [
  "coap-handler",
  "coap-handler-implementations",
@@ -726,7 +726,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "riot-coap-handler-demos"
 version = "0.2.0"
-source = "git+https://gitlab.com/etonomy/riot-module-examples/#09fa2d45e92ca4e46da7f18af3db3d1bcec238d3"
+source = "git+https://codeberg.org/RIOT/rust-module-examples#09fa2d45e92ca4e46da7f18af3db3d1bcec238d3"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",

--- a/examples/lang_support/official/rust-gcoap/Cargo.toml
+++ b/examples/lang_support/official/rust-gcoap/Cargo.toml
@@ -18,9 +18,9 @@ opt-level = "s"
 riot-wrappers = { version = "^0.9.0", features = [ "set_panic_handler", "panic_handler_format", "with_coap_message", "with_coap_handler", "provide_critical_section_1_0" ] }
 portable-atomic = { version = "1", features = [ "critical-section" ] }
 
-coap-message-demos = { git = "https://gitlab.com/chrysn/coap-message-demos/", default-features = false }
+coap-message-demos = { git = "https://codeberg.org/chrysn/coap-tools", default-features = false }
 coap-handler-implementations = "0.5"
-riot-coap-handler-demos = { git = "https://gitlab.com/etonomy/riot-module-examples/", features = [ "vfs", "saul", "nib", "ping" ] }
+riot-coap-handler-demos = { git = "https://codeberg.org/RIOT/rust-module-examples", features = [ "vfs", "saul", "nib", "ping" ] }
 
 # While currently this exmple does not use any RIOT modules implemented in
 # Rust, that may change; it is best practice for any RIOT application that has


### PR DESCRIPTION
### Contribution description

Repositories previously at https://gitlab.com/etonomy have been moved in with RIOT; experimentally, we're using the https://codeberg.org/RIOT organization for that.

The move of the upstream coap-message-demos repository (where I am upstream) is handled the same way in the same commit.

### Testing procedure

The only practical change in here is that the source of the files changed; after those can be fetched (which CI tests), the builds should be identical.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
