### PR TITLE
makefiles/info-global: speedup info-boards-* targets by using parallel execution

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -243,7 +243,9 @@ get_supported_boards() {
         export BOARDS="${QUICKBUILD_BOARDS}"
     fi
 
-    local boards="$(make --no-print-directory -C$appdir info-boards-supported 2>/dev/null || echo broken)"
+    # The `info-boards-supported` target supports multithreading, but
+    # using too many threads causes it to become flaky in CI.
+    local boards="$(make --no-print-directory -C$appdir -j2 info-boards-supported 2>/dev/null || echo broken)"
 
     export BOARDS="${BOARDS_}"
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -236,7 +236,10 @@ GLOBAL_GOALS += info-boards-features-blacklisted \
                 generate-Makefile.ci \
                 #
 
-ifneq (, $(filter $(GLOBAL_GOALS), $(MAKECMDGOALS)))
+PRIVATE_GLOBAL_GOALS := info-boards-collect \
+                        #
+
+ifneq (,$(filter $(GLOBAL_GOALS) $(PRIVATE_GLOBAL_GOALS),$(MAKECMDGOALS)))
   include $(RIOTMAKE)/info-global.inc.mk
 else
 

--- a/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
+++ b/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
@@ -296,10 +296,17 @@ class RIOTApplication:
         self.logger.info("Application has test: %s", has_test)
         return has_test
 
-    def board_is_supported(self):
-        """Return if current board is supported."""
+    def board_is_supported(self, jobs=False):
+        """Return if current board is supported.
+
+        :param jobs: Number of parallel jobs allowed
+        """
         env = {"BOARDS": self.board}
         cmd = ["info-boards-supported"]
+        if jobs is not None:
+            cmd += ["--jobs"]
+            if jobs:
+                cmd += [str(jobs)]
         ret = self.make(cmd, env=env, log_error=True).strip()
 
         supported = ret == self.board
@@ -393,11 +400,12 @@ class RIOTApplication:
         succeeds.
 
         :param incremental: Do not rerun successful compilation and tests
+        :param jobs: Number of parallel jobs allowed
         :raises ErrorInTest: on execution failed during one step
         """
 
         # Ignore incompatible APPS
-        if not self.board_is_supported():
+        if not self.board_is_supported(jobs):
             create_directory(self.resultdir, clean=True)
             self._skip("not_supported", "Board not supported")
             return

--- a/dist/tools/compile_test/compile_like_murdock.py
+++ b/dist/tools/compile_test/compile_like_murdock.py
@@ -154,7 +154,7 @@ def _all_apps(cwd):
 
 
 def _supported_boards(boards, env, cwd, all_boards=False):
-    cmd = ('make', 'info-boards-supported', '--no-print-directory')
+    cmd = ('make', 'info-boards-supported', '--no-print-directory', '-j')
     supported_boards = __exec_cmd(cmd, env=env, cwd=cwd).split()
     if all_boards:
         return supported_boards
@@ -163,7 +163,7 @@ def _supported_boards(boards, env, cwd, all_boards=False):
 
 def _supported_boards_from_cpu(cpu, env, cwd):
     cmd = (f'FEATURES_REQUIRED=cpu_{cpu} make info-boards-supported '
-           '--no-print-directory')
+           '--no-print-directory -j')
     __exec_cmd(cmd, shell=True, env=env, cwd=cwd).split()
 
 

--- a/doc/guides/build-system/advanced_build_system_tricks.md
+++ b/doc/guides/build-system/advanced_build_system_tricks.md
@@ -147,7 +147,7 @@ BOARD=board_name make dependency-debug
 Or with the "quick" version used by murdock to know supported boards (this is an incomplete resolution, details in `makefiles/dependencies_debug.inc.mk`) to a `dependencies_info-boards-supported_board_name` file:
 
 ```sh
-BOARDS=board_name DEPENDENCY_DEBUG=1 make info-boards-supported
+BOARDS=board_name DEPENDENCY_DEBUG=1 make info-boards-supported -j
 ```
 
 For more configuration and usage details, see in the file defining the targets `makefiles/dependencies_debug.inc.mk`.

--- a/examples/networking/coap/nanocoap_server/Makefile
+++ b/examples/networking/coap/nanocoap_server/Makefile
@@ -66,7 +66,7 @@ USEMODULE += hashes
 LOW_MEMORY_BOARDS := nucleo-f334r8
 
 ifneq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
-  $(info Using low-memory configuration for microcoap_server.)
+  $(shell echo 'Using low-memory configuration for nanocoap_server.' 1>&2)
   ## low-memory tuning values
   USEMODULE += prng_minstd
 endif

--- a/makefiles/app_dirs.inc.mk
+++ b/makefiles/app_dirs.inc.mk
@@ -29,7 +29,7 @@ info-applications:
 # All applications / board output of `info-boards-supported`.
 info-applications-supported-boards:
 	@for dir in $(APPLICATION_DIRS); do \
-	  $(MAKE) --no-print-directory -C $${dir} info-boards-supported 2>/dev/null | xargs -n 1 echo $${dir}; \
+	  $(MAKE) --no-print-directory -C $${dir} info-boards-supported -j 2>/dev/null | xargs -n 1 echo $${dir}; \
 	done
 # BOARDS values from 'boards.inc.mk' to only evaluate it once
 info-applications-supported-boards: export BOARDS ?=

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -5,95 +5,16 @@
         info-boards-features-conflicting \
         #
 
-BOARDDIR_GLOBAL := $(BOARDDIR)
-USEMODULE_GLOBAL := $(USEMODULE)
-USEPKG_GLOBAL := $(USEPKG)
-FEATURES_REQUIRED_GLOBAL := $(FEATURES_REQUIRED)
-FEATURES_REQUIRED_ANY_GLOBAL := $(FEATURES_REQUIRED_ANY)
-FEATURES_OPTIONAL_GLOBAL := $(FEATURES_OPTIONAL)
-FEATURES_CONFLICT_GLOBAL := $(FEATURES_CONFLICT)
-FEATURES_CONFLICT_MSG_GLOBAL := $(FEATURES_MSG_CONFLICT)
-DISABLE_MODULE_GLOBAL := $(DISABLE_MODULE)
-DEFAULT_MODULE_GLOBAL := $(DEFAULT_MODULE)
-FEATURES_BLACKLIST_GLOBAL := $(FEATURES_BLACKLIST)
-
-define board_unsatisfied_features
-  # BOARD might have been overwritten by `board_alias.ink.mk`
-  # To be able to re-set it here, we need to use override again
-  override BOARD    := $(1)
-  USEMODULE         := $(USEMODULE_GLOBAL)
-  USEPKG            := $(USEPKG_GLOBAL)
-  DISABLE_MODULE    := $(DISABLE_MODULE_GLOBAL)
-  DEFAULT_MODULE    := $(DEFAULT_MODULE_GLOBAL)
-  FEATURES_REQUIRED := $(FEATURES_REQUIRED_GLOBAL)
-  FEATURES_REQUIRED_ANY := $(FEATURES_REQUIRED_ANY_GLOBAL)
-  FEATURES_OPTIONAL := $(FEATURES_OPTIONAL_GLOBAL)
-  FEATURES_CONFLICT := $(FEATURES_CONFLICT_GLOBAL)
-  FEATURES_CONFLICT_MSG := $(FEATURES_CONFLICT_MSG_GLOBAL)
-  FEATURES_BLACKLIST:= $(FEATURES_BLACKLIST_GLOBAL)
-
-  # Find matching board folder
-  BOARDDIR := $$(word 1,$$(foreach dir,$$(BOARDSDIRS),$$(wildcard $$(dir)/$$(BOARD)/.)))
-
-  # Remove board specific variables set by Makefile.features/Makefile.dep
-  FEATURES_PROVIDED :=
-  FEATURES_USED :=
-
-  # Undefine variables that must not be defined when starting.
-  # Some are sometime set as `?=`
-  undefine CPU
-  undefine CPU_MODEL
-  undefine CPU_ARCH
-  undefine CPU_CORE
-  undefine CPU_FAM
-  undefine RUST_TARGET
-  undefine BOARD_VERSION
-
-  include $(RIOTBASE)/Makefile.features
-  # always select provided architecture features
-  FEATURES_REQUIRED += $$(filter arch_%,$$(FEATURES_PROVIDED))
-  # always select CPU core features
-  FEATURES_REQUIRED += $$(filter cpu_core_%,$$(FEATURES_PROVIDED))
-  # FEATURES_USED must be populated first in this case so that dependency
-  # resolution can take optional features into account during the first pass.
-  # Also: This allows us to skip resolution if already a missing feature is
-  # detected
-  include $(RIOTMAKE)/features_check.inc.mk
-  ifneq (,$$(FEATURES_MISSING))
-    # Skip full dependency resolution, as even without optional modules features
-    # and architecture specific limitations already some features are missing
-    BOARDS_FEATURES_MISSING += "$$(BOARD) $$(FEATURES_MISSING)"
-    BOARDS_WITH_MISSING_FEATURES += $$(BOARD)
-  else
-    # add default modules
-    include $(RIOTMAKE)/defaultmodules_regular.inc.mk
-    USEMODULE += $$(filter-out $$(DISABLE_MODULE),$$(DEFAULT_MODULE))
-
-    include $(RIOTMAKE)/dependency_resolution.inc.mk
-
-    ifneq (,$$(FEATURES_MISSING))
-      BOARDS_FEATURES_MISSING += "$$(BOARD) $$(FEATURES_MISSING)"
-      BOARDS_WITH_MISSING_FEATURES += $$(BOARD)
-    endif
-
-    ifneq (,$$(FEATURES_USED_BLACKLISTED))
-      BOARDS_FEATURES_USED_BLACKLISTED += "$$(BOARD) $$(FEATURES_USED_BLACKLISTED)"
-      BOARDS_WITH_BLACKLISTED_FEATURES += $$(BOARD)
-    endif
-
-    ifneq (,$$(FEATURES_CONFLICTING))
-      BOARDS_FEATURES_CONFLICTING += "$$(BOARD) $$(FEATURES_CONFLICTING)"
-      BOARDS_WITH_CONFLICTING_FEATURES += $$(BOARD)
-    endif
+ifneq (,$(filter info-boards-collect, $(MAKECMDGOALS)))
+  ifneq (1,$(INFO_OVERRIDE))
+    $(error info-boards-collect should not be called directly!)
   endif
-
-  ifneq (,$$(DEPENDENCY_DEBUG))
-    $$(call file_save_dependencies_variables,dependencies_info-boards-supported)
-  endif
-endef
+endif
 
 BOARDS := $(filter $(if $(BOARDS_SUPPORTED), $(BOARDS_SUPPORTED), %), $(BOARDS))
 BOARDS := $(filter-out $(BOARDS_UNSUPPORTED), $(BOARDS))
+
+BOARD_CANDIDATES := $(addprefix .board-result-,$(BOARDS))
 
 BOARDS_WITH_MISSING_FEATURES :=
 BOARDS_FEATURES_MISSING :=
@@ -102,16 +23,67 @@ BOARDS_FEATURES_USED_BLACKLISTED :=
 BOARDS_FEATURES_CONFLICTING :=
 BOARDS_WITH_CONFLICTING_FEATURES :=
 
-$(foreach board,$(BOARDS),$(eval $(call board_unsatisfied_features,$(board))))
-BOARDS := $(filter-out $(BOARDS_WITH_MISSING_FEATURES) \
-                       $(BOARDS_WITH_BLACKLISTED_FEATURES) \
-                       $(BOARDS_WITH_CONFLICTING_FEATURES), $(BOARDS))
+ifneq (, $(filter info-boards-collect,$(MAKECMDGOALS)))
+  # Find matching board folder
+  BOARDDIR := $(word 1,$(foreach dir,$(BOARDSDIRS),$(wildcard $(dir)/$(BOARD)/.)))
+
+  # Remove board specific variables set by Makefile.features/Makefile.dep
+  FEATURES_PROVIDED :=
+  FEATURES_USED :=
+
+  include $(RIOTBASE)/Makefile.features
+  # always select provided architecture features
+  FEATURES_REQUIRED += $(filter arch_%,$(FEATURES_PROVIDED))
+  # always select CPU core features
+  FEATURES_REQUIRED += $(filter cpu_core_%,$(FEATURES_PROVIDED))
+  # FEATURES_USED must be populated first in this case so that dependency
+  # resolution can take optional features into account during the first pass.
+  # Also: This allows us to skip resolution if already a missing feature is
+  # detected
+  include $(RIOTMAKE)/features_check.inc.mk
+  ifneq (,$(FEATURES_MISSING))
+    # Skip full dependency resolution, as even without optional modules features
+    # and architecture specific limitations already some features are missing
+    BOARDS_FEATURES_MISSING += "$(BOARD) $(FEATURES_MISSING)"
+    BOARDS_WITH_MISSING_FEATURES += $(BOARD)
+  else
+    # add default modules
+    include $(RIOTMAKE)/defaultmodules_regular.inc.mk
+    USEMODULE += $(filter-out $(DISABLE_MODULE),$(DEFAULT_MODULE))
+
+    include $(RIOTMAKE)/dependency_resolution.inc.mk
+
+    ifneq (,$(FEATURES_MISSING))
+      BOARDS_FEATURES_MISSING += "$(BOARD) $(FEATURES_MISSING)"
+      BOARDS_WITH_MISSING_FEATURES += $(BOARD)
+    endif
+
+    ifneq (,$(FEATURES_USED_BLACKLISTED))
+      BOARDS_FEATURES_USED_BLACKLISTED += "$(BOARD) $(FEATURES_USED_BLACKLISTED)"
+      BOARDS_WITH_BLACKLISTED_FEATURES += $(BOARD)
+    endif
+
+    ifneq (,$(FEATURES_CONFLICTING))
+      BOARDS_FEATURES_CONFLICTING += "$(BOARD) $(FEATURES_CONFLICTING)"
+      BOARDS_WITH_CONFLICTING_FEATURES += $(BOARD)
+    endif
+  endif
+
+  ifneq (,$(DEPENDENCY_DEBUG))
+    $(call file_save_dependencies_variables,dependencies_info-boards-supported)
+  endif
+
+  BOARDS := $(filter-out $(BOARDS_WITH_MISSING_FEATURES) \
+                         $(BOARDS_WITH_BLACKLISTED_FEATURES) \
+                         $(BOARDS_WITH_CONFLICTING_FEATURES), $(BOARD))
+endif
 
 info-buildsizes-diff: SHELL=bash
 info-buildsizes-diff:
 	@echo -e "text\tdata\tbss\tdec\tBOARD/BINDIRBASE\n"; \
 	COMMON_BOARDS=(); ONLY_OLD=(); ONLY_NEW=(); \
-	for board in $(BOARDS); do \
+	SUPPORTED_BOARDS="$($(MAKE) info-boards-supported --no-print-directory -j)"; \
+	for board in $(SUPPORTED_BOARDS); do \
 	  if [[ -e "$${OLDBIN}/$${board}" && -e "$${NEWBIN}/$${board}" ]]; then \
 	    COMMON_BOARDS+=($${board}); \
 	  elif [[ -e "$${OLDBIN}/$${board}" ]]; then \
@@ -148,21 +120,55 @@ info-buildsizes-diff:
 	  $(COLOR_ECHO) "$(COLOR_YELLOW)Boards in NEWBIN without complementary OLDBIN: $${ONLY_NEW[*]}$(COLOR_RESET)"; \
 	fi;
 
-info-boards-supported:
-	@echo $(BOARDS)
 
-info-boards-features-missing:
-	@for f in $(BOARDS_FEATURES_MISSING); do echo $${f}; done | column -t
+# Temporary files that contain the information gathered by the submake
+# processes started for each individual board. These reside in the `bin/`
+# subdirectory so they are removed by `make (dist)clean` and ignored by git.
+SUPPORT_FILES := bin/.INFO_BOARDS_SUPPORTED
+SUPPORT_FILES += bin/.INFO_BOARDS_FEATURES_MISSING
+SUPPORT_FILES += bin/.INFO_BOARDS_FEATURES_BLACKLISTED
+SUPPORT_FILES += bin/.INFO_BOARDS_FEATURES_CONFLICTING
 
-info-boards-features-blacklisted:
-	@for f in $(BOARDS_FEATURES_USED_BLACKLISTED); do echo $${f}; done | column -t
+.PHONY: $(SUPPORT_FILES)
+$(SUPPORT_FILES):
+	@rm -rf $@
+	@mkdir -p bin/
+	@touch $@
 
-info-boards-features-conflicting:
-	@for f in $(BOARDS_FEATURES_CONFLICTING); do echo $${f}; done | column -t
+.board-result-%:
+	@$(MAKE) BOARD=$* INFO_OVERRIDE=1 info-boards-collect --no-print-directory
+
+info-boards-supported: bin/.INFO_BOARDS_SUPPORTED $(BOARD_CANDIDATES)
+	@cat bin/.INFO_BOARDS_SUPPORTED | sort | xargs echo
+
+info-boards-features-missing: bin/.INFO_BOARDS_FEATURES_MISSING $(BOARD_CANDIDATES)
+	@cat bin/.INFO_BOARDS_FEATURES_MISSING | sort | column -t
+
+info-boards-features-blacklisted: bin/.INFO_BOARDS_FEATURES_BLACKLISTED $(BOARD_CANDIDATES)
+	@cat bin/.INFO_BOARDS_FEATURES_BLACKLISTED | sort | column -t
+
+info-boards-features-conflicting: bin/.INFO_BOARDS_FEATURES_CONFLICTING $(BOARD_CANDIDATES)
+	@cat bin/.INFO_BOARDS_FEATURES_CONFLICTING | sort | column -t
 
 generate-Makefile.ci:
 	@$(RIOTTOOLS)/insufficient_memory/create_makefile.ci.sh
 
 
-# Reset BOARDSDIR so unchanged for makefiles included after
-BOARDDIR := $(BOARDDIR_GLOBAL)
+# This target is run as a submake command by the `.board-result-%` for each
+# board in a new environment, since the evaluation of the features is only done
+# for one board at a time and the results are saved in temporary files.
+# These files are then printed by the `info-boards-*` targets.
+PHONY: info-boards-collect
+info-boards-collect:
+	@if [ ! -z '$(BOARDS)' ]; then \
+	  echo '$(BOARDS) ' >> bin/.INFO_BOARDS_SUPPORTED; \
+	fi
+	@if [ ! -z '$(BOARDS_FEATURES_MISSING)' ]; then \
+	  echo $(BOARDS_FEATURES_MISSING) >> bin/.INFO_BOARDS_FEATURES_MISSING; \
+	fi;
+	@if [ ! -z '$(BOARDS_FEATURES_USED_BLACKLISTED)' ]; then \
+	  echo $(BOARDS_FEATURES_USED_BLACKLISTED) >> bin/.INFO_BOARDS_FEATURES_BLACKLISTED; \
+	fi;
+	@if [ ! -z '$(BOARDS_FEATURES_CONFLICTING)' ]; then \
+	  echo $(BOARDS_FEATURES_CONFLICTING) >> bin/.INFO_BOARDS_FEATURES_CONFLICTING; \
+	fi;

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -35,7 +35,7 @@ info-build:
 	@echo 'APPDIR:      $(APPDIR)'
 	@echo ''
 	@echo 'supported boards:'
-	@echo $$(env -i PATH='$(PATH)' LANG='$(LANG)' HOME='$(HOME)' SHELL='$(SHELL)' $(MAKE) info-boards-supported)
+	@echo $$(env -i PATH='$(PATH)' LANG='$(LANG)' HOME='$(HOME)' SHELL='$(SHELL)' $(MAKE) info-boards-supported -j)
 	@echo ''
 	@echo 'BOARD:   $(BOARD)'
 	@echo 'CPU:     $(CPU)'

--- a/tests/drivers/dose/Makefile.ci
+++ b/tests/drivers/dose/Makefile.ci
@@ -10,6 +10,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-l011k4 \
     samd10-xmini \
+    stk3200 \
     stm32c0116-dk \
     stm32f030f4-demo \
     #

--- a/tests/pkg/microcoap/Makefile
+++ b/tests/pkg/microcoap/Makefile
@@ -20,7 +20,7 @@ USEPKG += microcoap
 LOW_MEMORY_BOARDS := nucleo-f334r8
 
 ifneq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
-  $(info Using low-memory configuration for microcoap_server.)
+  $(shell echo 'Using low-memory configuration for microcoap_server.' 1>&2)
   ## low-memory tuning values
   USEMODULE += prng_minstd
 endif


### PR DESCRIPTION
### Contribution description

Currently, `make info-boards-supported` is raaaather slow.

Instead of calling a subroutine with `eval` over and over for every board, which is not parallizable, I changed the targets in a way that a new RIOT environment is called for each board, which is perfectly parallizable. But even without multithreading, this is a significant performance boost.

The downside is, that temporary files have to be created to save the results.

The gain is that this will speed up scripts like `compile_like_murdock.py` *significantly*

### Testing procedure

Current `master`:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ time make -C examples/lang_support/community/micropython info-boards-supported
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/examples/lang_support/community/micropython'
using BOARD="native64" as "native" on a 64-bit system
acd52832 adafruit-clue adafruit-feather-nrf52840-express adafruit-feather-nrf52840-sense adafruit-grand-central-m4-express adafruit-itsybitsy-m4 adafruit-itsybitsy-nrf52 adafruit-metro-m4-express adafruit-pybadge airfy-beacon alientek-pandora arduino-due arduino-mkr1000 arduino-mkrfox1200 arduino-mkrwan1300 arduino-mkrzero arduino-nano-33-ble arduino-nano-33-ble-sense arduino-nano-33-iot arduino-zero avsextrem b-l072z-lrwan1 b-l475e-iot01a b-u585i-iot02a bastwan bitcraze-crazyflie21-main blackpill-stm32f103c8 blackpill-stm32f103cb bluepill-stm32f030c8 bluepill-stm32f103c8 bluepill-stm32f103cb calliope-mini cc1312-launchpad cc1350-launchpad cc1352-launchpad cc1352p-launchpad cc2538dk cc2650-launchpad cc2650stk dwm1001 e104-bt5010a-tb e104-bt5011a-tb e180-zg120b-tb ek-lm4f120xl f4vi1 feather-m0 feather-m0-lora feather-m0-wifi firefly frdm-k22f frdm-k64f frdm-kl43z frdm-kw41z generic-cc2538-cc2592-dk hamilton i-nucleo-lrwan1 ikea-tradfri im880b iotlab-a8-m3 iotlab-m3 limifrog-v1 lobaro-lorabox lora-e5-dev lsn50 maple-mini mbed_lpc1768 mcb2388 microbit microbit-v2 msba2 msbiot mulle native32 native64 nrf51dk nrf51dongle nrf52832-mdk nrf52840-mdk nrf52840-mdk-dongle nrf52840dk nrf52840dongle nrf52dk nrf5340dk-app nrf9160dk nucleo-c031c6 nucleo-c071rb nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 nucleo-f070rb nucleo-f072rb nucleo-f091rc nucleo-f103rb nucleo-f207zg nucleo-f302r8 nucleo-f303k8 nucleo-f303re nucleo-f303ze nucleo-f334r8 nucleo-f401re nucleo-f410rb nucleo-f411re nucleo-f412zg nucleo-f413zh nucleo-f429zi nucleo-f439zi nucleo-f446re nucleo-f446ze nucleo-f722ze nucleo-f746zg nucleo-f767zi nucleo-g070rb nucleo-g071rb nucleo-g431rb nucleo-g474re nucleo-h753zi nucleo-l011k4 nucleo-l031k6 nucleo-l053r8 nucleo-l073rz nucleo-l152re nucleo-l412kb nucleo-l432kc nucleo-l433rc nucleo-l452re nucleo-l476rg nucleo-l496zg nucleo-l4r5zi nucleo-l552ze-q nucleo-u575zi-q nucleo-wl55jc nz32-sc151 olimexino-stm32 omote opencm904 openlabs-kw41z-mini openlabs-kw41z-mini-256kib openmote-b openmote-cc2538 p-l496g-cell02 p-nucleo-wb55 particle-argon particle-boron particle-xenon pba-d-01-kw2x phynode-kw41z pinetime pro-micro-nrf52840 pyboard qn9080dk reel remote-pa remote-reva remote-revb rpi-pico rpi-pico-w ruuvitag sam4s-xpro samd10-xmini samd20-xpro samd21-xpro same51-curiosity-nano same54-xpro saml10-xpro saml11-xpro saml21-xpro samr21-xpro samr30-xpro samr34-xpro seeedstudio-sensecap-t1000e seeedstudio-xiao-nrf52840 seeedstudio-xiao-nrf52840-sense seeeduino_arch-pro seeeduino_xiao sensebox_samd21 serpente slstk3301a slstk3400a slstk3401a slstk3402a slstk3701a sltb001a sltb009a slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a slwstk6220a sodaq-autonomo sodaq-explorer sodaq-one sodaq-sara-aff sodaq-sara-sff spark-core stk3200 stk3600 stk3700 stm32c0116-dk stm32c0316-dk stm32f030f4-demo stm32f0discovery stm32f3discovery stm32f429i-disc1 stm32f429i-disco stm32f469i-disco stm32f4discovery stm32f723e-disco stm32f746g-disco stm32f7508-dk stm32f769i-disco stm32g0316-disco stm32l0538-disco stm32l476g-disco stm32l496g-disco stm32mp157c-dk2 teensy31 thingy52 ublox-c030-u201 udoo usb-kw41z waveshare-nrf52840-eval-kit weact-f401cc weact-f401ce weact-f411ce weact-g030f6 wemos-zero xg23-pk6068a yarm yunjia-nrf51822
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/examples/lang_support/community/micropython'

real    0m23.749s
user    0m10.668s
sys     0m12.731s
```

This PR without multithreading:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ time make -C examples/lang_support/community/micropython info-boards-supported
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/examples/lang_support/community/micropython'
using BOARD="native64" as "native" on a 64-bit system
acd52832 adafruit-clue adafruit-feather-nrf52840-express adafruit-feather-nrf52840-sense adafruit-grand-central-m4-express adafruit-itsybitsy-m4 adafruit-itsybitsy-nrf52 adafruit-metro-m4-express adafruit-pybadge airfy-beacon alientek-pandora arduino-due arduino-mkr1000 arduino-mkrfox1200 arduino-mkrwan1300 arduino-mkrzero arduino-nano-33-ble arduino-nano-33-ble-sense arduino-nano-33-iot arduino-zero avsextrem b-l072z-lrwan1 b-l475e-iot01a b-u585i-iot02a bastwan bitcraze-crazyflie21-main blackpill-stm32f103c8 blackpill-stm32f103cb bluepill-stm32f030c8 bluepill-stm32f103c8 bluepill-stm32f103cb calliope-mini cc1312-launchpad cc1350-launchpad cc1352-launchpad cc1352p-launchpad cc2538dk cc2650-launchpad cc2650stk dwm1001 e104-bt5010a-tb e104-bt5011a-tb e180-zg120b-tb ek-lm4f120xl f4vi1 feather-m0 feather-m0-lora feather-m0-wifi firefly frdm-k22f frdm-k64f frdm-kl43z frdm-kw41z generic-cc2538-cc2592-dk hamilton i-nucleo-lrwan1 ikea-tradfri im880b iotlab-a8-m3 iotlab-m3 limifrog-v1 lobaro-lorabox lora-e5-dev lsn50 maple-mini mbed_lpc1768 mcb2388 microbit microbit-v2 msba2 msbiot mulle native32 native64 nrf51dk nrf51dongle nrf52832-mdk nrf52840-mdk nrf52840-mdk-dongle nrf52840dk nrf52840dongle nrf52dk nrf5340dk-app nrf9160dk nucleo-c031c6 nucleo-c071rb nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 nucleo-f070rb nucleo-f072rb nucleo-f091rc nucleo-f103rb nucleo-f207zg nucleo-f302r8 nucleo-f303k8 nucleo-f303re nucleo-f303ze nucleo-f334r8 nucleo-f401re nucleo-f410rb nucleo-f411re nucleo-f412zg nucleo-f413zh nucleo-f429zi nucleo-f439zi nucleo-f446re nucleo-f446ze nucleo-f722ze nucleo-f746zg nucleo-f767zi nucleo-g070rb nucleo-g071rb nucleo-g431rb nucleo-g474re nucleo-h753zi nucleo-l011k4 nucleo-l031k6 nucleo-l053r8 nucleo-l073rz nucleo-l152re nucleo-l412kb nucleo-l432kc nucleo-l433rc nucleo-l452re nucleo-l476rg nucleo-l496zg nucleo-l4r5zi nucleo-l552ze-q nucleo-u575zi-q nucleo-wl55jc nz32-sc151 olimexino-stm32 omote opencm904 openlabs-kw41z-mini openlabs-kw41z-mini-256kib openmote-b openmote-cc2538 p-l496g-cell02 p-nucleo-wb55 particle-argon particle-boron particle-xenon pba-d-01-kw2x phynode-kw41z pinetime pro-micro-nrf52840 pyboard qn9080dk reel remote-pa remote-reva remote-revb rpi-pico rpi-pico-w ruuvitag sam4s-xpro samd10-xmini samd20-xpro samd21-xpro same51-curiosity-nano same54-xpro saml10-xpro saml11-xpro saml21-xpro samr21-xpro samr30-xpro samr34-xpro seeedstudio-sensecap-t1000e seeedstudio-xiao-nrf52840 seeedstudio-xiao-nrf52840-sense seeeduino_arch-pro seeeduino_xiao sensebox_samd21 serpente slstk3301a slstk3400a slstk3401a slstk3402a slstk3701a sltb001a sltb009a slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a slwstk6220a sodaq-autonomo sodaq-explorer sodaq-one sodaq-sara-aff sodaq-sara-sff spark-core stk3200 stk3600 stk3700 stm32c0116-dk stm32c0316-dk stm32f030f4-demo stm32f0discovery stm32f3discovery stm32f429i-disc1 stm32f429i-disco stm32f469i-disco stm32f4discovery stm32f723e-disco stm32f746g-disco stm32f7508-dk stm32f769i-disco stm32g0316-disco stm32l0538-disco stm32l476g-disco stm32l496g-disco stm32mp157c-dk2 teensy31 thingy52 ublox-c030-u201 udoo usb-kw41z waveshare-nrf52840-eval-kit weact-f401cc weact-f401ce weact-f411ce weact-g030f6 wemos-zero xg23-pk6068a yarm yunjia-nrf51822
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/examples/lang_support/community/micropython'

real    0m4.777s
user    0m3.646s
sys     0m0.912s
```

This PR with multithreading:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ time make -C examples/lang_support/community/micropython info-boards-supported -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/examples/lang_support/community/micropython'
using BOARD="native64" as "native" on a 64-bit system
acd52832 adafruit-clue adafruit-feather-nrf52840-express adafruit-feather-nrf52840-sense adafruit-grand-central-m4-express adafruit-itsybitsy-m4 adafruit-itsybitsy-nrf52 adafruit-metro-m4-express adafruit-pybadge airfy-beacon alientek-pandora arduino-due arduino-mkr1000 arduino-mkrfox1200 arduino-mkrwan1300 arduino-mkrzero arduino-nano-33-ble arduino-nano-33-ble-sense arduino-nano-33-iot arduino-zero avsextrem b-l072z-lrwan1 b-l475e-iot01a b-u585i-iot02a bastwan bitcraze-crazyflie21-main blackpill-stm32f103c8 blackpill-stm32f103cb bluepill-stm32f030c8 bluepill-stm32f103c8 bluepill-stm32f103cb calliope-mini cc1312-launchpad cc1350-launchpad cc1352-launchpad cc1352p-launchpad cc2538dk cc2650-launchpad cc2650stk dwm1001 e104-bt5010a-tb e104-bt5011a-tb e180-zg120b-tb ek-lm4f120xl f4vi1 feather-m0 feather-m0-lora feather-m0-wifi firefly frdm-k22f frdm-k64f frdm-kl43z frdm-kw41z generic-cc2538-cc2592-dk hamilton i-nucleo-lrwan1 ikea-tradfri im880b iotlab-a8-m3 iotlab-m3 limifrog-v1 lobaro-lorabox lora-e5-dev lsn50 maple-mini mbed_lpc1768 mcb2388 microbit microbit-v2 msba2 msbiot mulle native32 native64 nrf51dk nrf51dongle nrf52832-mdk nrf52840-mdk nrf52840-mdk-dongle nrf52840dk nrf52840dongle nrf52dk nrf5340dk-app nrf9160dk nucleo-c031c6 nucleo-c071rb nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 nucleo-f070rb nucleo-f072rb nucleo-f091rc nucleo-f103rb nucleo-f207zg nucleo-f302r8 nucleo-f303k8 nucleo-f303re nucleo-f303ze nucleo-f334r8 nucleo-f401re nucleo-f410rb nucleo-f411re nucleo-f412zg nucleo-f413zh nucleo-f429zi nucleo-f439zi nucleo-f446re nucleo-f446ze nucleo-f722ze nucleo-f746zg nucleo-f767zi nucleo-g070rb nucleo-g071rb nucleo-g431rb nucleo-g474re nucleo-h753zi nucleo-l011k4 nucleo-l031k6 nucleo-l053r8 nucleo-l073rz nucleo-l152re nucleo-l412kb nucleo-l432kc nucleo-l433rc nucleo-l452re nucleo-l476rg nucleo-l496zg nucleo-l4r5zi nucleo-l552ze-q nucleo-u575zi-q nucleo-wl55jc nz32-sc151 olimexino-stm32 omote opencm904 openlabs-kw41z-mini openlabs-kw41z-mini-256kib openmote-b openmote-cc2538 p-l496g-cell02 p-nucleo-wb55 particle-argon particle-boron particle-xenon pba-d-01-kw2x phynode-kw41z pinetime pro-micro-nrf52840 pyboard qn9080dk reel remote-pa remote-reva remote-revb rpi-pico rpi-pico-w ruuvitag sam4s-xpro samd10-xmini samd20-xpro samd21-xpro same51-curiosity-nano same54-xpro saml10-xpro saml11-xpro saml21-xpro samr21-xpro samr30-xpro samr34-xpro seeedstudio-sensecap-t1000e seeedstudio-xiao-nrf52840 seeedstudio-xiao-nrf52840-sense seeeduino_arch-pro seeeduino_xiao sensebox_samd21 serpente slstk3301a slstk3400a slstk3401a slstk3402a slstk3701a sltb001a sltb009a slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a slwstk6220a sodaq-autonomo sodaq-explorer sodaq-one sodaq-sara-aff sodaq-sara-sff spark-core stk3200 stk3600 stk3700 stm32c0116-dk stm32c0316-dk stm32f030f4-demo stm32f0discovery stm32f3discovery stm32f429i-disc1 stm32f429i-disco stm32f469i-disco stm32f4discovery stm32f723e-disco stm32f746g-disco stm32f7508-dk stm32f769i-disco stm32g0316-disco stm32l0538-disco stm32l476g-disco stm32l496g-disco stm32mp157c-dk2 teensy31 thingy52 ublox-c030-u201 udoo usb-kw41z waveshare-nrf52840-eval-kit weact-f401cc weact-f401ce weact-f411ce weact-g030f6 wemos-zero xg23-pk6068a yarm yunjia-nrf51822
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/examples/lang_support/community/micropython'

real    0m0.706s
user    0m5.573s
sys     0m1.953s
```


### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
