### PR TITLE
cpu/esp32: fix warning about conflicting symbols

### DIFF
--- a/cpu/esp32/periph/pm.c
+++ b/cpu/esp32/periph/pm.c
@@ -140,8 +140,8 @@ void pm_set(unsigned mode)
 
 #if SOC_PM_SUPPORT_RTC_SLOW_MEM_PD
     /* Labels for RTC slow memory that are defined in the linker script */
-    extern int _rtc_bss_rtc_start;
-    extern int _rtc_bss_rtc_end;
+    extern uint8_t _rtc_bss_rtc_start;
+    extern uint8_t _rtc_bss_rtc_end;
 
     /*
      * Activate the Power Domain for slow RTC memory when the .rtc.bss


### PR DESCRIPTION
### Contribution description

`cpu/esp32/startup.c` also has:

```c
extern uint8_t _rtc_bss_start;
extern uint8_t _rtc_bss_end;
extern uint8_t _rtc_bss_rtc_start;
extern uint8_t _rtc_bss_rtc_end;
extern uint8_t _iram_start;
```

but in `pm.c` two of those were defined as `int`, causing the compiler to issue a warning when compiled with LTO. This aligns the definition to get rid of the warning.

In any case, those symbols are defined by the linker script and to not really map to a C type. And the code is only using it to compare addresses.

In fact, the use of `uint8_t` instead of `int` might be a bit more safe here, in case the addresses are not aligned to the alignment requirement of `int`.

### Testing procedure

There is a good chance that the generated binaries do not differ after applying this change, in which case it should be pretty safe to merge.

In addition, compiling with `LTO=1` will still fail, but two warnings less should be shown prior to the failure.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none