### PR TITLE
drivers/ads1x1x: fix UB assert on uninitialized `dev` in init

### DIFF
--- a/drivers/ads1x1x/ads1x1x.c
+++ b/drivers/ads1x1x/ads1x1x.c
@@ -210,7 +210,7 @@ static int _ads1x1x_init_test(i2c_t i2c, uint8_t addr)
 int ads1x1x_init(ads1x1x_t *dev, const ads1x1x_params_t *params)
 {
     assert(dev && params);
-    assert(dev->params.bits_res > ADS1X1X_BITS_RES_UNDEF && params->dr != ADS1X1X_DATAR_UNDEF);
+    assert(params->bits_res > ADS1X1X_BITS_RES_UNDEF && params->dr != ADS1X1X_DATAR_UNDEF);
 
     DEBUG("[ads1x1x] init - i2c=%d, addr=0x%02x\n", params->i2c, params->addr);
 


### PR DESCRIPTION
In `ads1x1x_init()`, the assert checking `bits_res` and `dr` was reading
from `dev->params` instead of the `params` argument. Since `dev` is
uninitialized at that point, this is undefined behavior.

#### Fix
Check `params->bits_res` and `params->dr` instead of `dev->params.*`.

### Testing procedure
None (I think we don't need any specific tests for that)

### Issues/PRs references
None

### Declaration of AI Tools / LLMs usage
- none