### PR TITLE
make: riot version code typo

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -550,7 +550,7 @@ ifneq (,$(RIOT_VERSION_OVERRIDE))
 endif
 
 # Generate machine readable RIOT VERSION macro
-RIOT_VERSION_CODE ?= $(shell echo $(RIOT_VERSION_GIT) | \
+RIOT_VERSION_CODE ?= $(shell echo $(RIOT_VERSION) | \
                       sed -E 's/([0-9]+)\.([0-9]+)\.?([0-9]+)?.*/RIOT_VERSION_NUM\\\(\1,\2,0\3,$(RIOT_EXTRAVERSION)\\\)/' | \
                       grep RIOT_VERSION_NUM || echo "$(RIOT_VERSION_DUMMY_CODE)")
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

RIOT_VERSION_CODE is supposed to  provide a macro that exposes a machine readable form of RIOT_VERSION 

RIOT_VERSION  and RIOT_VERSION_GIT are not the same for release tar.gz ( RIOT_VERSION_GIT is UNKNOWN)

I assume this is a search and replace typo

### Testing procedure

try to build hello world for by downloading the release.tar.gz it 'll fail  

apply this patch it'll  succeed

### Issues/PRs references

Fixes  #22314 

### Declaration of AI-Tools / LLMs usage:

No LLM/other AI was was employed

AI-Tools / LLMs that were used are:
- none
