### PR TITLE
doc/guides: Extend documentation of submodules

### DIFF
--- a/doc/guides/advanced_tutorials/creating_modules.mdx
+++ b/doc/guides/advanced_tutorials/creating_modules.mdx
@@ -163,11 +163,14 @@ SRC := spam.c
 SUBMODULES = 1
 ```
 
-When using `SUBMODULES` in a `MODULE` all `SRC` file excluded from `foo/Makefile`
+When using `SUBMODULES` in a `MODULE` all `SRC` not referenced by `foo/Makefile`
 will be considered `SUBMODULES`. In the example above `ham.c` and `eggs.c`.
 These source files will be conditionally included depending if the modules have
 been added, i.e. `USEMODULE += foo_ham foo_eggs` (it's the same as case 1 but
-handled automatically in `Makefile.base`).
+handled automatically in `Makefile.base`). Please note however that you also
+need to add the parent module `foo_bar`, otherwise the linker might not find
+your submodules. This should usually happen inside the `Makefile.dep` of the
+parent module.
 
 The `SUBMODULES` mechanism is more flexible since `BASE_MODULE` allows matching
 the only parts of compounded module names and only match against part of that name.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

It turns out that adding a submodule without also adding the associated parent module can cause the linker to not find the object files of the submodules. This happens because the object files land inside the directory <parent module name>, which needs to be added to BASELIBS for the linker to find it.

I think this issue is important enough to mention it inside the documentation.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

I ran `make static-tests` to catch any obvious coding style violations.

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- none
