### PR TITLE
sys/[a-h]*: replaced license headers with SPDX format

### DIFF
--- a/sys/Kconfig
+++ b/sys/Kconfig
@@ -1,9 +1,6 @@
-# Copyright (c) 2019 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2019 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
+
 menu "System"
 
 rsource "auto_init/Kconfig"

--- a/sys/analog_util/adc_util.c
+++ b/sys/analog_util/adc_util.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Eistec AB
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Eistec AB
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/analog_util/dac_util.c
+++ b/sys/analog_util/dac_util.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/app_metadata/app_metadata.c
+++ b/sys/app_metadata/app_metadata.c
@@ -1,10 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 /**
-Copyright (C) 2019, HAW Hamburg.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
  * @ingroup sys_app_metadata
  * @{
  * @file

--- a/sys/arduino/include/Arduino.h
+++ b/sys/arduino/include/Arduino.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/arduino/include/SPI.h
+++ b/sys/arduino/include/SPI.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/arduino/include/Wire.h
+++ b/sys/arduino/include/Wire.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/arduino/include/arduino_board.h
+++ b/sys/arduino/include/arduino_board.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *               2017 Thomas Perrot <thomas.perrot@tupi.fr>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 Thomas Perrot <thomas.perrot@tupi.fr>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/arduino/include/arduino_board_analog.h
+++ b/sys/arduino/include/arduino_board_analog.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/arduino/include/arduino_board_pins.h
+++ b/sys/arduino/include/arduino_board_pins.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/arduino/include/arduino_board_pwm.h
+++ b/sys/arduino/include/arduino_board_pwm.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/auto_init/Kconfig
+++ b/sys/auto_init/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_AUTO_INIT
 

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -1,14 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2013 INRIA
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 /**
- * Auto initialization for used modules
- *
- * Copyright (C) 2020 Freie Universität Berlin
- *               2020 Kaspar Schleiser <kaspar@schleiser.de>
- *               2013  INRIA.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
  * @ingroup sys_auto_init
  * @{
  * @file
@@ -19,6 +16,7 @@
  * @author  Martine S. Lenders <m.lenders@fu-berlin.de>
  * @}
  */
+
 #include <stdint.h>
 #include <stdio.h>
 #include "sched.h"

--- a/sys/auto_init/can/auto_init_mcp2515.c
+++ b/sys/auto_init/can/auto_init_mcp2515.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/auto_init/can/auto_init_periph_can.c
+++ b/sys/auto_init/can/auto_init_periph_can.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2018 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2018 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/auto_init/can/init.c
+++ b/sys/auto_init/can/init.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/auto_init/include/auto_init_priorities.h
+++ b/sys/auto_init/include/auto_init_priorities.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Otto-von-Guericke-Universität Magdebug
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Otto-von-Guericke-Universität Magdebug
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/auto_init/loramac/auto_init_loramac.c
+++ b/sys/auto_init/loramac/auto_init_loramac.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/auto_init/multimedia/auto_init_dfplayer.c
+++ b/sys/auto_init/multimedia/auto_init_dfplayer.c
@@ -1,10 +1,6 @@
 /*
- * Copyright 2019 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2019 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/sys/auto_init/screen/auto_init_cst816s.c
+++ b/sys/auto_init/screen/auto_init_cst816s.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/auto_init/screen/auto_init_ft5x06.c
+++ b/sys/auto_init/screen/auto_init_ft5x06.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/auto_init/screen/auto_init_ili9341.c
+++ b/sys/auto_init/screen/auto_init_ili9341.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/auto_init/screen/auto_init_lvgl.c
+++ b/sys/auto_init/screen/auto_init_lvgl.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/auto_init/screen/auto_init_periph_ltdc.c
+++ b/sys/auto_init/screen/auto_init_periph_ltdc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/auto_init/screen/auto_init_st77xx.c
+++ b/sys/auto_init/screen/auto_init_st77xx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/auto_init/screen/auto_init_stmpe811.c
+++ b/sys/auto_init/screen/auto_init_stmpe811.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/auto_init/screen/init.c
+++ b/sys/auto_init/screen/init.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/auto_init/security/auto_init_atca.c
+++ b/sys/auto_init/security/auto_init_atca.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/auto_init/security/init.c
+++ b/sys/auto_init/security/init.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/auto_init/usb/auto_init_usb.c
+++ b/sys/auto_init/usb/auto_init_usb.c
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2018 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup     sys_auto_init
  * @{

--- a/sys/auto_init/wdt_event/wdt.c
+++ b/sys/auto_init/wdt_event/wdt.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/auto_init/wdt_thread/wdt.c
+++ b/sys/auto_init/wdt_thread/wdt.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/base64/base64.c
+++ b/sys/base64/base64.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2014 Hochschule für Angewandte Wissenschaften Hamburg (HAW)
- * Copyright (C) 2014 Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
- *               2020 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 HAW Hamburg
+ * SPDX-FileCopyrightText: 2014 Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+ * SPDX-FileCopyrightText: 2020 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/bcd/bcd.c
+++ b/sys/bcd/bcd.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2025 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/bhp/event.c
+++ b/sys/bhp/event.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/bhp/msg.c
+++ b/sys/bhp/msg.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/bitfield/bitfield.c
+++ b/sys/bitfield/bitfield.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/bloom/bloom.c
+++ b/sys/bloom/bloom.c
@@ -1,16 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2013 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 /**
- * Bloom filter implementation
- *
- * Copyright (C) 2013 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * @brief Bloom filter implementation
  *
  * @file
  * @author Jason Linehan <patientulysses@gmail.com>
  * @author Christian Mehlis <mehlis@inf.fu-berlin.de>
- *
  */
 
 #include <limits.h>

--- a/sys/bus/sys_bus_init.c
+++ b/sys/bus/sys_bus_init.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/can/conn/isotp.c
+++ b/sys/can/conn/isotp.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/can/conn/raw.c
+++ b/sys/can/conn/raw.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/can/device.c
+++ b/sys/can/device.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/can/dll.c
+++ b/sys/can/dll.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2018 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016-2018 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/can/isotp/isotp.c
+++ b/sys/can/isotp/isotp.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/can/pkt.c
+++ b/sys/can/pkt.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2018 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016-2018 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/can/router.c
+++ b/sys/can/router.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2018 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016-2018 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/cb_mux/cb_mux.c
+++ b/sys/cb_mux/cb_mux.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Acutam Automation, LLC
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Acutam Automation, LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/chunked_ringbuffer/Kconfig
+++ b/sys/chunked_ringbuffer/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CHUNK_NUM_MAX
     int "Maximum number of chunks to store"

--- a/sys/chunked_ringbuffer/chunked_ringbuffer.c
+++ b/sys/chunked_ringbuffer/chunked_ringbuffer.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**
@@ -57,7 +54,7 @@ bool crb_add_bytes(chunk_ringbuf_t *rb, const void *data, size_t len)
 {
     const uint8_t *in = data;
     for (size_t i = 0; i < len; ++i) {
-        if (!crb_add_byte(rb ,in[i])) {
+        if (!crb_add_byte(rb, in[i])) {
             return false;
         }
     }
@@ -71,9 +68,9 @@ bool crb_add_chunk(chunk_ringbuf_t *rb, const void *data, size_t len)
         return false;
     }
 
-    bool keep = crb_add_bytes(rb ,data, len);
+    bool keep = crb_add_bytes(rb, data, len);
 
-    return crb_end_chunk(rb ,keep);
+    return crb_end_chunk(rb, keep);
 }
 
 static unsigned _get_cur_len(chunk_ringbuf_t *rb)
@@ -228,7 +225,7 @@ bool crb_consume_chunk(chunk_ringbuf_t *rb, void *dst, size_t len)
 
 void crb_init(chunk_ringbuf_t *rb, void *buffer, size_t len)
 {
-    memset(rb ,0, sizeof(*rb));
+    memset(rb, 0, sizeof(*rb));
     rb->buffer = buffer;
     rb->buffer_end = &rb->buffer[len - 1];
     rb->cur = rb->buffer;

--- a/sys/clif/clif.c
+++ b/sys/clif/clif.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (c) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/clif/include/clif_internal.h
+++ b/sys/clif/include/clif_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/coding/xor.c
+++ b/sys/coding/xor.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Benjamin Valentin <benjamin.valentin@ml-pa.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/congure/Kconfig
+++ b/sys/congure/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2021 Freie Universität Berlin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "CongURE congestion control abstraction"
     depends on USEMODULE_CONGURE

--- a/sys/congure/abe/Kconfig
+++ b/sys/congure/abe/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2021 Freie Universität Berlin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_CONGURE_ABE
 rsource "Kconfig.config"

--- a/sys/congure/abe/congure_abe.c
+++ b/sys/congure/abe/congure_abe.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/congure/mock/congure_mock.c
+++ b/sys/congure/mock/congure_mock.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/congure/quic/congure_quic.c
+++ b/sys/congure/quic/congure_quic.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/congure/reno/congure_reno.c
+++ b/sys/congure/reno/congure_reno.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/congure/reno/methods/congure_reno_methods.c
+++ b/sys/congure/reno/methods/congure_reno_methods.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/congure/test/Kconfig
+++ b/sys/congure/test/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2021 Freie Universität Berlin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_CONGURE_TEST
 rsource "Kconfig.config"

--- a/sys/congure/test/Kconfig.config
+++ b/sys/congure/test/Kconfig.config
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Freie Universität Berlin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config CONGURE_TEST_LOST_MSG_POOL_SIZE
     int "Pool size for the list elements for a lost message report"

--- a/sys/congure/test/congure_test.c
+++ b/sys/congure/test/congure_test.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/crypto/aes.c
+++ b/sys/crypto/aes.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin, Computer Systems & Telematics
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Freie Universität Berlin, Computer Systems & Telematics
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/crypto/chacha20poly1305.c
+++ b/sys/crypto/chacha20poly1305.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2008  D. J. Bernstein  (dedicated to the public domain)
- * Copyright (C) 2015  René Kijewski  <rene.kijewski@fu-berlin.de>
- * Copyright (C) 2018  Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2008 D. J. Bernstein (dedicated to the public domain)
+ * SPDX-FileCopyrightText: 2015 René Kijewski <rene.kijewski@fu-berlin.de>
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/crypto/ciphers.c
+++ b/sys/crypto/ciphers.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /*

--- a/sys/crypto/helper.c
+++ b/sys/crypto/helper.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Nico von Geyso <nico.geyso@fu-berlin.de>
- * Copyright (C) 2015 René Kijewski <rene.kijewski@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Nico von Geyso <nico.geyso@fu-berlin.de>
+ * SPDX-FileCopyrightText: 2015 René Kijewski <rene.kijewski@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include "crypto/helper.h"

--- a/sys/crypto/modes/cbc.c
+++ b/sys/crypto/modes/cbc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/crypto/modes/ccm.c
+++ b/sys/crypto/modes/ccm.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/crypto/modes/ctr.c
+++ b/sys/crypto/modes/ctr.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/crypto/modes/ecb.c
+++ b/sys/crypto/modes/ecb.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/crypto/modes/ocb.c
+++ b/sys/crypto/modes/ocb.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Mathias Tausig
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Mathias Tausig
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/crypto/psa_riot_cipher/aes_128_cbc.c
+++ b/sys/crypto/psa_riot_cipher/aes_128_cbc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/crypto/psa_riot_cipher/aes_256_cbc.c
+++ b/sys/crypto/psa_riot_cipher/aes_256_cbc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/crypto/psa_riot_cipher/aes_common.c
+++ b/sys/crypto/psa_riot_cipher/aes_common.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/crypto/psa_riot_cipher/aes_common.h
+++ b/sys/crypto/psa_riot_cipher/aes_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/crypto/psa_riot_cipher/chacha20.c
+++ b/sys/crypto/psa_riot_cipher/chacha20.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/cxx_ctor_guards/cxa_guard.c
+++ b/sys/cxx_ctor_guards/cxa_guard.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/debug_irq_disable/Kconfig
+++ b/sys/debug_irq_disable/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (C) 2022 Benjamin Valentin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 Benjamin Valentin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config DEBUG_IRQ_DISABLE_THRESHOLD
     int "Suppress Threshold"

--- a/sys/debug_irq_disable/debug_irq_disable.c
+++ b/sys/debug_irq_disable/debug_irq_disable.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/div/div.c
+++ b/sys/div/div.c
@@ -1,10 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 /**
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
  * @ingroup     sys_div
  * @{
  * @file

--- a/sys/eepreg/eepreg.c
+++ b/sys/eepreg/eepreg.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Acutam Automation, LLC
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Acutam Automation, LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/embunit/ColorOutputter.c
+++ b/sys/embunit/ColorOutputter.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Janos Kutscherauer <noshky@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Janos Kutscherauer <noshky@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include <stdio.h>

--- a/sys/embunit/ColorTextColors.h
+++ b/sys/embunit/ColorTextColors.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Janos Kutscherauer <noshky@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Janos Kutscherauer <noshky@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/embunit/ColorTextOutputter.c
+++ b/sys/embunit/ColorTextOutputter.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Janos Kutscherauer <noshky@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Janos Kutscherauer <noshky@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include <stdio.h>

--- a/sys/entropy_source/Kconfig
+++ b/sys/entropy_source/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "Entropy sources"
     depends on USEMODULE_ENTROPY_SOURCE

--- a/sys/entropy_source/adc_noise/Kconfig
+++ b/sys/entropy_source/adc_noise/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "ADC Noise entropy source module"
     depends on USEMODULE_ENTROPY_SOURCE_ADC_NOISE

--- a/sys/entropy_source/adc_noise/adc_noise.c
+++ b/sys/entropy_source/adc_noise/adc_noise.c
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup     sys_entropy_source_adc
  *

--- a/sys/entropy_source/entropy_source.c
+++ b/sys/entropy_source/entropy_source.c
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup     sys_entropy_source_common
  *

--- a/sys/entropy_source/zero_entropy/Kconfig
+++ b/sys/entropy_source/zero_entropy/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "zero entropy source module"
     depends on USEMODULE_ENTROPY_SOURCE_ZERO_ENTROPY

--- a/sys/entropy_source/zero_entropy/zero_entropy.c
+++ b/sys/entropy_source/zero_entropy/zero_entropy.c
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup     sys_entropy_source_zero
  * @{

--- a/sys/event/callback.c
+++ b/sys/event/callback.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2017 Inria
- *               2017 Freie Universität Berlin
- *               2017 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FIleCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include "event/callback.h"

--- a/sys/event/event.c
+++ b/sys/event/event.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2017 Inria
- *               2017 Kaspar Schleiser <kaspar@schleiser.de>
- *               2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/event/periodic.c
+++ b/sys/event/periodic.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/event/thread.c
+++ b/sys/event/thread.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2019 Kaspar Schleiser <kaspar@schleiser.de>
- *               2018 Freie Universität Berlin
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/event/timeout_ztimer.c
+++ b/sys/event/timeout_ztimer.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2017 Inria
- *               2017 Freie Universität Berlin
- *               2017 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include "kernel_defines.h"

--- a/sys/evtimer/evtimer.c
+++ b/sys/evtimer/evtimer.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2016-17 Kaspar Schleiser <kaspar@schleiser.de>
- *               2017 Freie Universität Berlin
- *               2018 Josua Arndt
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 Josua Arndt
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/fido2/Kconfig
+++ b/sys/fido2/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (C) 2021 Freie Universität Berlin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_FIDO2
 

--- a/sys/fido2/ctap/Kconfig
+++ b/sys/fido2/ctap/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (C) 2021 Freie Universität Berlin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-
+# SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_FIDO2_CTAP
 

--- a/sys/fido2/ctap/ctap.c
+++ b/sys/fido2/ctap/ctap.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/fido2/ctap/ctap_cbor.c
+++ b/sys/fido2/ctap/ctap_cbor.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/fido2/ctap/ctap_crypto.c
+++ b/sys/fido2/ctap/ctap_crypto.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/fido2/ctap/ctap_mem.c
+++ b/sys/fido2/ctap/ctap_mem.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/fido2/ctap/ctap_utils.c
+++ b/sys/fido2/ctap/ctap_utils.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/fido2/ctap/transport/Kconfig
+++ b/sys/fido2/ctap/transport/Kconfig
@@ -1,7 +1,4 @@
-# Copyright (C) 2021 Freie Universität Berlin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 rsource "hid/Kconfig"

--- a/sys/fido2/ctap/transport/ctap_transport.c
+++ b/sys/fido2/ctap/transport/ctap_transport.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/fido2/ctap/transport/hid/Kconfig
+++ b/sys/fido2/ctap/transport/hid/Kconfig
@@ -1,8 +1,5 @@
-# Copyright (C) 2021 Freie Universität Berlin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_FIDO2_CTAP_TRANSPORT_HID
 

--- a/sys/fido2/ctap/transport/hid/ctap_hid.c
+++ b/sys/fido2/ctap/transport/hid/ctap_hid.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/fmt/table.c
+++ b/sys/fmt/table.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/frac/frac.c
+++ b/sys/frac/frac.c
@@ -1,10 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2018 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 /**
- * Copyright (C) 2018 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
  * @ingroup sys_frac
  * @{
  * @file

--- a/sys/fs/constfs/constfs.c
+++ b/sys/fs/constfs/constfs.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/fs/devfs/auto_init_devfs.c
+++ b/sys/fs/devfs/auto_init_devfs.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/fs/devfs/devfs.c
+++ b/sys/fs/devfs/devfs.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/fs/devfs/hwrng.c
+++ b/sys/fs/devfs/hwrng.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/fs/devfs/random-vfs.h
+++ b/sys/fs/devfs/random-vfs.h
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/fs/devfs/random.c
+++ b/sys/fs/devfs/random.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/fuzzing/fuzzing.c
+++ b/sys/fuzzing/fuzzing.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2019 Sören Tempel <tempel@uni-bremen.de>
- * Copyright (C) 2022 Bennet Blischke <bennet.blischke@haw-hamburg.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Sören Tempel <tempel@uni-bremen.de>
+ * SPDX-FileCopyrightText: 2022 Bennet Blischke <bennet.blischke@haw-hamburg.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include <errno.h>

--- a/sys/fuzzing/netdev.c
+++ b/sys/fuzzing/netdev.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Sören Tempel <tempel@uni-bremen.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Sören Tempel <tempel@uni-bremen.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include <assert.h>

--- a/sys/hashes/aes128_cmac.c
+++ b/sys/hashes/aes128_cmac.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Fundación Inria Chile
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Fundación Inria Chile
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/hashes.c
+++ b/sys/hashes/hashes.c
@@ -1,11 +1,6 @@
-/**
- * This file contains some simple hash function
- *
- * Copyright (C) 2013 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+/*
+ * SPDX-FileCopyrightText: 2013 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/md5.c
+++ b/sys/hashes/md5.c
@@ -1,20 +1,7 @@
 /*
- * Copyright (C) 2003-2005 by Christopher R. Hertel
- *               2015 Freie Universität Berlin
- *
- *  This library is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public
- *  License as published by the Free Software Foundation; either
- *  version 2.1 of the License, or (at your option) any later version.
- *
- *  This library is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- *  Lesser General Public License for more details.
- *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * SPDX-FileCopyrightText: 2003-2005 by Christopher R. Hertel
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/pbkdf2.c
+++ b/sys/hashes/pbkdf2.c
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2019 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup     examples
  * @{

--- a/sys/hashes/psa_riot_hashes/hmac_sha256.c
+++ b/sys/hashes/psa_riot_hashes/hmac_sha256.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/psa_riot_hashes/md5.c
+++ b/sys/hashes/psa_riot_hashes/md5.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/psa_riot_hashes/sha3_256.c
+++ b/sys/hashes/psa_riot_hashes/sha3_256.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/psa_riot_hashes/sha3_384.c
+++ b/sys/hashes/psa_riot_hashes/sha3_384.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/psa_riot_hashes/sha3_512.c
+++ b/sys/hashes/psa_riot_hashes/sha3_512.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/psa_riot_hashes/sha_1.c
+++ b/sys/hashes/psa_riot_hashes/sha_1.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/psa_riot_hashes/sha_224.c
+++ b/sys/hashes/psa_riot_hashes/sha_224.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/psa_riot_hashes/sha_256.c
+++ b/sys/hashes/psa_riot_hashes/sha_256.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/psa_riot_hashes/sha_384.c
+++ b/sys/hashes/psa_riot_hashes/sha_384.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/psa_riot_hashes/sha_512.c
+++ b/sys/hashes/psa_riot_hashes/sha_512.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/psa_riot_hashes/sha_512_224.c
+++ b/sys/hashes/psa_riot_hashes/sha_512_224.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/psa_riot_hashes/sha_512_256.c
+++ b/sys/hashes/psa_riot_hashes/sha_512_256.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/sha1.c
+++ b/sys/hashes/sha1.c
@@ -1,13 +1,8 @@
 /*
- * Copyright (C) 2016 Oliver Hahm <oliver.hahm@inria.fr>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- */
-
-/* This code is public-domain - it is based on libcrypt
- * placed in the public domain by Wei Dai and other contributors.
+ * SPDX-FileCopyrightText: 2016 Oliver Hahm <oliver.hahm@inria.fr>
+ * SPDX-FileCopyrightText: Implementation based on libcrypt that was released
+ *                         by Wei Dai et al. into the public domain.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/sha224.c
+++ b/sys/hashes/sha224.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/sha256.c
+++ b/sys/hashes/sha256.c
@@ -1,32 +1,9 @@
-/*-
- * Copyright 2005 Colin Percival
- * Copyright 2013 Christian Mehlis & René Kijewski
- * Copyright 2016 Martin Landsmann <martin.landsmann@haw-hamburg.de>
- * Copyright 2016 OTA keys S.A.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- *
- * $FreeBSD: src/lib/libmd/sha256c.c,v 1.2 2006/01/17 15:35:56 phk Exp $
+/*
+ * SPDX-FileCopyrightText: 2005 Colin Percival
+ * SPDX-FileCopyrightText: 2013 Christian Mehlis & René Kijewski
+ * SPDX-FileCopyrightText: 2016 Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 /**

--- a/sys/hashes/sha2xx_common.c
+++ b/sys/hashes/sha2xx_common.c
@@ -1,33 +1,10 @@
-/*-
- * Copyright 2005 Colin Percival
- * Copyright 2013 Christian Mehlis & René Kijewski
- * Copyright 2016 Martin Landsmann <martin.landsmann@haw-hamburg.de>
- * Copyright 2016 OTA keys S.A.
- * Copyright 2020 HAW Hamburg
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- *
- * $FreeBSD: src/lib/libmd/sha256.h,v 1.1.2.1 2005/06/24 13:32:25 cperciva Exp $
+/*
+ * SPDX-FileCopyrightText: 2005 Colin Percival
+ * SPDX-FileCopyrightText: 2013 Christian Mehlis & René Kijewski
+ * SPDX-FileCopyrightText: 2016 Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 /**

--- a/sys/hashes/sha384.c
+++ b/sys/hashes/sha384.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/sha512.c
+++ b/sys/hashes/sha512.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/sha512_224.c
+++ b/sys/hashes/sha512_224.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/sha512_256.c
+++ b/sys/hashes/sha512_256.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/hashes/sha512_common.c
+++ b/sys/hashes/sha512_common.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR attempts to convert all license headers for all folders inside the `sys/` directory starting with the letters A to H. Vendor specific files are left untouched as well as some files missing some copyright or license information.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
To check for correct license/copyright information in all files that are not vendor provided, use this command:

`reuse lint -l | grep "^sys/" | grep -v "/vendor/"`

### Declaration of AI-Tools / LLMs usage

AI-Tools / LLMs that were used are:
- VS Code Copilot for the python script

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Tracking #21515 
