### PR TITLE
core/thread_flags: collect predefined flags

### DIFF
--- a/core/include/thread_flags.h
+++ b/core/include/thread_flags.h
@@ -38,11 +38,12 @@
  * Usually, if it is only of interest that an event occurred, but not how many
  * of them, thread flags should be considered.
  *
- * Note that some flags (currently the two most significant bits) are used by
- * core functions and should not be set by the user. They can be waited for.
- * Unlike @ref core_msg "messages" (which are only ever sent when requested),
- * these flags can be set unprompted. (For example, @ref THREAD_FLAG_MSG_WAITING
- * is set on a thread automatically with every message sent there).
+ * Note that some flags are used by RIOT core functions and modules and should
+ * not be set by the user. They can be waited for. Unlike @ref core_msg
+ * "messages" (which are only ever sent when requested), these flags can be set
+ * unprompted. (For example, @ref THREAD_FLAG_MSG_WAITING is set on a thread
+ * automatically with every message sent there). Use @ref
+ * THREAD_FLAG_PREDEFINED_MASK to avoid collisions with predefined flags.
  *
  * This API is optional and must be enabled by adding "core_thread_flags" to USEMODULE.
  *
@@ -53,6 +54,7 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
+#include "modules.h"
 #include "sched.h"  /* for thread_t typedef */
 
 #ifdef __cplusplus
@@ -99,17 +101,110 @@ extern "C" {
 #define THREAD_FLAG_TIMEOUT         (1u << 14)
 
 /**
+ * @brief   Thread flag used to notify available events in an event queue
+ */
+#ifndef THREAD_FLAG_EVENT
+#define THREAD_FLAG_EVENT           (1u << 0)
+#endif
+
+/**
+ * @brief   Thread flag used by USBUS when a USB device ISR needs handling
+ */
+#define USBUS_THREAD_FLAG_USBDEV    (1u << 1)
+
+/**
+ * @brief   Thread flag used by USBUS when endpoints need servicing
+ */
+#define USBUS_THREAD_FLAG_USBDEV_EP (1u << 2)
+
+/**
+ * @brief   Thread flag used by POSIX select
+ */
+#define POSIX_SELECT_THREAD_FLAG    (1u << 3)
+
+/**
+ * @brief   Thread flag used by the libSCHC test application
+ */
+#define THREAD_FLAG_TX_END          (1u << 4)
+
+/**
+ * @brief   Thread flag used by LVGL
+ */
+#ifndef LVGL_THREAD_FLAG
+#define LVGL_THREAD_FLAG            (1u << 7)
+#endif
+
+/**
+ * @brief   Thread flag used by Kinetis I2C
+ */
+#define THREAD_FLAG_KINETIS_I2C     (1u << 8)
+
+/**
+ * @brief   Thread flag used by KW41ZRF
+ */
+#define KW41ZRF_THREAD_FLAG_ISR     (1u << 8)
+
+/**
+ * @brief   Thread flag used by the CST816S test application
+ */
+#define CST816S_THREAD_FLAG         (1u << 8)
+
+/**
+ * @brief   Thread flag used by lwIP netdev
+ */
+#define THREAD_FLAG_LWIP_TX_DONE    (1u << 11)
+
+/**
+ * @cond INTERNAL
+ */
+#define THREAD_FLAG_EVENT_MASK              (IS_USED(MODULE_EVENT) ? \
+                                             THREAD_FLAG_EVENT : 0)
+#define USBUS_THREAD_FLAG_MASK              (IS_USED(MODULE_USBUS) ? \
+                                             (USBUS_THREAD_FLAG_USBDEV | \
+                                              USBUS_THREAD_FLAG_USBDEV_EP) : 0)
+#define POSIX_SELECT_THREAD_FLAG_MASK       (IS_USED(MODULE_POSIX_SELECT) ? \
+                                             POSIX_SELECT_THREAD_FLAG : 0)
+#define THREAD_FLAG_TX_END_MASK             (IS_USED(MODULE_LIBSCHC_COAP) ? \
+                                             THREAD_FLAG_TX_END : 0)
+#define LVGL_THREAD_FLAG_MASK               (IS_USED(MODULE_LVGL_CONTRIB) ? \
+                                             LVGL_THREAD_FLAG : 0)
+#if defined(KINETIS_FAMILY)
+#define THREAD_FLAG_KINETIS_I2C_MASK        (IS_USED(MODULE_PERIPH_I2C) ? \
+                                             THREAD_FLAG_KINETIS_I2C : 0)
+#else
+#define THREAD_FLAG_KINETIS_I2C_MASK        (0)
+#endif
+#define KW41ZRF_THREAD_FLAG_ISR_MASK        (IS_USED(MODULE_KW41ZRF) ? \
+                                             KW41ZRF_THREAD_FLAG_ISR : 0)
+#define CST816S_THREAD_FLAG_MASK            (IS_USED(MODULE_CST816S) ? \
+                                             CST816S_THREAD_FLAG : 0)
+#define THREAD_FLAG_LWIP_TX_DONE_MASK       (IS_USED(MODULE_LWIP_NETDEV) ? \
+                                             THREAD_FLAG_LWIP_TX_DONE : 0)
+/** @endcond */
+
+/**
  * @brief Comprehensive set of all predefined flags
  *
- * This bit mask is set for all thread flag bits that are predefined in RIOT.
- * Flags within this set may be set on a thread by the operating system without
- * the thread soliciting them (though not all are; for example, @ref
- * THREAD_FLAG_TIMEOUT is not).
+ * This bit mask is set for all thread flag bits that are predefined by RIOT
+ * core or by the modules selected for the current application. Flags within
+ * this set may be set on a thread by the operating system without the thread
+ * soliciting them (though not all are; for example, @ref THREAD_FLAG_TIMEOUT
+ * is not).
  *
  * When using custom flags, asserting that they are not in this set can help
  * avoid conflict with future additions to the predefined flags.
  */
-#define THREAD_FLAG_PREDEFINED_MASK (THREAD_FLAG_MSG_WAITING | THREAD_FLAG_TIMEOUT)
+#define THREAD_FLAG_PREDEFINED_MASK (THREAD_FLAG_MSG_WAITING | \
+                                     THREAD_FLAG_TIMEOUT | \
+                                     THREAD_FLAG_EVENT_MASK | \
+                                     USBUS_THREAD_FLAG_MASK | \
+                                     POSIX_SELECT_THREAD_FLAG_MASK | \
+                                     THREAD_FLAG_TX_END_MASK | \
+                                     LVGL_THREAD_FLAG_MASK | \
+                                     THREAD_FLAG_KINETIS_I2C_MASK | \
+                                     KW41ZRF_THREAD_FLAG_ISR_MASK | \
+                                     CST816S_THREAD_FLAG_MASK | \
+                                     THREAD_FLAG_LWIP_TX_DONE_MASK)
 /** @} */
 
 /**

--- a/cpu/kinetis/periph/i2c.c
+++ b/cpu/kinetis/periph/i2c.c
@@ -49,11 +49,6 @@
 #endif
 
 /**
- * @brief   Thread flag used internally for signaling between ISR and user thread
- */
-#define THREAD_FLAG_KINETIS_I2C (1u << 8)
-
-/**
  * @brief   Array of I2C module clock dividers
  *
  * The index in this array is the I2C_F setting number

--- a/drivers/kw41zrf/kw41zrf_netdev.c
+++ b/drivers/kw41zrf/kw41zrf_netdev.c
@@ -58,9 +58,6 @@ static atomic_bool irq_is_queued = false;
 /* True while blocking the netdev thread waiting for some operation to finish */
 static bool blocking_for_irq = false;
 
-/* Set this to a flag bit that is not used by the MAC implementation */
-#define KW41ZRF_THREAD_FLAG_ISR (1u << 8)
-
 static void kw41zrf_irq_handler(void *arg)
 {
     netdev_t *netdev = arg;

--- a/pkg/lvgl/contrib/lvgl.c
+++ b/pkg/lvgl/contrib/lvgl.c
@@ -54,10 +54,6 @@
 #define CONFIG_LVGL_TASK_HANDLER_DELAY_MS   (5)                 /* 5ms */
 #endif
 
-#ifndef LVGL_THREAD_FLAG
-#define LVGL_THREAD_FLAG                    (1 << 7)
-#endif
-
 #if IS_USED(MODULE_LV_DRIVERS_SDL)
 
 #ifndef LCD_SCREEN_WIDTH

--- a/pkg/lwip/contrib/netdev/lwip_netdev.c
+++ b/pkg/lwip/contrib/netdev/lwip_netdev.c
@@ -55,7 +55,6 @@
 #define WPAN_IFNAME2 'P'
 
 event_queue_t lwip_event_queue = { 0 };
-#define THREAD_FLAG_LWIP_TX_DONE    (1U << 11)
 
 static kernel_pid_t _pid = KERNEL_PID_UNDEF;
 static WORD_ALIGNED char _stack[LWIP_NETDEV_STACKSIZE];

--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -112,13 +112,6 @@
 extern "C" {
 #endif
 
-#ifndef THREAD_FLAG_EVENT
-/**
- * @brief   Thread flag use to notify available events in an event queue
- */
-#define THREAD_FLAG_EVENT   (0x1)
-#endif
-
 /**
  * @brief   event_queue_t static initializer
  */

--- a/sys/include/usb/usbus.h
+++ b/sys/include/usb/usbus.h
@@ -111,18 +111,6 @@ extern "C" {
 #define USBUS_TNAME                 "usbus"
 
 /**
- * @name USBUS thread flags
- *
- * Thread flags used by the USBUS thread. @ref THREAD_FLAG_EVENT is also used,
- * but defined elsewhere
- * @{
- */
-#define USBUS_THREAD_FLAG_USBDEV    (0x02)  /**< usbdev esr needs handling */
-#define USBUS_THREAD_FLAG_USBDEV_EP (0x04)  /**< One or more endpoints requires
-                                                 servicing */
-/** @} */
-
-/**
  * @name USBUS handler subscription flags
  *
  * @{

--- a/sys/posix/include/sys/select.h
+++ b/sys/posix/include/sys/select.h
@@ -44,15 +44,11 @@ __extension__
 #endif
 
 #include "bitfield.h"
+#include "thread_flags.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @brief   @ref core_thread_flags for POSIX select
- */
-#define POSIX_SELECT_THREAD_FLAG    (1U << 3)
 
 #ifndef CPU_NATIVE
 

--- a/tests/drivers/cst816s/main.c
+++ b/tests/drivers/cst816s/main.c
@@ -23,7 +23,6 @@
 #include "thread.h"
 #include "thread_flags.h"
 
-#define CST816S_THREAD_FLAG     (1 << 8)
 #define CST816S_NUM_TOUCHES     5
 
 static void _cb(void *arg)

--- a/tests/pkg/libschc/main.c
+++ b/tests/pkg/libschc/main.c
@@ -36,7 +36,6 @@
 #include "fragmenter.h"
 #include "schc.h"
 
-#define THREAD_FLAG_TX_END  (1U << 4)
 #define FRAG_WIN_SIZE_MAX   (8U)
 #define TIMEOUT_EVENTS_MAX  (4U)
 


### PR DESCRIPTION
### Contribution description

This centralizes RIOT's predefined thread flag definitions in
`core/include/thread_flags.h`.

The PR moves the thread flag definitions listed in #20867 out of individual
modules and test applications, while preserving their existing bit values.
`THREAD_FLAG_PREDEFINED_MASK` now also accounts for module-specific predefined
flags when the corresponding module is selected.

The updated mask includes flags used by event queues, USBUS, POSIX select,
Kinetis I2C, KW41ZRF, LVGL, lwIP netdev, and the listed test applications.


### Testing procedure

I checked the diff locally with:

```sh
git diff --check
```


### Issues/PRs references

Fixes #20867
