### PR TITLE
GOVERNANCE.md: update process for inactive maintainers

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -119,11 +119,23 @@ their project duties.
 Maintainers may also be removed after being inactive, upon failure to fulfill their Maintainer
 responsibilities or because of violating the Code of Conduct. This also includes actively,
 persistently, and intentionally trying to harm or successfully harming the code base of RIOT.
-Especially, but not limited to, endangering the security or safety of RIOT. Inactivity is defined as
-a period of very low or no activity in the project. A yearly maintainer ping, an e-mail sent to
-inactive maintainers, determines if the maintainer is still willing to fulfill their project duties.
-During this process, the list of maintainers is reviewed. On failure to reply to the maintainer ping
-within the specified amount of time (usually a month), the maintainer will be removed.
+Especially, but not limited to, endangering the security or safety of RIOT.
+
+#### Retiring a Maintainer
+
+A maintainer who has not shown a single interaction in a pull request or issue that took more than
+5 minutes of effort over a period of 2 years will be retired. On retirement, all permissions to
+the repository will be revoked. The reason is that any account can be compromised. For maintainers
+that make active use of the permissions, this risk is justified.
+
+A retired maintainer will keep their permissions in the forum and their access to the internal
+maintainer matrix room. In addition, a retired maintainer may return to active maintainer duty
+at any point in time by reaching out to an admin to restore their permissions. A retired
+maintainer who returned to active duty can be retired again under the same rules, with the
+following exception: during a grace period of 3 months, starting from the point in time when
+the permissions have been restored, the maintainer should not be retired again due to inactivity.
+
+A maintainer may choose to retire at any point in time by reaching out to a RIOT admin.
 
 ### Release Managers
 


### PR DESCRIPTION
### Contribution description

Previously, maintainers were pinged on being inactive and removed if they failed to respond or agreed to be removed. However, there are some issues with this:

1. The maintainer ping is tedious and unthankful work that we could avoid
2. A maintainer account with repo access is a security risk, that for active maintainers is offset by the benefit of using the permissions to improve RIOT. For inactive maintainers, the security risk comes with no benefit. It is hard to justify the security risk of keeping the permissions of inactive maintainers.
3. Maintainers may become inactive for an extended period of time due to other things on their agenda, but may want to return to active duty afterwards. There is little reason to believe that someone who has been a capable RIOT maintainer will no longer be capable after returning from a sabbatical. Still, there currently is no fast track to restore their former status.

This tries to address these issues by just retiring maintainers after two years of activity, no questions asked. While this clearly is more rude than reaching out, the impact of becoming a retired maintainer is much more limited than the former process of removing them: They can just resume active duty by reaching out and will get their permissions restored and they stay in the loop by keeping access to the communication channels restricted to maintainers.

### Testing procedure

- review of the markup
- review of the generated doc

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
