### PR TITLE
dist/tools/check_pr: also error on Github commits

### DIFF
--- a/dist/tools/pr_check/no_merge_keywords
+++ b/dist/tools/pr_check/no_merge_keywords
@@ -10,3 +10,4 @@
 ^[0-9a-f]\+ \<DELETEME\>
 ^[0-9a-f]\+ \<WIP\>
 ^[0-9a-f]\+ \<TEMP\>
+^[0-9a-f]\+ Apply suggestions\? from


### PR DESCRIPTION
### Contribution description

~~Right now, fixup commits usually just error out because they go over the commit message length limit.~~ Automatic Github commits ("Apply suggestions from code review") just fail because they are missing the colon. Now we show the typical "squash needed" message instead.


### Testing procedure

~~CI should fail on this PR until I remove the fixup commit.~~

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
