### PR TITLE
net/unicoap: initialize .payload_representation in message_init helpers

### DIFF
--- a/sys/include/net/unicoap/message.h
+++ b/sys/include/net/unicoap/message.h
@@ -466,6 +466,7 @@ static inline void unicoap_message_init_empty(unicoap_message_t* message, uint8_
     message->options = NULL;
     message->payload = NULL;
     message->payload_size = 0;
+    message->payload_representation = UNICOAP_PAYLOAD_CONTIGUOUS;
 }
 
 /**
@@ -494,6 +495,7 @@ static inline void unicoap_message_init(unicoap_message_t* message, uint8_t code
     message->options = NULL;
     message->payload = payload;
     message->payload_size = payload_size;
+    message->payload_representation = UNICOAP_PAYLOAD_CONTIGUOUS;
 }
 
 /**
@@ -525,6 +527,7 @@ static inline void unicoap_message_init_string(unicoap_message_t* message, uint8
     message->options = NULL;
     message->payload = (uint8_t*)payload;
     message->payload_size = payload ? strlen(payload) : 0;
+    message->payload_representation = UNICOAP_PAYLOAD_CONTIGUOUS;
 }
 
 /**
@@ -560,6 +563,7 @@ static inline void unicoap_message_init_with_options(unicoap_message_t* message,
     message->options = options;
     message->payload = payload;
     message->payload_size = payload_size;
+    message->payload_representation = UNICOAP_PAYLOAD_CONTIGUOUS;
 }
 
 /**


### PR DESCRIPTION
### Contribution description

Fixes #22285.

The four `unicoap_message_init*` inline initializers in `sys/include/net/unicoap/message.h` populated `code`, `options`, `payload`, and `payload_size` but never wrote the `.payload_representation : 1` bitfield. The function-level contract above each initializer explicitly tells callers they do *not* need to zero the `unicoap_message_t` struct beforehand — but with a stack-allocated un-zeroed struct, the representation bit ends up holding whatever was on the stack. When that bit happens to be `1` (`UNICOAP_PAYLOAD_NONCONTIGUOUS`), subsequent calls to `unicoap_message_payload_get_size`, the chunks accessors, or any serialisation routine enter the noncontiguous codepath and dereference `message->payload_chunks` as an `iolist_t*` — even though the caller populated the contiguous-payload fields.

This PR adds `message->payload_representation = UNICOAP_PAYLOAD_CONTIGUOUS;` to each of the four initializers (`unicoap_message_init_empty`, `unicoap_message_init`, `unicoap_message_init_string`, `unicoap_message_init_with_options`).

The sibling `unicoap_message_alloc_*` helpers already get correct behaviour for free via designated initializers (any field not mentioned is value-initialised to zero, which is `UNICOAP_PAYLOAD_CONTIGUOUS`).

The fifth `unicoap_message_init_string_with_options` is deliberately *unchanged* — it delegates to `unicoap_message_init_with_options` internally, so it inherits the fix transitively.

### Testing procedure

Before this patch, the following reproducer (taken from the issue body) can segfault depending on what happened to be on the stack:

```c
unicoap_message_t message;  /* deliberately not zero-initialised */
unicoap_message_init_string(&message, code, "hello");
size_t n = unicoap_message_payload_get_size(&message);  /* may take noncontiguous branch and crash */
```

After the patch, `message.payload_representation` is always `UNICOAP_PAYLOAD_CONTIGUOUS` after any `unicoap_message_init*` call, so the contiguous-payload branch in `unicoap_message_payload_get_size` is always taken. The asserts in `unicoap_message_payload_get` and `unicoap_message_payload_get_chunks` keep the contract honest.

You can exercise this in the existing unicoap example app (`examples/networking/coap/unicoap`):

```sh
make -C examples/networking/coap/unicoap all
make -C examples/networking/coap/unicoap test  # if a test target exists for this board
```

The change is header-only and additive, so any build that pulls in `net/unicoap/message.h` covers it.

### Issues/PRs references

Fixes #22285.

### Declaration of AI-Tools / LLMs usage

AI-Tools / LLMs that were used are:

- **Claude (Sonnet)** for code analysis, identifying the four direct-write initializers vs. the fifth delegating one, drafting the commit message and this PR body, and confirming the constant name (`UNICOAP_PAYLOAD_CONTIGUOUS`) by reading the existing setter `unicoap_message_payload_set` and the asserts in the contiguous/noncontiguous getters — with user (@adityachilka1) review of every code line before submission ("agent mode" with explicit user review at each step).

The C source change itself is mechanical (one identical line added to four already-existing function bodies) and matches the exact pattern used by the `unicoap_message_payload_set` setter elsewhere in the same file. No new logic is introduced.
