### PR TITLE
boards/nucleo-g031k8: add support for STM32 Nucleo-G031K8

### DIFF
--- a/boards/common/nucleo32/include/board.h
+++ b/boards/common/nucleo32/include/board.h
@@ -27,9 +27,15 @@ extern "C" {
  * @name Macros for controlling the on-board LED (LD3).
  * @{
  */
-#define LED0_PIN_NUM        3
-#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
-#define LED0_PORT_NUM       PORT_B
+#ifdef BOARD_NUCLEO_G031K8
+#  define LED0_PIN_NUM        6
+#  define LED0_PORT           GPIO_PORT_C /**< GPIO port of LED 3 */
+#  define LED0_PORT_NUM       PORT_C
+#else
+#  define LED0_PIN_NUM        3
+#  define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
+#  define LED0_PORT_NUM       PORT_B
+#endif
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-g031k8/Kconfig
+++ b/boards/nucleo-g031k8/Kconfig
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 Hudson C. Dalpra
+# SPDX-License-Identifier: LGPL-2.1-only
+
+config BOARD
+    default "nucleo-g031k8" if BOARD_NUCLEO_G031K8
+
+config BOARD_NUCLEO_G031K8
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO32
+    select CPU_MODEL_STM32G031K8
+
+source "$(RIOTBOARD)/common/nucleo32/Kconfig"

--- a/boards/nucleo-g031k8/Makefile
+++ b/boards/nucleo-g031k8/Makefile
@@ -1,0 +1,4 @@
+MODULE = board
+DIRS = $(RIOTBOARD)/common/nucleo
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/nucleo-g031k8/Makefile.dep
+++ b/boards/nucleo-g031k8/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/nucleo32/Makefile.dep

--- a/boards/nucleo-g031k8/Makefile.features
+++ b/boards/nucleo-g031k8/Makefile.features
@@ -1,0 +1,9 @@
+CPU = stm32
+CPU_MODEL = stm32g031k8
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_uart
+
+# load the common Makefile.features for Nucleo-32 boards
+include $(RIOTBOARD)/common/nucleo32/Makefile.features

--- a/boards/nucleo-g031k8/Makefile.include
+++ b/boards/nucleo-g031k8/Makefile.include
@@ -1,0 +1,8 @@
+# load the common Makefile.include for Nucleo-32 boards
+include $(RIOTBOARD)/common/nucleo32/Makefile.include
+
+# When the NRST_MODE option byte is 2, the NRST pin is a GPIO and no longer
+# resets the MCU, so the ST-Link's SRST reset fails. Reset over SWD instead.
+# See doc.md.
+OPENOCD_RESET_USE_CONNECT_ASSERT_SRST = 0
+OPENOCD_EXTRA_INIT += -c 'reset_config none'

--- a/boards/nucleo-g031k8/doc.md
+++ b/boards/nucleo-g031k8/doc.md
@@ -1,0 +1,69 @@
+<!--
+SPDX-FileCopyrightText: 2026 Hudson C. Dalpra
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+
+@defgroup    boards_nucleo-g031k8 STM32 Nucleo-G031K8
+@ingroup     boards_common_nucleo32
+@brief       Support for the STM32 Nucleo-G031K8 board.
+
+## General information
+
+The Nucleo-G031K8 is a board from ST's Nucleo family supporting ARM Cortex-M0+
+STM32G031K8 microcontroller with 8KiB of RAM and 64KiB of Flash.
+
+You can find general information about the Nucleo32 boards on the
+@ref boards_common_nucleo32 page.
+
+## Pinout
+
+<img src="pinouts/nucleo-g031k8-and-more.svg" alt="Pinout for the Nucleo-G031K8 (from ST User Manual, UM2591, https://www.st.com/resource/en/user_manual/um2591-stm32g0-nucleo32-board-mb1455-stmicroelectronics.pdf, page 16)" width=25% />
+
+## MCU
+
+| MCU        |    STM32G031K8      |
+|:---------- |:------------------- |
+| Family     | ARM Cortex-M0+      |
+| Vendor     | ST Microelectronics |
+| RAM        | 8KiB                |
+| Flash      | 64KiB               |
+| Frequency  | up to 64MHz         |
+| FPU        | no                  |
+| Timers     | 11 (7x 16-bit, 1x 32-bit, 2x Watchdog, 1x Systick) |
+| ADC        | 1x 12-bit (16 channels) |
+| UARTs      | 3 (two USART)       |
+| SPIs       | 2                   |
+| CANs       | 0                   |
+| RTC        | 1                   |
+| I2Cs       | 2                   |
+| Vcc        | 1.7V - 3.6V         |
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32g031k8.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0444-stm32g0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) |
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0223-stm32-cortexm0-mcus-programming-manual-stmicroelectronics.pdf) |
+| Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/um2591-stm32g0-nucleo32-board-mb1455-stmicroelectronics.pdf) |
+
+## Flashing the board
+
+A detailed description about the flashing process can be found on the
+[guides page](https://guide.riot-os.org/board_specific/stm32/).
+The board name for the Nucleo-G031K8 is `nucleo-g031k8`.
+
+## Reset configuration
+
+Some boards ship with the `NRST_MODE` option byte set to `2` (the documented
+default is `3`), which turns the NRST pin into the `PF2` GPIO and disables its
+reset function, so the reset button, the NRST pin and the ST-Link reset no
+longer reset the MCU. RIOT works around this by resetting over SWD
+(`reset_config none`), so `make flash` always works.
+
+To restore the hardware reset, set `NRST_MODE` to `1` or `3`. The easiest way
+to do this is to use STM32CubeProgrammer, which is available for Linux,
+Mac (x86 and ARM) and Windows on the
+[ST website](https://www.st.com/en/development-tools/stm32cubeprog.html).
+
+@note STM32CubeProgrammer v2.22 from February 2026 has a bug that prevents
+writing the Option Bytes. Use an older or newer version instead!
+
+Alternatively, you can write a program that sets the `FLASH_OPTR` register.
+For more information, please refer to the STM32G0x1 Reference Manual
+linked in the table above.

--- a/boards/nucleo-g031k8/include/periph_conf.h
+++ b/boards/nucleo-g031k8/include/periph_conf.h
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Hudson C. Dalpra
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_nucleo-g031k8
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for STM32 Nucleo-G031K8 board
+ *
+ * @author      Hudson C. Dalpra <dalpra.hcd@gmail.com>
+ */
+
+#include "periph_cpu.h"
+#include "clk_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {   /* Connected to the ST-Link */
+        .dev        = USART2,
+        .rcc_mask   = RCC_APBENR1_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 3),
+        .tx_pin     = GPIO_PIN(PORT_A, 2),
+        .rx_af      = GPIO_AF1,
+        .tx_af      = GPIO_AF1,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn,
+    },
+    {   /* Arduino pinout on D0/D1 */
+        .dev        = USART1,
+        .rcc_mask   = RCC_APBENR2_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_B, 7),
+        .tx_pin     = GPIO_PIN(PORT_B, 6),
+        .rx_af      = GPIO_AF0,
+        .tx_af      = GPIO_AF0,
+        .bus        = APB12,
+        .irqn       = USART1_IRQn,
+    }
+};
+
+#define UART_0_ISR          (isr_usart2)
+#define UART_1_ISR          (isr_usart1)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/examples/lang_support/community/javascript/Makefile.ci
+++ b/examples/lang_support/community/javascript/Makefile.ci
@@ -35,6 +35,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-f410rb \
+    nucleo-g031k8 \
     nucleo-g070rb \
     nucleo-g071rb \
     nucleo-g431rb \

--- a/tests/core/cond_order/Makefile.ci
+++ b/tests/core/cond_order/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053 \

--- a/tests/core/mutex_order/Makefile.ci
+++ b/tests/core/mutex_order/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/core/rmutex_cpp/Makefile.ci
+++ b/tests/core/rmutex_cpp/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/core/thread_cooperation/Makefile.ci
+++ b/tests/core/thread_cooperation/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     msb-430h \
     nucleo-c031c6 \
     nucleo-f031k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     samd10-xmini \
     slstk3400a \

--- a/tests/pkg/libcose/Makefile.ci
+++ b/tests/pkg/libcose/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/pkg/littlefs2/Makefile.ci
+++ b/tests/pkg/littlefs2/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/pkg/lz4/Makefile.ci
+++ b/tests/pkg/lz4/Makefile.ci
@@ -27,6 +27,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l031k6 \
     nucleo-l053r8 \
     samd10-xmini \

--- a/tests/pkg/relic/Makefile.ci
+++ b/tests/pkg/relic/Makefile.ci
@@ -27,6 +27,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f103rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/pkg/spiffs/Makefile.ci
+++ b/tests/pkg/spiffs/Makefile.ci
@@ -14,6 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/pkg/tinyvcdiff/Makefile.ci
+++ b/tests/pkg/tinyvcdiff/Makefile.ci
@@ -13,6 +13,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/pkg/utensor/Makefile.ci
+++ b/tests/pkg/utensor/Makefile.ci
@@ -27,6 +27,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-f410rb \
+    nucleo-g031k8 \
     nucleo-g070rb \
     nucleo-g071rb \
     nucleo-g431rb \

--- a/tests/sys/psa_crypto/Makefile.ci
+++ b/tests/sys/psa_crypto/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/sys/suit_manifest/Makefile.ci
+++ b/tests/sys/suit_manifest/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \


### PR DESCRIPTION
### Contribution description

Add support for STM32 Nucleo-G031K8 (https://www.st.com/en/evaluation-tools/nucleo-g031k8.html#documentation)

Based on the existing nucleo-f031k6 and nucleo-g0 boards. Added only the UART configuration in this commit so the port is easy to verify and test.

Also adds a reset workaround: the ST-Link reset is dead when the NRST_MODE option byte is 2, so flashing resets over SWD (reset_config none) instead.

See:
- https://docs.zephyrproject.org/latest/boards/st/nucleo_g031k8/doc/index.html#restriction
- https://community.st.com/t5/stm32cubeprogrammer-mcus/nucleo-g031k8-reset-not-working/m-p/92438
- https://community.st.com/t5/stm32-mcus-boards-and-hardware/nucleo-g031k8-bricked/td-p/627055
- I also have one board that arrived like this

### Testing procedure

Because I am using Linux wsl with usbipd forwarding I was having a hard time catching the hello message, so I made the following git diff for testing:

``` diff
diff --git i/examples/basic/hello-world/main.c w/examples/basic/hello-world/main.c
index c1fe9bae12..75d6a940d4 100644
--- i/examples/basic/hello-world/main.c
+++ w/examples/basic/hello-world/main.c
@@ -16,14 +16,21 @@
  * @}
  */

 #include <stdio.h>
+#include <stdint.h>

 int main(void)
 {
-    puts("Hello World!");
-
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s CPU.\n", RIOT_CPU);

+    while (1) {
+        puts("Hello World!");
+
+        for (volatile uint32_t i = 0; i < 1000000; i++) {
+        }
+    }
+
     return 0;
 }
```

<img width="1902" height="742" alt="Capture" src="https://github.com/user-attachments/assets/630b67e4-6b7c-4cbe-be43-871e4bd15682" />

### Issues/PRs references

Maybe this one https://github.com/RIOT-OS/RIOT/issues/19264, but it doesn't list the stm32g0.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
