### PR TITLE
sys/crypto: add ACCESS() attribute

### DIFF
--- a/sys/include/crypto/aes.h
+++ b/sys/include/crypto/aes.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin, Computer Systems & Telematics
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Freie Universität Berlin, Computer Systems & Telematics
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once
@@ -20,16 +17,21 @@
  * your Makefile.
  *
  * If only one key size is needed and that key size is not 128 bits, the 128 bit
- * key size can be disabled with DISABLE_MODULE += crypto_aes_128 as an
+ * `USEMODULE += crypto_aes_192` and/or `USEMODULE += crypto_aes_256` to
+ * your Makefile.
+ *
+ * If only one key size is needed and that key size is not 128 bits, the 128 bit
+ * key size can be disabled with `DISABLE_MODULE += crypto_aes_128` as an
  * optimization.
  *
- * @author      Freie Universitaet Berlin, Computer Systems & Telematics
  * @author      Nicolai Schmittberger <nicolai.schmittberger@fu-berlin.de>
  * @author      Fabrice Bellard
  * @author      Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
  */
 
 #include <stdint.h>
+
+#include "compiler_hints.h"
 #include "crypto/ciphers.h"
 
 #ifdef __cplusplus
@@ -40,9 +42,9 @@ typedef uint32_t u32;
 typedef uint16_t u16;
 typedef uint8_t u8;
 
-# define GETU32(pt) (((u32)(pt)[0] << 24) ^ ((u32)(pt)[1] << 16) ^ \
+#define GETU32(pt)  (((u32)(pt)[0] << 24) ^ ((u32)(pt)[1] << 16) ^ \
                      ((u32)(pt)[2] <<  8) ^ ((u32)(pt)[3]))
-# define PUTU32(ct, st) { (ct)[0] = (u8)((st) >> 24); \
+#define PUTU32(ct, st)  { (ct)[0] = (u8)((st) >> 24); \
                           (ct)[1] = (u8)((st) >> 16); \
                           (ct)[2] = (u8)((st) >>  8); \
                           (ct)[3] = (u8)(st); }
@@ -77,11 +79,13 @@ typedef struct {
  *                        support key lengths of 24 or 32 bytes
  * @param       key       a pointer to the key
  *
- * @return  CIPHER_INIT_SUCCESS if the initialization was successful.
- * @return  CIPHER_ERR_BAD_CONTEXT_SIZE if CIPHER_MAX_CONTEXT_SIZE has not
- *          been defined (which means that the cipher has not been included
- *          in the build)
+ * @retval  CIPHER_INIT_SUCCESS            the initialization was successful
+ * @retval  CIPHER_ERR_BAD_CONTEXT_SIZE    `CIPHER_MAX_CONTEXT_SIZE` undefined
+ *
+ * @note    `CIPHER_ERR_BAD_CONTEXT_SIZE` error is typically when the
+ *          cipher has not been included in the build
  */
+ACCESS(read_only, 2, 3)
 int aes_init(cipher_context_t *context, const uint8_t *key, uint8_t keySize);
 
 /**
@@ -97,18 +101,19 @@ int aes_init(cipher_context_t *context, const uint8_t *key, uint8_t keySize);
  * @param       cipher_block  a pointer to the place where the ciphertext will
  *                            be stored
  *
- * @return  1 on success
- * @return  A negative value if the cipher key cannot be expanded with the
- *          AES key schedule
+ * @retval      1             success
+ * @retval      -1            @p context has not been initialized, see @p aes_init
+ * @retval      -2            key size in @p context invalid (memory safety bug?)
+ * @retval      <0            other error
  */
 int aes_encrypt(const cipher_context_t *context, const uint8_t *plain_block,
                 uint8_t *cipher_block);
 
 /**
- * @brief   decrypts one cipher-block and saves the plain-block in plainBlock.
- *          decrypts one blocksize long block of ciphertext pointed to by
- *          cipherBlock to one blocksize long block of plaintext and stores
- *          the plaintext in the memory-area pointed to by plainBlock
+ * @brief   Decrypts one cipher-block and saves the plain-block in @p plain_block.
+ *          Decrypts one blocksize long block of ciphertext pointed to by
+ *          @p cipher_block to one blocksize long block of plaintext and stores
+ *          the plaintext in the memory-area pointed to by @p plain_block.
  *
  * @param       context       the cipher_context_t-struct to use for this
  *                            decryption
@@ -117,9 +122,10 @@ int aes_encrypt(const cipher_context_t *context, const uint8_t *plain_block,
  * @param       plain_block   a pointer to the place where the decrypted
  *                            plaintext will be stored
  *
- * @return  1 on success
- * @return  A negative value if the cipher key cannot be expanded with the
- *          AES key schedule
+ * @retval      1             success
+ * @retval      -1            @p context has not been initialized, see @p aes_init
+ * @retval      -2            key size in @p context invalid (memory safety bug?)
+ * @retval      <0            other error
  */
 int aes_decrypt(const cipher_context_t *context, const uint8_t *cipher_block,
                 uint8_t *plain_block);

--- a/sys/include/crypto/chacha.h
+++ b/sys/include/crypto/chacha.h
@@ -1,24 +1,7 @@
 /*
- * Copyright (C) 2008  D. J. Bernstein  (dedicated to the public domain)
- * Copyright (C) 2015  René Kijewski  <rene.kijewski@fu-berlin.de>
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2008 D. J. Bernstein (dedicated to the public domain)
+ * SPDX-FileCopyrightText: 2015 René Kijewski <rene.kijewski@fu-berlin.de>
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once
@@ -35,6 +18,8 @@
 
 #include <stdint.h>
 #include <stddef.h>
+
+#include "compiler_hints.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -58,9 +43,10 @@ typedef struct {
  * @param[in]  keylen  Length (in bytes) of @p key. Must be 16 or 32.
  * @param[in]  nonce   IV / nonce to use.
  *
- * @return     `== 0` on success.
- * @return     `< 0` if an illegal value for @p rounds or @p keylen was supplied.
+ * @retval     0       success
+ * @retval     <0      value of @p rounds or @p keylen is illegal
  */
+ACCESS(read_only, 3, 4)
 int chacha_init(chacha_ctx *ctx,
                 unsigned rounds,
                 const uint8_t *key, uint32_t keylen,
@@ -122,6 +108,7 @@ static inline void chacha_decrypt_bytes(chacha_ctx *ctx, const uint8_t *m,
  * @param[in] data  Some random data.
  * @param[in] bytes Length of @p data in bytes where `0 < bytes <= 64`.
  */
+ACCESS(read_only, 1, 2)
 void chacha_prng_seed(const void *data, size_t bytes);
 
 /**
@@ -138,6 +125,4 @@ uint32_t chacha_prng_next(void);
 }
 #endif
 
-/**
- * @}
- */
+/** @} */

--- a/sys/include/crypto/chacha20poly1305.h
+++ b/sys/include/crypto/chacha20poly1305.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once
@@ -27,6 +24,7 @@
  * @author      Koen Zandberg <koen@bergzand.net>
  */
 
+#include "compiler_hints.h"
 #include "crypto/poly1305.h"
 
 #ifdef __cplusplus
@@ -69,6 +67,8 @@ typedef union {
  * @param[in]   nonce       Nonce to use. Must be CHACHA20POLY1305_NONCE_BYTES
  *                          long
  */
+ACCESS(read_only, 2, 3)
+ACCESS(read_only, 4, 5)
 void chacha20poly1305_encrypt(uint8_t *cipher, const uint8_t *msg,
                               size_t msglen, const uint8_t *aad, size_t aadlen,
                               const uint8_t *key, const uint8_t *nonce);
@@ -78,18 +78,23 @@ void chacha20poly1305_encrypt(uint8_t *cipher, const uint8_t *msg,
  *
  * It is allowed to have cipher == msg
  *
- * @param[in]   cipher      resulting ciphertext, is CHACHA20POLY1305_TAG_BYTES
- *                          longer than the message length
- * @param[in]   cipherlen   length of the ciphertext
- * @param[out]  msg         message to encrypt
- * @param[in]   msglen      resulting length in bytes of the message
- * @param[in]   aad         additional authenticated data to verify
- * @param[in]   aadlen      length of the additional authenticated data
- * @param[in]   key         key to decrypt with, must be
- *                          CHACHA20POLY1305_KEY_BYTES long
- * @param[in]   nonce       Nonce to use. Must be CHACHA20POLY1305_NONCE_BYTES
- *                          long
+ * @param[in]       cipher      resulting ciphertext, is CHACHA20POLY1305_TAG_BYTES
+ *                              longer than the message length
+ * @param[in]       cipherlen   length of the ciphertext
+ * @param[out]      msg         write the decrypted message here
+ * @param[in,out]   msglen      resulting length in bytes of the message
+ * @param[in]       aad         additional authenticated data to verify
+ * @param[in]       aadlen      length of the additional authenticated data
+ * @param[in]       key         key to decrypt with, must be
+ *                              CHACHA20POLY1305_KEY_BYTES long
+ * @param[in]       nonce       Nonce to use. Must be CHACHA20POLY1305_NONCE_BYTES
+ *                              long
+ * @retval          0           failed to decrypt/verify
+ * @retval          1           @p aad verified successfully and message decrypted
+ *                              into @p msg
  */
+ACCESS(read_only, 1, 2)
+ACCESS(read_only, 5, 6)
 int chacha20poly1305_decrypt(const uint8_t *cipher, size_t cipherlen,
                              uint8_t *msg, size_t *msglen,
                              const uint8_t *aad, size_t aadlen,
@@ -104,11 +109,13 @@ int chacha20poly1305_decrypt(const uint8_t *cipher, size_t cipherlen,
  *                          @ref CHACHA20POLY1305_KEY_BYTES long.
  * @param[in]   nonce       Nonce to use. Must be CHACHA20POLY1305_NONCE_BYTES
  *                          long.
- * @param[in]   inputlen    Length of the input byte array.
+ * @param[in]   inputlen    Length of the input and output byte array.
 */
+ACCESS(read_only, 1, 5)
+ACCESS(write_only, 2, 5)
 void chacha20_encrypt_decrypt(const uint8_t *input, uint8_t *output,
-                             const uint8_t *key, const uint8_t *nonce,
-                             size_t inputlen);
+                              const uint8_t *key, const uint8_t *nonce,
+                              size_t inputlen);
 
 #ifdef __cplusplus
 }

--- a/sys/include/crypto/poly1305.h
+++ b/sys/include/crypto/poly1305.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2016 Andrew Moon (dedicated to the public domain)
- * Copyright (C) 2018 Freie Universität Berlin
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Andrew Moon (dedicated to the public domain)
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once
@@ -34,6 +31,8 @@ extern "C" {
 
 #include <stddef.h>
 #include <stdint.h>
+
+#include "compiler_hints.h"
 
 /**
  * @brief Poly1305 block size
@@ -66,6 +65,7 @@ void poly1305_init(poly1305_ctx_t *ctx, const uint8_t *key);
  * @param   data    ptr to the message
  * @param   len     length of the message
  */
+ACCESS(read_only, 2, 3)
 void poly1305_update(poly1305_ctx_t *ctx, const uint8_t *data, size_t len);
 
 /**
@@ -84,6 +84,7 @@ void poly1305_finish(poly1305_ctx_t *ctx, uint8_t *mac);
  * @param   len     length of the message
  * @param   key     32 byte key
  */
+ACCESS(read_only, 2, 3)
 void poly1305_auth(uint8_t *mac, const uint8_t *data, size_t len,
                    const uint8_t *key);
 

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -789,7 +789,7 @@ ssize_t coap_build_udp_hdr(void *buf, size_t buf_len, uint8_t type,
 {
     assert(!(type & ~0x3));
 
-    uint16_t tkl_ext;
+    uint16_t tkl_ext = 0;
     uint8_t tkl_ext_len, tkl;
 
     if (token_len > 268 && IS_USED(MODULE_NANOCOAP_TOKEN_EXT)) {


### PR DESCRIPTION
### Contribution description

- annotate functions using the `ACCESS()` macro with the `access` attribute so that GCC can emit proper `-Wstringop-overflow` warnings
- some drive-by doxygen markup fixes

### Testing procedure

The CI will do this

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/22368

### Declaration of AI-Tools / LLMs usage:

Same as in https://github.com/RIOT-OS/RIOT/pull/22368