### PR TITLE
cpu/rp2350_common/periph/uart: enable RX/TX FIFO and fix related ISR/TX flow

### DIFF
--- a/cpu/rp2350_common/periph/uart.c
+++ b/cpu/rp2350_common/periph/uart.c
@@ -35,8 +35,13 @@ static uint32_t uartcr;
 void _irq_enable(uart_t uart)
 {
     UART0_Type *dev = uart_config[uart].dev;
-    /* We set the UART Receive Interrupt Mask (Bit 4) [See p979 UART 12.1] */
-    dev->UARTIMSC = UART_UARTIMSC_RXIM_BITS;
+    /* Enable RX FIFO-trigger interrupt (RXIM) and RX timeout interrupt
+     * (RTIM). RTIM asserts when the FIFO is non-empty but below the
+     * trigger level for ~32 baud-clocks; without it, the trailing
+     * sub-trigger bytes of a burst sit in the FIFO until enough new
+     * bytes arrive, which never happens at the end of a frame.
+     * See RP2350 datasheet section 12.1.6 Interrupts. */
+    dev->UARTIMSC = UART_UARTIMSC_RXIM_BITS | UART_UARTIMSC_RTIM_BITS;
     /* Enable the IRQ */
     rp_irq_enable(uart_config[uart].irqn);
 }
@@ -83,6 +88,15 @@ int uart_mode(uart_t uart, uart_data_bits_t data_bits, uart_parity_t parity,
      * the initialization code here
      * based on Table 1035 page 976 */
     dev->UARTLCR_H = (uint32_t)data_bits << 5;
+
+    /* Enable RX/TX FIFOs (FEN bit in UARTLCR_H). With FIFOs disabled,
+     * the UART operates in character mode and has only a 1-byte
+     * receive holding register, so any RX ISR latency above one byte
+     * time (~87 us at 115200 baud) overruns and drops a byte. With
+     * FIFOs enabled, RX gets a 32-byte buffer. See RP2350 datasheet
+     * section 12.1.3 Operation (FIFO vs. character mode) and section
+     * 12.1.8 UARTLCR_H. */
+    atomic_set(&dev->UARTLCR_H, UART_UARTLCR_H_FEN_BITS);
 
     if (stop_bits == UART_STOP_BITS_2) {
         atomic_set(&dev->UARTLCR_H, UART0_UARTLCR_H_STP2_Msk);
@@ -171,7 +185,12 @@ int uart_init(uart_t uart, uint32_t baud, uart_rx_cb_t rx_cb, void *arg)
         /* clear any pending data and IRQ to avoid receiving a garbage char */
         uint32_t status = dev->UARTRIS;
         dev->UARTICR = status;
-        (void)dev->UARTDR;
+        /* Drain the entire RX FIFO (with FEN on, it can hold up to 32
+         * bytes; the previous single-byte drain was sufficient only in
+         * character mode). */
+        while (!(dev->UARTFR & UART_UARTFR_RXFE_BITS)) {
+            (void)dev->UARTDR;
+        }
         atomic_set(&dev->UARTCR, UART_UARTCR_RXE_BITS);
     }
 
@@ -183,11 +202,15 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
     assert((unsigned)uart < UART_NUMOF);
     UART0_Type *dev = uart_config[uart].dev;
 
+    /* For each byte: wait while TX FIFO is full, then write to UARTDR.
+     * After the last byte: wait for UARTFR.BUSY to clear so the caller
+     * can rely on "all bytes have left the wire" once uart_write
+     * returns. See RP2350 datasheet section 12.1.8 UARTFR. */
     for (size_t i = 0; i < len; i++) {
+        while (dev->UARTFR & UART_UARTFR_TXFF_BITS) { }
         dev->UARTDR = data[i];
-        /* Wait until the TX FIFO is empty before sending the next byte */
-        while (!(dev->UARTRIS & UART0_UARTRIS_TXRIS_Msk)) { }
     }
+    while (dev->UARTFR & UART_UARTFR_BUSY_BITS) { }
 }
 
 void uart_poweron(uart_t uart)
@@ -234,6 +257,13 @@ void uart_poweroff(uart_t uart)
     _reset_uart(uart);
 }
 
+/* Counter for hardware-flagged RX errors (parity/break/framing).
+ * Bounded-time replacement for the previous puts() in the ISR error
+ * path. The faulty byte is still passed to rx_cb so the protocol
+ * layer can decide what to do; bit-level corruption is recoverable
+ * there, whereas byte loss is not. */
+volatile uint32_t rp2350_uart_rx_error_count;
+
 void isr_handler(uint8_t num)
 {
     UART0_Type *dev = uart_config[num].dev;
@@ -241,12 +271,15 @@ void isr_handler(uint8_t num)
     uint32_t status = dev->UARTMIS;
     atomic_set(&dev->UARTICR, status);
 
-    if (status & UART_UARTMIS_RXMIS_BITS) {
-        uint32_t data = dev->UARTDR;
-        if (data & (UART0_UARTDR_BE_Msk | UART0_UARTDR_PE_Msk | UART0_UARTDR_FE_Msk)) {
-            puts("[rpx0xx] uart RX error (parity, break, or framing error");
-        }
-        else {
+    /* Drain the entire RX FIFO on each fire. Handles both RXMIS
+     * (FIFO trigger reached) and RTMIS (sub-trigger bytes have been
+     * sitting for ~32 baud-clocks). UARTFR.RXFE = "RX FIFO empty". */
+    if (status & (UART_UARTMIS_RXMIS_BITS | UART_UARTMIS_RTMIS_BITS)) {
+        while (!(dev->UARTFR & UART_UARTFR_RXFE_BITS)) {
+            uint32_t data = dev->UARTDR;
+            if (data & (UART0_UARTDR_BE_Msk | UART0_UARTDR_PE_Msk | UART0_UARTDR_FE_Msk)) {
+                rp2350_uart_rx_error_count++;
+            }
             ctx[num].rx_cb(ctx[num].arg, (uint8_t)data);
         }
     }

--- a/tests/cpu/rp2350_uart_fifo/Makefile
+++ b/tests/cpu/rp2350_uart_fifo/Makefile
@@ -1,0 +1,21 @@
+BOARD ?= rpi-pico-2-arm
+
+# The test pokes RP2350-specific registers and the rp2350_common
+# UART driver directly. Limit to boards that use the rp2350_common BSP.
+BOARDS_SUPPORTED := rpi-pico-2-arm rpi-pico-2-riscv
+
+# This test stresses the UART RX FIFO under sustained 115200-baud
+# traffic; even small debug prints from the interrupt path add ISR
+# latency that overruns the FIFO and confounds the result. Opt out
+# of DEVELHELP so the RISC-V port's per-trap debug prints (under
+# #ifdef DEVELHELP in cpu/riscv_common/irq_arch.c and xh3irq.c) and
+# similar diagnostics elsewhere are compiled out. Set here BEFORE
+# the include of Makefile.cpu_common so it wins against the
+# tests/Makefile.tests_common default of DEVELHELP ?= 1.
+DEVELHELP ?= 0
+
+include ../Makefile.cpu_common
+
+USEMODULE += periph_uart
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/cpu/rp2350_uart_fifo/Makefile
+++ b/tests/cpu/rp2350_uart_fifo/Makefile
@@ -1,7 +1,8 @@
 BOARD ?= rpi-pico-2-arm
 
 # The test pokes RP2350-specific registers and the rp2350_common
-# UART driver directly. Limit to boards that use the rp2350_common BSP.
+# UART driver directly via an external GP8-GP9 jumper. Limit to
+# boards that use the rp2350_common BSP.
 BOARDS_SUPPORTED := rpi-pico-2-arm rpi-pico-2-riscv
 
 # This test stresses the UART RX FIFO under sustained 115200-baud

--- a/tests/cpu/rp2350_uart_fifo/main.c
+++ b/tests/cpu/rp2350_uart_fifo/main.c
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Mert Cakir <mert-cakir@outlook.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief   RP2350 UART FIFO / ISR drain self-test (internal loopback).
+ *
+ * Sends a 64-byte burst on UART_DEV(1) at 115200 baud and verifies all
+ * 64 bytes come back via the RX callback. Uses the UART internal
+ * loopback path so the test does not depend on external GP8/GP9
+ * wiring or the board console bridge.
+ *
+ * Without the RX FIFO enabled (FEN), the 1-byte holding register
+ * cannot absorb a 64-byte burst at 115200 baud; bytes get dropped.
+ * With the FIFO + full ISR drain in cpu/rp2350_common/periph/uart,
+ * all 64 bytes are buffered and delivered to the rx_cb.
+ *
+ * @author  Mert Cakir <mert-cakir@outlook.com>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "periph/uart.h"
+#include "periph_conf.h"
+#include "regs/uart.h"
+
+#define TEST_UART       UART_DEV(1)
+#define TEST_UART_IDX   1
+#define TEST_BAUD       115200
+#define BURST_SIZE      64
+
+static volatile size_t rx_count;
+static uint8_t rx_buf[BURST_SIZE];
+
+static void rx_cb(void *arg, uint8_t byte)
+{
+    (void)arg;
+    if (rx_count < sizeof(rx_buf)) {
+        rx_buf[rx_count++] = byte;
+    }
+}
+
+int main(void)
+{
+    puts("rp2350 uart fifo loopback test");
+
+    if (uart_init(TEST_UART, TEST_BAUD, rx_cb, NULL) != UART_OK) {
+        puts("FAIL: uart_init");
+        return 1;
+    }
+
+    /* Drain any residual RX FIFO data (defensive; uart_init's drain
+     * should already have done this with the updated driver). */
+    UART0_Type *dev = uart_config[TEST_UART_IDX].dev;
+    while (!(dev->UARTFR & UART_UARTFR_RXFE_BITS)) {
+        (void)dev->UARTDR;
+    }
+    dev->UARTCR |= UART_UARTCR_LBE_BITS;
+
+    uint8_t tx_buf[BURST_SIZE];
+    for (size_t i = 0; i < BURST_SIZE; i++) {
+        tx_buf[i] = (uint8_t)(i ^ 0x5a);
+    }
+
+    rx_count = 0;
+    uart_write(TEST_UART, tx_buf, BURST_SIZE);
+
+    /* Give the ISR time to drain the last bytes from the RX FIFO. The
+     * 64-byte transfer itself takes about 5.5 ms at 115200 baud. */
+    for (volatile uint32_t i = 0; i < 200000; i++) { }
+
+    if (rx_count != BURST_SIZE) {
+        printf("FAIL: expected %u bytes, got %u\n",
+               (unsigned)BURST_SIZE, (unsigned)rx_count);
+        return 1;
+    }
+
+    if (memcmp(tx_buf, rx_buf, BURST_SIZE) != 0) {
+        puts("FAIL: byte mismatch");
+        return 1;
+    }
+
+    printf("PASS: %u bytes round-tripped via external loopback\n",
+           (unsigned)BURST_SIZE);
+    puts("ALL TESTS PASSED");
+    return 0;
+}

--- a/tests/cpu/rp2350_uart_fifo/main.c
+++ b/tests/cpu/rp2350_uart_fifo/main.c
@@ -8,12 +8,12 @@
  * @{
  *
  * @file
- * @brief   RP2350 UART FIFO / ISR drain self-test (internal loopback).
+ * @brief   RP2350 UART FIFO / ISR drain self-test (external loopback).
  *
  * Sends a 64-byte burst on UART_DEV(1) at 115200 baud and verifies all
- * 64 bytes come back via the RX callback. Uses the UART internal
- * loopback path so the test does not depend on external GP8/GP9
- * wiring or the board console bridge.
+ * 64 bytes come back via the RX callback. Requires a physical jumper
+ * connecting the test UART's TX pin to its own RX pin on the same
+ * board (GP8 <-> GP9 on rpi-pico-2-*).
  *
  * Without the RX FIFO enabled (FEN), the 1-byte holding register
  * cannot absorb a 64-byte burst at 115200 baud; bytes get dropped.
@@ -64,7 +64,6 @@ int main(void)
     while (!(dev->UARTFR & UART_UARTFR_RXFE_BITS)) {
         (void)dev->UARTDR;
     }
-    dev->UARTCR |= UART_UARTCR_LBE_BITS;
 
     uint8_t tx_buf[BURST_SIZE];
     for (size_t i = 0; i < BURST_SIZE; i++) {
@@ -85,7 +84,7 @@ int main(void)
     }
 
     if (memcmp(tx_buf, rx_buf, BURST_SIZE) != 0) {
-        puts("FAIL: byte mismatch");
+        puts("FAIL: byte mismatch (check the GP8-GP9 jumper)");
         return 1;
     }
 

--- a/tests/cpu/rp2350_uart_fifo/tests/01-run.py
+++ b/tests/cpu/rp2350_uart_fifo/tests/01-run.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+#
+# SPDX-FileCopyrightText: 2026 Mert Cakir <mert-cakir@outlook.com>
+# SPDX-License-Identifier: LGPL-2.1-only
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact("rp2350 uart fifo loopback test")
+    child.expect_exact("PASS: 64 bytes round-tripped via external loopback")
+    child.expect_exact("ALL TESTS PASSED")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc, timeout=15))


### PR DESCRIPTION
## Contribution description

This change fixes the RP2350 UART driver in
`cpu/rp2350_common/periph/uart.c`. The current driver leaves the UART
in character mode, with the FIFO disabled. In that mode the receiver
has only a 1-byte holding register, so any time the RX path takes
longer than one byte time (about 87 microseconds at 115200 baud) the
next byte overwrites the previous one and is lost. This is the root
cause; everything else in the diff follows from enabling the FIFO.

**Enable the RX and TX FIFOs.** Setting FEN in `UARTLCR_H` switches
the UART from character mode to FIFO mode, giving RX a 32-byte
buffer instead of one byte (RP2350 datasheet section 12.1.3).

**Add the RX timeout interrupt.** With FIFO mode, the RX interrupt
fires when the FIFO crosses its trigger level (about 4 bytes). The
trailing bytes of a burst that don't reach trigger level need to come
out somehow; RTIM in `UARTIMSC` raises an interrupt when the FIFO
holds data for about 32 baud-clocks. Without RTIM, the last few bytes
of a frame can sit in the FIFO indefinitely (section 12.1.6).

**Drain the whole FIFO inside the ISR.** The previous ISR read one
byte per fire. With a 32-byte FIFO and a fast sender, the handler now
loops while `UARTFR.RXFE` is clear so it consumes every byte that has
arrived.

**Rewrite the TX polling loop.** The previous code polled
`UARTRIS.TXRIS`. In FIFO mode that bit is an edge condition meaning
"FIFO crossed the trigger threshold downward", which may never happen
for short writes and can hang the loop. The new loop uses two level
conditions from `UARTFR`: wait while `TXFF` is set for each byte
(don't write into a full FIFO), then wait for `BUSY` to clear after
the last byte (so the function returns only when the bytes have left
the wire). These work in both FIFO and character mode (section
12.1.8).

**Replace `puts()` in the ISR error path with a counter.** When the
UART flags a parity, framing, or break error in `UARTDR`, the
previous code called `puts()` from inside the ISR. At 115200 baud the
old 56-byte string takes about 5 ms to send. An ISR that stalls for
5 ms misses tens of subsequent bytes. This change is preventive
rather than a fix for an observed bug, but the structural problem is
unavoidable: ISR time has to stay bounded. The replacement is a
`volatile uint32_t rp2350_uart_rx_error_count` symbol that
applications can read for diagnostics, and the faulty byte is still
passed to the `rx_cb` so framing alignment is preserved (bit-level
corruption is recoverable at the protocol layer; byte loss desyncs
framing and is much harder to recover from).

Inline comments in the diff carry the same datasheet references
(sections 12.1.3, 12.1.6, 12.1.8). No public API change. The new
counter symbol is the only addition outside the existing API.

The PR also adds `tests/cpu/rp2350_uart_fifo` - a small testrunner
test that exercises the FIFO + ISR paths via external loopback.
The test sends a 64-byte burst on UART1 and verifies all 64 bytes
come back through the rx_cb path. Requires a physical jumper from
GP8 (UART1 TX) to GP9 (UART1 RX) on the same board, matching the
convention used by `tests/periph/uart`. Without the FIFO enabled,
the 1-byte RX holding register cannot absorb a 64-byte burst at
115200 baud; bytes drop and the test fails. With the fix it passes.

## Testing procedure

The PR ships an automated test in `tests/cpu/rp2350_uart_fifo`. To
run it, place a physical jumper from GP8 (UART1 TX) to GP9 (UART1
RX) on a Pi Pico 2 H, then:

```
BOARD=rpi-pico-2-arm make -C tests/cpu/rp2350_uart_fifo flash test
```

The test sends a 64-byte burst via `uart_write` and verifies that
all 64 bytes come back through the rx_cb. Expected output:

```
rp2350 uart fifo loopback test
PASS: 64 bytes round-tripped via external loopback
ALL TESTS PASSED
```

Why this exercises the fix: without the RX FIFO enabled, a 64-byte
burst into the 1-byte holding register at 115200 baud cannot all be
captured. Bytes drop. With the FIFO and the full ISR drain in this
PR, all 64 bytes are buffered and delivered.

Verified on a Pi Pico 2 H (RP2350) for both rpi-pico-2-arm and
rpi-pico-2-riscv. The driver lives in shared `cpu/rp2350_common`
code so the fix applies identically to either architecture; the
test's Makefile sets `DEVELHELP ?= 0` to keep the RISC-V port's
per-trap debug prints (which would otherwise add ISR latency at
115200 baud and confound the stress test) out of the build.

The driver was additionally exercised under sustained real-world
load on Pico 2 H during firmware development before this PR was
opened.

## Issues/PRs references

Re-submission of the UART FIFO fix from the now-closed #22269,
self-authored per the note on that PR.

## Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- Claude Code (Anthropic). Used as a reference and accelerator;
  hardware-tested and committed by me.