### PR TITLE
guides: Remove $ from code blocks and replace `console` with `shell`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ It is possible to check if your code follows these conventions:
 
 * You can [uncrustify] `.c` and `.h` files:
 
-  ```console
+  ```shell
   uncrustify -c $RIOTBASE/uncrustify-riot.cfg --no-backup <your file>
   ```
 
@@ -122,7 +122,7 @@ It is possible to check if your code follows these conventions:
   *Watch out:* the command below will rebase your branch on your master branch,
   so make sure they can be rebased (e.g. there's no potential conflict).
 
-  ```console
+  ```shell
   make static-test
   ```
 
@@ -136,7 +136,7 @@ It is possible to check if your code follows these conventions:
 * Each commit should target changes of specific parts/modules of RIOT. The
   commits use the following pattern:
 
-  ```
+  ```text
   area of code: description of changes
   ```
 
@@ -144,7 +144,7 @@ It is possible to check if your code follows these conventions:
   changes.
   For example:
 
-  ```
+  ```text
   periph/timer: Document that set_absolute is expected to wrap
 
   Most timers are implemented this way already, and keeping (documenting)
@@ -223,7 +223,7 @@ General documentation pages are written in Markdown and located in
 To generate the documentation, simply run the following
 from the base directory of the RIOT source code.
 
-```console
+```shell
 make doc
 ```
 
@@ -250,7 +250,7 @@ from the [RIOT main GitHub page][riot-github].
 
 If it's your first time with git, configure your name and emails:
 
-```console
+```shell
 git config --global user.name = "<your name here>"
 git config --global user.email = "<your email address here>"
 ```
@@ -258,14 +258,14 @@ git config --global user.email = "<your email address here>"
 Then clone locally your fork of RIOT (replace `account name` with your actual
 login on GitHub):
 
-```console
+```shell
 git clone git@github.com:<account name>/RIOT.git
 ```
 
 You can keep any branch of your local repository up-to-date with the upstream
 master branch with the following commands:
 
-```console
+```shell
 git checkout <branch name>
 git pull --rebase https://github.com/RIOT-OS/RIOT.git
 ```
@@ -281,7 +281,7 @@ Avoid opening a PR from the `master` branch of your fork to the master branch of
 the RIOT upstream repository: update your master branch and start a new branch
 from it.
 
-```console
+```shell
 git checkout master
 git pull --rebase https://github.com/RIOT-OS/RIOT.git
 git checkout -b <new branch>
@@ -290,7 +290,7 @@ git checkout -b <new branch>
 You can then do your changes, commit them and push them to your local repository
 by using the following command:
 
-```console
+```shell
 git push origin <your branch>
 ```
 
@@ -305,7 +305,7 @@ Let's say your PR contains 3 commits with comments: `prefix1: change 1`,
 Instead of committing changes in `prefix2` in a 4th commit `prefix2: change 4`,
 you can use the `--fixup` option:
 
-```console
+```shell
 git add /path/of/prefix2
 git commit --fixup <prefix2 commit hash>
 ```
@@ -344,7 +344,7 @@ reorder and squash the commits here.
 If you used [fixup commits](#add-fixup-commits-during-review) during the review
 phase, squashing commits can be performed in a single command:
 
-```console
+```shell
 git rebase -i --autosquash <last master hash>
 ```
 
@@ -354,14 +354,14 @@ or IDE.
 
 After the merge conflict is resolved you can continue the rebase by using
 
-```console
+```shell
 git rebase --continue
 ```
 
 Once squashing is done, you will have to force push your branch to update the
 PR:
 
-```console
+```shell
 git push origin <your branch> --force-with-lease
 ```
 
@@ -389,7 +389,7 @@ previous section.
 You then have to force push your updated branch to the remote repository by
 using the following command:
 
-```console
+```shell
 git push origin <your branch> --force-with-lease
 ```
 

--- a/doc/guides/advanced_tutorials/porting_boards.mdx
+++ b/doc/guides/advanced_tutorials/porting_boards.mdx
@@ -283,7 +283,7 @@ functions. This offset can be compensated for.
 It can be measured by running `tests/sys/ztimer_overhead` on your board, i.e:
 
 ```bash
-$ BOARD=my-new-board make -C tests/sys/ztimer_overhead flash term
+BOARD=my-new-board make -C tests/sys/ztimer_overhead flash term
 ```
 
 This should give the following output:

--- a/doc/guides/build-system/advanced_build_system_tricks.md
+++ b/doc/guides/build-system/advanced_build_system_tricks.md
@@ -121,6 +121,7 @@ recommended and easiest to use [**rustup**, installed as described
 on its project website].
 
 You can then proceed to install `git-cache-rs` by executing
+
 ```sh
 cargo install git-cache
 ```
@@ -174,16 +175,19 @@ all the boards compiled in the `NEWBIN` and `OLDBIN` and compare them.
 For boards that do not have a complementary partner, a warning is generated.
 You can use it like that:
 
-```sh
-$ cd RIOT/test/test_something
+```shell
+cd RIOT/test/test_something
 
-$ git checkout master
-$ BINDIRBASE=master-bin BOARD=native64 make all
+git checkout master
+BINDIRBASE=master-bin BOARD=native64 make all
 
-$ git checkout my-branch
-$ BINDIRBASE=my-branch-bin BOARD=native64 make all
+git checkout my-branch
+BINDIRBASE=my-branch-bin BOARD=native64 make all
 
-$ OLDBIN=master-bin NEWBIN=my-branch-bin make info-buildsizes-diff
+OLDBIN=master-bin NEWBIN=my-branch-bin make info-buildsizes-diff
+```
+
+```text
 text    data    bss     dec     BOARD/BINDIRBASE
 
 0       0       0       0       native64    **← this line contains the diff**

--- a/doc/guides/build-system/build-in-docker.md
+++ b/doc/guides/build-system/build-in-docker.md
@@ -8,20 +8,20 @@ which comes with the necessary compilers and toolchains and is fully managed by
 the build system. It can be enabled by passing `BUILD_IN_DOCKER=1` to make.
 
 ```shell
-$ BUILD_IN_DOCKER=1 make
+BUILD_IN_DOCKER=1 make
 ```
 
 If your user does not have permissions to access the Docker daemon:
 
 ```shell
-$ BUILD_IN_DOCKER=1 DOCKER="sudo docker" make
+BUILD_IN_DOCKER=1 DOCKER="sudo docker" make
 ```
 
 To always use Docker for building, set `BUILD_IN_DOCKER=1` (and if necessary
 `DOCKER="sudo docker"`) in the environment:
 
-```console
-$ export BUILD_IN_DOCKER=1
+```shell
+export BUILD_IN_DOCKER=1
 ```
 
 The used Docker image defaults to a pinned version of [riot/riotbuild] for a
@@ -29,7 +29,7 @@ given commit in the RIOT repository. It can be overwritten via the environment
 variable `DOCKER_IMAGE`, for example:
 
 ```shell
-$ BUILD_IN_DOCKER=1 DOCKER_IMAGE="local/tinybuild-native64:latest" make
+BUILD_IN_DOCKER=1 DOCKER_IMAGE="local/tinybuild-native64:latest" make
 ```
 
 ## Targets run in Docker: DOCKER_MAKECMDGOALS_POSSIBLE

--- a/doc/guides/build-system/flashing.md
+++ b/doc/guides/build-system/flashing.md
@@ -264,8 +264,8 @@ DEBUG_ADAPTER_ID = $(\
 - You can now add `makefile.pre` to `RIOT_MAKEFILES_GLOBAL_PRE` as an environment
   variable or on each `make` call:
 
-```sh
-$ RIOT_MAKEFILES_GLOBAL_PRE=/path/to/makefile.pre make -C examples/basic/hello-world flash term
+```shell
+RIOT_MAKEFILES_GLOBAL_PRE=/path/to/makefile.pre make -C examples/basic/hello-world flash term
 ```
 
 :::note
@@ -388,10 +388,13 @@ endif
 
 The array of board serial numbers has to be edited to match your local boards.
 The serial numbers used here is the USB device serial number as reported by
-the debugger hardware. With the `make list-ttys` it is reported as the 'serial':
+the debugger hardware. With the `make list-ttys` it is reported as the `serial`:
 
-```sh
-$ make list-ttys
+```shell
+make list-ttys
+```
+
+```text
 path         | driver  | vendor                   | model                                | model_db              | serial                   | ctime
 -------------|---------|--------------------------|--------------------------------------|-----------------------|--------------------------|---------
 /dev/ttyUSB0 | cp210x  | Silicon Labs             | CP2102 USB to UART Bridge Controller | CP210x UART Bridge    | 0001                     | 15:58:13

--- a/doc/guides/misc/emulators.md
+++ b/doc/guides/misc/emulators.md
@@ -23,10 +23,10 @@ The boards with emulator supported can be listed using the
 `info-emulated-boards` target:
 
 ```shell
-$ make info-emulated-boards
+make info-emulated-boards
 ```
 
-### Features
+## Features
 
 Be aware that not all hardware features provided by a board - and described as
 such in the build system by `FEATURES_PROVIDED` - are implemented in emulators.
@@ -35,7 +35,7 @@ implemented by the renode driver.
 So you may expect some failures when running advanced applications on the
 emulator.
 
-### Usage
+## Usage
 
 All emulators can be used the same way. Just add `EMULATE=1` to the command
 line.
@@ -43,19 +43,19 @@ line.
 To start an emulator and connect to the serial port of the emulated board, run:
 
 ```shell
-$ EMULATE=1 make BOARD=<board> -C <application directory> all term
+EMULATE=1 make BOARD=<board> -C <application directory> all term
 ```
 
 To start an emulator with a GDB server and connect a GDB client to it, run:
 
 ```shell
-$ EMULATE=1 make BOARD=<board> -C <application directory> all debug
+EMULATE=1 make BOARD=<board> -C <application directory> all debug
 ```
 
 To start an automatic test script with the emulated board, run:
 
 ```shell
-$ EMULATE=1 make BOARD=<board> -C <test application directory> all test
+EMULATE=1 make BOARD=<board> -C <test application directory> all test
 ```
 
 The `EMULATOR_SERIAL_PORT` variable can be used to specify a custom serial port


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

The `console` prefix for code blocks does not get syntax highlighted in starlight. We shall use `shell` instead.
Also remove $ characters from shell code blocks because they get copied when using the copy button, which is annoying.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- none
