### PR TITLE
sys/test_utils/netdev_eth_minimal: guard data_len

### DIFF
--- a/sys/test_utils/netdev_eth_minimal/netdev_eth_minimal.c
+++ b/sys/test_utils/netdev_eth_minimal/netdev_eth_minimal.c
@@ -44,11 +44,17 @@ void _recv(netdev_t *dev)
     ethernet_hdr_t *header = (ethernet_hdr_t *)_buffer;
     uint8_t *payload = _buffer + sizeof(ethernet_hdr_t);
 
-    putchar('\n');
     data_len = dev->driver->recv(dev, _buffer, sizeof(_buffer), &rx_info);
     if (data_len < 0) {
+        printf("Receive error: %" PRIdSIZE "\n", data_len);
         return;
     }
+    if ((size_t)data_len < sizeof(ethernet_hdr_t)) {
+        printf("Frame too small: %" PRIdSIZE "bytes\n", data_len);
+        return;
+    }
+
+    putchar('\n');
 
     l2util_addr_to_str(header->dst, ETHERNET_ADDR_LEN, _addr_str);
     printf("Dest. addr.: %s\n", _addr_str);


### PR DESCRIPTION
### Contribution description

When an invalid ethernet frame is received, `data_len` could become negative after `sizeof(ethernet_hdr_t)` gets subtracted. This can lead to issues where `od_hex_dump(..)` reads out of bounds due to `data_len` wrapping around.

Also moved the `putchar(..)` down and added `printf(..)` on error cases. This helps with testing.

### Testing procedure

This module is used by a few ethernet driver tests. I found it as a result of a bug in my ethernet driver, so it will be hard to test :-)

Anyways, here are some console dumps that shows the minor `putchar(..)` improvement.

Before:

```
main(): This is RIOT! (Version: 2026.07-devel-205-g7f3c2-feature/lpc1768_eth)
Test application for LPC1768 ethernet peripheral
[eth-netdev] lpc1768_eth_netdev_setup: registering netdev
Device 0 registered (type: 33)
[eth-netdev] _init: netdev init
Initialization successful - starting the shell now
>



[eth-netdev] _isr: link up
```

After:

```
main(): This is RIOT! (Version: 2026.07-devel-205-g7f3c2-feature/lpc1768_eth)
Test application for LPC1768 ethernet peripheral
[eth-netdev] lpc1768_eth_netdev_setup: registering netdev
Device 0 registered (type: 33)
[eth-netdev] _init: netdev init
Initialization successful - starting the shell now
> Receive error: -1
Receive error: -1
Receive error: -1
Receive error: -1
[eth-netdev] _isr: link up
```

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
