### PR TITLE
dist/testbed-support: add reset after flash for IoT-LAB nodes

### DIFF
--- a/dist/testbed-support/makefile.iotlab.single.inc.mk
+++ b/dist/testbed-support/makefile.iotlab.single.inc.mk
@@ -215,6 +215,14 @@ else
 
 endif
 
+define iotlab-flash-recipe
+  $(call check_cmd,$(FLASHER),Flash program)
+  $(PROGRAMMER_FLASH)
+  $(call check_cmd,$(RESET),Reset program)
+  $(PROGRAMMER_RESET)
+endef
+flash-recipe = $(iotlab-flash-recipe)
+
 ifneq (,$(filter firefly iotlab-a8-m3 zigduino,$(BOARD)))
   # Debugger not supported on these boards
   DEBUGGER =


### PR DESCRIPTION
`makefile.iotlab.single.inc.mk` does not define `flash-recipe`, so it falls back to the default defined in `Makefile.include:832`:

```makefile
define default-flash-recipe
  $(call check_cmd,$(FLASHER),Flash program)
  $(PROGRAMMER_FLASH)
endef
flash-recipe ?= $(default-flash-recipe)
```
This default doesn't reset the board after flashing. As a result, the node does not restart automatically and produces no output until a manual reset is triggered.

This was observed on `b-l072z-lrwan1` nodes at the IoT-LAB Saclay site: `examples/basic/hello-world` produced no serial output after `make flash term` until the node was reset manually.

**Fix:** define an `iotlab-flash-recipe` that appends a reset step after flashing.

### Testing procedure

Tested on `b-l072z-lrwan1` at IoT-LAB Saclay. After flashing, the node now resets automatically and serial output appears immediately without manual intervention.

### Issues/PRs references
_Originally posted in https://github.com/RIOT-OS/RIOT/issues/22271#issuecomment-4421285329_

### Declaration of AI Tools / LLMs usage
- Claude Code for code review and guidance, with user authorship of the implementation