### PR TITLE
sys/net/dhcpv6: guard against malicious packet length

### DIFF
--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -1110,7 +1110,10 @@ static bool _parse_reply(uint8_t *rep, size_t len, uint8_t request_type)
                 break;
 #endif  /* IS_USED(MODULE_DHCPV6_CLIENT_DNS) */
             case DHCPV6_OPT_IA_PD:
-                if (_parse_ia_pd_option((dhcpv6_opt_ia_pd_t *)opt)) {
+                if (_opt_len(opt) < sizeof(dhcpv6_opt_ia_pd_t)) {
+                    DEBUG("DHCPv6 client: IA_PD option underflow minimum size\n");
+                    return false;
+                } else if (_parse_ia_pd_option((dhcpv6_opt_ia_pd_t *)opt)) {
                      /* No error occurred */
                      break;
                  } else {
@@ -1118,7 +1121,10 @@ static bool _parse_reply(uint8_t *rep, size_t len, uint8_t request_type)
                      return false;
                  }
             case DHCPV6_OPT_IA_NA:
-                 if (_parse_ia_na_option((dhcpv6_opt_ia_na_t *)opt)) {
+                 if (_opt_len(opt) < sizeof(dhcpv6_opt_ia_na_t)) {
+                    DEBUG("DHCPv6 client: IA_NA option underflow minimum size\n");
+                    return false;
+                 } else if (_parse_ia_na_option((dhcpv6_opt_ia_na_t *)opt)) {
                      /* No error occurred */
                      break;
                  } else {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

When opt len (field) is 0 or lower than the packet itself our code would subtract beyond 0 causing a wrap around since the index variable is unsigned, effectively causing it to read through every single bit of available memory until it would (presumably) crash the device. 

Thank you to @kbhetrr for reporting this!

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- none
