### PR TITLE
sys/net/gnrc: add ACCESS() attribute and minor style fixes

### DIFF
--- a/dist/tools/doccheck/exclude_simple
+++ b/dist/tools/doccheck/exclude_simple
@@ -8413,7 +8413,7 @@ boards/esp32s2-wemos-mini/doc.md:38: warning: unable to resolve reference to 'es
 drivers/include/ph_oem.h:177: warning: unable to resolve reference to 'GPIO_IN_PU' for \ref command
 drivers/include/ph_oem.h:178: warning: unable to resolve reference to 'GPIO_IN_PD' for \ref command
 drivers/include/ph_oem.h:179: warning: unable to resolve reference to 'GPIO_IN_PD' for \ref command
-sys/include/net/gnrc/netif.h:210: warning: Potential recursion while resolving \ref command!
+sys/include/net/gnrc/netif.h:218: warning: Potential recursion while resolving \ref command!
 sys/include/net/ieee802154_security.h:69: warning: unable to resolve reference to 'ieee802154_sec_context_t::ieee802154_sec_dev_t' for \ref command
 sys/include/net/ieee802154_security.h:83: warning: unable to resolve reference to 'ieee802154_sec_context_t::ieee802154_sec_dev_t' for \ref command
 sys/include/net/ieee802154_security.h:59: warning: unable to resolve reference to 'ieee802154_sec_context_t::ieee802154_sec_dev_t' for \ref command

--- a/drivers/nrf24l01p_ng/gnrc_netif_nrf24l01p_ng.c
+++ b/drivers/nrf24l01p_ng/gnrc_netif_nrf24l01p_ng.c
@@ -19,10 +19,11 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-#include "net/gnrc.h"
-#include "luid.h"
 #include "gnrc_netif_nrf24l01p_ng.h"
+#include "luid.h"
+#include "net/gnrc.h"
 #include "nrf24l01p_ng.h"
+#include "utlist.h"
 
 /**
  * @brief   Broadcast/Multicast flag

--- a/pkg/ccn-lite/patches/0005-src-ccnl-riot-sort-and-fix-includes.patch
+++ b/pkg/ccn-lite/patches/0005-src-ccnl-riot-sort-and-fix-includes.patch
@@ -1,0 +1,54 @@
+From c95eadc77b493c37d7e564f59df2dc21e00cec86 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ml-pa.com>
+Date: Wed, 10 Jun 2026 19:43:12 +0200
+Subject: [PATCH] src/ccnl-riot: sort and fix includes
+
+- add missing include for `utlist.h` (this previously was included
+  indirectly)
+- use `time_units.h` as provider of time units, not `timex.h`
+- sort headers alphabetically
+---
+ src/ccnl-riot/src/ccn-lite-riot.c | 24 ++++++++++++------------
+ 1 file changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/src/ccnl-riot/src/ccn-lite-riot.c b/src/ccnl-riot/src/ccn-lite-riot.c
+index 0ddb488a..921521c8 100644
+--- a/src/ccnl-riot/src/ccn-lite-riot.c
++++ b/src/ccnl-riot/src/ccn-lite-riot.c
+@@ -29,21 +29,21 @@
+ #include <time.h>
+ 
+ /* RIOT specific includes */
+-#include "sched.h"
+-#include "random.h"
+-#include "timex.h"
+-#include "ztimer64.h"
+-#include "net/gnrc/netreg.h"
+-#include "net/gnrc/netif.h"
+-#include "net/gnrc/netif/hdr.h"
+-#include "net/gnrc/netapi.h"
+-#include "net/packet.h"
+ #include "ccn-lite-riot.h"
+-
+-#include "ccnl-os-time.h"
+ #include "ccnl-fwd.h"
+-#include "ccnl-producer.h"
++#include "ccnl-os-time.h"
+ #include "ccnl-pkt-builder.h"
++#include "ccnl-producer.h"
++#include "net/gnrc/netapi.h"
++#include "net/gnrc/netif.h"
++#include "net/gnrc/netif/hdr.h"
++#include "net/gnrc/netreg.h"
++#include "net/packet.h"
++#include "random.h"
++#include "sched.h"
++#include "time_units.h"
++#include "utlist.h"
++#include "ztimer64.h"
+ 
+ /**
+  * @brief RIOT specific local variables
+-- 
+2.53.0
+

--- a/sys/include/net/gnrc/icmpv6/echo.h
+++ b/sys/include/net/gnrc/icmpv6/echo.h
@@ -23,6 +23,7 @@
 #include <inttypes.h>
 
 #include "byteorder.h"
+#include "compiler_hints.h"
 #include "net/gnrc/netif.h"
 #include "net/gnrc/netif/hdr.h"
 #include "net/ipv6/hdr.h"
@@ -45,8 +46,9 @@ extern "C" {
  * @return  The echo message on success
  * @return  NULL, on failure
  */
+ACCESS(read_only, 4, 5)
 gnrc_pktsnip_t *gnrc_icmpv6_echo_build(uint8_t type, uint16_t id, uint16_t seq,
-                                       uint8_t *data, size_t data_len);
+                                       const void *data, size_t data_len);
 
 /**
  * @brief   ICMPv6 echo request handler

--- a/sys/include/net/gnrc/ipv6/nib.h
+++ b/sys/include/net/gnrc/ipv6/nib.h
@@ -25,17 +25,16 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include "compiler_hints.h"
 #include "net/gnrc/ipv6/nib/abr.h"
 #include "net/gnrc/ipv6/nib/ft.h"
 #include "net/gnrc/ipv6/nib/nc.h"
 #include "net/gnrc/ipv6/nib/pl.h"
-
+#include "net/gnrc/netif.h"
+#include "net/gnrc/pkt.h"
 #include "net/icmpv6.h"
 #include "net/ipv6/addr.h"
 #include "net/ipv6/hdr.h"
-#include "net/gnrc/ipv6/nib/nc.h"
-#include "net/gnrc/netif.h"
-#include "net/gnrc/pkt.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -412,6 +411,7 @@ int gnrc_ipv6_nib_get_next_hop_l2addr(const ipv6_addr_t *dst,
  *                          packet.
  * @param[in] icmpv6_len    The number of bytes at @p icmpv6.
  */
+ACCESS(read_only, 3, 4)
 void gnrc_ipv6_nib_handle_pkt(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
                               const icmpv6_hdr_t *icmpv6, size_t icmpv6_len);
 

--- a/sys/include/net/gnrc/ipv6/nib/nc.h
+++ b/sys/include/net/gnrc/ipv6/nib/nc.h
@@ -23,6 +23,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "compiler_hints.h"
 #include "net/eui64.h"
 #include "net/gnrc/netif/hdr.h"
 #include "net/gnrc/ipv6/nib/conf.h"
@@ -230,6 +231,7 @@ static inline unsigned gnrc_ipv6_nib_nc_get_ar_state(const gnrc_ipv6_nib_nc_t *e
  * @return  -EINVAL, if @p ipv6 is invalid (i.e.
  *          @ref CONFIG_GNRC_IPV6_NIB_ARSM == 0 and @p ipv6 is not link-local).
  */
+ACCESS(read_only, 3, 4)
 int gnrc_ipv6_nib_nc_set(const ipv6_addr_t *ipv6, unsigned iface,
                          const uint8_t *l2addr, size_t l2addr_len);
 
@@ -249,6 +251,7 @@ int gnrc_ipv6_nib_nc_set(const ipv6_addr_t *ipv6, unsigned iface,
  *          gnrc_netif_t::device_type of @p netif.
  * @retval  -ENOMEM if no space is left in neighbor cache.
  */
+ACCESS(read_only, 2, 3)
 int gnrc_ipv6_nib_nc_set_6ln(unsigned iface, const uint8_t *l2addr,
                              size_t l2addr_len);
 #else /* CONFIG_GNRC_IPV6_NIB_6LN */
@@ -289,6 +292,7 @@ void gnrc_ipv6_nib_nc_del(const ipv6_addr_t *ipv6, unsigned iface);
  * @retval  True if a neighbor with @p l2addr existed.
  * @retval  False otherwise.
  */
+ACCESS(read_only, 2, 3)
 bool gnrc_ipv6_nib_nc_del_l2(unsigned iface, const uint8_t *l2addr, size_t l2addr_len);
 #endif /* CONFIG_GNRC_IPV6_NIB_ARSM */
 

--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -23,6 +23,7 @@
  * @author  Francisco Molina <femolina@uc.cl>
  */
 
+#include "compiler_hints.h"
 #include "gnrc_lorawan_internal.h"
 #include "assert.h"
 
@@ -243,6 +244,7 @@ void gnrc_lorawan_mcps_request(gnrc_lorawan_t *mac,
  *            not successful.
  * @param[in] size size of the PSDU
  */
+ACCESS(read_write, 2, 3)
 void gnrc_lorawan_radio_rx_done_cb(gnrc_lorawan_t *mac, uint8_t *data,
                                    size_t size);
 

--- a/sys/include/net/gnrc/ndp.h
+++ b/sys/include/net/gnrc/ndp.h
@@ -22,6 +22,7 @@
 
 #include <stdint.h>
 
+#include "compiler_hints.h"
 #include "net/gnrc/pkt.h"
 #include "net/gnrc/netif.h"
 #include "net/ipv6/addr.h"
@@ -168,6 +169,7 @@ gnrc_pktsnip_t *gnrc_ndp_opt_build(uint8_t type, size_t size,
  * @return  The packet snip list of options, on success
  * @return  NULL, if packet buffer is full
  */
+ACCESS(read_only, 1, 2)
 gnrc_pktsnip_t *gnrc_ndp_opt_sl2a_build(const uint8_t *l2addr,
                                         uint8_t l2addr_len,
                                         gnrc_pktsnip_t *next);
@@ -191,6 +193,7 @@ gnrc_pktsnip_t *gnrc_ndp_opt_sl2a_build(const uint8_t *l2addr,
  * @return  The pkt snip list of options, on success
  * @return  NULL, if packet buffer is full
  */
+ACCESS(read_only, 1, 2)
 gnrc_pktsnip_t *gnrc_ndp_opt_tl2a_build(const uint8_t *l2addr,
                                         uint8_t l2addr_len,
                                         gnrc_pktsnip_t *next);
@@ -297,7 +300,9 @@ gnrc_pktsnip_t *gnrc_ndp_opt_mtu_build(uint32_t mtu, gnrc_pktsnip_t *next);
  * @return  @p next, if RDNSS is not supported
  * @return  NULL, if packet buffer is full
  */
-gnrc_pktsnip_t *gnrc_ndp_opt_rdnss_build(uint32_t lifetime, ipv6_addr_t *addrs,
+ACCESS(read_only, 2, 3)
+gnrc_pktsnip_t *gnrc_ndp_opt_rdnss_build(uint32_t lifetime,
+                                         const ipv6_addr_t *addrs,
                                          unsigned addrs_num,
                                          gnrc_pktsnip_t *next);
 

--- a/sys/include/net/gnrc/netapi.h
+++ b/sys/include/net/gnrc/netapi.h
@@ -58,11 +58,12 @@
  * @}
  */
 
-#include "thread.h"
-#include "net/netopt.h"
+#include "compiler_hints.h"
 #include "net/gnrc/netapi/notify.h"
 #include "net/gnrc/nettype.h"
 #include "net/gnrc/pkt.h"
+#include "net/netopt.h"
+#include "thread.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -206,6 +207,7 @@ static inline int gnrc_netapi_dispatch_send(gnrc_nettype_t type, uint32_t demux_
  *
  * @return Number of subscribers to (@p type, @p demux_ctx).
  */
+ACCESS(read_write, 4, 5)
 int gnrc_netapi_notify(gnrc_nettype_t type, uint32_t demux_ctx, netapi_notify_t event,
                        void *data, size_t data_len);
 
@@ -254,6 +256,7 @@ static inline int gnrc_netapi_dispatch_receive(gnrc_nettype_t type, uint32_t dem
  *                      actual error value is for the implementation to decide but should be
  *                      sensible to indicate what went wrong.
  */
+ACCESS(write_only, 4, 5)
 static inline int gnrc_netapi_get(kernel_pid_t pid, netopt_t opt,
                                   uint16_t context, void *data, size_t max_len)
 {
@@ -276,6 +279,7 @@ static inline int gnrc_netapi_get(kernel_pid_t pid, netopt_t opt,
  *                      implementation to decide but should be sensible to indicate what went
  *                      wrong.
  */
+ACCESS(read_only, 4, 5)
 static inline int gnrc_netapi_set(kernel_pid_t pid, netopt_t opt,
                                   uint16_t context, const void *data,
                                   size_t data_len)

--- a/sys/include/net/gnrc/netapi/notify.h
+++ b/sys/include/net/gnrc/netapi/notify.h
@@ -35,6 +35,7 @@
 extern "C" {
 #endif
 
+#include "compiler_hints.h"
 #include "net/gnrc/netif/conf.h"
 #include "sema_inv.h"
 
@@ -95,6 +96,7 @@ static inline void gnrc_netapi_notify_ack(sema_inv_t *ack)
  * @retval                  -EINVAL if the data in @p notify is invalid or doesn't match the expected
  *                          data length.
  */
+ACCESS(write_only, 3, 2)
 int gnrc_netapi_notify_copy_event_data(gnrc_netapi_notify_t *notify, uint8_t data_len, void *data);
 
 #ifdef __cplusplus

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -33,41 +33,49 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include "sched.h"
-#include "msg.h"
-#ifdef MODULE_GNRC_NETIF_BUS
-#include "msg_bus.h"
-#endif
+#include "compiler_hints.h"
 #include "event.h"
-#include "net/ipv6/addr.h"
+#include "msg.h"
 #include "net/gnrc/netapi.h"
-#include "net/gnrc/pkt.h"
 #include "net/gnrc/netif/conf.h"
-#if IS_USED(MODULE_GNRC_NETIF_LORAWAN)
-#include "net/gnrc/netif/lorawan.h"
-#endif
-#if IS_USED(MODULE_GNRC_NETIF_6LO)
-#include "net/gnrc/netif/6lo.h"
-#endif
-#if defined(MODULE_GNRC_NETIF_DEDUP) && (GNRC_NETIF_L2ADDR_MAXLEN > 0)
-#include "net/gnrc/netif/dedup.h"
-#endif
 #include "net/gnrc/netif/flags.h"
-#if IS_USED(MODULE_GNRC_NETIF_IPV6)
-#include "net/gnrc/netif/ipv6.h"
-#endif
-#if IS_USED(MODULE_GNRC_NETIF_PKTQ)
-#include "net/gnrc/netif/pktq/type.h"
-#endif
+#include "net/gnrc/pkt.h"
+#include "net/ipv6/addr.h"
 #include "net/l2util.h"
 #include "net/ndp.h"
 #include "net/netdev.h"
-#include "net/netopt.h"
-#ifdef MODULE_NETSTATS_L2
-#include "net/netstats.h"
-#endif
-#include "rmutex.h"
 #include "net/netif.h"
+#include "net/netopt.h"
+#include "rmutex.h"
+#include "sched.h"
+
+#ifdef MODULE_GNRC_NETIF_BUS
+#  include "msg_bus.h"
+#endif
+
+#if IS_USED(MODULE_GNRC_NETIF_LORAWAN)
+#  include "net/gnrc/netif/lorawan.h"
+#endif
+
+#if IS_USED(MODULE_GNRC_NETIF_6LO)
+#  include "net/gnrc/netif/6lo.h"
+#endif
+
+#if defined(MODULE_GNRC_NETIF_DEDUP) && (GNRC_NETIF_L2ADDR_MAXLEN > 0)
+#  include "net/gnrc/netif/dedup.h"
+#endif
+
+#if IS_USED(MODULE_GNRC_NETIF_IPV6)
+#  include "net/gnrc/netif/ipv6.h"
+#endif
+
+#if IS_USED(MODULE_GNRC_NETIF_PKTQ)
+#  include "net/gnrc/netif/pktq/type.h"
+#endif
+
+#ifdef MODULE_NETSTATS_L2
+#  include "net/netstats.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -409,6 +417,7 @@ void gnrc_netif_init_devs(void);
  * @return  0 on success
  * @return  negative number on error
  */
+ACCESS(write_only, 2, 3)
 int gnrc_netif_create(gnrc_netif_t *netif, char *stack, int stacksize,
                       char priority, const char *name, netdev_t *dev,
                       const gnrc_netif_ops_t *ops);

--- a/sys/include/net/gnrc/netif/ethernet.h
+++ b/sys/include/net/gnrc/netif/ethernet.h
@@ -18,6 +18,7 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
+#include "compiler_hints.h"
 #include "net/gnrc/netif.h"
 
 #ifdef __cplusplus
@@ -39,6 +40,7 @@ extern "C" {
  * @return  0 on success
  * @return  negative number on error
  */
+ACCESS(write_only, 2, 3)
 int gnrc_netif_ethernet_create(gnrc_netif_t *netif, char *stack, int stacksize,
                                char priority, char *name, netdev_t *dev);
 

--- a/sys/include/net/gnrc/netif/hdr.h
+++ b/sys/include/net/gnrc/netif/hdr.h
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "compiler_hints.h"
 #include "net/gnrc/netif/internal.h"
 #include "net/gnrc/pkt.h"
 #include "net/gnrc/pktbuf.h"
@@ -204,8 +205,9 @@ static inline uint8_t *gnrc_netif_hdr_get_src_addr(const gnrc_netif_hdr_t *hdr)
  *
  * @param[in] hdr           header to write to
  * @param[in] addr          new source address
- * @param[in] addr_len      *addr* length
+ * @param[in] addr_len      length of @p addr in bytes
  */
+ACCESS(read_only, 2, 3)
 static inline void gnrc_netif_hdr_set_src_addr(gnrc_netif_hdr_t *hdr,
                                                const uint8_t *addr,
                                                uint8_t addr_len)
@@ -235,8 +237,9 @@ static inline uint8_t *gnrc_netif_hdr_get_dst_addr(const gnrc_netif_hdr_t *hdr)
  *
  * @param[in] hdr           header to write to
  * @param[in] addr          new destination address
- * @param[in] addr_len      *addr* length
+ * @param[in] addr_len      length of @p addr in bytes
  */
+ACCESS(read_only, 2, 3)
 static inline void gnrc_netif_hdr_set_dst_addr(gnrc_netif_hdr_t *hdr,
                                                const uint8_t *addr,
                                                uint8_t addr_len)
@@ -365,6 +368,8 @@ static inline int gnrc_netif_hdr_ipv6_iid_from_dst(const gnrc_netif_t *netif,
  * @return  The generic network layer header on success.
  * @return  NULL on error.
  */
+ACCESS(read_only, 1, 2)
+ACCESS(read_only, 3, 4)
 gnrc_pktsnip_t *gnrc_netif_hdr_build(const uint8_t *src, uint8_t src_len,
                                      const uint8_t *dst, uint8_t dst_len);
 

--- a/sys/include/net/gnrc/netif/ieee802154.h
+++ b/sys/include/net/gnrc/netif/ieee802154.h
@@ -18,6 +18,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include "compiler_hints.h"
 #include "net/gnrc/netif.h"
 
 #ifdef __cplusplus
@@ -39,6 +40,7 @@ extern "C" {
  * @return  0 on success
  * @return  negative number on error
  */
+ACCESS(write_only, 2, 3)
 int gnrc_netif_ieee802154_create(gnrc_netif_t *netif, char *stack, int stacksize,
                                  char priority, const char *name, netdev_t *dev);
 

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -21,8 +21,8 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include "compiler_hints.h"
 #include "modules.h"
-
 #include "net/gnrc/netif.h"
 #include "net/l2util.h"
 #include "net/netopt.h"
@@ -513,6 +513,7 @@ netopt_t gnrc_netif_get_l2addr_opt(const gnrc_netif_t *netif);
  * @return  `-EINVAL`, when @p addr_len is invalid for the
  *          gnrc_netif_t::device_type of @p netif.
  */
+ACCESS(read_only, 2, 3)
 int gnrc_netif_eui64_from_addr(const gnrc_netif_t *netif,
                                const uint8_t *addr, size_t addr_len,
                                eui64_t *eui64);
@@ -586,6 +587,7 @@ void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif);
  * @return  `-EINVAL`, when @p addr_len is invalid for the
  *          gnrc_netif_t::device_type of @p netif.
  */
+ACCESS(read_only, 2, 3)
 int gnrc_netif_ipv6_iid_from_addr(const gnrc_netif_t *netif,
                                   const uint8_t *addr, size_t addr_len,
                                   eui64_t *iid);

--- a/sys/include/net/gnrc/netif/lorawan.h
+++ b/sys/include/net/gnrc/netif/lorawan.h
@@ -18,8 +18,8 @@
  * @author  Jose Ignacio Alamos <jose.alamos@haw-hamburg.de>
  */
 
+#include "compiler_hints.h"
 #include "net/gnrc/lorawan.h"
-
 #include "ztimer.h"
 
 #ifdef __cplusplus
@@ -65,13 +65,15 @@ typedef struct {
  *  This getter function exists to allow if (IS_USED(...)) constructs in the
  *  LoRaWAN code in order to increase code coverage.
  *
- * @param[in] lw_netif      pointer to the interface descriptor
- * @param[in] key           pointer to the app key
- * @param[in] len           length of the app key
- * @return 0 on success
- * @return <0 on failure
+ * @param[in,out]   lw_netif  pointer to the interface descriptor
+ * @param[in]       key       pointer to the app key
+ * @param[in]       len       length of the app key
+ * @retval          0         success
+ * @retval          <0        failure
  */
-static inline int gnrc_netif_lorawan_set_appkey(gnrc_netif_lorawan_t *lw_netif, const uint8_t *key,
+ACCESS(read_only, 2, 3)
+static inline int gnrc_netif_lorawan_set_appkey(gnrc_netif_lorawan_t *lw_netif,
+                                                const uint8_t *key,
                                                 size_t len)
 {
     (void)lw_netif;
@@ -112,12 +114,13 @@ static inline uint8_t * gnrc_netif_lorawan_get_appkey(gnrc_netif_lorawan_t *lw_n
  *  This getter function exists to allow if (IS_USED(...)) constructs in the
  *  LoRaWAN code in order to increase code coverage.
  *
- * @param[in] lw_netif      pointer to the interface descriptor
- * @param[in] key           pointer to the serving network session integrity key
- * @param[in] len           length of serving network session integrity key
- * @return 0 on success
- * @return <0 on failure
+ * @param[in,out]   lw_netif  pointer to the interface descriptor
+ * @param[in]       key       pointer to the serving network session integrity key
+ * @param[in]       len       length of serving network session integrity key
+ * @retval          0         success
+ * @retval          <0        failure
  */
+ACCESS(read_only, 2, 3)
 static inline int gnrc_netif_lorawan_set_snwksintkey(gnrc_netif_lorawan_t *lw_netif,
                                                      const uint8_t *key, size_t len)
 {
@@ -140,12 +143,13 @@ static inline int gnrc_netif_lorawan_set_snwksintkey(gnrc_netif_lorawan_t *lw_ne
  *  This getter function exists to allow if (IS_USED(...)) constructs in the
  *  LoRaWAN code in order to increase code coverage.
  *
- * @param[in] lw_netif      pointer to the interface descriptor
- * @param[in] key           pointer to the network session encryption key
- * @param[in] len           length of network session encryption key
- * @return 0 on success
- * @return <0 on failure
+ * @param[in,out]   lw_netif  pointer to the interface descriptor
+ * @param[in]       key       pointer to the network session encryption key
+ * @param[in]       len       length of network session encryption key
+ * @retval          0         success
+ * @retval          <0        failure
  */
+ACCESS(read_only, 2, 3)
 static inline int gnrc_netif_lorawan_set_nwksenckey(gnrc_netif_lorawan_t *lw_netif,
                                                     const uint8_t *key, size_t len)
 {

--- a/sys/include/net/gnrc/netif/lorawan_base.h
+++ b/sys/include/net/gnrc/netif/lorawan_base.h
@@ -18,6 +18,7 @@
  * @author  Jose Ignacio Alamos <jose.alamos@haw-hamburg.de>
  */
 
+#include "compiler_hints.h"
 #include "net/gnrc/netif.h"
 
 #ifdef __cplusplus
@@ -39,6 +40,7 @@ extern "C" {
  * @return  0 on success
  * @return  negative number on error
  */
+ACCESS(write_only, 2, 3)
 int gnrc_netif_lorawan_create(gnrc_netif_t *netif, char *stack, int stacksize,
                               char priority, char *name, netdev_t *dev);
 

--- a/sys/include/net/gnrc/netif/raw.h
+++ b/sys/include/net/gnrc/netif/raw.h
@@ -19,6 +19,7 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include "compiler_hints.h"
 #include "net/gnrc/netif.h"
 
 #ifdef __cplusplus
@@ -40,6 +41,7 @@ extern "C" {
  * @return  0 on success
  * @return  negative number on error
  */
+ACCESS(write_only, 2, 3)
 int gnrc_netif_raw_create(gnrc_netif_t *netif, char *stack, int stacksize,
                           char priority, char *name, netdev_t *dev);
 

--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -54,12 +54,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "cpu_conf.h"
-#include "mutex.h"
+#include "compiler_hints.h"
 #include "net/gnrc/pkt.h"
 #include "net/gnrc/neterr.h"
 #include "net/gnrc/nettype.h"
-#include "utlist.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/net/gnrc/sixlowpan/frag/vrb.h
+++ b/sys/include/net/gnrc/sixlowpan/frag/vrb.h
@@ -25,14 +25,15 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "compiler_hints.h"
 #include "modules.h"
 #include "net/gnrc/netif.h"
 #include "net/gnrc/sixlowpan/config.h"
-#ifdef MODULE_GNRC_SIXLOWPAN_FRAG
-#include "net/gnrc/sixlowpan/frag.h"
-#endif /* MODULE_GNRC_SIXLOWPAN_FRAG */
 #include "net/gnrc/sixlowpan/frag/rb.h"
-#include "timex.h"
+
+#ifdef MODULE_GNRC_SIXLOWPAN_FRAG
+#  include "net/gnrc/sixlowpan/frag.h"
+#endif /* MODULE_GNRC_SIXLOWPAN_FRAG */
 
 #ifdef __cplusplus
 extern "C" {
@@ -79,6 +80,7 @@ typedef struct {
  * @return  A new VRB entry.
  * @return  NULL, if VRB is full.
  */
+ACCESS(read_only, 3, 4)
 gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_add(
         const gnrc_sixlowpan_frag_rb_base_t *base,
         gnrc_netif_t *out_netif, const uint8_t *out_dst, size_t out_dst_len);
@@ -121,6 +123,7 @@ void gnrc_sixlowpan_frag_vrb_gc(void);
  * @return  NULL, if there is no entry in the VRB that could be identified
  *          by the given parameters.
  */
+ACCESS(read_only, 1, 2)
 gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_get(
         const uint8_t *src, size_t src_len, unsigned src_tag);
 
@@ -137,6 +140,7 @@ gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_get(
  * @return  The VRB entry with `vrb->super.dst == src` and `vrb->out_tag == tag`.
  * @return  NULL, if there is no entry in the VRB that has these values.
  */
+ACCESS(read_only, 2, 3)
 gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_reverse(
         const gnrc_netif_t *netif, const uint8_t *src, size_t src_len,
         unsigned tag);

--- a/sys/include/net/gnrc/tcp.h
+++ b/sys/include/net/gnrc/tcp.h
@@ -22,15 +22,17 @@
  */
 
 #include <stdint.h>
+
+#include "compiler_hints.h"
 #include "net/gnrc/pkt.h"
 #include "net/gnrc/tcp/tcb.h"
 
 #ifdef SOCK_HAS_IPV6
-#include "net/sock.h"
+#  include "net/sock.h"
 #else
-#ifdef MODULE_GNRC_IPV6
-#include "net/gnrc/ipv6.h"
-#endif
+#  ifdef MODULE_GNRC_IPV6
+#    include "net/gnrc/ipv6.h"
+#  endif
 #endif
 
 #ifdef __cplusplus
@@ -83,6 +85,7 @@ typedef struct {
  * @return   -EAFNOSUPPORT if @p address_family is not supported.
  * @return   -EINVAL if @p addr_size does not match @p family.
  */
+ACCESS(read_only, 3, 4)
 int gnrc_tcp_ep_init(gnrc_tcp_ep_t *ep, int family, const uint8_t *addr, size_t addr_size,
                      uint16_t port, uint16_t netif);
 
@@ -230,6 +233,7 @@ int gnrc_tcp_accept(gnrc_tcp_tcb_queue_t *queue, gnrc_tcp_tcb_t **tcb,
  * @return   -ECONNABORTED if the connection was aborted.
  * @return   -ETIMEDOUT if @p user_timeout_duration_ms expired.
  */
+ACCESS(read_only, 2, 3)
 ssize_t gnrc_tcp_send(gnrc_tcp_tcb_t *tcb, const void *data, const size_t len,
                       const uint32_t user_timeout_duration_ms);
 
@@ -264,8 +268,9 @@ ssize_t gnrc_tcp_send(gnrc_tcp_tcb_t *tcb, const void *data, const size_t len,
  * @return   -ECONNABORTED if the connection was aborted.
  * @return   -ETIMEDOUT if @p user_timeout_duration_ms expired.
  */
-ssize_t gnrc_tcp_recv(gnrc_tcp_tcb_t *tcb, void *data, const size_t max_len,
-                      const uint32_t user_timeout_duration_ms);
+ACCESS(write_only, 2, 3)
+ssize_t gnrc_tcp_recv(gnrc_tcp_tcb_t *tcb, void *data, size_t max_len,
+                      uint32_t user_timeout_duration_ms);
 
 /**
  * @brief Close a TCP connection.

--- a/sys/net/gnrc/netif/gnrc_netif_raw.c
+++ b/sys/net/gnrc/netif/gnrc_netif_raw.c
@@ -16,6 +16,7 @@
 #include "net/gnrc/pktbuf.h"
 #include "net/gnrc/netif/hdr.h"
 #include "net/gnrc/netif/raw.h"
+#include "utlist.h"
 
 #define ENABLE_DEBUG    0
 #include "debug.h"

--- a/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
+++ b/sys/net/gnrc/network_layer/icmpv6/echo/gnrc_icmpv6_echo.c
@@ -26,7 +26,7 @@
 #include "debug.h"
 
 gnrc_pktsnip_t *gnrc_icmpv6_echo_build(uint8_t type, uint16_t id, uint16_t seq,
-                                       uint8_t *data, size_t data_len)
+                                       const void *data, size_t data_len)
 {
     gnrc_pktsnip_t *pkt;
     icmpv6_echo_t *echo;

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -240,7 +240,8 @@ gnrc_pktsnip_t *gnrc_ndp_opt_mtu_build(uint32_t mtu, gnrc_pktsnip_t *next)
     return pkt;
 }
 
-gnrc_pktsnip_t *gnrc_ndp_opt_rdnss_build(uint32_t ltime, ipv6_addr_t *addrs,
+gnrc_pktsnip_t *gnrc_ndp_opt_rdnss_build(uint32_t ltime,
+                                         const ipv6_addr_t *addrs,
                                          unsigned addrs_num,
                                          gnrc_pktsnip_t *next)
 {

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -20,19 +20,23 @@
 #include <string.h>
 
 #include "byteorder.h"
+#include "gnrc_sock_internal.h"
 #include "net/af.h"
-#include "net/protnum.h"
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc/udp.h"
+#include "net/protnum.h"
 #include "net/sock/udp.h"
 #include "net/udp.h"
 #include "random.h"
 
 #ifdef SOCK_HAS_ASYNC_CTX
-#include "net/sock/async/event.h"
+#  include "net/sock/async/event.h"
 #endif
 
-#include "gnrc_sock_internal.h"
+#ifdef MODULE_GNRC_SOCK_CHECK_REUSE
+#  include "utlist.h"
+#endif
+
 
 #define ENABLE_DEBUG 0
 #include "debug.h"

--- a/tests/net/gnrc_ipv6_nib/main.c
+++ b/tests/net/gnrc_ipv6_nib/main.c
@@ -31,7 +31,7 @@
 #include "sched.h"
 #include "timex.h"
 
-#define _BUFFER_SIZE    (128)
+#define _BUFFER_SIZE    (192)
 #define _CUR_HL         (155)
 #define _RTR_LTIME      (6612U)
 #define _REACH_TIME     (1210388825UL)


### PR DESCRIPTION
### Contribution description

Add the `ACCESS(<mode>, <ptr_idx>, <size_idx>)` macro to annotate functions with the information GCC needs for `-Wstringop-overflow` to be more effective.

In addition a few style fixes have been addressed:

- format includes as per coding convention
- add missing `const` qualifier for pointers that are only read
- drop `const` qualifier for variables passed by value instead of by reference (as there the `const` has no effect - except for confusion)
- use `const void *` instead of `uint8_t *` to pass arbitrary data in `gnrc_icmpv6_echo_build()`

### Testing procedure

The CI should do this for us.

### Issues/PRs references

Same as https://github.com/RIOT-OS/RIOT/pull/22366

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- `sgpt` + `llama-server --gpt-oss-20b-default` to identify possible functions to annotate using:

```sh
for header in $(find sys/include/net/gnrc -type f -name '*.h'); do
	echo "<\"header_file\": \"$header\">"; cat "$header" | sgpt 'List the names of all functions that take a pointer to a buffer or an array as parameter if one of the following is true: a) the size is given as another function parameter or b) the size is a compile time constant and we could e.g. turn `char *buf` into `char buf[128]` to enable the compiler to do warn when called with a too small bufer. If one or more functions are found, list their names as a markdown list. If none are found, print nothing.'
done
```