### PR TITLE
make: riot version code typo [backport 2026.04]

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -550,7 +550,7 @@ ifneq (,$(RIOT_VERSION_OVERRIDE))
 endif
 
 # Generate machine readable RIOT VERSION macro
-RIOT_VERSION_CODE ?= $(shell echo $(RIOT_VERSION_GIT) | \
+RIOT_VERSION_CODE ?= $(shell echo $(RIOT_VERSION) | \
                       sed -E 's/([0-9]+)\.([0-9]+)\.?([0-9]+)?.*/RIOT_VERSION_NUM\\\(\1,\2,0\3,$(RIOT_EXTRAVERSION)\\\)/' | \
                       grep RIOT_VERSION_NUM || echo "$(RIOT_VERSION_DUMMY_CODE)")
 

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -5,7 +5,7 @@
 # When the docker image is updated, checks at
 # dist/tools/buildsystem_sanity_check/check.sh start complaining in CI, and
 # provide the latest values to verify and fill in.
-DOCKER_TESTED_IMAGE_REPO_DIGEST := 028d9267e715e992d9b47bb8738685c6cc96b1a3bc3924489e7e543a333e8486
+DOCKER_TESTED_IMAGE_REPO_DIGEST := 84746b38b9a6248a21bfa2f9bd4d7a052870c35a689d9b32a06be2f5d7042156
 
 DOCKER_PULL_IDENTIFIER := docker.io/riot/riotbuild@sha256:$(DOCKER_TESTED_IMAGE_REPO_DIGEST)
 export DOCKER_IMAGE ?= $(DOCKER_PULL_IDENTIFIER)


### PR DESCRIPTION
# Backport of #22315

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

RIOT_VERSION_CODE is supposed to  provide a macro that exposes a machine readable form of RIOT_VERSION 

RIOT_VERSION  and RIOT_VERSION_GIT are not the same for release tar.gz ( RIOT_VERSION_GIT is UNKNOWN)

I assume this is a search and replace typo

### Testing procedure

try to build hello world for by downloading the release.tar.gz it 'll fail  

apply this patch it'll  succeed

### Issues/PRs references

Fixes  #22314 

### Declaration of AI-Tools / LLMs usage:

No LLM/other AI was was employed

AI-Tools / LLMs that were used are:
- none
