### PR TITLE
sys/net/l2util: add missing bounds check to l2util_addr_from_str

### DIFF
--- a/examples/advanced/twr_aloha/twr_shell.c
+++ b/examples/advanced/twr_aloha/twr_shell.c
@@ -130,7 +130,7 @@ static int _twr_handler(int argc, char **argv)
         for (int i = 2; i < argc; i++) {
             char *arg = argv[i];
             if (arg[0] != '-') {
-                size_t addr_len = l2util_addr_from_str(arg, addr);
+                size_t addr_len = l2util_addr_from_str_sized(arg, addr, sizeof(addr));
                 if (addr_len != 2) {
                     puts("[Error]: unable to parse address.\n"
                          "Must be of format [0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*\n"

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -710,9 +710,10 @@ static inline char *gnrc_netif_addr_to_str(const uint8_t *addr, size_t addr_len,
  * @return  Actual length of @p out on success.
  * @return  0, on failure.
  */
-static inline size_t gnrc_netif_addr_from_str(const char *str, uint8_t *out)
+static inline size_t gnrc_netif_addr_from_str(const char *str,
+                                              uint8_t out[GNRC_NETIF_L2ADDR_MAXLEN])
 {
-    return l2util_addr_from_str(str, out);
+    return l2util_addr_from_str_sized(str, out, GNRC_NETIF_L2ADDR_MAXLEN );
 }
 
 /**

--- a/sys/include/net/l2util.h
+++ b/sys/include/net/l2util.h
@@ -27,6 +27,7 @@
 
 #include <stdint.h>
 
+#include "compiler_hints.h"
 #include "net/eui64.h"
 #include "net/ndp.h"
 
@@ -177,18 +178,41 @@ char *l2util_addr_to_str(const uint8_t *addr, size_t addr_len, char *out);
  * @details The input format must be like `xx:xx:xx:xx` where `xx` will be the
  *          bytes of @p addr in hexadecimal representation.
  *
- * @pre `(out != NULL)`
- * @pre @p out **MUST** have allocated at least
- *      @ref GNRC_NETIF_L2ADDR_MAXLEN bytes.
+ * @pre     `(out != NULL)`
+ * @pre     @p out **MUST** have allocated at least @ref L2UTIL_ADDR_MAX_LEN
+ *          bytes.
+ * @pre     @p str must be `\0` terminated
  *
- * @param[in] str       A string of colon-separated hexadecimals.
- * @param[out] out      The resulting hardware address. Must at least have
+ * @param[in]   str         A string of colon-separated hexadecimals.
+ * @param[out]  addr        The resulting hardware address.
+ * @param[in]   addr_size   Size of @p addr
+ *
+ * @return  Actual length of @p out on success (may be less than @p addr_size)
+ * @retval  0           Invalid input
+ */
+ACCESS(write_only, 2, 3)
+size_t l2util_addr_from_str_sized(const char *str, void *addr, size_t addr_size);
+
+/**
+ * @brief   Parses a string of colon-separated hexadecimals to a hardware
+ *          address.
+ *
+ * @details The input format must be like `xx:xx:xx:xx` where `xx` will be the
+ *          bytes of @p addr in hexadecimal representation.
+ *
+ * @pre     `(out != NULL)`
+ * @pre     @p out **MUST** have allocated at least @ref L2UTIL_ADDR_MAX_LEN
+ *          bytes.
+ * @pre     @p str must be `\0` terminated
+ *
+ * @param[in]   str     A string of colon-separated hexadecimals.
+ * @param[out]  out     The resulting hardware address. Must at least have
  *                      @ref GNRC_NETIF_L2ADDR_MAXLEN bytes allocated.
  *
  * @return  Actual length of @p out on success.
- * @return  0, on failure.
+ * @retval  0           Invalid input
  */
-size_t l2util_addr_from_str(const char *str, uint8_t *out);
+size_t l2util_addr_from_str(const char *str, uint8_t out[L2UTIL_ADDR_MAX_LEN]);
 
 /**
  * @brief   Checks if two l2 addresses are equal.

--- a/sys/net/link_layer/l2util/l2util.c
+++ b/sys/net/link_layer/l2util/l2util.c
@@ -350,7 +350,7 @@ char *l2util_addr_to_str(const uint8_t *addr, size_t addr_len, char *out)
     return res;
 }
 
-size_t l2util_addr_from_str(const char *str, uint8_t *out)
+size_t l2util_addr_from_str_sized(const char *str, void *_addr, size_t addr_size)
 {
     /* Walk over str from the end. */
     /* Take two chars a time as one hex value (%hhx). */
@@ -358,46 +358,61 @@ size_t l2util_addr_from_str(const char *str, uint8_t *out)
     /* Every non-hexadimal character is a delimiter. */
     /* Leading, tailing and adjacent delimiters are forbidden. */
     const char *end_str = str;
-    uint8_t *out_end = out;
+    uint8_t *addr = _addr;
+    uint8_t *addr_end = addr;
     size_t count = 0;
     int assert_cell = 1;
 
-    assert(out != NULL);
+    assert(addr != NULL);
     if ((str == NULL) || (str[0] == '\0')) {
         return 0;
     }
+
     /* find end of string */
     while (end_str[1]) {
         ++end_str;
     }
+
     while (end_str >= str) {
-        int a = 0, b = _dehex(*end_str--, -1);
+        int a = 0;
+        int b = _dehex(*end_str--, -1);
 
         if (b < 0) {
             if (assert_cell) {
                 return 0;
             }
-            else {
-                assert_cell = 1;
-                continue;
-            }
+
+            assert_cell = 1;
+            continue;
         }
         assert_cell = 0;
         if (end_str >= str) {
             a = _dehex(*end_str--, 0);
         }
         count++;
-        *out_end++ = (a << 4) | b;
+
+        if (count > addr_size) {
+            return 0;
+        }
+
+        *addr_end++ = (a << 4) | b;
     }
+
     if (assert_cell) {
         return 0;
     }
+
     /* out is reversed */
-    while (out < --out_end) {
-        uint8_t tmp = *out_end;
-        *out_end = *out;
-        *out++ = tmp;
+    while (addr < --addr_end) {
+        uint8_t tmp = *addr_end;
+        *addr_end = *addr;
+        *addr++ = tmp;
     }
     return count;
+}
+
+size_t l2util_addr_from_str(const char *str, uint8_t out[L2UTIL_ADDR_MAX_LEN])
+{
+    return l2util_addr_from_str_sized(str, out, L2UTIL_ADDR_MAX_LEN);
 }
 /** @} */

--- a/sys/shell/cmds/gnrc_netif.c
+++ b/sys/shell/cmds/gnrc_netif.c
@@ -1312,7 +1312,7 @@ static int _netif_set_lw_key(netif_t *iface, netopt_t opt, char *key_str)
 static int _netif_set_addr(netif_t *iface, netopt_t opt, char *addr_str)
 {
     uint8_t addr[GNRC_NETIF_L2ADDR_MAXLEN];
-    size_t addr_len = l2util_addr_from_str(addr_str, addr);
+    size_t addr_len = l2util_addr_from_str_sized(addr_str, addr, sizeof(addr));
 
     if (addr_len == 0) {
         printf("error: unable to parse address.\n"
@@ -1461,7 +1461,7 @@ static int _netif_set_encrypt_key(netif_t *iface, netopt_t opt, char *key_str)
 static int _netif_addrm_l2filter(netif_t *iface, char *val, bool add)
 {
     uint8_t addr[GNRC_NETIF_L2ADDR_MAXLEN];
-    size_t addr_len = l2util_addr_from_str(val, addr);
+    size_t addr_len = l2util_addr_from_str_sized(val, addr, sizeof(addr));
 
     if ((addr_len == 0) || (addr_len > CONFIG_L2FILTER_ADDR_MAXLEN)) {
         printf("error: given address is invalid\n");

--- a/sys/shell/cmds/gnrc_txtsnd.c
+++ b/sys/shell/cmds/gnrc_txtsnd.c
@@ -21,10 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "net/gnrc.h"
-#include "net/gnrc.h"
 #include "net/gnrc/netif/hdr.h"
-#include "net/ipv6/addr.h"
 #include "shell.h"
 #include "container.h"
 
@@ -33,7 +30,8 @@ static int _gnrc_netif_send(int argc, char **argv)
     netif_t *iface;
     uint8_t addr[GNRC_NETIF_L2ADDR_MAXLEN];
     size_t addr_len;
-    gnrc_pktsnip_t *pkt, *hdr;
+    gnrc_pktsnip_t *pkt;
+    gnrc_pktsnip_t *hdr;
     gnrc_netif_hdr_t *nethdr;
     uint8_t flags = 0x00;
 

--- a/sys/test_utils/netdev_eth_minimal/shell_commands.c
+++ b/sys/test_utils/netdev_eth_minimal/shell_commands.c
@@ -69,7 +69,7 @@ static int _print_txtsnd_usage(char *cmd) {
 static int cmd_txtsnd(int argc, char **argv)
 {
     ethernet_hdr_t header;
-    int res;
+    size_t addr_len;
 
     if (4 != argc) {
         return _print_txtsnd_usage(argv[0]);
@@ -82,9 +82,9 @@ static int cmd_txtsnd(int argc, char **argv)
     }
 
     /* build Ethernet header */
-    res = l2util_addr_from_str(argv[2], header.dst);
-    if (!res) {
-        puts("Could not parse address");
+    addr_len = l2util_addr_from_str_sized(argv[2], header.dst, sizeof(header.dst));
+    if (addr_len != sizeof(header.dst)) {
+        printf("\"%s\" is not a valid Ethernet address\n", argv[2]);
         return _print_txtsnd_usage(argv[0]);
     }
 
@@ -107,7 +107,7 @@ static int cmd_txtsnd(int argc, char **argv)
     io_header.iol_next = &io_data;
 
     /* send */
-    res = dev->driver->send(dev, &io_header);
+    int res = dev->driver->send(dev, &io_header);
     if (res < 0) {
         puts("txtsnd: Could not send");
         return 1;

--- a/sys/test_utils/netdev_ieee802154_minimal/shell_commands.c
+++ b/sys/test_utils/netdev_ieee802154_minimal/shell_commands.c
@@ -189,7 +189,7 @@ static int cmd_txtsnd(int argc, char **argv)
     case 4:
         break;
     case 5:
-        res = l2util_addr_from_str(argv[idx++], pan.u8);
+        res = l2util_addr_from_str_sized(argv[idx++], pan.u8, sizeof(pan));
         if ((res == 0) || (res > sizeof(pan))) {
             txtsnd_usage(argv[0]);
             return 1;

--- a/tests/net/l2util/main.c
+++ b/tests/net/l2util/main.c
@@ -446,7 +446,9 @@ static void test_l2util_addr_from_str(void)
     static const uint8_t ethernet_l2addr[] = ETHERNET_SRC;
     static const uint8_t ieee802154_l2addr_long[] = IEEE802154_LONG_SRC;
     static const uint8_t ieee802154_l2addr_short[] = IEEE802154_SHORT_SRC;
-    uint8_t out[GNRC_NETIF_L2ADDR_MAXLEN];
+    uint8_t out[L2UTIL_ADDR_MAX_LEN + 1];
+    const uint8_t canary = 0x67;
+    out[L2UTIL_ADDR_MAX_LEN] = canary;
 
     TEST_ASSERT_EQUAL_INT(0, l2util_addr_from_str("", out));
     TEST_ASSERT_EQUAL_INT(sizeof(ethernet_l2addr),
@@ -458,10 +460,17 @@ static void test_l2util_addr_from_str(void)
                                                    out));
     TEST_ASSERT_EQUAL_INT(0, memcmp(ieee802154_l2addr_long, out,
                                     sizeof(ieee802154_l2addr_long)));
+    TEST_ASSERT_EQUAL_INT(0,
+                          l2util_addr_from_str_sized("3E:E6:B5:0F:19:22:FD:0A",
+                                                     out,
+                                                     6));
     TEST_ASSERT_EQUAL_INT(sizeof(ieee802154_l2addr_short),
                           l2util_addr_from_str("FD:0A", out));
     TEST_ASSERT_EQUAL_INT(0, memcmp(ieee802154_l2addr_short, out,
                                     sizeof(ieee802154_l2addr_short)));
+    TEST_ASSERT_EQUAL_INT(0, l2util_addr_from_str("01:02:03:04:05:06:07:08:09",
+                                                  out));
+    TEST_ASSERT_EQUAL_INT(canary, out[L2UTIL_ADDR_MAX_LEN]);
 }
 
 TestRef test_l2util(void)


### PR DESCRIPTION
### Contribution description

- fix doc: refert o `L2UTIL_ADDR_MAX_LEN` instead of `GNRC_NETIF_L2ADDR_MAXLEN`, as the former is the network stack independent macro
- add missing precondition that the input string is zero terminated (even though that is pretty obvious given the missing length argument)
- add expected buffer size to the API so that GCC and clang can warn on insufficiently small buffers
- add the bounds check to not write more than `L2UTIL_ADDR_MAX_LEN` bytes.
- extend the test app to check that overflows do not occur

### Testing procedure

1. Run `make BOARD=native64 -j32 flash test -C tests/net/l2util` in this PR.
2. Cherry pick the second commit on top of master and run it again

#### Test output on `master` (with the test extension cherry-picked)

```
RIOT native interrupts/signals initialized.
TZ not set, setting UTC
RIOT native64 board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2026.07-devel-314-g04fac)
...............
tests_l2util.test_l2util_addr_from_str (tests/net/l2util/main.c 467) exp 0 was 9

run 15 failures 1
Unexpected end of file in expect script at "child.expect(r'OK \((\d+) tests\)', timeout=timeout)" (dist/pythonlibs/testrunner/__init__.py:57)

Process already stopped
```

#### Test output with this PR

```
RIOT native interrupts/signals initialized.
TZ not set, setting UTC
RIOT native64 board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2026.07-devel-316-ga42a6-sys/net/l2util/l2util_addr_from_str/bounds-check)
...............
OK (15 tests)

Process already stopped
```

### Issues/PRs references

Depends on an includes:

- [ ] https://github.com/RIOT-OS/RIOT/pull/22359

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
