### PR TITLE
rust/cpu: Set value for cortex-m33

### DIFF
--- a/cpu/cortexm_common/Makefile.features
+++ b/cpu/cortexm_common/Makefile.features
@@ -38,7 +38,16 @@ else ifeq ($(CPU_CORE),cortex-m3)
 else ifeq ($(CPU_CORE),cortex-m33)
   CPU_ARCH := armv8m
   FEATURES_PROVIDED += cortexm_stack_limit
-  RUST_TARGET = thumbv8m.main-none-eabihf
+  # Final value to be set in Makefile.include when we know if
+  # USEMODULE=cortexm_fpu is set
+  #
+  # (*Usually* we know ahead of time, so the variable doubles as an indicator
+  # to see that Rust support *is* present. We get away with the trick of using
+  # a dummy value here as long as we can be sure that no matter the chosen
+  # modules, there *will* be a target that we can set. If that changes or this
+  # trick gets needed more often, we might need to reconsider where RUST_TARGET
+  # is set.)
+  RUST_TARGET = to-be-set-later
 else ifeq ($(CPU_CORE),cortex-m4)
   CPU_ARCH := armv7m
   RUST_TARGET = thumbv7em-none-eabi

--- a/cpu/cortexm_common/Makefile.features
+++ b/cpu/cortexm_common/Makefile.features
@@ -38,7 +38,7 @@ else ifeq ($(CPU_CORE),cortex-m3)
 else ifeq ($(CPU_CORE),cortex-m33)
   CPU_ARCH := armv8m
   FEATURES_PROVIDED += cortexm_stack_limit
-  #RUST_TARGET = thumbv8m.main-none-eabi
+  RUST_TARGET = thumbv8m.main-none-eabihf
 else ifeq ($(CPU_CORE),cortex-m4)
   CPU_ARCH := armv7m
   RUST_TARGET = thumbv7em-none-eabi

--- a/cpu/cortexm_common/Makefile.include
+++ b/cpu/cortexm_common/Makefile.include
@@ -1,6 +1,16 @@
 # include module specific includes
 INCLUDES += -I$(RIOTCPU)/cortexm_common/include
 
+ifeq ($(CPU_CORE),cortex-m33)
+  # See Makefile.features where RUST_TARGET is set the first time -- but it is
+  # set to "to-be-set-later". See there for full explanation.
+  ifneq (,$(filter cortexm_fpu,$(USEMODULE)))
+    RUST_TARGET = thumbv8m.main-none-eabihf
+  else
+    RUST_TARGET = thumbv8m.main-none-eabi
+  endif
+endif
+
 # All variables must be defined in the CPU configuration when using the common
 # `ldscripts/cortexm.ld`
 ifneq (,$(ROM_START_ADDR)$(RAM_START_ADDR)$(ROM_LEN)$(RAM_LEN))

--- a/cpu/rp2350_arm/Makefile.features
+++ b/cpu/rp2350_arm/Makefile.features
@@ -5,3 +5,6 @@ CPU_MODEL   = rp2350_cortexm
 
 include $(RIOTCPU)/rp2350_common/Makefile.features
 include $(RIOTCPU)/cortexm_common/Makefile.features
+
+# Explicitly *not* supported, see <https://github.com/RIOT-OS/RIOT/issues/22294>
+FEATURES_PROVIDED := $(filter-out rust_target,$(FEATURES_PROVIDED))


### PR DESCRIPTION
### Contribution description

Updating some Rust tests I needed something to test on, and the nRF5340dk was closed but … oh my, no Rust support?

That was because the target triple (RUST_TARGET = thumbv8m.main-none-eabihf) was not set. More precisely, it was commented out because I mad an assumption originally but had no hardware to test it.

### Testing procedure

* Run any example on nrf5340dk.
* Note that before this, things failed with "There are unsatisfied feature requirements: rust_target", or when run with `CONTINUE_ON_EXPECTED_ERRORS=1`, with "Error: No RUST_TARGET was set for this platform."
* If we just uncommented the old value (no `hf` suffix), the linker complains about inconsistent calling conventions ("uses VFP register arguments, [...] does not").

Note that I didn't have a built-in usable programmer; nrf53 doesn't have openocd support, and JLink is proprietary. I flashed using probe-rs (cf. https://github.com/RIOT-OS/RIOT/pull/21466 but I did it manually here).

### Open questions

Do we have a non-hard-float variant of m33 too? If so, there'd need to be another if/else, but probably then also have a different CPU_CORE value, so I think we just only support M33 with HF (it's optional in the ISA, but are there even any M33 we support that don't have it?).

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
