### PR TITLE
core: annotate function declarations with access attribute

### DIFF
--- a/core/include/mbox.h
+++ b/core/include/mbox.h
@@ -18,8 +18,9 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
-#include "list.h"
 #include "cib.h"
+#include "compiler_hints.h"
+#include "list.h"
 #include "msg.h"
 
 #ifdef __cplusplus
@@ -55,6 +56,7 @@ enum {
  * @param[in]   queue       array of msg_t used as queue
  * @param[in]   queue_size  number of msg_t objects in queue
  */
+ACCESS(write_only, 2, 3)
 static inline void mbox_init(mbox_t *mbox, msg_t *queue,
                              unsigned int queue_size)
 {

--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -175,6 +175,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "compiler_hints.h"
 #include "sched.h"
 
 #ifdef __cplusplus
@@ -411,6 +412,7 @@ unsigned msg_queue_capacity(kernel_pid_t pid);
  * If array resides on the stack, the containing stack frame must never be
  * left, not even if it is the current thread's entry function.
  */
+ACCESS(write_only, 1, 2)
 void msg_init_queue(msg_t *array, int num);
 
 /**

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -273,6 +273,7 @@ struct _thread {
  *                      @ref SCHED_PRIO_LEVELS or @p stacksize is too small
  * @retval  -EOVERFLOW  there are too many threads running already
  */
+ACCESS(write_only, 1, 2)
 kernel_pid_t thread_create(char *stack,
                            int stacksize,
                            uint8_t priority,
@@ -463,6 +464,7 @@ static inline thread_t *thread_get_active(void)
  *
  * @return stack pointer
  */
+ACCESS(write_only, 3, 4)
 char *thread_stack_init(thread_task_func_t task_func, void *arg,
                         void *stack_start, int stack_size);
 
@@ -516,6 +518,7 @@ static inline const char *thread_getname(kernel_pid_t pid)
  *
  * @return              the amount of unused space of the thread's stack
  */
+ACCESS(read_only, 1, 2)
 uintptr_t measure_stack_free_internal(const char *stack, size_t size);
 
 /**

--- a/core/lib/include/ringbuffer.h
+++ b/core/lib/include/ringbuffer.h
@@ -21,6 +21,8 @@
  * @}
  */
 
+#include "compiler_hints.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -51,6 +53,7 @@ typedef struct {
  * @param[in]    buffer    Buffer to use by rb.
  * @param[in]    bufsize   `sizeof (buffer)`
  */
+ACCESS(write_only, 2, 3)
 static inline void ringbuffer_init(ringbuffer_t *__restrict rb, char *buffer,
                                    unsigned bufsize)
 {
@@ -81,6 +84,7 @@ int ringbuffer_add_one(ringbuffer_t *__restrict rb, char c);
  * @param[in]       n     Maximum number of elements to add.
  * @returns         Number of elements actually added. 0 if rb is full.
  */
+ACCESS(read_only, 2, 3)
 unsigned ringbuffer_add(ringbuffer_t *__restrict rb, const char *buf,
                         unsigned n);
 
@@ -98,6 +102,7 @@ int ringbuffer_get_one(ringbuffer_t *__restrict rb);
  * @param[in]       n     Read at most n elements.
  * @returns         Number of elements actually read.
  */
+ACCESS(write_only, 2, 3)
 unsigned ringbuffer_get(ringbuffer_t *__restrict rb, char *buf, unsigned n);
 
 /**
@@ -153,6 +158,7 @@ int ringbuffer_peek_one(const ringbuffer_t *__restrict rb);
  * @param[in]       n     Read at most n elements.
  * @returns         Same as ringbuffer_get()
  */
+ACCESS(write_only, 2, 3)
 unsigned ringbuffer_peek(const ringbuffer_t *__restrict rb, char *buf,
                          unsigned n);
 


### PR DESCRIPTION
### Contribution description

This add annotations via the `ACCESS(<mode>, <ptr_pos>, <size_pos>)` macro to allow GCC to provide better warnings with `-Wstringop-overflow`: If a supplied buffer / array is known to be smaller than expected by the function, the compile will warn (or with `WERROR=1`, fail).

### Testing procedure

The CI will do this for us :)

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- `sgpt` (shell GPT) as front-end and `llama-server --gpt-oss-20b-default` as backend for listing candidate functions that could provide
- none for actual code changes

here is the command line I used to list the functions:

```console
for header in $(find core -type f -name '*.h'); do
    echo "<\"header_file\": \"$header\">"; cat "$header" | sgpt 'List the names of all functions that take a pointer to a buffer or an array as parameter if one of the following is true: a) the size is given as another function parameter or b) the size is a compile time constant and we could e.g. turn `char *buf` into `char buf[128]` to enable the compiler to do warn when called with a too small buffer. If one or more functions are found, list their names as a markdown list. If none are found, print nothing.'
done
```

here is a snippet of the output:

```
<"header_file": "core/include/thread_flags_group.h">
none                                                                                                                                                                                                                                                           
<"header_file": "core/include/thread.h">
- thread_create                                                                                                                                                                                                                                               
- thread_stack_init                                                                                                                                                                                                                                           
- measure_stack_free_internal   
 ```