### PR TITLE
lwip: include lwip_udp if lwip_dhcp is used

### DIFF
--- a/pkg/lwip/Makefile.dep
+++ b/pkg/lwip/Makefile.dep
@@ -110,6 +110,10 @@ ifneq (,$(filter lwip_dhcp_auto,$(USEMODULE)))
   USEMODULE += lwip_dhcp
 endif
 
+ifneq (,$(filter lwip_dhcp,$(USEMODULE)))
+  USEMODULE += lwip_udp
+endif
+
 # if an actual netdev is used, we need lwip_netdev to integrate it
 ifneq (,$(filter lwip_ethernet lwip_sixlowpan,$(USEMODULE)))
   USEMODULE += lwip_netdev


### PR DESCRIPTION
### Contribution description

`lwip_dhcp` depends on `lwip_udp`, so add it as a dependency. If it is not added, it fails with

```
lwip/src/core/init.c:95:2: error: #error "If you want to use DHCP, you have to define LWIP_UDP=1 in your lwipopts.h
```

### Testing procedure

Test this by compiling `examples/networking/misc/lwiperf` with DHCP support enabled, before and after this patch:

```
LWIP_IPV4=1 LWIP_IPV6=1 USEMODULE=lwip_dhcp_auto make -C examples/networking/misc/lwiperf
```

The `examples/networking/misc/lwip_ipv4` example uses UDP, so it never failed compiling.

### Issues/PRs references

#22286

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
