### PR TITLE
pkg/lwip: add stm32_eth_link_up as dependency of lwip_ipv6

### DIFF
--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -52,12 +52,6 @@ ifneq (,$(filter stm32_eth,$(USEMODULE)))
   USEMODULE += netdev_new_api
   USEMODULE += ztimer
   USEMODULE += ztimer_msec
-
-  # lwip IPv6 supports needs link up events to perform duplicate address
-  # detection
-  ifneq (,$(filter lwip_ipv6,$(USEMODULE)))
-    USEMODULE += stm32_eth_link_up
-  endif
 endif
 
 ifneq (,$(filter lcd_parallel_ll_mcu,$(USEMODULE)))

--- a/pkg/lwip/Makefile.dep
+++ b/pkg/lwip/Makefile.dep
@@ -18,8 +18,11 @@ ifneq (,$(filter sock_udp,$(USEMODULE)))
   USEMODULE += lwip_sock_udp
 endif
 
-ifneq (,$(filter stm32_eth,$(USEMODULE)))
-  ifneq (,$(filter lwip_dhcp_auto,$(USEMODULE)))
+# if lwip_dhcp_auto or lwip_ipv6 is used, enable link up detection:
+# - lwip_dhcp_auto needs link up events to trigger the DHCP process
+# - lwip_ipv6 needs link up events to perform duplicate address detection
+ifneq (,$(filter lwip_dhcp_auto lwip_ipv6,$(USEMODULE)))
+  ifneq (,$(filter stm32_eth,$(USEMODULE)))
     USEMODULE += stm32_eth_link_up
   endif
 endif


### PR DESCRIPTION
### Contribution description

This moves the inclusion of `stm32_eth_link_up` for `lwip_ipv6` to `pkg/lwip`, so that it now combines with the same inclusion for `lwip_dhcp_auto`.

With #22305 and #22306, I have added `lpc1768_eth_link_up` and `efm32_eth_link_up`, which would otherwise scatter lwIP-specific dependencies around in `cpu/*/Makefile.dep`.

### Testing procedure

Run the following for current `master` and this branch.

```
LWIP=1 BOARD=nucleo-f207zg make info-build -C examples/networking/misc/benchmark_udp
```

The `info-build` target should mention `stm32_eth_link_up` as being included for both builds.

Then comment the change in `pkg/lwip/Makefile.dep` and run the build again. Observe that it is not included.

The chosen example is one that uses lwIP with IPv6.

### Issues/PRs references

- #22305 
- #22306 

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none