### PR TITLE
boards/xg23-pk6068a: remove HFXO_FREQ and LFXO_FREQ

### DIFF
--- a/boards/xg23-pk6068a/doc.md
+++ b/boards/xg23-pk6068a/doc.md
@@ -98,6 +98,23 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | LCD driver                    | LS013B7DH03 | yes       | Sharp Low Power Memory LCD via the U8g2 package                |
 | Temperature + humidity sensor | Si7021      | yes       | Silicon Labs Temperature + Humidity sensor                     |
 
+## Board configuration
+
+### Clock selection
+There are several clock sources that are available for the different
+peripherals. You are advised to read [AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
+to get familiar with the different clocks.
+
+| Source | Internal | Speed      | Comments                           |
+|--------|----------|------------|------------------------------------|
+| HFXO   | No       | 39 MHz     |                                    |
+| LFXO   | No       | 32.768 kHz |                                    |
+
+It is important that the clock speeds are known to the code, for proper
+calculations of speeds and baud rates. If the HFXO or LFXO are different from
+the speeds above, ensure to pass `HFXO_FREQ=freq_in_hz` and
+`LFXO_FREQ=freq_in_hz` to your compiler defines.
+
 ## Flashing the device
 
 To flash, [SEGGER JLink](https://www.segger.com/jlink-software.html) is

--- a/boards/xg23-pk6068a/include/board.h
+++ b/boards/xg23-pk6068a/include/board.h
@@ -36,7 +36,7 @@ extern "C" {
  * @{
  */
 #define CONFIG_ZTIMER_LPTIMER_DEV            TIMER_DEV(1)
-#define CONFIG_ZTIMER_LPTIMER_FREQ           LFXO_FREQ
+#define CONFIG_ZTIMER_LPTIMER_FREQ           (32768UL)
 #define CONFIG_ZTIMER_LPTIMER_WIDTH          24
 #define CONFIG_ZTIMER_LPTIMER_BLOCK_PM_MODE  EFM32_PM_MODE_EM3
 /** @} */

--- a/boards/xg23-pk6068a/include/periph_conf.h
+++ b/boards/xg23-pk6068a/include/periph_conf.h
@@ -28,10 +28,7 @@ extern "C" {
  * @name    Clock configuration
  * @{
  */
-#define HFXO_FREQ           (39000000UL)
 #define CMU_HFXOINIT        CMU_HFXOINIT_DEFAULT
-
-#define LFXO_FREQ           (32768UL)
 #define CMU_LFXOINIT        CMU_LFXOINIT_DEFAULT
 
 static const clk_mux_t clk_mux_config[] = {

--- a/dist/tools/doccheck/exclude_simple
+++ b/dist/tools/doccheck/exclude_simple
@@ -2597,7 +2597,6 @@ warning: Member HDC1000_TRES_MSK (macro definition) of file hdc1000_regs.h is no
 warning: Member HDC1010_PARAM_ADDR (macro definition) of file board.h is not documented.
 warning: Member HDC1010_PARAM_I2C (macro definition) of file board.h is not documented.
 warning: Member HDC1010_PIN_DRDY (macro definition) of file board.h is not documented.
-warning: Member HFXO_FREQ (macro definition) of file periph_conf.h is not documented.
 warning: Member HMC5883L_PARAM_DEV (macro definition) of file hmc5883l_params.h is not documented.
 warning: Member HMC5883L_PARAM_DOR (macro definition) of file hmc5883l_params.h is not documented.
 warning: Member HMC5883L_PARAM_GAIN (macro definition) of file hmc5883l_params.h is not documented.
@@ -3084,7 +3083,6 @@ warning: Member LED_RED_OFF (macro definition) of file board.h is not documented
 warning: Member LED_RED_ON (macro definition) of file board.h is not documented.
 warning: Member LED_RED_PIN (macro definition) of file board.h is not documented.
 warning: Member LED_RED_TOGGLE (macro definition) of file board.h is not documented.
-warning: Member LFXO_FREQ (macro definition) of file periph_conf.h is not documented.
 warning: Member LINEFILL (macro definition) of file ColorTextColors.h is not documented.
 warning: Member LIS2DH12_CLICK_THS_LIR (macro definition) of file lis2dh12_registers.h is not documented.
 warning: Member LIS2DH12_CTRL_REG2_FDS (macro definition) of file lis2dh12_registers.h is not documented.


### PR DESCRIPTION
### Contribution description

Prior to the use of Gecko SDK 4.5, RIOT shipped with patched vendor files, such as `system_xxx.c`. These system files included `periph_config.h`, which allowed one to redefine `HFXO_FREQ` and `LFXO_FREQ`.

This was not intended, and other EFM32-based boards documented this to redefine this using compiler defines. After all, a board configuration is considered to be somewhat pre-defined and static.

With the new Gecko SDK 4.5, this (unintended) feature got lost for the `xg23-pk6068a` board. To bring it in-line with the other boards, remove the defines, and document how it should be used. Do note that, for some reason, Silicon Labs decided not to prefix the aforementioned defines with `EFM32_`.

Within the codebase, `LFXO_FREQ` was used for ztimer configuration. Similar to the other boards, this has been replaced with a static value.

Behind the scenes, the vendor `system_xxx.c` file will still use the same values.

### Testing procedure

The compiler defines are equal to the values used in `system_efr32zg.c`, so there is effectively no change if you don't override these values. See https://github.com/basilfx/RIOT-gecko-sdk/blob/master/dist/platform/Device/SiliconLabs/EFR32ZG23/Source/system_efr32zg23.c.

I do not own this board, so I cannot test if the documented alternative works.

### Issues/PRs references

Regression introduced in #22040
Fixes #22283

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
