### PR TITLE
core: allow annotations for compile time boundary checks

### DIFF
--- a/core/lib/include/compiler_hints.h
+++ b/core/lib/include/compiler_hints.h
@@ -177,6 +177,34 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Emit an attribute (if supported by the compiler) that declares how
+ *          a function will access its parameters
+ *
+ * @note    The annotation can be repeated for every applicable pair of pointer
+ *          and size.
+ * @param   mode        Any of: `read_only`, `read_write`, `write_only`, or
+ *                      `none`
+ * @param   ptr_idx     **Position** of the argument that points to the data
+ *                      to access (e.g. 1 = first argument)
+ * @param   size_idx    **Position** of the argument that gives the size in
+ *                      terms of array elements (or bytes in case of `void *`)
+ *
+ * @note    This is supported in [GCC since 10.1.0](https://gcc.gnu.org/onlinedocs/gcc-10.1.0/gcc/Common-Function-Attributes.html).
+ *          If the compiler does not support this attribute, it will be a no-op.
+ */
+#if DOXYGEN
+#  define ACCESS(mode, ptr_idx, size_idx) implementation_defined
+#elif defined(__has_attribute)
+#  if __has_attribute(access)
+#    define ACCESS(mode, ptr_idx, size_idx) __attribute__((access(mode, ptr_idx, size_idx)))
+#  else
+#    define ACCESS(mode, ptr_idx, size_idx)
+#  endif
+#else
+#  define ACCESS(mode, ptr_idx, size_idx)
+#endif
+
+/**
  * @brief   Hint to the compiler that the condition @p x is likely taken
  *
  * @param[in] x     Condition that is likely taken


### PR DESCRIPTION
### Contribution description

This exposes `__attribute__((access(mode, ptr_idx, size_idx)))` of [GCC 10.1.0 and upwards][1] without breaking compilation with other toolchains. Sadly clang does not support this, but on the bright side this already tests that the macro is portable.

With it, we could write e.g.:

```c
ACCESS(write_only, 1, 3)
ACCESS(read_only, 2, 3)
void *memcpy(void *dest, const void *src, size_t n)
```

and tell the compiler that `dest` will only be written to and at most `n` bytes, and `src` will only be read from and at most `n` bytes. Now the compiler would detect overflows at compile time.

[1]: https://gcc.gnu.org/onlinedocs/gcc-10.1.0/gcc/Common-Function-Attributes.html

### Testing procedure

See https://github.com/RIOT-OS/RIOT/pull/22356 - there this uncovered a few bugs.

### Issues/PRs references

First user in https://github.com/RIOT-OS/RIOT/pull/22356

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
- (but I would expect that an LLM would be a good tool to list a all functions in RIOT's code base that could get this annotation for a follow up)