### PR TITLE
sys/checksum: add ACCESS() attribute()

### DIFF
--- a/sys/include/checksum/crc32.h
+++ b/sys/include/checksum/crc32.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once
@@ -22,6 +19,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "compiler_hints.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -31,7 +30,7 @@ extern "C" {
  *
  * Uses the `0xedb88320` polynomial
  *
- * @note enable the `crc32_fast` module for a look-up table based implementation
+ * @note Enable the `crc32_fast` module for a look-up table based implementation
  *       that trades code size for speed.
  *
  * @param[in] buf   The data to checksum
@@ -39,6 +38,7 @@ extern "C" {
  *
  * @return 32 bit sized hash in the interval [0..2^32]
  */
+ACCESS(read_only, 1, 2)
 uint32_t crc32(const void *buf, size_t size);
 
 #ifdef __cplusplus

--- a/sys/include/checksum/crc8.h
+++ b/sys/include/checksum/crc8.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once
@@ -24,6 +21,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "compiler_hints.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -42,6 +41,7 @@ extern "C" {
  *
  * @return  Checksum of the specified memory area.
  */
+ACCESS(read_only, 1, 2)
 uint8_t crc8(const uint8_t *data, size_t len, uint8_t poly, uint8_t seed);
 
 /**
@@ -58,6 +58,7 @@ uint8_t crc8(const uint8_t *data, size_t len, uint8_t poly, uint8_t seed);
  *
  * @return  Checksum of the specified memory area.
  */
+ACCESS(read_only, 1, 2)
 uint8_t crc8_lsb(const uint8_t *data, size_t len, uint8_t poly, uint8_t seed);
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

- annotate functions using the `ACCESS()` macro with the `access` attribute so that GCC can emit proper `-Wstringop-overflow` warnings
- sneak in some style fixes
- convert license boilerplate into SPDX format

### Testing procedure

The CI will do this

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/22368

### Declaration of AI-Tools / LLMs usage:

Same as in https://github.com/RIOT-OS/RIOT/pull/22368