### PR TITLE
cpu/samd5x: provide a common OpenOCD script with PM fix

### DIFF
--- a/boards/adafruit-grand-central-m4-express/dist/openocd.cfg
+++ b/boards/adafruit-grand-central-m4-express/dist/openocd.cfg
@@ -1,2 +1,0 @@
-source [find target/atsame5x.cfg]
-$_TARGETNAME configure -rtos auto

--- a/boards/adafruit-metro-m4-express/dist/openocd.cfg
+++ b/boards/adafruit-metro-m4-express/dist/openocd.cfg
@@ -1,2 +1,0 @@
-source [find target/atsame5x.cfg]
-$_TARGETNAME configure -rtos auto

--- a/boards/same51-curiosity-nano/dist/openocd.cfg
+++ b/boards/same51-curiosity-nano/dist/openocd.cfg
@@ -1,2 +1,0 @@
-source [find target/atsame5x.cfg]
-$_TARGETNAME configure -rtos auto

--- a/boards/same54-xpro/dist/openocd.cfg
+++ b/boards/same54-xpro/dist/openocd.cfg
@@ -1,2 +1,0 @@
-source [find target/atsame5x.cfg]
-$_TARGETNAME configure -rtos auto

--- a/cpu/samd5x/Makefile.include
+++ b/cpu/samd5x/Makefile.include
@@ -23,3 +23,7 @@ include $(RIOTMAKE)/arch/cortexm.inc.mk
 
 # The Black Magic Probe has tested to work fine on SAMD5x
 PROGRAMMERS_SUPPORTED += bmp
+
+# The same OpenOCD configuration can be used for probably all SAMD5x boards.
+# We do allow the board to override it, though, just in case.
+OPENOCD_CONFIG ?= $(RIOTCPU)/samd5x/dist/openocd.cfg

--- a/cpu/samd5x/dist/openocd.cfg
+++ b/cpu/samd5x/dist/openocd.cfg
@@ -1,0 +1,28 @@
+source [find target/atsame5x.cfg]
+$_TARGETNAME configure -rtos auto
+
+# Guard the power mangement fix: We only want to extend the pre-shutdown-cmds
+# if the fix is not already provided by target/atsame5x.cfg.
+if {
+    ![info exists pre_shutdown_commands] ||
+    [lsearch -exact $pre_shutdown_commands {atsame5.dap dpreg 4 0}] < 0
+} {
+    # The documentation of dpreg suggests to use `poll off` to prevent background
+    # activity to disturg low level access. Specifically, we will allow the target
+    # to enter low power modes again, which may result in the target to immediately
+    # do so and become unresponsive on the debug port. Not having background
+    # activity failing will result in a clear output.
+    lappend pre_shutdown_commands {poll off}
+
+    # Now we clear CTRL/STAT register (at offset 4) of the debug port.
+    # We mostly care about the CSYSPWRUPREQ and CDBGPWRUPREQ bits that request the
+    # MCU to be powered, so that target's power management is resuming normal
+    # operation once we disconnect.
+    lappend pre_shutdown_commands {atsame5.dap dpreg 4 0}
+}
+
+# Return explicitly nothing, as lappend would return the value of
+# pre_shutdown_commands after the appending (so
+# `{poll off} {atsame5.dap dreg 4 0}`), which would be confusing to the user if
+# that pops up in the OpenOCD output.
+return


### PR DESCRIPTION
### Contribution description

- Drop the OpenOCD script from both SAME5x boards we supported and provide it at a single place instead.
- Add required pre-shutdown commands to restore power management right before OpenOCD shuts down
    - low power modes will work after flashing with OpenOCD

### Testing procedure

1. `make BOARD=same54-xpro PROGRAMMER=openocd -C examples/basic/default debug` should still work
2. after flashing / debugging, the MCU should still be able to enter low power modes

> [!NOTE]
> If flashing with `edbg`, the debugger is configured into a different mode and OpenOCD won't be able to find it. 
>
> A power cycle restores the mode of the eDBG embedded debugger on the board. Or just flashing with `PROGRAMMER=openocd` directly prevents the issue from popping up.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
