### PR TITLE
buildsystem: enable LTO by default

### DIFF
--- a/cpu/cortexm_common/Makefile
+++ b/cpu/cortexm_common/Makefile
@@ -1,3 +1,7 @@
 DIRS = periph
 
+# LTO would fail with
+# relocation truncated to fit: R_ARM_THM_JUMP11 against symbol `_svc_dispatch'
+SRC_NOLTO := thread_arch.c
+
 include $(RIOTBASE)/Makefile.base

--- a/cpu/esp32/syscalls.c
+++ b/cpu/esp32/syscalls.c
@@ -317,6 +317,7 @@ static rmutex_t s_shared_rmutex = RMUTEX_INIT;
 /* definition of locks required by the newlib if retargetable locking is used */
 extern struct __lock __attribute__((alias("s_shared_rmutex"))) __lock___sinit_recursive_mutex;
 extern struct __lock __attribute__((alias("s_shared_rmutex"))) __lock___sfp_recursive_mutex;
+__attribute__((used)) /* fixes linker errors when building with LTO */
 extern struct __lock __attribute__((alias("s_shared_rmutex"))) __lock___atexit_recursive_mutex;
 extern struct __lock __attribute__((alias("s_shared_rmutex"))) __lock___malloc_recursive_mutex;
 extern struct __lock __attribute__((alias("s_shared_rmutex"))) __lock___env_recursive_mutex;

--- a/cpu/riscv_common/irq_arch.c
+++ b/cpu/riscv_common/irq_arch.c
@@ -82,7 +82,7 @@ void riscv_irq_init(void)
 /**
  * @brief Global trap and interrupt handler
  */
-__attribute((used)) static void handle_trap(uword_t mcause)
+__attribute((used)) void handle_trap(uword_t mcause)
 {
     /*  Tell RIOT to set sched_context_switch_request instead of
      *  calling thread_yield(). */

--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -52,8 +52,12 @@ ifeq ($(filter -std=%,$(CXXEXFLAGS)),)
   endif
 endif
 
+# fails to compile with LLVM
+ifneq (llvm, $(TOOLCHAIN))
+  LTO ?= 1
+endif
+
 ifeq ($(LTO),1)
-  $(warning Building with Link-Time-Optimizations is currently an experimental feature. Expect broken binaries.)
   LTOFLAGS = -flto
   LINKFLAGS += $(LTOFLAGS) -ffunction-sections -fdata-sections
 endif

--- a/sys/newlib_syscalls_default/syscalls.c
+++ b/sys/newlib_syscalls_default/syscalls.c
@@ -242,6 +242,7 @@ pid_t _getpid(void)
  *
  * @return      the process ID of the current thread
  */
+__attribute__((used)) /* fixes linker errors when building with LTO */
 pid_t _getpid_r(struct _reent *ptr)
 {
     (void) ptr;
@@ -257,7 +258,8 @@ pid_t _getpid_r(struct _reent *ptr)
  *
  * @return      TODO
  */
-__attribute__ ((weak))
+__attribute__((weak))
+__attribute__((used)) /* fixes linker errors when building with LTO */
 int _kill_r(struct _reent *r, pid_t pid, int sig)
 {
     (void) pid;

--- a/sys/picolibc_syscalls_default/syscalls.c
+++ b/sys/picolibc_syscalls_default/syscalls.c
@@ -254,6 +254,7 @@ FILE *const stdin = &picolibc_stdio;
 STDIO_ALIAS(stdout);
 STDIO_ALIAS(stderr);
 #else
+__attribute__((used)) /* fixes linker errors when building with LTO */
 FILE *const __iob[] = {
     &picolibc_stdio,        /* stdin  */
     &picolibc_stdio,        /* stdout */

--- a/sys/ssp/Makefile.include
+++ b/sys/ssp/Makefile.include
@@ -1,3 +1,3 @@
 ifneq (,$(filter ssp,$(USEMODULE)))
-    CFLAGS += -fstack-protector
+    CFLAGS += -fstack-protector-strong
 endif

--- a/sys/ssp/ssp.c
+++ b/sys/ssp/ssp.c
@@ -22,8 +22,10 @@
 
 #include "panic.h"
 
+__attribute__((used)) /* fixes linker errors when building with LTO */
 uintptr_t __stack_chk_guard = (uintptr_t) STACK_CHK_GUARD;
 
+__attribute__((used)) /* fixes linker errors when building with LTO */
 __attribute__((noreturn)) void __stack_chk_fail(void)
 {
     core_panic(PANIC_SSP, "ssp: stack smashing detected");

--- a/sys/tiny_strerror/tiny_strerror.c
+++ b/sys/tiny_strerror/tiny_strerror.c
@@ -259,6 +259,7 @@ const char *tiny_strerror(int errnum)
 }
 
 #if IS_USED(MODULE_TINY_STRERROR_AS_STRERROR)
+__attribute__((used)) /* fixes linker errors when building with LTO */
 __attribute__((alias("tiny_strerror"))) const char *__wrap_strerror(int errnum);
 #endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Let's see where we are at this now.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Replaces #14795.

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- none
