### PR TITLE
sys/{flash_utils,fmt}: add ACCESS() attribute

### DIFF
--- a/sys/include/flash_utils.h
+++ b/sys/include/flash_utils.h
@@ -46,6 +46,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "compiler_hints.h"
 #include "cpu_conf.h"
 #include "kernel_defines.h"
 
@@ -102,6 +103,8 @@ int flash_strcmp(const char *ram, FLASH_ATTR const char *flash);
  *          von-Neumann architectures or Harvard architectures that also map
  *          their flash into the data address space.
  */
+ACCESS(read_only, 1, 3)
+ACCESS(read_only, 2, 3)
 int flash_strncmp(const char *ram, FLASH_ATTR const char *flash, size_t n);
 
 /**
@@ -129,6 +132,8 @@ char * flash_strcpy(char *ram, FLASH_ATTR const char *flash);
  *          von-Neumann architectures or Harvard architectures that also map
  *          their flash into the data address space.
  */
+ACCESS(write_only, 1, 3)
+ACCESS(read_only, 2, 3)
 char * flash_strncpy(char *ram, FLASH_ATTR const char *flash, size_t n);
 
 /**
@@ -174,6 +179,7 @@ int flash_vfprintf(FILE *stream, FLASH_ATTR const char *flash, va_list args);
  *          von-Neumann architectures or Harvard architectures that also map
  *          their flash into the data address space.
  */
+ACCESS(write_only, 1, 2)
 int flash_snprintf(char *buf, size_t buf_len, FLASH_ATTR const char *flash, ...);
 
 /**
@@ -183,6 +189,7 @@ int flash_snprintf(char *buf, size_t buf_len, FLASH_ATTR const char *flash, ...)
  *          von-Neumann architectures or Harvard architectures that also map
  *          their flash into the data address space.
  */
+ACCESS(write_only, 1, 2)
 int flash_vsnprintf(char *buf, size_t buf_len, FLASH_ATTR const char *flash,
                     va_list args);
 

--- a/sys/include/flash_utils.h
+++ b/sys/include/flash_utils.h
@@ -15,18 +15,18 @@
  * that map flash into the data address space (e.g. ARM) and those which
  * doesn't (e.g. most AVR, Xtensa).
  *
- * # Usage
+ * ## Usage
  *
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+ * ```c
  * #include "flash_utils.h"
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * ```
  *
  * No module needs to be selected, this is a header-only implementation that
  * is always available.
  *
- * # Porting Code to Use `flash_utils`
+ * ## Porting Code to use `flash_utils`
  *
- * This is mainly targeting applications developers to ease developing apps
+ * This is mainly targeting application developers to ease developing apps
  * that work well on both legacy modified Harvard architectures (e.g. ATmega)
  * and modern modified Harvard architectures (e.g. ARM, ATtiny, ...) as well
  * as von-Neumann machines.
@@ -51,7 +51,7 @@
 #include "kernel_defines.h"
 
 #if IS_ACTIVE(HAS_FLASH_UTILS_ARCH)
-#include "flash_utils_arch.h" /* IWYU pragma: export */
+#  include "flash_utils_arch.h" /* IWYU pragma: export */
 #endif
 
 #ifdef __cplusplus
@@ -63,45 +63,47 @@ extern "C" {
  * @brief   C type qualifier required to place a variable in flash
  */
 #define FLASH_ATTR <IMPLEMTATION_DEFINED>
+#  define FLASH_ATTR <IMPLEMTATION_DEFINED>
+
 /**
  * @brief   Format specifier for printing `FLASH CONST char *`
  *
  * Usage:
  *
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
- *     FLASH_ATTR const char fmt[] = "I am printing \"%" PRIsflash "\" from flash\n";
- *     FLASH_ATTR const char msg[] = "message from flash";
- *     flash_printf(fmt, msg);
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * ```c
+ * FLASH_ATTR const char fmt[] = "I am printing \"%" PRIsflash "\" from flash\n";
+ * FLASH_ATTR const char msg[] = "message from flash";
+ * flash_printf(fmt, msg);
+ * ```
  */
-#define PRIsflash <IMPLEMTATION_DEFINED>
+#  define PRIsflash <IMPLEMTATION_DEFINED>
 
 /**
  * @brief   Macro to allocate a string literal on flash and return a
  *          `FLASH_ATTR const char *` pointer to it
  * Usage:
  *
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
- *     flash_puts(TO_FLASH("Hello world"));
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * ```c
+ * flash_puts(TO_FLASH("Hello world"));
+ * ```c
  */
-#define TO_FLASH(str_literal) <IMPLEMTATION_DEFINED>
+#  define TO_FLASH(str_literal) <IMPLEMTATION_DEFINED>
 
 /**
  * @brief   Like `strcmp()`, but the second string resides in flash
  *
- * @details This will be a zero-overhead wrapper on top of `strcmp()` for
- *          von-Neumann architectures or Harvard architectures that also map
- *          their flash into the data address space.
+ * This will be a zero-overhead wrapper on top of `strcmp()` for
+ * von-Neumann architectures or Harvard architectures that also map
+ * their flash into the data address space.
  */
 int flash_strcmp(const char *ram, FLASH_ATTR const char *flash);
 
 /**
  * @brief   Like `strncmp()`, but the first string resides in flash
  *
- * @details This will be a zero-overhead wrapper on top of `strncmp()` for
- *          von-Neumann architectures or Harvard architectures that also map
- *          their flash into the data address space.
+ * This will be a zero-overhead wrapper on top of `strncmp()` for
+ * von-Neumann architectures or Harvard architectures that also map
+ * their flash into the data address space.
  */
 ACCESS(read_only, 1, 3)
 ACCESS(read_only, 2, 3)
@@ -110,27 +112,27 @@ int flash_strncmp(const char *ram, FLASH_ATTR const char *flash, size_t n);
 /**
  * @brief   Like `strlen()`, but the string resides in flash
  *
- * @details This will be a zero-overhead wrapper on top of `strlen()` for
- *          von-Neumann architectures or Harvard architectures that also map
- *          their flash into the data address space.
+ * This will be a zero-overhead wrapper on top of `strlen()` for
+ * von-Neumann architectures or Harvard architectures that also map
+ * their flash into the data address space.
  */
 size_t flash_strlen(FLASH_ATTR const char *flash);
 
 /**
  * @brief   Like `strcpy()`, but the source flash resides in flash
  *
- * @details This will be a zero-overhead wrapper on top of `strcpy()` for
- *          von-Neumann architectures or Harvard architectures that also map
- *          their flash into the data address space.
+ * This will be a zero-overhead wrapper on top of `strcpy()` for
+ * von-Neumann architectures or Harvard architectures that also map
+ * their flash into the data address space.
  */
 char * flash_strcpy(char *ram, FLASH_ATTR const char *flash);
 
 /**
  * @brief   Like `strncpy()`, but the source flash resides in flash
  *
- * @details This will be a zero-overhead wrapper on top of `strncpy()` for
- *          von-Neumann architectures or Harvard architectures that also map
- *          their flash into the data address space.
+ * This will be a zero-overhead wrapper on top of `strncpy()` for
+ * von-Neumann architectures or Harvard architectures that also map
+ * their flash into the data address space.
  */
 ACCESS(write_only, 1, 3)
 ACCESS(read_only, 2, 3)
@@ -139,45 +141,45 @@ char * flash_strncpy(char *ram, FLASH_ATTR const char *flash, size_t n);
 /**
  * @brief   Like `printf()`, but the format string resides in flash
  *
- * @details This will be a zero-overhead wrapper on top of `printf()` for
- *          von-Neumann architectures or Harvard architectures that also map
- *          their flash into the data address space.
+ * This will be a zero-overhead wrapper on top of `printf()` for
+ * von-Neumann architectures or Harvard architectures that also map
+ * their flash into the data address space.
  */
 int flash_printf(FLASH_ATTR const char *flash, ...);
 
 /**
  * @brief   Like `vprintf()`, but the format string resides in flash
  *
- * @details This will be a zero-overhead wrapper on top of `vprintf()` for
- *          von-Neumann architectures or Harvard architectures that also map
- *          their flash into the data address space.
+ * This will be a zero-overhead wrapper on top of `vprintf()` for
+ * von-Neumann architectures or Harvard architectures that also map
+ * their flash into the data address space.
  */
 int flash_vprintf(FLASH_ATTR const char *flash, va_list args);
 
 /**
  * @brief   Like `fprintf()`, but the format string resides in flash
  *
- * @details This will be a zero-overhead wrapper on top of `fprintf()` for
- *          von-Neumann architectures or Harvard architectures that also map
- *          their flash into the data address space.
+ * This will be a zero-overhead wrapper on top of `fprintf()` for
+ * von-Neumann architectures or Harvard architectures that also map
+ * their flash into the data address space.
  */
 int flash_fprintf(FILE *stream, FLASH_ATTR const char *flash, ...);
 
 /**
  * @brief   Like `vfprintf()`, but the format string resides in flash
  *
- * @details This will be a zero-overhead wrapper on top of `vfprintf()` for
- *          von-Neumann architectures or Harvard architectures that also map
- *          their flash into the data address space.
+ * This will be a zero-overhead wrapper on top of `vfprintf()` for
+ * von-Neumann architectures or Harvard architectures that also map
+ * their flash into the data address space.
  */
 int flash_vfprintf(FILE *stream, FLASH_ATTR const char *flash, va_list args);
 
 /**
  * @brief   Like `snprintf()`, but the format string resides in flash
  *
- * @details This will be a zero-overhead wrapper on top of `snprintf()` for
- *          von-Neumann architectures or Harvard architectures that also map
- *          their flash into the data address space.
+ * This will be a zero-overhead wrapper on top of `snprintf()` for
+ * von-Neumann architectures or Harvard architectures that also map
+ * their flash into the data address space.
  */
 ACCESS(write_only, 1, 2)
 int flash_snprintf(char *buf, size_t buf_len, FLASH_ATTR const char *flash, ...);
@@ -185,9 +187,9 @@ int flash_snprintf(char *buf, size_t buf_len, FLASH_ATTR const char *flash, ...)
 /**
  * @brief   Like `vsnprintf()`, but the format string resides in flash
  *
- * @details This will be a zero-overhead wrapper on top of `vsnprintf()` for
- *          von-Neumann architectures or Harvard architectures that also map
- *          their flash into the data address space.
+ * This will be a zero-overhead wrapper on top of `vsnprintf()` for
+ * von-Neumann architectures or Harvard architectures that also map
+ * their flash into the data address space.
  */
 ACCESS(write_only, 1, 2)
 int flash_vsnprintf(char *buf, size_t buf_len, FLASH_ATTR const char *flash,
@@ -196,9 +198,9 @@ int flash_vsnprintf(char *buf, size_t buf_len, FLASH_ATTR const char *flash,
 /**
  * @brief   Like `puts()`, but the string resides in flash
  *
- * @details This will be a zero-overhead wrapper on top of `puts()` for
- *          von-Neumann architectures or Harvard architectures that also map
- *          their flash into the data address space.
+ * This will be a zero-overhead wrapper on top of `puts()` for
+ *  von-Neumann architectures or Harvard architectures that also map
+ *  their flash into the data address space.
  */
 void flash_puts(FLASH_ATTR const char *flash);
 
@@ -236,7 +238,7 @@ void * flash_memcpy(void *dest, FLASH_ATTR const void *src, size_t n);
  * @brief   A convenience wrapper for `flash_puts(TO_FLASH("str literal"))`
  *
  * Usage:
- * ```
+ * ```c
  * FLASH_PUTS("Hello world!");
  * ```
  */

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -42,6 +42,8 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "compiler_hints.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -112,6 +114,7 @@ size_t fmt_byte_hex(char *out, uint8_t byte);
  *
  * @return     2*n
  */
+ACCESS(read_only, 2, 3)
 size_t fmt_bytes_hex(char *out, const uint8_t *ptr, size_t n);
 
 /**
@@ -127,6 +130,7 @@ size_t fmt_bytes_hex(char *out, const uint8_t *ptr, size_t n);
  *
  * @return     2*n
  */
+ACCESS(read_only, 2, 3)
 size_t fmt_bytes_hex_reverse(char *out, const uint8_t *ptr, size_t n);
 
 /**
@@ -469,6 +473,8 @@ uint32_t scn_u32_hex(const char *str, size_t n);
  * }
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
+ACCESS(write_only, 1, 2)
+ACCESS(read_only, 3, 4)
 ssize_t scn_buf_hex(void *dest, size_t dest_len, const char *hex, size_t hex_len);
 
 /**
@@ -574,6 +580,7 @@ void print_byte_hex(uint8_t byte);
  * @param[in]  bytes Byte array to print
  * @param[in]  n     Number of bytes to print
  */
+ACCESS(read_only, 1, 2)
 void print_bytes_hex(const void *bytes, size_t n);
 
 /**

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -25,9 +25,9 @@
  *       This can be used to ensure the `out` buffer is large enough.
  *
  * @note The print functions in this library do not buffer any output.
- * Mixing calls to standard @c printf from stdio.h with the @c print_xxx
- * functions in fmt, especially on the same output line, may cause garbled
- * output.
+ *       Mixing calls to standard @c printf from `stdio.h` with the @c print_xxx
+ *       functions in fmt, especially on the same output line, may cause garbled
+ *       output.
  *
  * @{
  *
@@ -49,7 +49,7 @@ extern "C" {
 #endif
 
 #ifndef FMT_USE_MEMMOVE
-#define FMT_USE_MEMMOVE (1) /**< use memmove() or internal implementation */
+#  define FMT_USE_MEMMOVE (1) /**< use memmove() or internal implementation */
 #endif
 
 /**
@@ -57,7 +57,8 @@ extern "C" {
  *
  * @param[in] c     Character to test
  *
- * @return  true if @p c is a digit, false otherwise
+ * @retval  true if @p c is a digit
+ * @retval false otherwise
  */
 static inline int fmt_is_digit(char c)
 {
@@ -69,7 +70,8 @@ static inline int fmt_is_digit(char c)
  *
  * @param[in] c     Character to test
  *
- * @return  true if @p c is an uppercase letter, false otherwise
+ * @retval  true if @p c is an uppercase letter
+ * @retval  false otherwise
  */
 static inline int fmt_is_upper(char c)
 {
@@ -81,7 +83,8 @@ static inline int fmt_is_upper(char c)
  *
  * @param[in] str   String to test, **must be `\0` terminated**
  *
- * @return  true if @p str solely contains decimal digits, false otherwise
+ * @retval  true if @p str solely contains decimal digits
+ * @retval  false otherwise
  */
 int fmt_is_number(const char *str);
 
@@ -97,7 +100,7 @@ int fmt_is_number(const char *str);
  * @param[out] out  Pointer to output buffer, or NULL
  * @param[in]  byte Byte value to convert
  *
- * @return     2
+ * @retval     2 in any case
  */
 size_t fmt_byte_hex(char *out, uint8_t byte);
 
@@ -112,7 +115,7 @@ size_t fmt_byte_hex(char *out, uint8_t byte);
  * @param[in]  ptr  Pointer to bytes to convert
  * @param[in]  n    Number of bytes to convert
  *
- * @return     2*n
+ * @retval     2*n in any case
  */
 ACCESS(read_only, 2, 3)
 size_t fmt_bytes_hex(char *out, const uint8_t *ptr, size_t n);
@@ -128,7 +131,7 @@ size_t fmt_bytes_hex(char *out, const uint8_t *ptr, size_t n);
  * @param[in]  ptr  Pointer to bytes to convert
  * @param[in]  n    Number of bytes to convert
  *
- * @return     2*n
+ * @retval     2*n in any case
  */
 ACCESS(read_only, 2, 3)
 size_t fmt_bytes_hex_reverse(char *out, const uint8_t *ptr, size_t n);
@@ -160,7 +163,8 @@ uint8_t fmt_hex_byte(const char *hex);
  * @param[out] out  Pointer to converted bytes, or NULL
  * @param[in]  hex  Pointer to input buffer
  * @returns    strlen(hex) / 2 when length of @p hex was even
- * @returns    0 otherwise
+ * @retval     strlen(hex)/2 when length of @p hex was even
+ * @retval     0 otherwise
  */
 size_t fmt_hex_bytes(uint8_t *out, const char *hex);
 
@@ -174,7 +178,7 @@ size_t fmt_hex_bytes(uint8_t *out, const char *hex);
  * @param[out]  out  Pointer to output buffer, or NULL
  * @param[in]   val  Value to convert
  *
- * @return      4
+ * @retval      4 in any case
  */
 size_t fmt_u16_hex(char *out, uint16_t val);
 
@@ -188,7 +192,7 @@ size_t fmt_u16_hex(char *out, uint16_t val);
  * @param[out]  out  Pointer to output buffer, or NULL
  * @param[in]   val  Value to convert
  *
- * @return      8
+ * @retval      8 in any case
  */
 size_t fmt_u32_hex(char *out, uint32_t val);
 
@@ -202,7 +206,7 @@ size_t fmt_u32_hex(char *out, uint32_t val);
  * @param[out]  out  Pointer to output buffer, or NULL
  * @param[in]   val  Value to convert
  *
- * @return      16
+ * @retval      16 in any case
  */
 size_t fmt_u64_hex(char *out, uint64_t val);
 
@@ -215,7 +219,7 @@ size_t fmt_u64_hex(char *out, uint64_t val);
  * @param[out]  out  Pointer to output buffer, or NULL
  * @param[in]   val  Value to convert
  *
- * @return      nr of characters written to (or needed in) @p out
+ * @return      Number of characters written to (or needed in) @p out
  */
 size_t fmt_u16_dec(char *out, uint16_t val);
 
@@ -228,7 +232,7 @@ size_t fmt_u16_dec(char *out, uint16_t val);
  * @param[out]  out  Pointer to output buffer, or NULL
  * @param[in]   val  Value to convert
  *
- * @return      nr of characters written to (or needed in) @p out
+ * @return      Number of characters written to (or needed in) @p out
  */
 size_t fmt_u32_dec(char *out, uint32_t val);
 
@@ -243,12 +247,12 @@ size_t fmt_u32_dec(char *out, uint32_t val);
  * @param[out]  out  Pointer to output buffer, or NULL
  * @param[in]   val  Value to convert
  *
- * @return      nr of characters written to (or needed in) @p out
+ * @return      Number of characters written to (or needed in) @p out
  */
 size_t fmt_u64_dec(char *out, uint64_t val);
 
 /**
- * @brief Convert a int64 value to decimal string.
+ * @brief Convert an int64 value to decimal string.
  *
  * Will add a leading "-" if @p val is negative.
  *
@@ -258,12 +262,12 @@ size_t fmt_u64_dec(char *out, uint64_t val);
  * @param[out]  out  Pointer to output buffer, or NULL
  * @param[in]   val  Value to convert
  *
- * @return      nr of characters written to (or needed in) @p out
+ * @return      Number of characters written to (or needed in) @p out
  */
 size_t fmt_s64_dec(char *out, int64_t val);
 
 /**
- * @brief Convert a int32 value to decimal string.
+ * @brief Convert an int32 value to decimal string.
  *
  * Will add a leading "-" if @p val is negative.
  *
@@ -273,12 +277,12 @@ size_t fmt_s64_dec(char *out, int64_t val);
  * @param[out]  out  Pointer to output buffer, or NULL
  * @param[in]   val  Value to convert
  *
- * @return      nr of characters written to (or needed in) @p out
+ * @return      Number of characters written to (or needed in) @p out
  */
 size_t fmt_s32_dec(char *out, int32_t val);
 
 /**
- * @brief Convert a int16 value to decimal string.
+ * @brief Convert an int16 value to decimal string.
  *
  * Will add a leading "-" if @p val is negative.
  *
@@ -288,7 +292,7 @@ size_t fmt_s32_dec(char *out, int32_t val);
  * @param[out]  out  Pointer to output buffer, or NULL
  * @param[in]   val  Value to convert
  *
- * @return      nr of characters written to (or needed in) @p out
+ * @return      Number of characters written to (or needed in) @p out
  */
 size_t fmt_s16_dec(char *out, int16_t val);
 
@@ -342,7 +346,7 @@ size_t fmt_s32_dfp(char *out, int32_t val, int scale);
  * @param[in]   f           float value to convert
  * @param[in]   precision   number of digits after decimal point
  *
- * @returns     nr of characters the function did or would write to out
+ * @return      Number of characters the function did or would write to out
  */
 size_t fmt_float(char *out, float f, unsigned precision);
 
@@ -355,7 +359,7 @@ size_t fmt_float(char *out, float f, unsigned precision);
  * @param[out]  out     string to write to (or NULL)
  * @param[in]   c       char value to append
  *
- * @return      nr of characters the function did or would write to out
+ * @return      Number of characters the function did or would write to out
  */
 size_t fmt_char(char *out, char c);
 
@@ -364,7 +368,7 @@ size_t fmt_char(char *out, char c);
  *
  * @param[in]   str  Pointer to string
  *
- * @return      nr of characters in string @p str points to
+ * @return      Number of characters in string @p str points to
  */
 size_t fmt_strlen(const char *str);
 
@@ -374,7 +378,7 @@ size_t fmt_strlen(const char *str);
  * @param[in]   str     Pointer to string
  * @param[in]   maxlen  Maximum number of chars to count
  *
- * @return      nr of characters in string @p str points to, or @p maxlen if no
+ * @return      Number of characters in string @p str points to, or @p maxlen if no
  *              null terminator is found within @p maxlen chars
  */
 size_t fmt_strnlen(const char *str, size_t maxlen);
@@ -388,7 +392,7 @@ size_t fmt_strnlen(const char *str, size_t maxlen);
  * @param[out]  out  Pointer to output buffer, or NULL
  * @param[in]   str  Pointer to null-terminated source string
  *
- * @return      nr of characters written to (or needed in) @p out
+ * @return      Number of characters written to (or needed in) @p out
  */
 size_t fmt_str(char *out, const char *str);
 
@@ -401,7 +405,7 @@ size_t fmt_str(char *out, const char *str);
  * @param[out]  out     Pointer to output buffer, or NULL
  * @param[in]   str     Pointer to null-terminated source string
  *
- * @return      nr of characters written to (or needed in) @p out
+ * @return      Number of characters written to (or needed in) @p out
  */
 size_t fmt_to_lower(char *out, const char *str);
 
@@ -430,7 +434,7 @@ int fmt_time_tm_iso8601(char out[20], const struct tm *tm, char separator);
  * Will convert up to @p n digits. Stops at any non-digit or '\0' character.
  *
  * @param[in]   str  Pointer to string to read from
- * @param[in]   n    Maximum nr of characters to consider
+ * @param[in]   n    Maximum number of characters to consider
  *
  * @return      converted uint32_t value
  */
@@ -451,6 +455,19 @@ uint32_t scn_u32_hex(const char *str, size_t n);
 /**
  * @brief   Convert a hex to binary
  *
+ * @pre     If @p dest_len is > 0, @p dest is not a null pointer
+ * @pre     If @p hex_len is > 0, @p hex is not a null pointer
+ *
+ * Example usage:
+ * ```c
+ * const char *hex = "deadbeef";
+ * uint8_t binary[sizeof(hex) / 2];
+ * ssize_t len = scn_buf_hex(binary, sizeof(binary), hex, strlen(hex));
+ * if (len >= 0) {
+ *     make_use_of(binary, len);
+ * }
+ * ```
+ *
  * @param[out]  dest        Destination buffer to write to
  * @param[in]   dest_len    Size of @p dest in bytes
  * @param[in]   hex         Hex string to convert
@@ -459,19 +476,6 @@ uint32_t scn_u32_hex(const char *str, size_t n);
  * @return  Number of bytes written
  * @retval  -EINVAL     @p hex_len is odd or @p hex contains non-hex chars
  * @retval  -EOVERFLOW  Destination to small
- *
- * @pre     If @p dest_len is > 0, @p dest is not a null pointer
- * @pre     If @p hex_len is > 0, @p hex is not a null pointer
- *
- * Examples
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
- * const char *hex = "deadbeef";
- * uint8_t binary[sizeof(hex) / 2];
- * ssize_t len = scn_buf_hex(binary, sizeof(binary), hex, strlen(hex));
- * if (len >= 0) {
- *     make_use_of(binary, len);
- * }
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
 ACCESS(write_only, 1, 2)
 ACCESS(read_only, 3, 4)
@@ -480,7 +484,7 @@ ssize_t scn_buf_hex(void *dest, size_t dest_len, const char *hex, size_t hex_len
 /**
  * @brief   Convert an ISO 8601 time string to time structure
  *
- * This function parses a string in the format YYYY-MM-DD.
+ * This function parses a string in the format `YYYY-MM-DD`.
  *
  * A terminating '\0' is not required.
  *
@@ -523,7 +527,7 @@ int scn_time_tm_iso8601_time(struct tm *tm, const char *str);
  * @brief   Convert an ISO 8601 string to time structure
  *
  * This function parses a string in the format
- * YYYY-MM-DD\<separator\>HH:MM:SS or YYYY-MM-DD.
+ * `YYYY-MM-DD\<separator\>HH:MM:SS` or `YYYY-MM-DD`.
  *
  * A terminating '\0' is not required.
  *
@@ -640,11 +644,10 @@ void print_str(const char* str);
  *
  * This function left-pads a given string @p str with @p pad_char.
  *
- * For example, calling
- *
- *     fmt_lpad("abcd", 4, 7, ' ');
- *
- * would result in "   abcd".
+  * For example, calling the following function would result in "   abcd".
+   * ```c
+   * fmt_lpad("abcd", 4, 7, ' ');
+  * ```
  *
  * The function only writes to @p str if str is non-NULL and @p pad_len is < @p
  * in_len.


### PR DESCRIPTION
### Contribution description

- annotate functions using the `ACCESS()` macro with the `access` attribute so that GCC can emit proper `-Wstringop-overflow` warnings

### Testing procedure

The CI will do this

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/22368

### Declaration of AI-Tools / LLMs usage:

Same as in https://github.com/RIOT-OS/RIOT/pull/22368