### PR TITLE
CODING_CONVENTIONS: add info about code block style, update Python guide to use SPDX

### DIFF
--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -531,10 +531,13 @@ Wrong:
 * Every header file includes a general description about the provided
   functionality.
 * Every function must be documented - including parameters and return value.
+* Example code and shell commands should be put in blocks separated by
+  backticks instead of using other block types to ensure compatibility with
+  Doxygen *and* Starlight.
 
-An exemplary doxygen documentation in a header file can look like this.
+An exemplary Doxygen documentation in a header file can look like this:
 
-```c
+````c
 /*
  * SPDX-FileCopyrightText: 2014 Peter Schmerzl <peter@schmerzl-os.org>
  * SPDX-License-Identifier: LGPL-2.1-only
@@ -549,8 +552,18 @@ An exemplary doxygen documentation in a header file can look like this.
  *
  * More detailed information about the file and the functionality implemented.
  *
- * @author      Peter Schmerzl <peter@schmerzl-os.org>
+ * Some example code in a C code block:
+ * ```c
+ * set_my_function(foo, bar, 0);
+ * int ret = check_my_function();
+ * ```
  *
+ * An exemplary shell command that explains how to change compile time options.
+ * ```shell
+ * CFLAGS=-D"CONFIG_FOO='BAR'" BOARD=fooboard make ...
+ * ```
+ *
+ * @author      Peter Schmerzl <peter@schmerzl-os.org>
  */
 
 /**
@@ -575,7 +588,9 @@ An exemplary doxygen documentation in a header file can look like this.
  * @retval  -ENOMEM on small microcontrollers with little RAM
  */
 int get_foolength(void);
-```
+
+/** @} */
+````
 
 ### SPDX
 
@@ -598,7 +613,6 @@ Old Style - License Information:
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
-
 ```
 
 New Style - SPDX Format:
@@ -667,9 +681,9 @@ not a string literal`.
   comment, including a rationale why it is a false positive and why the code
   can't be fixed otherwise, in the following format:
 ```c
-    /* cppcheck-suppress <category of error/warning>
-     * (reason: cppcheck is being really silly. this is certainly not a
-     * null-pointer dereference */
+/* cppcheck-suppress <category of error/warning>
+ * (reason: cppcheck is being really silly. this is certainly not a
+ * null-pointer dereference */
 ```
 
 ## Python coding convention
@@ -693,11 +707,8 @@ not a string literal`.
 ```python
 #!/usr/bin/env python3
 
-# Copyright (C) <your copyright>
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2026 <your name/company>
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # put the module imports first
 # see https://www.python.org/dev/peps/pep-0008/#imports


### PR DESCRIPTION
### Contribution description

As discussed in the weekly, our Coding Conventions did not mention that we should use backticks instead of `~~~` or indentation to separate code blocks from text.

### Testing procedure

Look at the documentation 👀 

### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
