### PR TITLE
boards/nrf: update reset button documentation

### DIFF
--- a/boards/nrf52840dk/doc.md
+++ b/boards/nrf52840dk/doc.md
@@ -31,15 +31,6 @@ including Bluetooth Low Energy, Thread and Zigbee.
 | MCU Manual            | [Manual](https://docs-be.nordicsemi.com/bundle/ps_nrf52840/attach/nRF52840_PS_v1.11.pdf)                          |
 | Board Documentation   | [Documentation](https://docs.nordicsemi.com/bundle/ug_nrf52840_dk/page/UG/dk/intro.html)                          |
 
-### RESET pin configuration
-
-On many (all?) nrf52840dk boards, the reset pin is not configured out-of-the box.
-This means, that simply nothing happens if the RESET pin is pressed. To change
-this, RIOT provides a little tool in `dist/tools/nrf52_resetpin_cfg`.
-
-Simply compile, flash, and run that tool on your board, and the reset pin should
-work for the time being.
-
 ## Flash the board
 
 See the `Flashing` section in @ref boards_common_nrf52.

--- a/boards/nrf52dk/doc.md
+++ b/boards/nrf52dk/doc.md
@@ -35,15 +35,6 @@ pin headers and an integrated J-Link programmer, debugger and UART adapter.
 | MCU Reference Manual  | [Reference Manual](https://infocenter.nordicsemi.com/pdf/nRF52832_PS_v1.4.pdf)        |
 | Board Datasheet       | [User Guide](https://infocenter.nordicsemi.com/pdf/nRF52_DK_User_Guide_v1.3.1.pdf)    |
 
-### RESET pin configuration
-
-On many (all?) nrf52dk boards, the reset pin is not configured out-of-the box.
-This means, that simply nothing happens if the RESET pin is pressed. To change
-this, RIOT provides a little tool in `dist/tools/nrf52_resetpin_cfg`.
-
-Simply compile, flash, and run that tool on your board, and the reset pin should
-work for the time being.
-
 ## Current measurement
 
 There are two pins for current measurement on board. Don't connect these pins

--- a/boards/reel/doc.md
+++ b/boards/reel/doc.md
@@ -9,3 +9,8 @@ It was developed by PHYTEC in cooperation with the Zephyr project.
 
 @see https://www.phytec.eu/product-eu/internet-of-things/reelboard/
 @see https://docs.zephyrproject.org/latest/boards/arm/reel_board/doc/reel_board.html
+
+## Buttons
+
+The board has a user button (S5) connected to P0.07 and exposed as `BTN0`.
+The reset button (S4) is connected to P0.18 and resets the nRF52840.

--- a/boards/waveshare-nrf52840-eval-kit/doc.md
+++ b/boards/waveshare-nrf52840-eval-kit/doc.md
@@ -147,16 +147,3 @@ the following command to connect to the board serial port:
 ```shell
 make BOARD=waveshare-nrf52840-eval-kit -C examples/basic/hello-world PORT=/dev/ttyUSB<n> term
 ```
-
-## RESET Pin Configuration
-
-On nRF52840 boards, the RESET pin is not configured out-of-the box.
-This means, that simply nothing happens if the RESET button is pressed. To
-change this, RIOT provides a little tool in `dist/tools/nrf52_resetpin_cfg`:
-
-```shell
-RESET_PIN='GPIO_PIN\(0,18\)' make BOARD=waveshare-nrf52840-eval-kit -C dist/tools/nrf52_resetpin_cfg/ flash
-```
-
-Simply compile, flash, and run that tool on your board, and the reset pin should
-work for the time being.


### PR DESCRIPTION
### Contribution description

This updates parts of the nRF board documentation.

The PR removes outdated reset pin configuration instructions that referenced
`dist/tools/nrf52_resetpin_cfg` from the nRF52 DK, nRF52840 DK, and Waveshare
nRF52840 Eval Kit board documentation.

It also adds a short button note to the PHYTEC reel board documentation,
mentioning the user button and reset button pins.


### Testing procedure

Documentation-only change.

I checked the diff locally and ran:

```sh
git diff --check
```

### Issues/PRs references

Addresses part of #20592
