### PR TITLE
cpu/riscv_common: move trap print to specific debug define

### DIFF
--- a/cpu/riscv_common/Kconfig
+++ b/cpu/riscv_common/Kconfig
@@ -10,3 +10,7 @@ config CPU_CORE_RV32IMAC
 
 config CPU_ARCH
     default "rv32" if CPU_CORE_RV32IMAC
+
+config PRINT_VERBOSE_TRAP_INFO
+    bool "Print verbose trap information"
+    default n

--- a/cpu/riscv_common/include/irq_arch.h
+++ b/cpu/riscv_common/include/irq_arch.h
@@ -33,6 +33,15 @@ extern "C" {
  */
 #define CPU_CSR_MCAUSE_CAUSE_MSK        (0x0fffu)
 
+/**
+ * @brief   If defined, the trap handler will print additional information about
+ *          the trap. This is useful for debugging, but causes heavy performance
+ *          degradation.
+ */
+#ifndef CONFIG_PRINT_VERBOSE_TRAP_INFO
+#  define CONFIG_PRINT_VERBOSE_TRAP_INFO 0
+#endif
+
 extern volatile int riscv_in_isr;
 
 /**

--- a/cpu/riscv_common/irq_arch.c
+++ b/cpu/riscv_common/irq_arch.c
@@ -93,7 +93,7 @@ __attribute((used)) static void handle_trap(uword_t mcause)
     /* Check if this is an interrupt or a trap, indicated by the left most bit */
     bool is_interrupt = (mcause & MCAUSE_INT) == MCAUSE_INT;
 
-#ifdef DEVELHELP
+#ifdef CONFIG_PRINT_VERBOSE_TRAP_INFO
     printf("Trap: mcause=0x%" PRIx32 " mepc=0x%lx mtval=0x%lx\n",
            (uint32_t)mcause, read_csr(mepc), read_csr(mtval));
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

While extremely useful in some scenarios, the trap print would cause massive performance degradation when `DEVELHELP` usually wouldn't. When this was originally added I targeted my specific niche issues but when developing an application that doesn't directly deal with traps it would completely clog the entire output.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

Note that, as long as you declare the use of AI/LLM tools transparently with full authorship and responsibility over your contribution, there is no issue with using them for your contribution.
-->

AI-Tools / LLMs that were used are:
- Noooooooooooooooooooooooooooooo