### PR TITLE
sys/base64: add ACCESS() attribute

### DIFF
--- a/sys/include/base64.h
+++ b/sys/include/base64.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2014 Hochschule für Angewandte Wissenschaften Hamburg (HAW)
+ * SPDX-FileCopyrightText: 2014 HAW Hamburg
  * SPDX-FileCopyrightText: 2014 Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
  * SPDX-License-Identifier: LGPL-2.1-only
  */
@@ -18,6 +18,8 @@
 
 #include <stddef.h> /* for size_t */
 #include <stdbool.h> /* for bool */
+
+#include "compiler_hints.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -93,6 +95,7 @@ static inline bool base64_can_estimate_encode_size(size_t data_in_size)
  * @retval  BASE64_ERROR_DATA_IN            if `data_in` equals NULL
  * @retval  BASE64_ERROR_OVERFLOW           if `data_in_size` is too large to be encoded to base64
  */
+ACCESS(read_only, 1, 2)
 int base64_encode(const void *data_in, size_t data_in_size,
                   void *base64_out, size_t *base64_out_size);
 
@@ -121,6 +124,7 @@ int base64_encode(const void *data_in, size_t data_in_size,
  * @retval  BASE64_ERROR_DATA_IN            if `data_in` equals NULL
  * @retval  BASE64_ERROR_OVERFLOW           if `data_in_size` is too large to be encoded to base64
  */
+ACCESS(read_only, 1, 2)
 int base64url_encode(const void *data_in, size_t data_in_size,
                      void *base64_out, size_t *base64_out_size);
 
@@ -144,6 +148,7 @@ int base64url_encode(const void *data_in, size_t data_in_size,
  * @retval  BASE64_ERROR_DATA_IN            if `base64_in` equals NULL
  * @retval  BASE64_ERROR_DATA_IN_SIZE       if `base64_in_size` has remainder 1 (mod 4)
  */
+ACCESS(read_only, 1, 2)
 int base64_decode(const void *base64_in, size_t base64_in_size,
                   void *data_out, size_t *data_out_size);
 

--- a/tests/unittests/tests-base64/tests-base64.c
+++ b/tests/unittests/tests-base64/tests-base64.c
@@ -406,7 +406,20 @@ static void test_base64_12_encode_overflow(void)
 
     size_t base64_out_size = 0;
 
+    /* To test if `base64_encode()` detects an overflow of the output size
+     * argument, we need to pass a size argument that is incredibly large. The
+     * compiler is unaware that base64_encode() won't actually read from
+     * `data_in` due to the overflow and will complain about reading
+     * `SIZE_MAX - 1` bytes beyond `data_in`. So we just disable the diagnostics
+     * here temporarily. */
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 8)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
     int ret = base64_encode(data_in, SIZE_MAX, NULL, &base64_out_size);
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 8)
+#  pragma GCC diagnostic pop
+#endif
 
     TEST_ASSERT_EQUAL_INT(BASE64_ERROR_OVERFLOW, ret);
 }


### PR DESCRIPTION
### Contribution description

- annotate functions using the `ACCESS()` macro with the `access` attribute so that GCC can emit proper `-Wstringop-overflow` warnings
- use SPDX license IDs


### Testing procedure

The CI will do this

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/22368

### Declaration of AI-Tools / LLMs usage:

Same as in https://github.com/RIOT-OS/RIOT/pull/22368