### PR TITLE
doc(tree): remove colon from doxygen-cmds

### DIFF
--- a/core/lib/include/clist.h
+++ b/core/lib/include/clist.h
@@ -207,7 +207,7 @@ static inline void clist_lpoprpush(clist_node_t *list)
 /**
  * @brief Returns first element in list
  *
- * @note: Complexity: O(1)
+ * @note Complexity: O(1)
  *
  * @param[in]   list        The list to work upon.
  * @returns     first (leftmost) list element, or NULL if list is empty
@@ -223,7 +223,7 @@ static inline clist_node_t *clist_lpeek(const clist_node_t *list)
 /**
  * @brief Returns last element in list
  *
- * @note: Complexity: O(1)
+ * @note Complexity: O(1)
  *
  * @param[in]   list        The list to work upon.
  * @returns     last (rightmost) list element, or NULL if list is empty

--- a/cpu/arm7_common/include/iap.h
+++ b/cpu/arm7_common/include/iap.h
@@ -45,9 +45,9 @@ extern "C" {
 #define PLLCON_PLLC     (0x03)      /**< PLL Connect */
 #define PLLSTAT_PLOCK   (0x0400)    /**< PLL Lock Status */
 
-/*
- * @brief:  Converts 'addr' to sector number
- * @note:   Sector table (Users Manual P. 610)
+/**
+ * @brief  Converts 'addr' to sector number
+ * @note   Sector table (Users Manual P. 610)
  *
  * @param addr      Flash address
  *

--- a/cpu/avr8_common/periph/pm.c
+++ b/cpu/avr8_common/periph/pm.c
@@ -25,10 +25,10 @@
 #include "debug.h"
 
 /**
- * @note: The pm_set assumes that interrupts are disable and there is no reason
+ * @note  The pm_set assumes that interrupts are disable and there is no reason
  *        to save SREG here.
  *
- * @note: DEBUG affects this routine.
+ * @note  DEBUG affects this routine.
  */
 void pm_set(unsigned mode)
 {

--- a/cpu/esp32/periph/i2c_hw.c
+++ b/cpu/esp32/periph/i2c_hw.c
@@ -393,7 +393,7 @@ int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_t len, uint
 #endif
 
 /*
- * @note:
+ * @note
  * It is a known problem that the ESP32x I2C hardware implementation checks
  * the ACK when the next command in the pipeline is executed. That is,
  * for a segmented write operation of type `START ADDR DATA0 STOP` the
@@ -416,7 +416,7 @@ static int _i2c_status_to_errno(i2c_t dev)
         LOG_TAG_DEBUG("i2c", "ack error dev=%u\n", dev);
         if (_i2c_bus[dev].cmd_op == I2C_LL_CMD_WRITE) {
             /*
-             * @note: In a write transfer, an ACK error can happen for the
+             * @note  In a write transfer, an ACK error can happen for the
              * address field as well as for data. If the FIFO still contains
              * all data bytes, the ACK error happened in address field and we
              * have to return -ENXIO. Otherwise, the ACK error happened in data
@@ -429,7 +429,7 @@ static int _i2c_status_to_errno(i2c_t dev)
         }
         else {
             /*
-             * @note: In a read transfer, an ACK is only expected for the
+             * @note  In a read transfer, an ACK is only expected for the
              * address field. Thus, an ACK error can only happen for the address
              * field. Therefore, we always return -ENXIO in case of an ACK
              * error.

--- a/cpu/esp_common/include/cpu.h
+++ b/cpu/esp_common/include/cpu.h
@@ -28,7 +28,7 @@ extern "C" {
 /**
  * @brief   Gets the last instruction's address
  *
- * @todo:   Not supported
+ * @todo    Not supported
  */
 static inline uintptr_t cpu_get_caller_pc(void)
 {

--- a/cpu/esp_common/include/irq_arch_common.h
+++ b/cpu/esp_common/include/irq_arch_common.h
@@ -47,7 +47,7 @@ extern volatile uint32_t irq_interrupt_nesting;
 /**
  * @name   Macros to enter and exit a critical region
  *
- * @note: since they use a local variable they can be used only in same function
+ * @note   since they use a local variable they can be used only in same function
  *
  * @{
  */

--- a/cpu/qn908x/periph/spi.c
+++ b/cpu/qn908x/periph/spi.c
@@ -213,7 +213,7 @@ void spi_release(spi_t bus)
 }
 
 /**
- * @brief: Wait for the FIFO to be empty.
+ * @brief Wait for the FIFO to be empty.
  */
 static void _spi_wait_txempty(SPI_Type *spi_bus)
 {

--- a/cpu/riscv_common/include/cpu_common.h
+++ b/cpu/riscv_common/include/cpu_common.h
@@ -43,7 +43,7 @@ void riscv_irq_init(void);
 /**
  * @brief   Gets the last instruction's address
  *
- * @todo:   Not supported
+ * @todo    Not supported
  */
 static inline uintptr_t cpu_get_caller_pc(void)
 {

--- a/dist/tools/buildsystem_sanity_check/save_all_dependencies_resolution_variables.sh
+++ b/dist/tools/buildsystem_sanity_check/save_all_dependencies_resolution_variables.sh
@@ -12,7 +12,7 @@
 #
 # The script takes a long time
 #
-# @author: Gaëtan Harter <gaetan.harter@fu-berlin.de>
+# @author  Gaëtan Harter <gaetan.harter@fu-berlin.de>
 
 : "${RIOTBASE:="$(cd "$(dirname "$0")/../../../" || exit; pwd)"}"
 

--- a/drivers/aip31068/include/aip31068_regs.h
+++ b/drivers/aip31068/include/aip31068_regs.h
@@ -25,7 +25,7 @@ extern "C"
 /**
  * @brief Clears entire display and sets cursor to position (0, 0).
  *
- * @note: Also changes AIP31068_BIT_ENTRY_MODE_INCREMENT to 1
+ * @note  Also changes AIP31068_BIT_ENTRY_MODE_INCREMENT to 1
  */
 #define AIP31068_CMD_CLEAR_DISPLAY          0x01
 

--- a/drivers/include/aip31068.h
+++ b/drivers/include/aip31068.h
@@ -140,7 +140,7 @@ int aip31068_turn_off(aip31068_t *dev);
 /**
  * @brief Clear the display and set the cursor to position (0, 0).
  *
- * @note: Also changes to setTextInsertionMode(LEFT_TO_RIGHT)
+ * @note  Also changes to setTextInsertionMode(LEFT_TO_RIGHT)
  *
  * @param[in] dev   Device descriptor of the AIP31068
  *
@@ -283,7 +283,7 @@ int aip31068_move_cursor_left(aip31068_t *dev);
  * When the cursor passes the 40th character of the first line and a second line
  * is available, the cursor will move to the second line.
  *
- * @note: The cursor respects the setting for the insertion mode and is set
+ * @note  The cursor respects the setting for the insertion mode and is set
  *        to (1, 0) for LEFT_TO_RIGHT and to (1, COL_MAX) for RIGHT_TO_LEFT.
  *
  * @param[in] dev   Device descriptor of the AIP31068
@@ -302,7 +302,7 @@ int aip31068_move_cursor_right(aip31068_t *dev);
 /**
  * @brief Scroll the entire display content (all lines) one unit to the left.
  *
- * @note: The cursor respects the setting for the insertion mode and is set
+ * @note  The cursor respects the setting for the insertion mode and is set
  *        to (1, 0) for LEFT_TO_RIGHT and to (1, COL_MAX) for RIGHT_TO_LEFT.
  *
  * @param[in] dev   Device descriptor of the AIP31068
@@ -343,7 +343,7 @@ int aip31068_scroll_display_right(aip31068_t *dev);
  * @param[in] customSymbol  Key to which a custom symbol should be assigned
  * @param[in] charmap       Bitmap definition of the custom symbol
  *
- * @note: The size of charmap depends on how the AIP31068 was initialized.
+ * @note  The size of charmap depends on how the AIP31068 was initialized.
  *        8 bytes for FONT_SIZE_5x8 and 10 bytes for FONT_SIZE_5x10.
  *
  *        This function resets the cursor position. Therefore this function

--- a/drivers/include/mma8x5x.h
+++ b/drivers/include/mma8x5x.h
@@ -207,7 +207,7 @@ void mma8x5x_set_motiondetect(const mma8x5x_t *dev, uint8_t int_pin, uint8_t thr
  * Acknowledges (clears) a motion detection interrupt.
  * See @ref mma8x5x_set_motiondetect().
  *
- * @warning: this does incur an I2C write, thus should not be done from within
+ * @warning  this does incur an I2C write, thus should not be done from within
  *           the ISR.
  *
  * @param[in]   dev         device descriptor of accelerometer

--- a/drivers/kw41zrf/vendor/OSAbstraction/Interface/fsl_os_abstraction.h
+++ b/drivers/kw41zrf/vendor/OSAbstraction/Interface/fsl_os_abstraction.h
@@ -517,10 +517,10 @@ osaStatus_t OSA_EventDestroy(osaEventId_t eventId);
  *
  * This function  allocates memory for and initializes a message queue. Message queue elements are hardcoded as void*.
  *
- * @param msgNo :number of messages the message queue should accommodate.
+ * @param msgNo  number of messages the message queue should accommodate.
  *               This parameter should not exceed osNumberOfMessages defined in OSAbstractionConfig.h.
  *
-* @return:  Handler to access the queue for put and get operations. If message queue
+* @return  Handler to access the queue for put and get operations. If message queue
  *         creation failed, return NULL.
  */
 osaMsgQId_t OSA_MsgQCreate(uint32_t  msgNo);

--- a/drivers/pcf857x/pcf857x.c
+++ b/drivers/pcf857x/pcf857x.c
@@ -356,7 +356,7 @@ static void _irq_handler(event_t* event)
 }
 
 /*
- * @warning: It is expected that the I2C bus is already acquired when the
+ * @warning  It is expected that the I2C bus is already acquired when the
  *           function is called. However, it is released by this function
  *           before the function returns.
  */

--- a/pkg/tinyusb/contrib/tinyusb_descriptors.c
+++ b/pkg/tinyusb/contrib/tinyusb_descriptors.c
@@ -168,7 +168,7 @@ uint8_t const *tud_hid_descriptor_report_cb(uint8_t itf)
  * It fills the report buffer content and returns its length. Returning
  * zero will causes the stack to send a STALL request.
  *
- * @note: The function is only a dummy function and therefore defined as a weak
+ * @note  The function is only a dummy function and therefore defined as a weak
  *        symbol that can be overwritten by real functions if needed by the
  *        application. */
 __attribute__((weak))
@@ -188,7 +188,7 @@ uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id,
 /* The function is invoked when SET_REPORT control request is received or
  * data are received on OUT endpoint (Report ID = 0, Type = 0).
  *
- * @note: The function is only a dummy function and therefore defined as a weak
+ * @note  The function is only a dummy function and therefore defined as a weak
  *        symbol that can be overwritten by real functions if needed by the
  *        application. */
 __attribute__((weak))

--- a/sys/arduino/include/spiport.hpp
+++ b/sys/arduino/include/spiport.hpp
@@ -228,7 +228,7 @@ public:
 };
 
 /**
- * @brief: Instance of the SPI interface as required by the Arduino API
+ * @brief   Instance of the SPI interface as required by the Arduino API
  */
 extern SPIClass SPI;
 

--- a/sys/include/event/periodic.h
+++ b/sys/include/event/periodic.h
@@ -60,7 +60,7 @@ typedef struct {
 /**
  * @brief   Initialize a periodic event timeout
  *
- * @note: On init the periodic event is to to run forever.
+ * @note  On init the periodic event is to to run forever.
  *
  * @param[in]       event_periodic  event_periodic object to initialize
  * @param[in]       clock           the clock to configure this timer on
@@ -77,12 +77,12 @@ void event_periodic_init(event_periodic_t *event_periodic, ztimer_clock_t *clock
  * This will make the event as configured in @p event_periodic be triggered
  * at every interval ticks (based on event_periodic->clock).
  *
- * @note: the used event_periodic struct must stay valid until after the timeout
+ * @note  the used event_periodic struct must stay valid until after the timeout
  *        event has been processed!
  *
- * @note: this function does not touch the current count value.
+ * @note  this function does not touch the current count value.
  *
- * @note: the periodic event will start without delay.
+ * @note  the periodic event will start without delay.
  *
  * @param[in]   event_periodic   event_timout context object to use
  * @param[in]   interval         period length for the event
@@ -99,10 +99,10 @@ static inline void event_periodic_start_now(event_periodic_t *event_periodic, ui
  * This will make the event as configured in @p event_periodic be triggered
  * at every interval ticks (based on event_periodic->clock).
  *
- * @note: the used event_periodic struct must stay valid until after the timeout
+ * @note  the used event_periodic struct must stay valid until after the timeout
  *        event has been processed!
  *
- * @note: this function does not touch the current count value.
+ * @note  this function does not touch the current count value.
  *
  * @param[in]   event_periodic   event_timout context object to use
  * @param[in]   interval         period length for the event

--- a/sys/include/event/periodic_callback.h
+++ b/sys/include/event/periodic_callback.h
@@ -54,7 +54,7 @@ static inline void *event_periodic_callback_get_arg(event_periodic_callback_t *e
 /**
  * @brief   Initialize a periodic callback event
  *
- * @note: On init the periodic event is configured to run forever.
+ * @note  On init the periodic event is configured to run forever.
  *
  * @param[in]   event           event_periodic_callback object to initialize
  * @param[in]   clock           the clock to configure this timer on
@@ -83,10 +83,10 @@ static inline void event_periodic_callback_init(event_periodic_callback_t *event
  * This will make the event as configured in @p event be triggered
  * at every interval ticks (based on event->periodic.clock).
  *
- * @note: @p event must stay valid until after all periodic timeout
+ * @note  @p event must stay valid until after all periodic timeout
  *        events have been processed!
  *
- * @note: this function does not touch the current count value.
+ * @note  this function does not touch the current count value.
  *
  * @param[in]   event           event_periodic_callback context object to use
  * @param[in]   interval        period length for the event
@@ -107,12 +107,12 @@ static inline void event_periodic_callback_start(event_periodic_callback_t *even
  * This will make the event as configured in @p event be triggered
  * at every interval ticks (based on event->periodic.clock).
  *
- * @note: @p event must stay valid until after all periodic timeout
+ * @note  @p event must stay valid until after all periodic timeout
  *        events have been processed!
  *
- * @note: this function does not touch the current count value.
+ * @note  this function does not touch the current count value.
  *
- * @note: the periodic event will start without initial delay.
+ * @note  the periodic event will start without initial delay.
  *
  * @param[in]   event           event_periodic_callback context object to use
  * @param[in]   interval        period length for the event
@@ -130,7 +130,7 @@ static inline void event_periodic_callback_start_now(event_periodic_callback_t *
  * This is a convenience function that combines @ref event_periodic_callback_init
  * and @ref event_periodic_callback_start
  *
- * @note: The periodic callback event is configured to run forever, and the first
+ * @note  The periodic callback event is configured to run forever, and the first
  *        occurrence happens after the delay given by @p timeout .
  *
  * @param[out]  event           event_periodic_callback object to initialize

--- a/sys/include/event/timeout.h
+++ b/sys/include/event/timeout.h
@@ -85,7 +85,7 @@ void event_timeout_init(event_timeout_t *event_timeout, event_queue_t *queue,
  * after @p timeout microseconds (if using @ref xtimer) or the @ref
  * ztimer_clock_t ticks.
  *
- * @note: the used event_timeout struct must stay valid until after the timeout
+ * @note  the used event_timeout struct must stay valid until after the timeout
  *        event has been processed!
  *
  * @param[in]   event_timeout   event_timeout context object to use

--- a/sys/include/net/gnrc/tcp.h
+++ b/sys/include/net/gnrc/tcp.h
@@ -292,7 +292,7 @@ void gnrc_tcp_abort(gnrc_tcp_tcb_t *tcb);
  *
  * @pre @p queue must not be NULL
  *
- * @note: Blocks until all currently opened connections maintained
+ * @note  Blocks until all currently opened connections maintained
  *        by @p queue were closed.
  *
  * @param[in,out] queue   TCB queue to stop listening

--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -514,7 +514,7 @@ void ztimer_set_msg(ztimer_clock_t *clock, ztimer_t *timer, uint32_t offset,
  * Similar to msg_receive(), but with a timeout parameter.
  * The function will return after waiting at most @p timeout ticks.
  *
- * @note: This might function might leave a message with type MSG_ZTIMER in the
+ * @note  This might function might leave a message with type MSG_ZTIMER in the
  *        thread's message queue, which must be handled (ignored).
  *
  * @param[in]   clock           ztimer clock to operate on
@@ -734,7 +734,7 @@ void ztimer_sleep(ztimer_clock_t *clock, uint32_t duration);
 /**
  * @brief   Busy-wait specified duration
  *
- * @note: This blocks lower priority threads. Use only for *very* short delays.
+ * @note  This blocks lower priority threads. Use only for *very* short delays.
  *
  * @param[in]   clock           ztimer clock to use
  * @param[in]   duration        duration to spin, in @p clock time units

--- a/sys/include/ztimer64.h
+++ b/sys/include/ztimer64.h
@@ -253,7 +253,7 @@ static inline void ztimer64_set_msg(ztimer64_clock_t *clock, ztimer64_t *timer,
  * Similar to msg_receive(), but with a timeout parameter.
  * The function will return after waiting at most until @p target.
  *
- * @note: This might function might leave a message with type MSG_ZTIMER64 in the
+ * @note  This might function might leave a message with type MSG_ZTIMER64 in the
  *        thread's message queue, which must be handled (ignored).
  *
  * @param[in]   clock           ztimer64 clock to operate on
@@ -273,7 +273,7 @@ int ztimer64_msg_receive_until(ztimer64_clock_t *clock, msg_t *msg,
  * Similar to msg_receive(), but with a timeout parameter.
  * The function will return after waiting at most @p timeout ticks.
  *
- * @note: This might function might leave a message with type MSG_ZTIMER64 in the
+ * @note  This might function might leave a message with type MSG_ZTIMER64 in the
  *        thread's message queue, which must be handled (ignored).
  *
  * @param[in]   clock           ztimer64 clock to operate on
@@ -339,7 +339,7 @@ static inline void ztimer64_sleep(ztimer64_clock_t *clock, uint64_t duration)
 /**
  * @brief   Busy-wait until specified target time
  *
- * @note: This blocks lower priority threads. Use only for *very* short delays.
+ * @note  This blocks lower priority threads. Use only for *very* short delays.
  *
  * @param[in]   clock           ztimer64 clock to use
  * @param[in]   target          time when spinning should end, in @p clock time

--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -201,7 +201,7 @@ static void on_pingreq(sock_udp_ep_t *remote)
 
 static void on_pingresp(void)
 {
-    /** @todo: trigger update something like a 'last seen' value */
+    /** @todo trigger update something like a 'last seen' value */
 }
 
 static void send_ping(void)

--- a/tests/drivers/aip31068/main.c
+++ b/tests/drivers/aip31068/main.c
@@ -67,11 +67,11 @@ static void _init_progress_bar(aip31068_t* dev, uint8_t row);
  * line will be reserved completely for the progress bar. Any text written to
  * that line will be overwritten by the progress bar on an update.
  *
- * @note: Auto scroll will be disabled and the display will be scrolled to
+ * @note  Auto scroll will be disabled and the display will be scrolled to
  *        its original position. Don't use scrolling when using the
  *        progressbar, otherwise it won't display correctly.
  *
- * @note: Text insertion mode will be set to LEFT_TO_RIGHT.
+ * @note  Text insertion mode will be set to LEFT_TO_RIGHT.
  *
  * @param[in] dev       Device descriptor of the AIP31068
  * @param[in] enabled   Enable or disable
@@ -90,7 +90,7 @@ static void _set_progress_bar_row(uint8_t row);
 /**
  * @brief Set the progress of the progress bar and draw the update.
  *
- * @note: This function changes the cursor position. You will have to use
+ * @note  This function changes the cursor position. You will have to use
  *        setCursorPosition in order to return to your required cursor position.
  *
  * @param[in] dev       Device descriptor of the AIP31068

--- a/tests/unittests/tests-base64/tests-base64.c
+++ b/tests/unittests/tests-base64/tests-base64.c
@@ -30,12 +30,8 @@ static void test_base64_01_encode_string(void)
     char base64_out[sizeof(expected_encoding)];
 
     /*
-    * @Note
-    * The first encoding attempt fails, but reveals the required out size.
-    *
-    * This size is a lower bound estimation,
-    * thus it can require few more bytes then the actual used size for the output.
-    */
+     * The first encoding attempt fails, but reveals the required out size.
+     */
     int ret = base64_encode(data_in, data_in_size, NULL, &base64_out_size);
 
     TEST_ASSERT_EQUAL_INT(BASE64_ERROR_BUFFER_OUT_SIZE, ret);
@@ -188,15 +184,14 @@ static void test_base64_05_decode_larger(void)
 static void test_base64_06_stream_encode(void)
 {
     /*
-    * @Note
-    * In this test we divide the `stream_encode[]` input for the encoding
-    * into several portions (chunks).
-    *
-    * Every chunk is encoded and appended to the base64 `encode_result[]`.
-    * To enable appending further, the chunks MUST be dividable by 3.
-    * Only the final chunk MAY be prime to 3. (it is in this test)
-    *
-    */
+     * In this test we divide the `stream_encode[]` input for the encoding
+     * into several portions (chunks).
+     *
+     * Every chunk is encoded and appended to the base64 `encode_result[]`.
+     * To enable appending further, the chunks MUST be dividable by 3.
+     * Only the final chunk MAY be prime to 3. (it is in this test)
+     *
+     */
 
     static const char stream_encode[] =
         "Peter Piper picked a peck of pickled peppers.\n"
@@ -245,12 +240,13 @@ static void test_base64_06_stream_encode(void)
 
 static void test_base64_07_stream_decode(void)
 {
-    /* @Note
-    * Here we decode the base64 string `encoded[]`
-    *
-    * Every base64 chunk is decoded and appended to `stream_decoded[]`.
-    * The chunks passed to decode MUST be dividable by 4.
-    */
+
+    /*
+     * Here we decode the base64 string `encoded[]`
+     *
+     * Every base64 chunk is decoded and appended to `stream_decoded[]`.
+     * The chunks passed to decode MUST be dividable by 4.
+     */
 
     static const char encoded[] =
         "UGV0ZXIgUGlwZXIgcGlja2VkIGEgcGVjayBvZiBwaWNrbGVkIH"
@@ -338,7 +334,7 @@ static void test_base64_09_encode_size_determination(void)
     size_t element_base64_out_size = expected_out_size;
     unsigned char element_base64_out[expected_out_size];
 
-    // test 20 bytes input, expected 28 bytes output
+    /* test 20 bytes input, expected 28 bytes output */
     size_t required_out_size = 0;
     int ret = base64_encode(buffer, buffer_size,
                             element_base64_out, &required_out_size);
@@ -352,7 +348,7 @@ static void test_base64_09_encode_size_determination(void)
     TEST_ASSERT_EQUAL_INT(BASE64_SUCCESS, ret);
     TEST_ASSERT_EQUAL_INT(expected_out_size, element_base64_out_size);
 
-    // test 19 bytes input, expected 28 bytes output
+    /* test 19 bytes input, expected 28 bytes output */
     required_out_size = 0;
     ret = base64_encode(buffer, 19,
                         element_base64_out, &required_out_size);
@@ -360,7 +356,7 @@ static void test_base64_09_encode_size_determination(void)
     TEST_ASSERT_EQUAL_INT(BASE64_ERROR_BUFFER_OUT_SIZE, ret);
     TEST_ASSERT_EQUAL_INT(required_out_size, expected_out_size);
 
-    // test 18 bytes input, expected 24 bytes output
+    /* test 18 bytes input, expected 24 bytes output */
     expected_out_size = 24;
     required_out_size = 0;
     ret = base64_encode(buffer, 18,
@@ -369,7 +365,7 @@ static void test_base64_09_encode_size_determination(void)
     TEST_ASSERT_EQUAL_INT(BASE64_ERROR_BUFFER_OUT_SIZE, ret);
     TEST_ASSERT_EQUAL_INT(required_out_size, expected_out_size);
 
-    // test 17 bytes input, expected 24 bytes output
+    /* test 17 bytes input, expected 24 bytes output */
     expected_out_size = 24;
     required_out_size = 0;
     ret = base64_encode(buffer, 17,
@@ -418,12 +414,8 @@ static void test_base64_11_urlsafe_encode_int(void)
     char base64_out[sizeof(expected_encoding) + 2];
 
     /*
-    * @Note
-    * The first encoding attempt fails, but reveals the required out size.
-    *
-    * This size is a lower bound estimation,
-    * thus it can require few more bytes then the actual used size for the output.
-    */
+     * The first encoding attempt fails, but reveals the required out size.
+     */
     int ret = base64url_encode(&data_in, sizeof(data_in), NULL, &base64_out_size);
 
     TEST_ASSERT_EQUAL_INT(BASE64_ERROR_BUFFER_OUT_SIZE, ret);

--- a/tests/unittests/tests-base64/tests-base64.c
+++ b/tests/unittests/tests-base64/tests-base64.c
@@ -30,7 +30,7 @@ static void test_base64_01_encode_string(void)
     char base64_out[sizeof(expected_encoding)];
 
     /*
-    * @Note:
+    * @Note
     * The first encoding attempt fails, but reveals the required out size.
     *
     * This size is a lower bound estimation,
@@ -188,7 +188,7 @@ static void test_base64_05_decode_larger(void)
 static void test_base64_06_stream_encode(void)
 {
     /*
-    * @Note:
+    * @Note
     * In this test we divide the `stream_encode[]` input for the encoding
     * into several portions (chunks).
     *
@@ -245,7 +245,7 @@ static void test_base64_06_stream_encode(void)
 
 static void test_base64_07_stream_decode(void)
 {
-    /* @Note:
+    /* @Note
     * Here we decode the base64 string `encoded[]`
     *
     * Every base64 chunk is decoded and appended to `stream_decoded[]`.
@@ -418,7 +418,7 @@ static void test_base64_11_urlsafe_encode_int(void)
     char base64_out[sizeof(expected_encoding) + 2];
 
     /*
-    * @Note:
+    * @Note
     * The first encoding attempt fails, but reveals the required out size.
     *
     * This size is a lower bound estimation,


### PR DESCRIPTION
<!-- -->

### Contribution description

found this 
```
dist/tools/buildsystem_sanity_check/save_all_dependencies_resolution_variables.sh
15:# @author: Gaëtan Harter <gaetan.harter@fu-berlin.de>
```

searched for similar (ignoring esp since they use `@varname documentation`)

```
rg --glob='!esp*' -P '@\S+:'
```
got this:

```
cpu/rp2350_common/periph/uart.c
214:    /* @TODO: properly clear UART on deinit */

sys/arduino/include/spiport.hpp
231: * @brief: Instance of the SPI interface as required by the Arduino API

tests/unittests/tests-uri_parser/tests-uri_parser.c
79:    char *legacy_test_case_01 = "coap://RIOT:test@[fe80:db8::1%tap0]:5683/.well-known/core?v=1";
82:    char *legacy_test_case_04 = "coap://R@[2001:db8::1]:5/v=1";
83:    char *legacy_test_case_05 = "coap://R@[2001:db8::1]:5/:v=1";
84:    char *legacy_test_case_06 = "cap://R@[2001:db8::1]:5/?v=1";
87:    char *legacy_test_case_09 = "coap:///R@[2008::1]:5own//R@[2008::1]:5own/?v=1";
164:    char *trailing_percent = "coap://RIOT:test@[fe80:db8::1%]:5683/.well-known/core?v=1";
165:    char *invalid_port = "coap://R@[2001:db8::1]:5own/v=1";
166:    char *invalid_port_colon = "coap://R@[2001:db8::1]:5own/:v=1";
167:    char *invalid_port_short_scheme = "cap://R@[2001:db8::1]:5own/?v=1";
169:    char *double_scheme = "coap://oap://P@[2001:b";
395:        .input_uri = "coap://user@[2001:db8::1]",
407:        .input_uri = "coap://user@[2001:db8::1]:12345",
419:        .input_uri = "coap://user@[2001:db8::1%eth0]:12345",
496:        .input_uri = "coap://RIOT:test@[fe80:db8::1%eth2]:5683/.well-known/core?v=1",

sys/ut_process/ut_process.c
196:        case ',': case '=': case '|': case '@':

cpu/arm7_common/include/iap.h
49: * @brief:  Converts 'addr' to sector number
50: * @note:   Sector table (Users Manual P. 610)

core/lib/include/clist.h
210: * @note: Complexity: O(1)
226: * @note: Complexity: O(1)

pkg/lorabasics/doc.txt
12: * @see      git@github.com:lorabasics/lorabasicsmodem.git

tests/unittests/tests-base64/tests-base64.c
33:    * @Note:
191:    * @Note:
248:    /* @Note:
421:    * @Note:

pkg/tinyusb/contrib/tinyusb_descriptors.c
171: * @note: The function is only a dummy function and therefore defined as a weak
191: * @note: The function is only a dummy function and therefore defined as a weak

cpu/avr8_common/periph/pm.c
28: * @note: The pm_set assumes that interrupts are disable and there is no reason
31: * @note: DEBUG affects this routine.

sys/include/ztimer64.h
256: * @note: This might function might leave a message with type MSG_ZTIMER64 in the
276: * @note: This might function might leave a message with type MSG_ZTIMER64 in the
342: * @note: This blocks lower priority threads. Use only for *very* short delays.

sys/include/event/timeout.h
88: * @note: the used event_timeout struct must stay valid until after the timeout

sys/include/ztimer.h
517: * @note: This might function might leave a message with type MSG_ZTIMER in the
737: * @note: This blocks lower priority threads. Use only for *very* short delays.

sys/include/event/periodic_callback.h
57: * @note: On init the periodic event is configured to run forever.
86: * @note: @p event must stay valid until after all periodic timeout
89: * @note: this function does not touch the current count value.
110: * @note: @p event must stay valid until after all periodic timeout
113: * @note: this function does not touch the current count value.
115: * @note: the periodic event will start without initial delay.
133: * @note: The periodic callback event is configured to run forever, and the first

sys/include/event/periodic.h
63: * @note: On init the periodic event is to to run forever.
80: * @note: the used event_periodic struct must stay valid until after the timeout
83: * @note: this function does not touch the current count value.
85: * @note: the periodic event will start without delay.
102: * @note: the used event_periodic struct must stay valid until after the timeout
105: * @note: this function does not touch the current count value.

drivers/pcf857x/pcf857x.c
359: * @warning: It is expected that the I2C bus is already acquired when the

sys/net/application_layer/emcute/emcute.c
204:    /** @todo: trigger update something like a 'last seen' value */

cpu/qn908x/periph/spi.c
216: * @brief: Wait for the FIFO to be empty.

sys/include/net/gnrc/tcp.h
295: * @note: Blocks until all currently opened connections maintained

cpu/riscv_common/include/cpu_common.h
46: * @todo:   Not supported

drivers/aip31068/include/aip31068_regs.h
28: * @note: Also changes AIP31068_BIT_ENTRY_MODE_INCREMENT to 1

drivers/kw41zrf/vendor/OSAbstraction/Interface/fsl_os_abstraction.h
523:* @return:  Handler to access the queue for put and get operations. If message queue

boards/cc2538dk/dist/board.resc
24:    sysbus LoadBinary @http://antmicro.com/projects/renode/cc2538_rom_dump.bin-s_524288-0c196cdc21b5397f82e0ff42b206d1cc4b6d7522 0x0

drivers/include/mma8x5x.h
210: * @warning: this does incur an I2C write, thus should not be done from within

cpu/lpc1768/include/vendor/LPC17xx.h
5: * @version: V1.09
6: * @date:    17. March 2010

drivers/include/aip31068.h
143: * @note: Also changes to setTextInsertionMode(LEFT_TO_RIGHT)
286: * @note: The cursor respects the setting for the insertion mode and is set
305: * @note: The cursor respects the setting for the insertion mode and is set
346: * @note: The size of charmap depends on how the AIP31068 was initialized.

dist/tools/bmp/README.md
73:user@pc:~$ ./bmp.py --connect-srst
84:user@pc:~$ ./bmp.py --connect-srst flash example.elf
105:user@pc:~$ ./bmp.py --connect-srst erase
120:user@pc:~$ ./bmp.py --connect-srst debug example.elf
154:user@pc:~$ ./bmp.py --connect-srst term

dist/tools/coccinelle/warn/notnull.cocci
97:@script:python depends on !s && !t && !u && !fix@

dist/tools/buildsystem_sanity_check/save_all_dependencies_resolution_variables.sh
15:# @author: Gaëtan Harter <gaetan.harter@fu-berlin.de>

dist/tools/goodfet/goodfet.bsl
838:            elif l[0] == '@':        #if @ => new address => send frame and set new addr.

tests/drivers/aip31068/main.c
70: * @note: Auto scroll will be disabled and the display will be scrolled to
74: * @note: Text insertion mode will be set to LEFT_TO_RIGHT.
93: * @note: This function changes the cursor position. You will have to use
```

ignored  ssh user@ip and vendor and fixed the rest 

now the result is 

```
CONTRIBUTING.md
262:git clone git@github.com:<account name>/RIOT.git

fuzzing/uri_parser/input/input4.txt
1:coap://user@[2001:db8::1%eth0]:12345

fuzzing/uri_parser/input/input1.txt
1:coap://user@[2001:db8::1]:12345

fuzzing/uri_parser/input/input0.txt
1:coap:///R@[2008::1]:5own//R@[2008::1]:5own/?v=1

makefiles/docker.inc.mk
10:DOCKER_PULL_IDENTIFIER := docker.io/riot/riotbuild@sha256:$(DOCKER_TESTED_IMAGE_REPO_DIGEST)

dist/tools/bmp/README.md
73:user@pc:~$ ./bmp.py --connect-srst
84:user@pc:~$ ./bmp.py --connect-srst flash example.elf
105:user@pc:~$ ./bmp.py --connect-srst erase
120:user@pc:~$ ./bmp.py --connect-srst debug example.elf
154:user@pc:~$ ./bmp.py --connect-srst term

cpu/rp2350_common/periph/uart.c
214:    /* @TODO: properly clear UART on deinit */

tests/unittests/tests-uri_parser/tests-uri_parser.c
79:    char *legacy_test_case_01 = "coap://RIOT:test@[fe80:db8::1%tap0]:5683/.well-known/core?v=1";
82:    char *legacy_test_case_04 = "coap://R@[2001:db8::1]:5/v=1";
83:    char *legacy_test_case_05 = "coap://R@[2001:db8::1]:5/:v=1";
84:    char *legacy_test_case_06 = "cap://R@[2001:db8::1]:5/?v=1";
87:    char *legacy_test_case_09 = "coap:///R@[2008::1]:5own//R@[2008::1]:5own/?v=1";
164:    char *trailing_percent = "coap://RIOT:test@[fe80:db8::1%]:5683/.well-known/core?v=1";
165:    char *invalid_port = "coap://R@[2001:db8::1]:5own/v=1";
166:    char *invalid_port_colon = "coap://R@[2001:db8::1]:5own/:v=1";
167:    char *invalid_port_short_scheme = "cap://R@[2001:db8::1]:5own/?v=1";
169:    char *double_scheme = "coap://oap://P@[2001:b";
395:        .input_uri = "coap://user@[2001:db8::1]",
407:        .input_uri = "coap://user@[2001:db8::1]:12345",
419:        .input_uri = "coap://user@[2001:db8::1%eth0]:12345",
496:        .input_uri = "coap://RIOT:test@[fe80:db8::1%eth2]:5683/.well-known/core?v=1",

sys/ut_process/ut_process.c
196:        case ',': case '=': case '|': case '@':

dist/tools/coccinelle/warn/notnull.cocci
97:@script:python depends on !s && !t && !u && !fix@

dist/tools/goodfet/goodfet.bsl
838:            elif l[0] == '@':        #if @ => new address => send frame and set new addr.

pkg/lorabasics/doc.txt
12: * @see      git@github.com:lorabasics/lorabasicsmodem.git

cpu/lpc1768/include/vendor/LPC17xx.h
5: * @version: V1.09
6: * @date:    17. March 2010

boards/cc2538dk/dist/board.resc
24:    sysbus LoadBinary @http://antmicro.com/projects/renode/cc2538_rom_dump.bin-s_524288-0c196cdc21b5397f82e0ff42b206d1cc4b6d7522 0x0
```

### Testing procedure

read 

example misrendering:
[https://api.riot-os.org/periodic__callback_8h.html](https://api.riot-os.org/periodic__callback_8h.html#adb704fbdad6b1031c60ac2dbcd578b45)

### Issues/PRs references


### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
