### PR TITLE
examples/networking/misc/lwiperf: add application

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -135,7 +135,8 @@ Here is a quick overview of the examples available in the RIOT:
 | [sniffer](./networking/misc/sniffer/README.md) | This application is built to run together with the script `./tools/sniffer.py` as a sniffer for (wireless) data traffic. |
 | [benckmark_udp](./networking/misc/benchmark_udp/README.md) | This example uses the `benchmark_udp` module to create a stress-test for the RIOT network stack. |
 | [sock_tcp_echo](./networking/misc/sock_tcp_echo/README.md) | This is a simple TCP echo server / client that uses the SOCK API. |
-| [lwip_ipv4](./networking/misc/lwip_ipv4/README.md) | This is a simple UDP client / server using LWIP for IPv4. |
+| [lwip_ipv4](./networking/misc/lwip_ipv4/README.md) | This is a simple UDP client / server using lwIP for IPv4. |
+| [lwiperf](./networking/misc/lwiperf/README.md) | This is a lwIP benchmark application, providing an iPerf client and server. |
 
 
 ## Advanced Examples

--- a/examples/networking/misc/lwiperf/Makefile
+++ b/examples/networking/misc/lwiperf/Makefile
@@ -1,0 +1,50 @@
+# Set the name of your application:
+APPLICATION = lwiperf
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../../../../
+
+# Uncomment this to enable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+# Change this to 0 to show compiler invocation lines by default:
+QUIET ?= 1
+
+# Modules to include:
+USEMODULE += shell
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
+
+USEMODULE += netdev_default
+
+# Enables lwIP stack
+LWIP_IPV4 ?= 0
+LWIP_IPV6 ?= 1
+
+ifeq (1,$(LWIP_IPV4))
+  USEMODULE += ipv4_addr
+  USEMODULE += lwip_ipv4
+
+  # Uncomment the following two lines to use DHCP. Refer to the README.md for
+  # more details.
+  #USEMODULE += lwip_dhcp_auto
+  #CFLAGS += -DETHARP_SUPPORT_STATIC_ENTRIES=1
+endif
+
+ifeq (1,$(LWIP_IPV6))
+  USEMODULE += ipv6_addr
+  USEMODULE += lwip_ipv6
+  USEMODULE += lwip_ipv6_autoconfig
+endif
+
+USEMODULE += lwip_app_lwiperf
+
+# Enables ifconfig command, which allows IP address configuration
+USEMODULE += shell_cmds_default
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/networking/misc/lwiperf/Makefile.ci
+++ b/examples/networking/misc/lwiperf/Makefile.ci
@@ -1,0 +1,22 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    bluepill-stm32f030c8 \
+    i-nucleo-lrwan1 \
+    nucleo-c031c6 \
+    nucleo-f030r8 \
+    nucleo-f031k6 \
+    nucleo-f042k6 \
+    nucleo-l011k4 \
+    nucleo-l031k6 \
+    nucleo-l053r8 \
+    samd10-xmini \
+    slstk3400a \
+    stk3200 \
+    stm32c0116-dk \
+    stm32c0316-dk \
+    stm32f030f4-demo \
+    stm32f0discovery \
+    stm32f7508-dk \
+    stm32g0316-disco \
+    stm32l0538-disco \
+    weact-g030f6 \
+    #

--- a/examples/networking/misc/lwiperf/README.md
+++ b/examples/networking/misc/lwiperf/README.md
@@ -1,0 +1,112 @@
+# lwIP iPerf benchmark
+
+This application exposes the lwIP iPerf server and client functionality to
+perform network throughput benchmarks between a node and another host.
+
+Note: this example needs iPerf version 2 to work, not iPerf version 3. It
+currently only supports TCP.
+
+## Building
+
+The default configuration compiles for the `native` target with only IPv6
+support enabled.
+
+IPv4 support can be enabled simultaneously by providing the `LWIP_IPV4` flag,
+e.g. `make LWIP_IPV4=1`. However, when starting a server, it will only listen
+on the IPv4 address.
+
+Refer to the `Makefile` for more details.
+
+## Usage
+
+First make sure that the network interface is properly configured, and has an
+address. Then, to interact with the lwIP iPerf app, the shell exposes three
+commands:
+
+* `abort` - stop the currently running server or client
+* `client <host>` - start an iPerf client, connecting to the specified host
+* `server` - start an iPerf server
+
+The server and client will run in the background.
+
+## Demonstration
+
+This is a demonstration of the client running on a node, connecting to a server
+running on the host.
+
+When testing this on a `native` target, refer to the
+`examples/networking/misc/lwip_ipv4` instructions on how to set-up a local
+network.
+
+First, check if the network interface is up and has an address. This can be
+done with the `ifconfig` command:
+
+```
+> ifconfig
+Iface ET0 HWaddr: d2:16:6c:09:78:35 Link: up State: up
+        Link type: wired
+        inet6 addr: fe80:0:0:0:d016:6cff:fe09:7835 scope: link state: valid preferred
+```
+
+When using IPv4 without DHCP (the default), the address can be configured
+manually. For example:
+
+```
+> ifconfig add ET0 192.168.100.11/24
+
+> ifconfig
+Iface ET0 HWaddr: d2:16:6c:09:78:35 Link: up State: up
+        Link type: wired
+        inet addr: 192.168.100.11 mask: 255.255.255.0 gw: 0.0.0.0
+```
+
+On the host, start an iPerf server (`-V` is for IPv6):
+
+```
+$ iperf -V -s
+```
+
+Find the host IPv6 address (this will be machine-specific):
+
+```
+$ ip addr
+...
+3: tapbr0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
+    link/ether 0a:04:9b:b4:23:de brd ff:ff:ff:ff:ff:ff
+    inet 192.168.100.100/24 scope global tapbr0
+       valid_lft forever preferred_lft forever
+    inet6 fe80::804:9bff:feb4:23de/64 scope link proto kernel_ll
+       valid_lft forever preferred_lft forever
+...
+```
+
+Finally, run the client on the node, connecting to the host:
+
+```
+> client fe80::804:9bff:feb4:23de
+TCP client connecting to fe80::804:9bff:feb4:23de port 5001
+```
+
+The node will connect to the server and print a report afterwards:
+
+```
+--- Results ---
+Status      : TCP client done
+Remote      : FE80::804:9BFF:FEB4:23DE:5001
+Transferred : 309149816 bytes
+Duration    : 10000 ms
+Bandwidth   : 247312 kbit/s
+--------------
+```
+
+The host output will look as follows:
+
+```
+------------------------------------------------------------
+Server listening on TCP port 5001
+TCP window size:  128 KByte (default)
+------------------------------------------------------------
+[  1] local fe80::804:9bff:feb4:23de port 5001 connected with fe80::d016:6cff:fe09:7835 port 49153
+[ ID] Interval       Transfer     Bandwidth
+[  1] 0.0000-9.9988 sec   295 MBytes   247 Mbits/sec
+```

--- a/examples/networking/misc/lwiperf/main.c
+++ b/examples/networking/misc/lwiperf/main.c
@@ -1,0 +1,226 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Network throughput benchmarks using lwIP iPerf.
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#include "shell.h"
+#include "thread.h"
+#include "ztimer.h"
+
+#include "arch/sys_arch.h"
+#include "lwip.h"
+#include "lwip/apps/lwiperf.h"
+#include "lwip/ip_addr.h"
+#include "lwip/netif.h"
+
+/**
+ * @brief Default DHCP timeout in seconds.
+ */
+#ifndef TEST_DHCP_TIMEOUT_SEC
+#  define TEST_DHCP_TIMEOUT_SEC   10
+#endif
+
+/**
+ * @brief Default local IPv4 address, when DHCP is not used.
+ */
+#ifndef TEST_ADDR4_LOCAL
+#  define TEST_ADDR4_LOCAL        IP4_ADDR_INIT(192, 168, 100, 11)
+#endif
+
+/**
+ * @brief Default local IPv4 subnet mask, when DHCP is not used.
+ */
+#ifndef TEST_ADDR4_MASK
+#  define TEST_ADDR4_MASK         IP4_ADDR_INIT(255, 255, 255, 0)
+#endif
+
+static void *_session;
+
+static void _iperf_report_cb(void *arg,
+                             enum lwiperf_report_type report_type,
+                             const ip_addr_t *local_addr,  u16_t local_port,
+                             const ip_addr_t *remote_addr, u16_t remote_port,
+                             u32_t bytes_transferred,
+                             u32_t ms_duration,
+                             u32_t bandwidth_kbitpsec)
+{
+    (void)arg;
+    (void)local_addr;
+    (void)local_port;
+
+    const char *type_str;
+
+    switch (report_type) {
+    case LWIPERF_TCP_DONE_SERVER:
+        type_str = "TCP server done";
+        break;
+    case LWIPERF_TCP_DONE_CLIENT:
+        type_str = "TCP client done";
+        break;
+    case LWIPERF_TCP_ABORTED_LOCAL:
+        type_str = "aborted (local)";
+        break;
+    case LWIPERF_TCP_ABORTED_REMOTE:
+        type_str = "aborted (remote)";
+        break;
+    default:
+        type_str = "unknown";
+        break;
+    }
+
+    puts("--- Results ---");
+    printf("Status      : %s\n", type_str);
+    printf("Remote      : %s:%" PRIu16 "\n", ipaddr_ntoa(remote_addr), remote_port);
+    printf("Transferred : %" PRIu32 " bytes\n", bytes_transferred);
+    printf("Duration    : %" PRIu32 " ms\n",    ms_duration);
+    printf("Bandwidth   : %" PRIu32 " kbit/s\n", bandwidth_kbitpsec);
+    puts("--------------");
+    puts("");
+
+    /* runs from the lwIP thread, so locking not necessary */
+    _session = NULL;
+}
+
+static int _cmd_server(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    sys_lock_tcpip_core();
+
+    if (_session != NULL) {
+        sys_unlock_tcpip_core();
+        puts("Error: another session is already active. Run 'abort' first.");
+        return 1;
+    }
+
+    _session = lwiperf_start_tcp_server_default(_iperf_report_cb, NULL);
+
+    if (_session == NULL) {
+        sys_unlock_tcpip_core();
+        puts("Error: failed to start server");
+        return 1;
+    }
+
+    sys_unlock_tcpip_core();
+
+    printf("TCP server listening on port %d\n", LWIPERF_TCP_PORT_DEFAULT);
+
+#if IS_USED(MODULE_LWIP_IPV4) && !IS_USED(MODULE_LWIP_IPV6)
+    puts("Run on host: iperf -c <board_ip>");
+#elif !IS_USED(MODULE_LWIP_IPV4) && IS_USED(MODULE_LWIP_IPV6)
+    puts("Run on host: iperf -V -c <board_ip>");
+#else
+    puts("Run on host: iperf -c <board_ip>    (for IPv4)");
+    puts("             iperf -V -c <board_ip> (for IPv6)");
+#endif
+
+    return 0;
+}
+
+static int _cmd_client(int argc, char **argv)
+{
+    ip_addr_t remote_addr;
+
+    if (argc < 2) {
+        printf("Usage: %s <ip>\n", argv[0]);
+        return 1;
+    }
+
+    sys_lock_tcpip_core();
+
+    if (_session != NULL) {
+        sys_unlock_tcpip_core();
+        puts("Error: another session is already active. Run 'abort' first.");
+        return 1;
+    }
+
+    if (!ipaddr_aton(argv[1], &remote_addr)) {
+        sys_unlock_tcpip_core();
+        printf("Error: invalid IP address: %s\n", argv[1]);
+        return 1;
+    }
+
+    _session = lwiperf_start_tcp_client_default(&remote_addr, _iperf_report_cb, NULL);
+
+    if (_session == NULL) {
+        sys_unlock_tcpip_core();
+        puts("Error: failed to start client.");
+        return 1;
+    }
+
+    sys_unlock_tcpip_core();
+
+    printf("TCP client connecting to %s port %d\n", argv[1], LWIPERF_TCP_PORT_DEFAULT);
+
+    return 0;
+}
+
+static int _cmd_abort(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    sys_lock_tcpip_core();
+
+    if (_session == NULL) {
+        sys_unlock_tcpip_core();
+        puts("Error: no active session.");
+        return 1;
+    }
+
+    lwiperf_abort(_session);
+    _session = NULL;
+
+    sys_unlock_tcpip_core();
+
+    puts("Session aborted.");
+
+    return 0;
+}
+
+SHELL_COMMAND(abort,  "abort active iPerf session", _cmd_abort);
+SHELL_COMMAND(client, "start iPerf client <ip>", _cmd_client);
+SHELL_COMMAND(server, "start iPerf server", _cmd_server);
+
+int main(void)
+{
+#if IS_USED(MODULE_LWIP_IPV4) && IS_USED(MODULE_LWIP_DHCP_AUTO)
+    /* auto-configure using DHCP */
+    puts("Waiting for DHCP address autoconfiguration ...");
+    ztimer_sleep(ZTIMER_MSEC, TEST_DHCP_TIMEOUT_SEC * MS_PER_SEC);
+#elif IS_USED(MODULE_LWIP_IPV4)
+    /* configure static IP address */
+    ip4_addr_t ip = TEST_ADDR4_LOCAL;
+    ip4_addr_t subnet = TEST_ADDR4_MASK;
+
+    sys_lock_tcpip_core();
+    struct netif *iface = netif_find("ET0");
+    netif_set_addr(iface, &ip, &subnet, NULL);
+    sys_unlock_tcpip_core();
+#endif
+
+    /* print usage instruction */
+    puts("lwIP iPerf application running. Use `help` to get started.");
+
+    /* spawn a shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/pkg/lwip/Makefile
+++ b/pkg/lwip/Makefile
@@ -6,8 +6,8 @@ PKG_LICENSE=BSD-3-Clause
 
 include $(RIOTBASE)/pkg/pkg.mk
 
-LWIP_MODULES         = lwip_api lwip_core lwip_ipv4 lwip_ipv6 \
-                       lwip_netif lwip_netif_ppp lwip_polarssl
+LWIP_MODULES         = lwip_api lwip_app_lwiperf lwip_core lwip_ipv4 \
+                       lwip_ipv6 lwip_netif lwip_netif_ppp lwip_polarssl
 LWIP_USEMODULE       = $(filter $(LWIP_MODULES),$(USEMODULE))
 LWIP_MODULE_MAKEFILE = $(RIOTBASE)/Makefile.base
 
@@ -29,6 +29,9 @@ lwip: $(LWIP_USEMODULE)
 
 lwip_api:
 	$(call make_module,$@,$(PKG_SOURCE_DIR)/src/api)
+
+lwip_app_lwiperf:
+	$(call make_module,$@,$(PKG_SOURCE_DIR)/src/apps/lwiperf)
 
 lwip_core:
 	$(call make_module,$@,$(PKG_SOURCE_DIR)/src/core)

--- a/pkg/lwip/Makefile.dep
+++ b/pkg/lwip/Makefile.dep
@@ -24,6 +24,13 @@ ifneq (,$(filter stm32_eth,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter lwip_app_lwiperf,$(USEMODULE)))
+  USEMODULE += lwip_tcp
+  ifneq (,$(filter lwip_ipv4,$(USEMODULE)))
+    USEMODULE += lwip_arp
+  endif
+endif
+
 ifneq (,$(filter lwip_ipv6_autoconfig lwip_ipv6_mld,$(USEMODULE)))
   USEMODULE += lwip_ipv6
 endif


### PR DESCRIPTION
### Contribution description

This is lwIP's built-in iPerf2 'app', provided as an example application for RIOT-OS. I came across this functionality, researching possibilities to test (to be PR'd) ethernet drivers.

I am aware of `benchmark_udp`. Given that the code for the built-in iPerf2 'app' is already [distributed](https://github.com/lwip-tcpip/lwip/blob/master/src/apps/lwiperf/lwiperf.c) with lwIP, I think this is a nice addition to test TCP throughput, and have another utility to stress test an ethernet driver.

### Testing procedure

This can be easily tested on `native`.

```
$ make -C examples/networking/misc/lwiperf
$ examples/networking/misc/lwiperf/bin/native64/lwiperf.elf tap0
```

On the host, start an iPerf server (`-V` is for IPv6):

```
$ iperf -V -s
```

Run the client on the node, connecting to the host:

```
> client fe80::804:9bff:feb4:23de
TCP client connecting to fe80::804:9bff:feb4:23de port 5001
```

The node will connect to the server and print a report afterwards:

```
--- Results ---
Status      : TCP client done
Remote      : FE80::804:9BFF:FEB4:23DE:5001
Transferred : 309149816 bytes
Duration    : 10000 ms
Bandwidth   : 247312 kbit/s
--------------
```

The host output will look as follows:

```
------------------------------------------------------------
Server listening on TCP port 5001
TCP window size:  128 KByte (default)
------------------------------------------------------------
[  1] local fe80::804:9bff:feb4:23de port 5001 connected with fe80::d016:6cff:fe09:7835 port 49153
[ ID] Interval       Transfer     Bandwidth
[  1] 0.0000-9.9988 sec   295 MBytes   247 Mbits/sec
```

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- Claude Code for the final review of the three commits
