### PR TITLE
makefiles/docker: fix building Espressif boards when using `podman` instead of plain `docker`

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -36,7 +36,8 @@ export DOCKER_MAKECMDGOALS := $(filter $(DOCKER_MAKECMDGOALS_POSSIBLE),$(MAKECMD
 
 # Docker creates the files .dockerinit and .dockerenv in the root directory of
 # the container, we check for the files to determine if we are inside a container.
-ifneq (,$(wildcard /.dockerinit /.dockerenv))
+# Podman uses /run/.containerenv instead.
+ifneq (,$(wildcard /.dockerinit /.dockerenv /run/.containerenv))
   export INSIDE_DOCKER := 1
 else
   export INSIDE_DOCKER := 0


### PR DESCRIPTION
### Contribution description

Docker builds for Expressif boards use two different virtualenvs, `venv` for the host (for the flashing tools) and `venv_docker` for the in-docker build tools.

When using Podman, the logic for setting `INSIDE_DOCKER` make variable is broken, because neither of `/.dockerinit` or `/.dockerenv` get created inside the container. Luckily, Podman creates `/run/.containerenv` - so adding a check for this file is all that's needed to fix the build system.

### Testing procedure

Before the fix, the command
```
cd examples/basic/blinky
BUILD_IN_DOCKER=1 BOARD=seeedstudio-xiao-esp32s3 make flash
```

fails - only `dist/tools/espressif/venv` is created, and contains the docker and not the host stuff.

After the fix, everything works.


### Issues/PRs references

https://github.com/podman-container-tools/podman/issues/1583

### Declaration of AI-Tools / LLMs usage:

No AI was used.
