### PR TITLE
sys/rtc_utils: correctly handle units rolling under

### DIFF
--- a/examples/basic/default/Makefile.ci
+++ b/examples/basic/default/Makefile.ci
@@ -1,4 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     atmega8 \
     nucleo-l011k4 \
+    samd10-xmini \
+    stm32f030f4-demo \
     #

--- a/sys/rtc_utils/rtc_utils.c
+++ b/sys/rtc_utils/rtc_utils.c
@@ -131,43 +131,75 @@ static int _yday(int day, int month, int year)
     return d[month] + day - 1;
 }
 
+static div_t _euclidean_div(int a, int b)
+{
+    div_t d = div(a, b);
+
+    /* Check if the remainder is negative */
+    if (d.rem < 0) {
+        d.quot--;
+        /* The remainder will be positive afterwards */
+        d.rem += b;
+    }
+
+    return d;
+}
+
 void rtc_tm_normalize(struct tm *t)
 {
     div_t d;
 
-    if (t->tm_mday == 0) {
-        t->tm_mday = 1;
-    }
-
-    d = div(t->tm_sec, 60);
+    d = _euclidean_div(t->tm_sec, 60);
     t->tm_min += d.quot;
     t->tm_sec  = d.rem;
 
-    d = div(t->tm_min, 60);
+    d = _euclidean_div(t->tm_min, 60);
     t->tm_hour += d.quot;
     t->tm_min   = d.rem;
 
-    d = div(t->tm_hour, 24);
+    d = _euclidean_div(t->tm_hour, 24);
     t->tm_mday += d.quot;
     t->tm_hour  = d.rem;
 
-    d = div(t->tm_mon, 12);
+    d = _euclidean_div(t->tm_mon, 12);
     t->tm_year += d.quot;
     t->tm_mon   = d.rem;
 
-    /* Loop to handle days overflowing the month. */
+    /* Handle days underflowing the month */
+    while (t->tm_mday <= 0) {
+
+        /* Go to the previous month */
+        t->tm_mon -= 1;
+
+        /* Check for year roll under */
+        if (t->tm_mon < 0) {
+            t->tm_mon = 11;
+            t->tm_year -= 1;
+        }
+
+        /* Add the number of days of the month we rolled under to */
+        t->tm_mday += _month_length(t->tm_mon, t->tm_year + 1900);
+    }
+
+    /* Handle days overflowing the month */
     while (1) {
         int days = _month_length(t->tm_mon, t->tm_year + 1900);
 
         if (t->tm_mday <= days) {
             break;
         }
-
-        if (++t->tm_mon > 11) {
-            t->tm_mon = 0;
-            ++t->tm_year;
+        else {
+            /* Roll over to the next month */
+            t->tm_mon += 1;
         }
 
+        /* Check for year roll over */
+        if (t->tm_mon > 11) {
+            t->tm_mon = 0;
+            t->tm_year += 1;
+        }
+
+        /* Subtract the number of days of the month we rolled over from */
         t->tm_mday -= days;
     }
 
@@ -206,6 +238,7 @@ void rtc_localtime(uint32_t time, struct tm *t)
 
     memset(t, 0, sizeof(*t));
     t->tm_sec  = time;
+    t->tm_mday = 1;
     t->tm_year = year - 1900;
 
     rtc_tm_normalize(t);

--- a/tests/unittests/tests-rtc/tests-rtc.c
+++ b/tests/unittests/tests-rtc/tests-rtc.c
@@ -14,6 +14,8 @@
 #include "embUnit.h"
 
 #include "periph/rtc.h"
+#include "time_units.h"
+#include "tm.h"
 
 static void _test_equal_tm(const struct tm *a, const struct tm *b)
 {
@@ -306,6 +308,95 @@ static void test_rtc_localtime(void)
     _test_equal_tm(&t3, &t);
 }
 
+static void test_rtc_rollunder_mday_zero(void)
+{
+    /* The range of mday is given as [1 to 31], so it should roll under
+     * to the previous month on 0. */
+    struct tm tm_source = {
+        .tm_sec  = 0,
+        .tm_min  = 0,
+        .tm_hour = 12,
+        .tm_mday = 0,
+        .tm_mon  = 0,
+        .tm_year = 120
+    };
+    rtc_tm_normalize(&tm_source);
+
+    /* 31st December 2019 */
+    struct tm tm_target = {
+        .tm_sec  = 0,
+        .tm_min  = 0,
+        .tm_hour = 12,
+        .tm_mday = 31,
+        .tm_mon  = TM_MON_DEC,
+        .tm_year = 120 - 1,
+        .tm_wday = TM_WDAY_TUE,
+        .tm_yday = 364,
+        .tm_isdst= 0
+    };
+
+    _test_equal_tm(&tm_target, &tm_source);
+}
+
+static void test_rtc_rollunder_mday_neg(void)
+{
+    /* A negative mday should roll under to the previous month. */
+    struct tm tm_source = {
+        .tm_sec  = 0,
+        .tm_min  = 0,
+        .tm_hour = 12,
+        .tm_mday = -11,
+        .tm_mon  = 0,
+        .tm_year = 120
+    };
+    rtc_tm_normalize(&tm_source);
+
+    /* 20th December 2019 */
+    struct tm tm_target = {
+        .tm_sec  = 0,
+        .tm_min  = 0,
+        .tm_hour = 12,
+        .tm_mday = 20,
+        .tm_mon  = TM_MON_DEC,
+        .tm_year = 120 - 1,
+        .tm_wday = TM_WDAY_FRI,
+        .tm_yday = 353,
+        .tm_isdst= 0
+    };
+
+    _test_equal_tm(&tm_target, &tm_source);
+}
+
+static void test_rtc_rollunder_chained(void)
+{
+    /* Negative values for the basic tm fields (sec, min, hour, mday, mon)
+     * should lead to a chain of roll under events. */
+    struct tm tm_source = {
+        .tm_sec  = -15, /* roll under -1 minute */
+        .tm_min  = -15, /* roll under -1 hour */
+        .tm_hour = -6,  /* roll under -1 day */
+        .tm_mday = -15, /* roll under -1 month */
+        .tm_mon  = -6,  /* roll under -1 year */
+        .tm_year = 120
+    };
+    rtc_tm_normalize(&tm_source);
+
+    /* 14th June 2019 */
+    struct tm tm_target = {
+        .tm_sec  = SEC_PER_MIN - 15,
+        .tm_min  = (MIN_PER_HOUR - 15) - 1,
+        .tm_hour = (HOURS_PER_DAY - 6) - 1,
+        .tm_mday = 14,
+        .tm_mon  = TM_MON_JUN,
+        .tm_year = 120 - 1,
+        .tm_wday = TM_WDAY_FRI,
+        .tm_yday = 164,
+        .tm_isdst= 0
+    };
+
+    _test_equal_tm(&tm_target, &tm_source);
+}
+
 Test *tests_rtc_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -319,6 +410,9 @@ Test *tests_rtc_tests(void)
         new_TestFixture(test_rtc_mktime),
         new_TestFixture(test_mktime),
         new_TestFixture(test_rtc_localtime),
+        new_TestFixture(test_rtc_rollunder_mday_zero),
+        new_TestFixture(test_rtc_rollunder_mday_neg),
+        new_TestFixture(test_rtc_rollunder_chained),
     };
 
     EMB_UNIT_TESTCALLER(rtc_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description

The existing implementation of `rtc_tm_normalize` would leave you e.g. with negative seconds if the input `tm_sec` was negative. In addition, the hack of checking for `t->tm_mday == 0` was removed, as setting `tm_mday` to `0` is not the correct behaviour. Since the range is given as `[1 to 31]` by definition `tm_mday=0` must roll under to the last day of the previous month. For the same reason `rtc_localtime` was adapted to set `t->tm_mday = 1;` instead of using `0` implicitly.

### Testing procedure

I added relevant test cases to `tests/unittests/tests-rtc/tests-rtc.c`. I checked the values for `tm_target` manually by using a calendar. Please check this part for yourself. I could have made a mistake. 

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- GitHub Copilot pointed me to this issue while I was debugging a higher level module.
