### PR TITLE
doc tree: fix verbatim block mismatch

### DIFF
--- a/cpu/doc.md
+++ b/cpu/doc.md
@@ -21,7 +21,7 @@ Don't call `board_init()`, leave all pins in their default state.
 This is intended to be used with basic riotboot_slot which does not interact
 with any external hardware.
 
-@experimental    Only use this if you know what you are doing
+@experimental   Only use this if you know what you are doing
 
     #define DISABLE_BOARD_INIT  0
 

--- a/cpu/esp8266/doc.md
+++ b/cpu/esp8266/doc.md
@@ -920,7 +920,7 @@ The GPIOs in this configuration can be overridden by
 ## SD-Card Device {#esp8266_sd_card_device}
 
 ESP8266 port of RIOT is preconfigured for RIOT applications that use the
-\ref drivers_sdcard_spi "SPI SD-Card driver.
+\ref drivers_sdcard_spi "SPI SD-Card driver".
 To use SPI SD-Card driver, the `sdcard_spi` module has to be added to
 a makefile:
 

--- a/cpu/sam0_common/include/sdhc.h
+++ b/cpu/sam0_common/include/sdhc.h
@@ -11,7 +11,7 @@
  * @brief       SD card interface functions for sam0 class devices
  *
  * @warning     This driver is deprecated. Use the `sdmmc` driver module
- *              instead. You can refer to the `same54-xpro´ board as an example
+ *              instead. You can refer to the `same54-xpro` board as an example
  *              on how to use it.
  * @{
  *

--- a/cpu/stm32/include/periph/cpu_eth.h
+++ b/cpu/stm32/include/periph/cpu_eth.h
@@ -134,7 +134,7 @@ typedef struct eth_dma_desc {
  * | `0b00` | Checksum insertion disabled                                                   |
  * | `0b01` | Calculate and insert checksum in IPv4 header                                  |
  * | `0b10` | Calculate and insert IPv4 checksum, insert pre-calculated payload checksum    |
- * | `0b11  | Calculated and insert both IPv4 and payload checksum                          |
+ * | `0b11` | Calculated and insert both IPv4 and payload checksum                          |
  */
 #define TX_DESC_STAT_CIC                    (BIT22 | BIT23)
 #define TX_DESC_STAT_CIC_NO_HW_CHECKSUM     (0)             /**< Do not compute checksums in hardware */

--- a/dist/tools/doccheck/exclude_simple
+++ b/dist/tools/doccheck/exclude_simple
@@ -8361,51 +8361,8 @@ warning: Member LSM6DSL_REG_Y_OFS_USR (macro definition) of file lsm6dsxx_intern
 warning: Member LSM6DSL_REG_Z_OFS_USR (macro definition) of file lsm6dsxx_internal.h is not documented.
 warning: Member LSM6DS33_REG_ORIENT_CFG_G (macro definition) of file lsm6dsxx_internal.h is not documented.
 warning: Member AT6561_STBY_PIN (macro definition) of file board.h is not documented.
-cpu/sam0_common/include/sdhc.h:167: warning: Reached end of file while still searching closing '`' of a verbatim block starting at line 14
-cpu/sam0_common/include/sdhc.h:167: warning: Reached end of file while still inside a (nested) comment. Nesting level 1 (possible line reference(s): 8)
-cpu/sam0_common/include/sdhc.h:23: warning: Found end of C comment inside a '`' block without matching start of the comment! Maybe the end marker for the block is missing?
-cpu/stm32/include/periph/cpu_eth.h:164: warning: Reached end of file while still searching closing '`' of a verbatim block starting at line 137
-cpu/stm32/include/periph/cpu_eth.h:164: warning: Reached end of file while still inside a (nested) comment. Nesting level 1 (possible line reference(s): 129)
-cpu/stm32/include/periph/cpu_eth.h:138: warning: Found end of C comment inside a '`' block without matching start of the comment! Maybe the end marker for the block is missing?
-drivers/include/mcp23x17.h:689: warning: Reached end of file while still searching closing '``' of a verbatim block starting at line 78
-drivers/include/mcp23x17.h:689: warning: Reached end of file while still inside a (nested) comment. Nesting level 1 (possible line reference(s): 11)
-drivers/include/mcp23x17.h:343: warning: Found end of C comment inside a '``' block without matching start of the comment! Maybe the end marker for the block is missing?
-drivers/include/periph/gpio_ll.h:1036: warning: Reached end of file while still searching closing '`' of a verbatim block starting at line 1029
-drivers/include/periph/gpio_ll.h:1036: warning: Reached end of file while still inside a (nested) comment. Nesting level 1 (possible line reference(s): 412)
-drivers/include/periph/gpio_ll.h:422: warning: Found end of C comment inside a '`' block without matching start of the comment! Maybe the end marker for the block is missing?
-drivers/include/periph/pwm.h:189: warning: Reached end of file while still searching closing '`' of a verbatim block starting at line 39
-drivers/include/periph/pwm.h:189: warning: Reached end of file while still inside a (nested) comment. Nesting level 1 (possible line reference(s): 11)
-drivers/include/periph/pwm.h:61: warning: Found end of C comment inside a '`' block without matching start of the comment! Maybe the end marker for the block is missing?
-drivers/include/periph/qdec.h:202: warning: Reached end of file while still searching closing '`' of a verbatim block starting at line 65
-drivers/include/periph/qdec.h:202: warning: Reached end of file while still inside a (nested) comment. Nesting level 1 (possible line reference(s): 11)
-drivers/include/periph/qdec.h:77: warning: Found end of C comment inside a '`' block without matching start of the comment! Maybe the end marker for the block is missing?
-drivers/include/vl6180x.h:1076: warning: Reached end of file while still searching closing '`' of a verbatim block starting at line 1011
-drivers/include/vl6180x.h:1076: warning: Reached end of file while still inside a (nested) comment. Nesting level 1 (possible line reference(s): 11)
-drivers/include/vl6180x.h:393: warning: Found end of C comment inside a '`' block without matching start of the comment! Maybe the end marker for the block is missing?
-pkg/nimble/autoconn/include/nimble_autoconn.h:220: warning: Reached end of file while still searching closing '`' of a verbatim block starting at line 81
-pkg/nimble/autoconn/include/nimble_autoconn.h:220: warning: Reached end of file while still inside a (nested) comment. Nesting level 1 (possible line reference(s): 11)
-pkg/nimble/autoconn/include/nimble_autoconn.h:109: warning: Found end of C comment inside a '`' block without matching start of the comment! Maybe the end marker for the block is missing?
-pkg/wamr/CMakeLists.txt:61: warning: More #if's than #endif's found (might be in an included file).
-sys/include/net/gnrc/ipv6/nib/pl.h:182: warning: Reached end of file while still searching closing '`' of a verbatim block starting at line 171
-sys/include/net/gnrc/ipv6/nib/pl.h:182: warning: Reached end of file while still inside a (nested) comment. Nesting level 1 (possible line reference(s): 49)
-sys/include/net/gnrc/ipv6/nib/pl.h:76: warning: Found end of C comment inside a '`' block without matching start of the comment! Maybe the end marker for the block is missing?
-sys/include/net/gnrc/ndp.h:103: warning: Found end of C comment inside a '`' block without matching start of the comment! Maybe the end marker for the block is missing?
-sys/include/net/gnrc/ndp.h:132: warning: Found end of C comment inside a '`' block without matching start of the comment! Maybe the end marker for the block is missing?
-sys/include/net/gnrc/netif.h:479: warning: Found end of C comment inside a '`' block without matching start of the comment! Maybe the end marker for the block is missing?
-sys/include/net/gnrc/netif.h:564: warning: Found end of C comment inside a '`' block without matching start of the comment! Maybe the end marker for the block is missing?
-sys/include/net/sock/dtls.h:1130: warning: Reached end of file while still searching closing '`' of a verbatim block starting at line 1115
-sys/include/net/sock/dtls.h:1130: warning: Reached end of file while still inside a (nested) comment. Nesting level 1 (possible line reference(s): 15)
-sys/include/net/sock/dtls.h:533: warning: Found end of C comment inside a '`' block without matching start of the comment! Maybe the end marker for the block is missing?
-sys/posix/include/semaphore.h:43: warning: Found end of C comment inside a '`' block without matching start of the comment! Maybe the end marker for the block is missing?
-sys/posix/include/semaphore.h:243: warning: Found end of C comment inside a '`' block without matching start of the comment! Maybe the end marker for the block is missing?
-sys/posix/include/sys/socket.h:512: warning: Reached end of file while still searching closing '``' of a verbatim block starting at line 472
-sys/posix/include/sys/socket.h:512: warning: Reached end of file while still inside a (nested) comment. Nesting level 1 (possible line reference(s): 462)
-sys/posix/include/sys/socket.h:482: warning: Found end of C comment inside a '``' block without matching start of the comment! Maybe the end marker for the block is missing?
-sys/psa_crypto/doc.md:1092: warning: Reached end of file while still searching closing '``' of a verbatim block starting at line 848
-cpu/sam0_common/include/sdhc.h:37: warning: Compound sdhc_state_t is not documented.
 sys/include/net/gnrc/netif/pktq.h:16: warning: Potential recursion while resolving \ref command!
 sys/include/net/gnrc/netif/pktq/type.h:15: warning: Potential recursion while resolving \ref command!
-sys/posix/include/sys/socket.h:55: warning: unable to resolve reference to 'socket()' for \ref command
 sys/include/net/gnrc/netif/pktq.h:0: warning: Potential recursion while resolving \ref command!
 boards/common/arduino-mkr/include/periph_conf_common.h:71: warning: Member CLOCK_DIV (macro definition) of file periph_conf_common.h is not documented.
 boards/common/native/include/board.h:136: warning: Member SPIFFS_MTD_DEV (macro definition) of file board.h is not documented.
@@ -8423,11 +8380,8 @@ boards/serpente/include/periph_conf.h:67: warning: Member CLOCK_DIV (macro defin
 boards/common/sodaq/include/cfg_clock_default.h:68: warning: Member CLOCK_DIV (macro definition) of file cfg_clock_default.h is not documented.
 cpu/stm32/include/periph/cpu_eth.h:139: warning: Member TX_DESC_STAT_CIC (macro definition) of file cpu_eth.h is not documented.
 cpu/stm32/include/periph/cpu_eth.h:140: warning: Member TX_DESC_STAT_CIC_NO_HW_CHECKSUM (macro definition) of file cpu_eth.h is not documented.
-cpu/stm32/include/periph/cpu_eth.h:148: warning: explicit link request to 'define' could not be resolved
-cpu/stm32/include/periph/cpu_eth.h:149: warning: explicit link request to 'define' could not be resolved
 drivers/include/periph/pwm.h:77: warning: Member PWM_DEV(x) (macro definition) of group drivers_periph_pwm is not documented.
 drivers/include/periph/qdec.h:93: warning: Member QDEC_DEV(x) (macro definition) of group drivers_periph_qdec is not documented.
-drivers/include/vl6180x.h:409: warning: explicit link request to 'define' could not be resolved
 drivers/include/vl6180x.h:409: warning: Member VL6180X_I2C_ADDR (macro definition) of file vl6180x.h is not documented.
 sys/posix/include/semaphore.h:44: warning: Member SEM_FAILED (macro definition) of file semaphore.h is not documented.
 sys/include/net/sock/dodtls.h:135: warning: unable to resolve reference to 'sock_dtls_create()' for \ref command
@@ -8441,16 +8395,7 @@ sys/include/net/sock/dtls.h:853: warning: Found unexpanded alias '@experimental'
 boards/esp32c6-devkit/doc.md:44: warning: unable to resolve reference to 'esp32c6_devkit_optional_hardware' for \ref command
 boards/esp32h2-devkit/doc.md:40: warning: unable to resolve reference to 'esp32h2_devkit_optional_hardware' for \ref command
 cpu/esp8266/doc.md:600: warning: explicit link request to 'PWM_DEV(0)' could not be resolved
-cpu/esp8266/doc.md:927: warning: Illegal command '@icode' found as part of a \ref
-cpu/esp8266/doc.md:929: warning: Illegal command '@endicode' found as part of a \ref
-cpu/esp8266/doc.md:938: warning: Illegal command '@ref' found as part of a \ref
 sys/include/net/gnrc.h:109: warning: unable to resolve reference to 'net_gnrc_netapi::GNRC_NETAPI_MSG_TYPE_RCV' for \ref command
-sys/include/net/gnrc/ndp.h:96: warning: argument 'cur_hl' of command @param is not found in the argument list of gnrc_ndp_opt_build(uint8_t type, size_t size, gnrc_pktsnip_t *next)
-sys/include/net/gnrc/ndp.h:96: warning: argument 'flags' of command @param is not found in the argument list of gnrc_ndp_opt_build(uint8_t type, size_t size, gnrc_pktsnip_t *next)
-sys/include/net/gnrc/ndp.h:96: warning: argument 'ltime' of command @param is not found in the argument list of gnrc_ndp_opt_build(uint8_t type, size_t size, gnrc_pktsnip_t *next)
-sys/include/net/gnrc/ndp.h:96: warning: argument 'reach_time' of command @param is not found in the argument list of gnrc_ndp_opt_build(uint8_t type, size_t size, gnrc_pktsnip_t *next)
-sys/include/net/gnrc/ndp.h:96: warning: argument 'retrans_timer' of command @param is not found in the argument list of gnrc_ndp_opt_build(uint8_t type, size_t size, gnrc_pktsnip_t *next)
-sys/include/net/gnrc/ndp.h:96: warning: argument 'options' of command @param is not found in the argument list of gnrc_ndp_opt_build(uint8_t type, size_t size, gnrc_pktsnip_t *next)
 drivers/include/mcp23x17.h:190: warning: explicit link request to 'mcp23x17_interrupt_context_problem' could not be resolved
 boards/msbiot/doc.md:68: warning: unable to resolve reference to 'LED0_PIN' for \ref command
 boards/msbiot/doc.md:68: warning: unable to resolve reference to 'LED1_PIN' for \ref command
@@ -8462,25 +8407,6 @@ boards/msbiot/doc.md:72: warning: unable to resolve reference to 'LED0_TOGGLE' f
 boards/msbiot/doc.md:73: warning: unable to resolve reference to 'LED1_ON' for \ref command
 boards/msbiot/doc.md:73: warning: unable to resolve reference to 'LED1_OFF' for \ref command
 boards/msbiot/doc.md:73: warning: unable to resolve reference to 'LED1_TOGGLE' for \ref command
-sys/include/net/gnrc/netif.h:463: warning: argument 'addrs' of command @param is not found in the argument list of gnrc_netif_ipv6_addr_add(const gnrc_netif_t *netif, const ipv6_addr_t *addr, unsigned pfx_len, uint8_t flags)
-sys/include/net/gnrc/netif.h:463: warning: argument 'max_len' of command @param is not found in the argument list of gnrc_netif_ipv6_addr_add(const gnrc_netif_t *netif, const ipv6_addr_t *addr, unsigned pfx_len, uint8_t flags)
-sys/include/net/gnrc/netif.h:463: warning: argument netif from the argument list of gnrc_netif_ipv6_addr_add has multiple @param documentation sections
-sys/include/net/gnrc/netif.h:549: warning: argument 'groups' of command @param is not found in the argument list of gnrc_netif_ipv6_group_join(const gnrc_netif_t *netif, const ipv6_addr_t *group)
-sys/include/net/gnrc/netif.h:549: warning: argument 'max_len' of command @param is not found in the argument list of gnrc_netif_ipv6_group_join(const gnrc_netif_t *netif, const ipv6_addr_t *group)
-sys/include/net/gnrc/netif.h:549: warning: argument netif from the argument list of gnrc_netif_ipv6_group_join has multiple @param documentation sections
-sys/posix/include/semaphore.h:44: warning: explicit link request to 'define' could not be resolved
-sys/posix/include/semaphore.h:174: warning: unable to resolve reference to 'SEM_FAILED' for \ref command
-sys/posix/include/semaphore.h:227: warning: argument 'abstime' of command @param is not found in the argument list of sem_trywait(sem_t *sem)
-sys/posix/include/semaphore.h:227: warning: argument sem from the argument list of sem_trywait has multiple @param documentation sections
-sys/posix/include/sys/socket.h:464: warning: argument 'domain' of command @param is not found in the argument list of getsockopt(int socket, int level, int option_name, void *option_value, socklen_t *option_len)
-sys/posix/include/sys/socket.h:464: warning: argument 'protocol' of command @param is not found in the argument list of getsockopt(int socket, int level, int option_name, void *option_value, socklen_t *option_len)
-sys/posix/include/sys/socket.h:464: warning: The following parameters of getsockopt(int socket, int level, int option_name, void *option_value, socklen_t *option_len) are not documented:
-sys/include/net/gnrc/ipv6/nib/pl.h:52: warning: argument 'valid_ltime' of command @param is not found in the argument list of gnrc_ipv6_nib_pl_del(unsigned iface, const ipv6_addr_t *pfx, unsigned pfx_len)
-sys/include/net/gnrc/ipv6/nib/pl.h:52: warning: argument 'pref_ltime' of command @param is not found in the argument list of gnrc_ipv6_nib_pl_del(unsigned iface, const ipv6_addr_t *pfx, unsigned pfx_len)
-sys/include/net/gnrc/ipv6/nib/pl.h:52: warning: argument iface from the argument list of gnrc_ipv6_nib_pl_del has multiple @param documentation sections
-sys/include/net/gnrc/ipv6/nib/pl.h:52: warning: argument pfx from the argument list of gnrc_ipv6_nib_pl_del has multiple @param documentation sections
-sys/include/net/gnrc/ipv6/nib/pl.h:52: warning: argument pfx_len from the argument list of gnrc_ipv6_nib_pl_del has multiple @param documentation sections
-sys/include/net/gnrc/ipv6/nib/pl.h:52: warning: found documented return type for gnrc_ipv6_nib_pl_del that does not return anything
 sys/include/net/gnrc/netif/pktq/type.h:12: warning: Potential recursion while resolving \ref command!
 drivers/include/vl6180x.h:338: warning: explicit link request to 'VL6180X_I2C_ADDR' could not be resolved
 boards/esp32s2-wemos-mini/doc.md:38: warning: unable to resolve reference to 'esp32s2-wemos-mini_toc' for \ref command
@@ -8493,4 +8419,3 @@ sys/include/net/ieee802154_security.h:83: warning: unable to resolve reference t
 sys/include/net/ieee802154_security.h:59: warning: unable to resolve reference to 'ieee802154_sec_context_t::ieee802154_sec_dev_t' for \ref command
 sys/include/net/gnrc/netif/>:1: warning: Potential recursion while resolving \ref command!
 sys/include/net/gnrc/netif/pktq/>:1: warning: Potential recursion while resolving \ref command!
-makefiles/pseudomodules.inc.mk:232: warning: maximum nesting level exceeded for group net_gnrc_sixlowpan_frag_sfr_congure_sfr: check for possible recursive group relation!

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -1099,7 +1099,8 @@ EXCLUDE_PATTERNS       = */board/*/tools/* \
                          */sys/random/fortuna/* \
                          */sys/random/tinymt32/* \
                          */toolchain/* \
-                         */vendor/*
+                         */vendor/* \
+                         */CMakeLists.txt
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/pkg/nimble/autoconn/include/nimble_autoconn.h
+++ b/pkg/nimble/autoconn/include/nimble_autoconn.h
@@ -78,7 +78,7 @@
  * during build time:
  *
  * 1. `USEMDOULE += nimble_autoconn_ipsp`
- * 2. `USEMODULE += nibmle_autoconn_ndnsp'
+ * 2. `USEMODULE += nibmle_autoconn_ndnsp`
  *
  * @note    The NDN support service (NDNSP) is defined by us and it is not at
  *          all standardized nor sanctioned by the BT SIG. For experimental use

--- a/pkg/wamr/CMakeLists.txt
+++ b/pkg/wamr/CMakeLists.txt
@@ -16,7 +16,7 @@ if (DEFINED WAMR_CONFIG)
 endif ()
 
 # Build as X86_32 by default, change to "AARCH64[sub]", "ARM[sub]", "THUMB[sub]", "XTENSA"
-# if we want to support arm, thumb, xtensa
+# in case we want to support arm, thumb, xtensa
 if (NOT DEFINED WAMR_BUILD_TARGET)
   set (WAMR_BUILD_TARGET "X86_32")
 endif ()

--- a/sys/include/net/gnrc/ipv6/nib/pl.h
+++ b/sys/include/net/gnrc/ipv6/nib/pl.h
@@ -69,9 +69,9 @@ typedef struct {
  *                          be greater then @p valid_ltime.
  *
  * @return  0, on success.
- * @return  -EINVAL, if @p pfx was fe80::` or multicast,
- *          @p pfx_len was == 0, the first @p pfx_len bits of @ pfx were 0,
- *          or if pref_ltime > valid_ltime.
+ * @return  -EINVAL, if @p pfx was `fe80::` or multicast,
+ *          @p pfx_len was == 0, the first @p pfx_len bits of @p pfx were 0,
+ *          or if @p pref_ltime > @p valid_ltime.
  * @return  -ENOMEM, if no space was left in the prefix list.
  */
 int gnrc_ipv6_nib_pl_set(unsigned iface,

--- a/sys/include/net/gnrc/ndp.h
+++ b/sys/include/net/gnrc/ndp.h
@@ -93,7 +93,7 @@ gnrc_pktsnip_t *gnrc_ndp_nbr_adv_build(const ipv6_addr_t *tgt, uint8_t flags,
 /**
  * @brief   Builds a router solicitation message for sending.
  *
- * @see `[RFC 4861, section 4.1](https://tools.ietf.org/html/rfc4861#section-4.1")
+ * @see [RFC 4861, section 4.1](https://tools.ietf.org/html/rfc4861#section-4.1")
  *
  * @param[in] options   Options to append to the router solicitation.
  *                      May be NULL for none.
@@ -106,7 +106,7 @@ gnrc_pktsnip_t *gnrc_ndp_rtr_sol_build(gnrc_pktsnip_t *options);
 /**
  * @brief   Builds a router advertisement message for sending.
  *
- * @see `[RFC 4861, section 4.2](https://tools.ietf.org/html/rfc4861#section-4.2")
+ * @see [RFC 4861, section 4.2](https://tools.ietf.org/html/rfc4861#section-4.2")
  *
  * @note    The source address for the packet MUST be the link-local address
  *          of the interface.

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -469,7 +469,7 @@ gnrc_netif_t *gnrc_netif_get_by_pid(kernel_pid_t pid);
  *                      addresses assigned to @p netif. May not be `NULL`
  * @param[in] max_len   Number of *bytes* available in @p addrs. Must be at
  *                      least `sizeof(ipv6_addr_t)`. It is recommended to use
- *                      @p CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF `* sizeof(ipv6_addr_t)
+ *                      @p CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF `* sizeof(ipv6_addr_t)`
  *                      here (and have @p addrs of the according length).
  *
  * @return  Size of the array of addresses in @p addrs on success.
@@ -555,7 +555,7 @@ static inline int gnrc_netif_ipv6_addr_remove(const gnrc_netif_t *netif,
  *                      is joined to. May not be `NULL`
  * @param[in] max_len   Number of *bytes* available in @p groups. Must be at
  *                      least `sizeof(ipv6_addr_t)`. It is recommended to use
- *                      @p GNRC_NETIF_IPV6_GROUPS_NUMOF `* sizeof(ipv6_addr_t)
+ *                      @p GNRC_NETIF_IPV6_GROUPS_NUMOF `* sizeof(ipv6_addr_t)`
  *                      here (and have @p groups of the according length).
  *
  * @return  Number of addresses in @p groups times `sizeof(ipv6_addr_t)` on

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -60,7 +60,7 @@
  * a module that implements
  * this API in our applications Makefile. For example the module that
  * implements this API for [tinydtls](@ref pkg_tinydtls) is called
- * `tinydtls_sock_dtls'.
+ * `tinydtls_sock_dtls`.
  *
  * The corresponding [pkg](@ref pkg) providing the DTLS implementation will be
  * automatically included so there is no need to use `USEPKG` to add the pkg

--- a/sys/posix/include/semaphore.h
+++ b/sys/posix/include/semaphore.h
@@ -39,7 +39,7 @@ extern "C" {
 typedef sema_t sem_t;
 
 /**
- * @brief Value returned if `sem_open' failed.
+ * @brief Value returned if `sem_open` failed.
  */
 #define SEM_FAILED      ((sem_t *) 0)
 
@@ -222,7 +222,7 @@ static inline int sem_unlink(const char *name)
 }
 
 /**
- * @brief Similar to `sem_wait' but wait only until @p abstime.
+ * @brief Similar to `sem_wait` but wait only until @p abstime.
  *
  * @see <a href="http://pubs.opengroup.org/onlinepubs/9699919799/functions/sem_timedwait.html">
  *          The Open Group Base Specifications Issue 7, sem_timedwait()

--- a/sys/posix/include/sys/socket.h
+++ b/sys/posix/include/sys/socket.h
@@ -466,10 +466,10 @@ static inline ssize_t send(int socket, const void *buffer, size_t length,
  *          that operate on sockets.
  *
  * @param[in] domain    Specifies the communications domain in which a socket
- *                      is to be created. Valid values are prefixed with ``AF_`
+ *                      is to be created. Valid values are prefixed with `AF_`
  *                      and defined in @ref socket.h.
  * @param[in] type      Specifies the type of socket to be created. Valued
- *                      values are prefixed with ``SOCK_`` and defined in
+ *                      values are prefixed with `SOCK_` and defined in
  *                      @ref socket.h.
  * @param[in] protocol  Specifies a particular protocol to be used with the
  *                      socket. Specifying a protocol of 0 causes socket() to

--- a/sys/psa_crypto/doc.md
+++ b/sys/psa_crypto/doc.md
@@ -845,7 +845,7 @@ config CPU_FAM_MYCPU
     select HAS_PERIPH_ECC_P256R1
     select HAS_PERIPH_SPEEDYCRYPT
 ```
-The `HAS_PERIPH_*` symbols are defined in ``. If your device
+The `HAS_PERIPH_*` symbols are defined in. If your device
 provides capabilities that are not yet defined, you can add them to that file.
 
 Next we need to define selectable modules for this in the `cpu/myCPU/periph` folder, which


### PR DESCRIPTION
<!-- The RIOT community cares a lot about code quality. -->

### Contribution description

fix verbatim block mismatches

- remove verbatim block mismatches and
- a few minor other doxygen warnings

from doccheck/exclude_simple

### Testing procedure

read

### Issues/PRs references

#22327 

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
