### PR TITLE
build-system: do not pass `--userns keep-id` to podman

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -146,7 +146,7 @@ _docker_is_podman = $(shell $(DOCKER) --version | grep podman 2>/dev/null)
 # - remove container on exit
 # - set username/UID to executor
 DOCKER_USER ?= $$(id -u):$$(id -g)
-DOCKER_USER_OPT = $(if $(_docker_is_podman),--userns keep-id,--user $(DOCKER_USER))
+DOCKER_USER_OPT = $(if $(_docker_is_podman),,--user $(DOCKER_USER))
 DOCKER_RUN_FLAGS ?= --rm --tty $(DOCKER_USER_OPT)
 
 # Explicitly set the platform to what the image is expecting


### PR DESCRIPTION
### Contribution description

Seemingly, running the build in rootless container (so, podman) without neither `--user <UID>:<GID>` nor `--userns keep-id` works just fine, as what is root inside the container maps already to what the current user is outside of the container.

There seems to be an issue with `--userns keep-id` when having the container storage (typically `~/.local/share/containers/storage`) in a `btrfs` file system, at least on Ubuntu 26.04. But since `--userns keep-id` doesn't seem to be required to avoid creating files as a different user when using `podman` in the first place, just dropping `--userns keep-id` should be fine.

### Testing procedure

1. Run `make BOARD=samr21-xpro BUILD_IN_DOCKER=1 -C examples/basic/hello-world` with docker. No regressions should occur. (After all, the same command as used before should be passed.)
2. Run the same command with `podman`. It should work just fine, even when using `btrfs` as file system
3. Confirm that the created ELF and `*.o` files are owned by the user that ran `make`

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
