### PR TITLE
sys/net/gnrc: minor clean-ups init_devs

### DIFF
--- a/sys/net/gnrc/netif/init_devs/auto_init_at86rf215.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_at86rf215.c
@@ -7,7 +7,7 @@
  *
  */
 
-/*
+/**
  * @ingroup sys_auto_init_gnrc_netif
  * @{
  *

--- a/sys/net/gnrc/netif/init_devs/auto_init_at86rf2xx.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_at86rf2xx.c
@@ -7,7 +7,7 @@
  *
  */
 
-/*
+/**
  * @ingroup sys_auto_init_gnrc_netif
  * @{
  *

--- a/sys/net/gnrc/netif/init_devs/auto_init_atwinc15x0.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_atwinc15x0.c
@@ -17,8 +17,6 @@
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 
-#ifdef MODULE_ATWINC15X0
-
 #include "log.h"
 #include "atwinc15x0.h"
 #include "atwinc15x0_params.h"
@@ -67,8 +65,4 @@ void auto_init_atwinc15x0(void)
                                    &dev[i].netdev);
     }
 }
-
-#else
-typedef int dont_be_pedantic;
-#endif /* MODULE_ATWINC15X0 */
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_cc2420.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_cc2420.c
@@ -8,7 +8,7 @@
  *
  */
 
-/*
+/**
  * @ingroup     sys_auto_init_gnrc_netif
  * @{
  *

--- a/sys/net/gnrc/netif/init_devs/auto_init_cc2538_rf.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_cc2538_rf.c
@@ -7,7 +7,7 @@
  *
  */
 
-/*
+/**
  * @ingroup sys_auto_init_gnrc_netif
  * @{
  *

--- a/sys/net/gnrc/netif/init_devs/auto_init_esp_ieee802154.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_esp_ieee802154.c
@@ -7,7 +7,7 @@
  *
  */
 
-/*
+/**
  * @ingroup sys_auto_init_gnrc_netif
  * @{
  *

--- a/sys/net/gnrc/netif/init_devs/auto_init_kw2xrf.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_kw2xrf.c
@@ -8,7 +8,7 @@
  *
  */
 
-/*
+/**
  * @ingroup sys_auto_init_gnrc_netif
  * @{
  *

--- a/sys/net/gnrc/netif/init_devs/auto_init_mrf24j40.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_mrf24j40.c
@@ -7,7 +7,7 @@
  *
  */
 
-/*
+/**
  * @ingroup sys_auto_init_gnrc_netif
  * @{
  *

--- a/sys/net/gnrc/netif/init_devs/auto_init_mrf24j40.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_mrf24j40.c
@@ -54,8 +54,8 @@ void auto_init_mrf24j40(void)
 
         /* Init Bottom Half Processor (with events module) and radio */
         bhp_event_init(&mrf24j40_bhp[i], &_netif[i].evq[GNRC_NETIF_EVQ_INDEX_PRIO_HIGH], &mrf24j40_radio_irq_handler, &mrf24j40_netdev[i].submac.dev);
-        mrf24j40_init(&mrf24j40_devs[i], (mrf24j40_params_t*) p,&mrf24j40_netdev[i].submac.dev,
-                        bhp_event_isr_cb, &mrf24j40_bhp[i]);
+        mrf24j40_init(&mrf24j40_devs[i], (mrf24j40_params_t*) p, &mrf24j40_netdev[i].submac.dev,
+                      bhp_event_isr_cb, &mrf24j40_bhp[i]);
 
         netdev_register(&mrf24j40_netdev[i].dev.netdev, NETDEV_MRF24J40, i);
         netdev_ieee802154_submac_init(&mrf24j40_netdev[i]);

--- a/sys/net/gnrc/netif/init_devs/auto_init_nrf24l01p_ng.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_nrf24l01p_ng.c
@@ -16,7 +16,6 @@
  *
  * @author      Fabian Hüßler <fabian.huessler@ovgu.de>
  */
-#ifdef MODULE_NRF24L01P_NG
 
 #include "nrf24l01p_ng.h"
 #include "nrf24l01p_ng_params.h"
@@ -82,8 +81,4 @@ void auto_init_nrf24l01p_ng(void)
                                        &_nrf24l01p_ng_devs[i].netdev);
     }
 }
-
-#else
-typedef int dont_be_pedantic;
-#endif /* MODULE_NRF24L01P_NG */
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_nrf802154.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_nrf802154.c
@@ -7,7 +7,7 @@
  *
  */
 
-/*
+/**
  * @ingroup sys_auto_init_gnrc_netif
  * @{
  *

--- a/sys/net/gnrc/netif/init_devs/auto_init_sam0_eth.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_sam0_eth.c
@@ -15,8 +15,6 @@
  * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
  */
 
-#ifdef MODULE_SAM0_ETH
-
 #include "net/gnrc/netif/ethernet.h"
 #include "sam0_eth_netdev.h"
 #include "include/init_devs.h"
@@ -33,8 +31,4 @@ void auto_init_sam0_eth(void)
     gnrc_netif_ethernet_create(&_netif, stack, GNRC_NETIF_STACKSIZE_DEFAULT,
                                GNRC_NETIF_PRIO, "sam0_eth", &sam0eth);
 }
-
-#else
-typedef int dont_be_pedantic;
-#endif /* MODULE_SAM0_ETH */
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_stm32_eth.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_stm32_eth.c
@@ -1,8 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: 2019 Robin Lösch
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 /**
  * @ingroup     sys_auto_init_gnrc_netif
  * @{
  *
- * @brief       Auto initzialize stm32 ethernet driver
+ * @brief       Auto initialize STM32 ethernet driver
  *
  * @author      Robin Lösch <robin@chilio.net>
  */
@@ -17,10 +22,10 @@ static gnrc_netif_t _netif;
 
 void auto_init_stm32_eth(void)
 {
-  /* setup netdev device */
-  stm32_eth_netdev_setup(&stm32eth);
-        /* initialize netdev <-> gnrc adapter state */
-  gnrc_netif_ethernet_create(&_netif, stack, GNRC_NETIF_STACKSIZE_DEFAULT, GNRC_NETIF_PRIO, "stm32_eth",
-                             &stm32eth);
+    /* setup netdev device */
+    stm32_eth_netdev_setup(&stm32eth);
+    /* initialize netdev <-> gnrc adapter state */
+    gnrc_netif_ethernet_create(&_netif, stack, GNRC_NETIF_STACKSIZE_DEFAULT, GNRC_NETIF_PRIO,
+                               "stm32_eth", &stm32eth);
 }
 /** @} */


### PR DESCRIPTION
### Contribution description

Minor cleanups for the init_devs in `sys/net/gnrc`:

- Fix doxygen blocks
- Add missing copyright header
- Fix indentation
- Remove unnecessary module guards

Found them while adding new drivers.

### Testing procedure

Builds should pass.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
