### PR TITLE
boards/nrf5340dk-app: Map out saul_gpio

### DIFF
--- a/boards/nrf5340dk-app/Makefile.dep
+++ b/boards/nrf5340dk-app/Makefile.dep
@@ -7,3 +7,7 @@ ifneq (,$(filter vfs_default,$(USEMODULE)))
   USEPKG += littlefs2
   USEMODULE += mtd
 endif
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/nrf5340dk-app/include/gpio_params.h
+++ b/boards/nrf5340dk-app/include/gpio_params.h
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Christian Amsüss <chrysn@fsfe.org>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup    boards_nrf5340dk-app
+ * @{
+ *
+ * @file
+ * @brief      Configuration of SAUL mapped GPIO pins
+ *
+ * @author     Christian Amsüss <chrysn@fsfe.org>
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "Button 1",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name  = "Button 2",
+        .pin   = BTN1_PIN,
+        .mode  = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name  = "Button 2",
+        .pin   = BTN2_PIN,
+        .mode  = BTN2_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name  = "Button 4",
+        .pin   = BTN3_PIN,
+        .mode  = BTN3_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name  = "LED1",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED2",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED3",
+        .pin   = LED2_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED4",
+        .pin   = LED3_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */


### PR DESCRIPTION
### Contribution description

All the Nordic DKs have 4 buttons and 4 LEDs, but for the nRF5340 they were not mapped out.

One could set up PWMs to make the LEDs dimmable, but let's not have the better be the enemy of the good, and also, I don't know how to translate Fleißaufgabe.

### Testing procedure

Running the SAUL example:

```
> saul
saul
ID      Class           Name
#0      SENSE_BTN       Button 1
#1      SENSE_BTN       Button 2
#2      SENSE_BTN       Button 2
#3      SENSE_BTN       Button 4
#4      ACT_SWITCH      LED1
#5      ACT_SWITCH      LED2
#6      ACT_SWITCH      LED3
#7      ACT_SWITCH      LED4
> saul read 0
saul read 0
Reading from #0 (Button 1|SENSE_BTN)
Data:                 0 
> saul write 4 1
saul write 4 1
Writing to device #4 - LED1
Data:                 1 
data successfully written to device #4
```

(And to be thorough, I wrote to all the LEDs in sequence to check their maping, and did the read-all for every single pressed button.)

### Issues/PRs references

Based on https://github.com/RIOT-OS/RIOT/pull/22289

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
