### PR TITLE
cpu/native/socket_zep: fix frame checksum handling

### DIFF
--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -491,7 +491,7 @@ static int _write(ieee802154_dev_t *dev, const iolist_t *iolist)
 
     for (unsigned i = 0; i < n; i++) {
         memcpy(out, iolist->iol_base, iolist->iol_len);
-        chksum = crc16_ccitt_false_update(chksum, iolist->iol_base, iolist->iol_len);
+        chksum = crc16_ccitt_kermit_update(chksum, iolist->iol_base, iolist->iol_len);
         out += iolist->iol_len;
         iolist = iolist->iol_next;
     }

--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -597,7 +597,15 @@ static int _read(ieee802154_dev_t *dev, void *buf, size_t max_size,
     }
 
     /* skip the ZEP header, just copy payload without FCS */
-    memcpy(buf, zep + 1, res);
+    const void *payload = zep + 1;
+    memcpy(buf, payload, res);
+
+    uint16_t crc = unaligned_get_u16((uint8_t *)payload + res);
+    if (crc16_ccitt_kermit_calc(payload, res) != crc) {
+        DEBUG("socket_zep::read: crc mismatch!\n");
+        return -EINVAL;
+    }
+
     return res;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

#18779 used the wrong CRC16 variant, but it never got noticed as the checksum was never checked.

Fix this by also checking the frame checksum on RX.


### Testing procedure

 - run zep dispacther `dist/tools/zep_dispatch/bin/zep_dispatch ::1 17754`
 - run two instances of `gnrc_networking`:
     `make -C examples/networking/gnrc/networking USE_ZEP=1 all term`

ping still works

```
2026-05-20 18:33:14,436 # > ping ff02::1
2026-05-20 18:33:14,440 # 12 bytes from fe80::e85c:6146:4ba8:22d2%6: icmp_seq=0 ttl=64 rssi=-26 dBm time=3.826 ms
2026-05-20 18:33:15,440 # 12 bytes from fe80::e85c:6146:4ba8:22d2%6: icmp_seq=1 ttl=64 rssi=-28 dBm time=3.580 ms
2026-05-20 18:33:16,441 # 12 bytes from fe80::e85c:6146:4ba8:22d2%6: icmp_seq=2 ttl=64 rssi=-25 dBm time=4.184 ms
```


### Issues/PRs references

fixes #22313

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- none
