### PR TITLE
dist/tools/picotool: Temporary glibc bug fix

### DIFF
--- a/dist/tools/picotool/patches/picotool_glibc.patch
+++ b/dist/tools/picotool/patches/picotool_glibc.patch
@@ -1,0 +1,45 @@
+From: RIOT buildsystem <buildsystem@riot>
+Date: Wed, 20 May 2026 00:00:00 +0100
+Subject: [PATCH] model: work around __unused redefinition with glibc
+
+ Based on https://github.com/raspberrypi/picotool/issues/300#issuecomment-4495672748
+ Affected version (at least):
+    - gcc 16.1.1 20260430 (2.43)
+    - gcc 16.1.1 20260515 (2.43-5)
+---
+ model/model.h | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/model/model.h b/model/model.h
+index 17bf824..318b0d2 100644
+--- a/model/model.h
++++ b/model/model.h
+@@ -4,9 +4,16 @@
+  * SPDX-License-Identifier: BSD-3-Clause
+  */
+ #pragma once
++
++/* 2026-05-20 Temporary fix for https://github.com/raspberrypi/picotool/issues/300 */
++#undef __unused
++#define __unused __glibc_unused
++
+ #include "boot/uf2.h"
+ #include "boot/picoboot.h"
+ 
++#undef __unused
++
+ // Unreadable ROM data
+ #include "rp2350_a2_rom_end.h"
+ #include "rp2350_a3_rom_end.h"
+@@ -418,4 +425,7 @@ static bool contains_unreadable_rom(uint32_t addr, uint32_t size, const model_t&
+             (addr < model->unreadable_rom_start() && addr + size > model->unreadable_rom_end());
+ }
+ 
+-#endif
+\ No newline at end of file
++#endif
++
++/* 2026-05-20 Temporary fix for https://github.com/raspberrypi/picotool/issues/300 */
++#define __unused __attribute__((__unused__))
+--
+2.49.0


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

While working on stuff using the pico 2 @MichelRottleuthner noticed that picotool was broken, same happened for me, it turns out that current glibc has a bug that will be fixed soon :tm: which causes picotool to not compile properly. This small patch "graciously copied" from the related issue on the repo fixes this.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`BOARD=rpi-pico-2-arm make flash`

should result in

```sh
[ 95%] Building CXX object CMakeFiles/picotool.dir/lib/whereami/whereami++.cpp.o
[ 96%] Building CXX object CMakeFiles/picotool.dir/picoboot_connection/picoboot_connection_cxx.cpp.o
[ 98%] Building C object CMakeFiles/picotool.dir/picoboot_connection/picoboot_connection.c.o
[100%] Linking CXX executable picotool
[100%] Built target picotool
[INFO] picotool successfully fetched!
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- Claude changed the patch format to conform with the email style we use