### PR TITLE
.clang-format: minor tweaks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -90,9 +90,9 @@ MacroBlockEnd: ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 
-# Taken from git's rules
-PenaltyBreakAssignment: 10
-PenaltyBreakBeforeFirstCallParameter: 30
+# Adapted from git's rules
+PenaltyBreakAssignment: 100
+PenaltyBreakBeforeFirstCallParameter: 100
 PenaltyBreakComment: 10
 PenaltyBreakFirstLessLess: 0
 PenaltyBreakString: 10
@@ -106,6 +106,9 @@ SortUsingDeclarations: false
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
+# This results in consistently having no space after a
+# type cast, even when a braced initializer list comes
+SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatementsExceptForEachMacros


### PR DESCRIPTION
### Contribution description

- adjust penalties to better match current code style
- abuse SpaceBeforeCpp11BracedList to fix formation of NANOCOAP_RESOURCE macro.

### Testing procedure

Run `clang-format` e.g. on `examples/networking/coap/nanocoap_server/coap_handler.c`. It should no longer remove the space between `NANOCOAP_RESOURCE(echo)` and `{`.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
