### PR TITLE
cpu/rp2350: implement timers

### DIFF
--- a/boards/common/rpi-pico-2/include/periph_conf.h
+++ b/boards/common/rpi-pico-2/include/periph_conf.h
@@ -55,6 +55,27 @@ static const uart_conf_t uart_config[] = {
 
 #define UART_NUMOF      ARRAY_SIZE(uart_config)
 
+/**
+ * @brief   Timer configuration
+ *
+ * The entries have to be ordered by hardware instance, see
+ * @ref timer_conf_t for details.
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev = TIMER0,
+        .irqn_base = TIMER0_IRQ_0_IRQn,
+        .ch_numof = TIMER_CHANNEL_NUMOF,
+    },
+    {
+        .dev = TIMER1,
+        .irqn_base = TIMER1_IRQ_0_IRQn,
+        .ch_numof = TIMER_CHANNEL_NUMOF
+    }
+};
+
+#define TIMER_NUMOF      2
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/rp2350_common/Makefile.features
+++ b/cpu/rp2350_common/Makefile.features
@@ -1,2 +1,4 @@
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_timer_periodic

--- a/cpu/rp2350_common/Makefile.features
+++ b/cpu/rp2350_common/Makefile.features
@@ -1,4 +1,4 @@
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_timer_periodic
+FEATURES_PROVIDED += periph_uart

--- a/cpu/rp2350_common/clock.c
+++ b/cpu/rp2350_common/clock.c
@@ -31,6 +31,15 @@ void cpu_clock_init(void) {
     /* Enable the XOSC */
     xosc_start();
 
+    /* Out of reset clk_ref runs from the ROSC, which is only specified to be
+     * somewhere between 4.6 MHz and 19.6 MHz. Move it over to the XOSC, since
+     * the tick generators feeding the system timers divide clk_ref and rely on
+     * it being an accurate 12 MHz (see chapter 8.5). */
+    CLOCKS->CLK_REF_DIV = CLK_REF_DIV_INT_VALUE << CLK_REF_DIV_INT_LSB;
+    CLOCKS->CLK_REF_CTRL = CLK_REF_CTRL_SRC_XOSC_VALUE;
+    while (CLOCKS->CLK_REF_SELECTED != CLK_REF_SELECTED_XOSC_FIELD_VALUE) {
+    }
+
     /* Setup the PLL using the XOSC as the reference clock. */
     PLL_SYS->FBDIV_INT =
     PLL_FEEDBACK_DIVIDER_VALUE; /* Set the feedback divider */

--- a/cpu/rp2350_common/include/clock_conf.h
+++ b/cpu/rp2350_common/include/clock_conf.h
@@ -61,7 +61,7 @@
 #define PLL_PWR_POSTDIVPD_BITS 0x00000008u
 /** Enable bit for the peripheral clock control register */
 #define CLK_PERI_CTRL_ENABLE_BIT (1u << 11u)
-/** Default CPU frequency in Hz, set to 125 MHz as per hardware manual */
+/** Default CPU frequency in Hz, set to 150 MHz as per hardware manual */
 #define CPUFREQ 125000000u
 /** Maximum crystal frequency */
 #define CLOCK_XOSC_MAX MHZ(15u)
@@ -91,6 +91,17 @@
 /** Selected field value for the system clock control register
  * to select the peripheral clock */
 #define CLK_SYS_SELECTED_PERI_FIELD_VALUE 2u
+/** SRC field value of the reference clock control register that selects the
+ * crystal oscillator */
+#define CLK_REF_CTRL_SRC_XOSC_VALUE 2u
+/** Selected field value of the reference clock, one decoded bit per source
+ * just like CLK_SYS_SELECTED */
+#define CLK_REF_SELECTED_XOSC_FIELD_VALUE (1u << CLK_REF_CTRL_SRC_XOSC_VALUE)
+/** LSB of the integer divider in the reference clock divider register */
+#define CLK_REF_DIV_INT_LSB 16u
+/** Integer divider for the reference clock, the tick generators expect an
+ * undivided crystal */
+#define CLK_REF_DIV_INT_VALUE 1u
 /** RIOT core clock frequency defined as the CPU frequency */
 #define CLOCK_CORECLOCK MHZ(12u)
 

--- a/cpu/rp2350_common/include/periph_cpu.h
+++ b/cpu/rp2350_common/include/periph_cpu.h
@@ -43,6 +43,7 @@ typedef uint32_t gpio_t;
 #include "gpio_conf.h"
 #include "clock_conf.h"
 #include "uart_conf.h"
+#include "timer_conf.h"
 #include "multicore.h"
 
 #if !(defined(RP2350_USE_ARM) || defined(RP2350_USE_RISCV))

--- a/cpu/rp2350_common/include/timer_conf.h
+++ b/cpu/rp2350_common/include/timer_conf.h
@@ -19,12 +19,6 @@
 #include "RP2350.h"
 #include "periph_cpu.h"
 
-/** Reset bit for the TIMER0 peripheral */
-#define RESET_TIMER0 (1u << 23u)
-
-/** Reset bit for the TIMER1 peripheral */
-#define RESET_TIMER1 (1u << 24u)
-
 /** Number of alarm channels per timer block */
 #define TIMER_CHANNEL_NUMOF 4u
 

--- a/cpu/rp2350_common/include/timer_conf.h
+++ b/cpu/rp2350_common/include/timer_conf.h
@@ -25,9 +25,6 @@
 /** Reset bit for the TIMER1 peripheral */
 #define RESET_TIMER1 (1u << 24u)
 
-/** Enable bit of a tick generator control register */
-#define TICKS_CTRL_ENABLE_BITS (1u << 0u)
-
 /** Number of alarm channels per timer block */
 #define TIMER_CHANNEL_NUMOF 4u
 

--- a/cpu/rp2350_common/include/timer_conf.h
+++ b/cpu/rp2350_common/include/timer_conf.h
@@ -22,6 +22,15 @@
 /** Number of alarm channels per timer block */
 #define TIMER_CHANNEL_NUMOF 4u
 
+/** Reset bit for the TIMER0 peripheral */
+#define RESET_TIMER0 (1u << 23u)
+
+/** Reset bit for the TIMER1 peripheral */
+#define RESET_TIMER1 (1u << 24u)
+
+/** Enable bit of a tick generator control register */
+#define TICKS_CTRL_ENABLE_BITS (1u << 0u)
+
 /**
  * @brief   A low-level timer_set() implementation is provided
  */

--- a/cpu/rp2350_common/include/timer_conf.h
+++ b/cpu/rp2350_common/include/timer_conf.h
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Tom Hert <git@annsann.eu>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup         cpu_rp2350
+ * @{
+ *
+ * @file
+ * @brief           Timer configuration for the RP2350
+ *
+ * @author          Tom Hert <git@annsann.eu>
+ */
+
+#include "RP2350.h"
+#include "periph_cpu.h"
+
+/** Reset bit for the TIMER0 peripheral */
+#define RESET_TIMER0 (1u << 23u)
+
+/** Reset bit for the TIMER1 peripheral */
+#define RESET_TIMER1 (1u << 24u)
+
+/** Enable bit of a tick generator control register */
+#define TICKS_CTRL_ENABLE_BITS (1u << 0u)
+
+/** Number of alarm channels per timer block */
+#define TIMER_CHANNEL_NUMOF 4u
+
+/**
+ * @brief   A low-level timer_set() implementation is provided
+ */
+#define PERIPH_TIMER_PROVIDES_SET
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Configuration details for a timer device
+ */
+typedef struct {
+    TIMER0_Type *dev;   /**< Base address of the I/O registers of the device */
+    IRQn_Type irqn_base; /**< IRQ number of alarm 0 */
+    uint8_t ch_numof;   /**< Number of alarm channels to use */
+} timer_conf_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/cpu/rp2350_common/include/timer_conf.h
+++ b/cpu/rp2350_common/include/timer_conf.h
@@ -18,18 +18,11 @@
 
 #include "RP2350.h"
 #include "periph_cpu.h"
+#include "regs/ticks.h"
+#include "regs/resets.h"
 
 /** Number of alarm channels per timer block */
 #define TIMER_CHANNEL_NUMOF 4u
-
-/** Reset bit for the TIMER0 peripheral */
-#define RESET_TIMER0 (1u << 23u)
-
-/** Reset bit for the TIMER1 peripheral */
-#define RESET_TIMER1 (1u << 24u)
-
-/** Enable bit of a tick generator control register */
-#define TICKS_CTRL_ENABLE_BITS (1u << 0u)
 
 /**
  * @brief   A low-level timer_set() implementation is provided

--- a/cpu/rp2350_common/periph/timer.c
+++ b/cpu/rp2350_common/periph/timer.c
@@ -21,7 +21,7 @@
 #include "macros/units.h"
 #include "periph_conf.h"
 #include "periph_cpu.h"
-#include "timex.h"
+#include "time_units.h"
 
 #include "periph/timer.h"
 

--- a/cpu/rp2350_common/periph/timer.c
+++ b/cpu/rp2350_common/periph/timer.c
@@ -85,11 +85,11 @@ int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
     /* Generate one tick per microsecond from clk_ref, which runs from xosc */
     if (DEV(dev) == TIMER0) {
         assert(CLOCK_XOSC % freq == 0)
-        TICKS->TIMER0_CTRL = TICKS_TIMER0_CTRL_ENABLE_BITS;
+        TICKS->TIMER1_CYCLES = CLOCK_XOSC / MHZ(1);
         TICKS->TIMER0_CTRL = TICKS_TIMER0_CTRL_ENABLE_BITS;
     }
     else {
-        TICKS->TIMER1_CTRL = TICKS_TIMER1_CTRL_ENABLE_BITS;
+        TICKS->TIMER1_CYCLES = CLOCK_XOSC / MHZ(1);
         TICKS->TIMER1_CTRL = TICKS_TIMER1_CTRL_ENABLE_BITS;
     }
 

--- a/cpu/rp2350_common/periph/timer.c
+++ b/cpu/rp2350_common/periph/timer.c
@@ -1,0 +1,261 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Tom Hert <git@annsann.eu>
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup         cpu_rp2350
+ * @{
+ *
+ * @file
+ * @brief           Timer implementation for the RP2350
+ *
+ * @author          Tom Hert <git@annsann.eu>
+ */
+
+#include <errno.h>
+
+#include "compat_layer.h"
+#include "irq.h"
+#include "macros/units.h"
+#include "periph_conf.h"
+#include "periph_cpu.h"
+#include "timex.h"
+
+#include "periph/timer.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+#define DEV(d)          (timer_config[d].dev)
+#define ALARM(d, a)     ((&(DEV(d)->ALARM0)) + (a))
+
+static timer_cb_t ctx_cb[TIMER_NUMOF];
+static void *ctx_arg[TIMER_NUMOF];
+static uint8_t flag_periodic[TIMER_NUMOF];
+static uint8_t flag_reset[TIMER_NUMOF];
+
+static void _timer_reset(tim_t dev)
+{
+    unsigned state = irq_disable();
+    /* Always write TIMELW before TIMEHW, the value is only copied to the
+     * counter once TIMEHW is written (see table 1229) */
+    DEV(dev)->TIMELW = 0;
+    DEV(dev)->TIMEHW = 0;
+    irq_restore(state);
+}
+
+static void _isr(tim_t dev, int channel)
+{
+    /* The latched interrupt flags are write-1-clear (see table 1243) */
+    DEV(dev)->INTR = 1u << channel;
+
+    if (flag_periodic[dev] & (1u << channel)) {
+        if (flag_reset[dev] & (1u << channel)) {
+            _timer_reset(dev);
+        }
+        /* Bomb has been planted */
+        *ALARM(dev, channel) = *ALARM(dev, channel);
+    }
+
+    if (ctx_cb[dev]) {
+        ctx_cb[dev](ctx_arg[dev], channel);
+    }
+}
+
+int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
+{
+    if (dev >= TIMER_NUMOF) {
+        return -ENODEV;
+    }
+    /* TICKS blocks are designed to generate 1 us ticks, so we can only support that frequency */
+    assert(freq == US_PER_SEC);
+    (void)freq;
+
+    ctx_cb[dev] = cb;
+    ctx_arg[dev] = arg;
+    flag_periodic[dev] = 0;
+    flag_reset[dev] = 0;
+
+    /* Reset the timer block, so we can be sure it is in a known state */
+    uint32_t reset_bit = (DEV(dev) == TIMER0) ? RESET_TIMER0 : RESET_TIMER1;
+    reset_component(reset_bit, reset_bit);
+
+    /* Generate one tick per microsecond from clk_ref, which runs from xosc */
+    if (DEV(dev) == TIMER0) {
+        TICKS->TIMER0_CYCLES = CLOCK_XOSC / MHZ(1);
+        TICKS->TIMER0_CTRL = TICKS_CTRL_ENABLE_BITS;
+    }
+    else {
+        TICKS->TIMER1_CYCLES = CLOCK_XOSC / MHZ(1);
+        TICKS->TIMER1_CTRL = TICKS_CTRL_ENABLE_BITS;
+    }
+
+    for (uint8_t i = 0; i < timer_config[dev].ch_numof; i++) {
+        rp_irq_enable(timer_config[dev].irqn_base + i);
+        atomic_set(&DEV(dev)->INTE, 1u << i);
+    }
+
+    return 0;
+}
+
+int timer_set(tim_t dev, int channel, unsigned int timeout)
+{
+    if (dev >= TIMER_NUMOF) {
+        return -ENODEV;
+    }
+    if ((channel < 0) || (channel >= timer_config[dev].ch_numof)) {
+        return -EINVAL;
+    }
+
+    if (!timeout) {
+        /* catch case that a tick happens right before arming the alarm */
+        if (ctx_cb[dev]) {
+            ctx_cb[dev](ctx_arg[dev], channel);
+        }
+    }
+    else {
+        unsigned state = irq_disable();
+        flag_periodic[dev] &= ~(1u << channel);
+        /* An alarm matches on the lower 32 bits */
+        *ALARM(dev, channel) = DEV(dev)->TIMERAWL + timeout;
+        irq_restore(state);
+    }
+
+    return 0;
+}
+
+int timer_set_absolute(tim_t dev, int channel, unsigned int value)
+{
+    if (dev >= TIMER_NUMOF) {
+        return -ENODEV;
+    }
+    if ((channel < 0) || (channel >= timer_config[dev].ch_numof)) {
+        return -EINVAL;
+    }
+
+    unsigned state = irq_disable();
+    flag_periodic[dev] &= ~(1u << channel);
+    *ALARM(dev, channel) = (uint32_t)value;
+    irq_restore(state);
+
+    return 0;
+}
+
+int timer_set_periodic(tim_t dev, int channel, unsigned int value, uint8_t flags)
+{
+    if (dev >= TIMER_NUMOF) {
+        return -ENODEV;
+    }
+    if ((channel < 0) || (channel >= timer_config[dev].ch_numof)) {
+        return -EINVAL;
+    }
+
+    if (flags & TIM_FLAG_SET_STOPPED) {
+        timer_stop(dev);
+    }
+    if (flags & TIM_FLAG_RESET_ON_SET) {
+        _timer_reset(dev);
+    }
+
+    unsigned state = irq_disable();
+    flag_periodic[dev] |= (1u << channel);
+    if (flags & TIM_FLAG_RESET_ON_MATCH) {
+        flag_reset[dev] |= (1u << channel);
+    }
+    else {
+        flag_reset[dev] &= ~(1u << channel);
+    }
+    *ALARM(dev, channel) = (uint32_t)value;
+    irq_restore(state);
+
+    return 0;
+}
+
+int timer_clear(tim_t dev, int channel)
+{
+    if (dev >= TIMER_NUMOF) {
+        return -ENODEV;
+    }
+    if ((channel < 0) || (channel >= timer_config[dev].ch_numof)) {
+        return -EINVAL;
+    }
+
+    unsigned state = irq_disable();
+    /* The ARMED bits are write-1-clear (table 1236) */
+    DEV(dev)->ARMED = 1u << channel;
+    flag_periodic[dev] &= ~(1u << channel);
+    irq_restore(state);
+
+    return 0;
+}
+
+unsigned int timer_read(tim_t dev)
+{
+    assert(dev < TIMER_NUMOF);
+    /* TIMERAWL reads the lower 32 bits without latching */
+    return DEV(dev)->TIMERAWL;
+}
+
+void timer_start(tim_t dev)
+{
+    assert(dev < TIMER_NUMOF);
+    atomic_clear(&DEV(dev)->PAUSE, 1u);
+}
+
+void timer_stop(tim_t dev)
+{
+    assert(dev < TIMER_NUMOF);
+    atomic_set(&DEV(dev)->PAUSE, 1u);
+}
+
+void isr_timer0_0(void)
+{
+    _isr(0, 0);
+    rp_end_isr();
+}
+
+void isr_timer0_1(void)
+{
+    _isr(0, 1);
+    rp_end_isr();
+}
+
+void isr_timer0_2(void)
+{
+    _isr(0, 2);
+    rp_end_isr();
+}
+
+void isr_timer0_3(void)
+{
+    _isr(0, 3);
+    rp_end_isr();
+}
+
+void isr_timer1_0(void)
+{
+    _isr(1, 0);
+    rp_end_isr();
+}
+
+void isr_timer1_1(void)
+{
+    _isr(1, 1);
+    rp_end_isr();
+}
+
+void isr_timer1_2(void)
+{
+    _isr(1, 2);
+    rp_end_isr();
+}
+
+void isr_timer1_3(void)
+{
+    _isr(1, 3);
+    rp_end_isr();
+}
+
+/** @} */

--- a/cpu/rp2350_common/periph/timer.c
+++ b/cpu/rp2350_common/periph/timer.c
@@ -84,7 +84,7 @@ int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
 
     /* Generate one tick per microsecond from clk_ref, which runs from xosc */
     if (DEV(dev) == TIMER0) {
-        assert(CLOCK_XOSC % freq == 0)
+        assert((CLOCK_XOSC % freq) == 0);
         TICKS->TIMER1_CYCLES = CLOCK_XOSC / MHZ(1);
         TICKS->TIMER0_CTRL = TICKS_TIMER0_CTRL_ENABLE_BITS;
     }

--- a/cpu/rp2350_common/periph/timer.c
+++ b/cpu/rp2350_common/periph/timer.c
@@ -86,11 +86,11 @@ int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
     if (DEV(dev) == TIMER0) {
         assert(CLOCK_XOSC % freq == 0)
         TICKS->TIMER0_CTRL = TICKS_TIMER0_CTRL_ENABLE_BITS;
-        TICKS->TIMER0_CTRL = TICKS_CTRL_ENABLE_BITS;
+        TICKS->TIMER0_CTRL = TICKS_TIMER0_CTRL_ENABLE_BITS;
     }
     else {
         TICKS->TIMER1_CTRL = TICKS_TIMER1_CTRL_ENABLE_BITS;
-        TICKS->TIMER1_CTRL = TICKS_CTRL_ENABLE_BITS;
+        TICKS->TIMER1_CTRL = TICKS_TIMER1_CTRL_ENABLE_BITS;
     }
 
     for (uint8_t i = 0; i < timer_config[dev].ch_numof; i++) {

--- a/cpu/rp2350_common/periph/timer.c
+++ b/cpu/rp2350_common/periph/timer.c
@@ -33,8 +33,8 @@
 
 static timer_cb_t ctx_cb[TIMER_NUMOF];
 static void *ctx_arg[TIMER_NUMOF];
-static uint8_t flag_periodic[TIMER_NUMOF];
-static uint8_t flag_reset[TIMER_NUMOF];
+static uint8_t _flag_periodic[TIMER_NUMOF];
+static uint8_t _flag_reset[TIMER_NUMOF];
 
 static void _timer_reset(tim_t dev)
 {
@@ -46,13 +46,13 @@ static void _timer_reset(tim_t dev)
     irq_restore(state);
 }
 
-static void _isr(tim_t dev, int channel)
+static void _timer_isr(tim_t dev, int channel)
 {
     /* The latched interrupt flags are write-1-clear (see table 1243) */
     DEV(dev)->INTR = 1u << channel;
 
-    if (flag_periodic[dev] & (1u << channel)) {
-        if (flag_reset[dev] & (1u << channel)) {
+    if (_flag_periodic[dev] & (1u << channel)) {
+        if (_flag_reset[dev] & (1u << channel)) {
             _timer_reset(dev);
         }
         /* Bomb has been planted */
@@ -71,24 +71,25 @@ int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
     }
     /* TICKS blocks are designed to generate 1 us ticks, so we can only support that frequency */
     assert(freq == US_PER_SEC);
-    (void)freq;
 
     ctx_cb[dev] = cb;
     ctx_arg[dev] = arg;
-    flag_periodic[dev] = 0;
-    flag_reset[dev] = 0;
+    _flag_periodic[dev] = 0;
+    _flag_reset[dev] = 0;
 
     /* Reset the timer block, so we can be sure it is in a known state */
-    uint32_t reset_bit = (DEV(dev) == TIMER0) ? RESET_TIMER0 : RESET_TIMER1;
+    uint32_t reset_bit;
+    reset_bit = (DEV(dev) == TIMER0) ? RESETS_RESET_TIMER0_BITS : RESETS_RESET_TIMER1_BITS;
     reset_component(reset_bit, reset_bit);
 
     /* Generate one tick per microsecond from clk_ref, which runs from xosc */
     if (DEV(dev) == TIMER0) {
-        TICKS->TIMER0_CYCLES = CLOCK_XOSC / MHZ(1);
+        assert(CLOCK_XOSC % freq == 0)
+        TICKS->TIMER0_CTRL = TICKS_TIMER0_CTRL_ENABLE_BITS;
         TICKS->TIMER0_CTRL = TICKS_CTRL_ENABLE_BITS;
     }
     else {
-        TICKS->TIMER1_CYCLES = CLOCK_XOSC / MHZ(1);
+        TICKS->TIMER1_CTRL = TICKS_TIMER1_CTRL_ENABLE_BITS;
         TICKS->TIMER1_CTRL = TICKS_CTRL_ENABLE_BITS;
     }
 
@@ -109,15 +110,14 @@ int timer_set(tim_t dev, int channel, unsigned int timeout)
         return -EINVAL;
     }
 
-    if (!timeout) {
-        /* catch case that a tick happens right before arming the alarm */
+    if (timeout == 0) {
         if (ctx_cb[dev]) {
             ctx_cb[dev](ctx_arg[dev], channel);
         }
     }
     else {
         unsigned state = irq_disable();
-        flag_periodic[dev] &= ~(1u << channel);
+        _flag_periodic[dev] &= ~(1u << channel);
         /* An alarm matches on the lower 32 bits */
         *ALARM(dev, channel) = DEV(dev)->TIMERAWL + timeout;
         irq_restore(state);
@@ -136,7 +136,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
     }
 
     unsigned state = irq_disable();
-    flag_periodic[dev] &= ~(1u << channel);
+    _flag_periodic[dev] &= ~(1u << channel);
     *ALARM(dev, channel) = (uint32_t)value;
     irq_restore(state);
 
@@ -160,12 +160,12 @@ int timer_set_periodic(tim_t dev, int channel, unsigned int value, uint8_t flags
     }
 
     unsigned state = irq_disable();
-    flag_periodic[dev] |= (1u << channel);
+    _flag_periodic[dev] |= (1u << channel);
     if (flags & TIM_FLAG_RESET_ON_MATCH) {
-        flag_reset[dev] |= (1u << channel);
+        _flag_reset[dev] |= (1u << channel);
     }
     else {
-        flag_reset[dev] &= ~(1u << channel);
+        _flag_reset[dev] &= ~(1u << channel);
     }
     *ALARM(dev, channel) = (uint32_t)value;
     irq_restore(state);
@@ -185,7 +185,7 @@ int timer_clear(tim_t dev, int channel)
     unsigned state = irq_disable();
     /* The ARMED bits are write-1-clear (table 1236) */
     DEV(dev)->ARMED = 1u << channel;
-    flag_periodic[dev] &= ~(1u << channel);
+    _flag_periodic[dev] &= ~(1u << channel);
     irq_restore(state);
 
     return 0;
@@ -210,51 +210,56 @@ void timer_stop(tim_t dev)
     atomic_set(&DEV(dev)->PAUSE, 1u);
 }
 
+/* Interrupt Service Routines 
+ * Each one calls the common _timer_isr function with the appropriate timer and channel,
+ * then ends the ISR. These replace the default weak ISRs.
+*/
+
 void isr_timer0_0(void)
 {
-    _isr(0, 0);
+    _timer_isr(0, 0);
     rp_end_isr();
 }
 
 void isr_timer0_1(void)
 {
-    _isr(0, 1);
+    _timer_isr(0, 1);
     rp_end_isr();
 }
 
 void isr_timer0_2(void)
 {
-    _isr(0, 2);
+    _timer_isr(0, 2);
     rp_end_isr();
 }
 
 void isr_timer0_3(void)
 {
-    _isr(0, 3);
+    _timer_isr(0, 3);
     rp_end_isr();
 }
 
 void isr_timer1_0(void)
 {
-    _isr(1, 0);
+    _timer_isr(1, 0);
     rp_end_isr();
 }
 
 void isr_timer1_1(void)
 {
-    _isr(1, 1);
+    _timer_isr(1, 1);
     rp_end_isr();
 }
 
 void isr_timer1_2(void)
 {
-    _isr(1, 2);
+    _timer_isr(1, 2);
     rp_end_isr();
 }
 
 void isr_timer1_3(void)
 {
-    _isr(1, 3);
+    _timer_isr(1, 3);
     rp_end_isr();
 }
 

--- a/cpu/rp2350_common/periph/timer.c
+++ b/cpu/rp2350_common/periph/timer.c
@@ -210,11 +210,9 @@ void timer_stop(tim_t dev)
     atomic_set(&DEV(dev)->PAUSE, 1u);
 }
 
-/* Interrupt Service Routines 
+/* Interrupt Service Routines
  * Each one calls the common _timer_isr function with the appropriate timer and channel,
- * then ends the ISR. These replace the default weak ISRs.
-*/
-
+ * then ends the ISR. These replace the default weak ISRs. */
 void isr_timer0_0(void)
 {
     _timer_isr(0, 0);

--- a/cpu/rp2350_common/periph/timer.c
+++ b/cpu/rp2350_common/periph/timer.c
@@ -71,6 +71,7 @@ int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
     }
     /* TICKS blocks are designed to generate 1 us ticks, so we can only support that frequency */
     assert(freq == US_PER_SEC);
+    assert((CLOCK_XOSC % freq) == 0);
 
     ctx_cb[dev] = cb;
     ctx_arg[dev] = arg;
@@ -82,13 +83,16 @@ int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
     reset_bit = (DEV(dev) == TIMER0) ? RESETS_RESET_TIMER0_BITS : RESETS_RESET_TIMER1_BITS;
     reset_component(reset_bit, reset_bit);
 
-    /* Generate one tick per microsecond from clk_ref, which runs from xosc */
+    /* Generate one tick per microsecond from clk_ref, which runs from xosc.
+     * The tick generator has to be stopped while its cycle count is changed
+     * (see section 8.5.1) */
     if (DEV(dev) == TIMER0) {
-        assert((CLOCK_XOSC % freq) == 0);
-        TICKS->TIMER1_CYCLES = CLOCK_XOSC / MHZ(1);
+        TICKS->TIMER0_CTRL = 0;
+        TICKS->TIMER0_CYCLES = CLOCK_XOSC / MHZ(1);
         TICKS->TIMER0_CTRL = TICKS_TIMER0_CTRL_ENABLE_BITS;
     }
     else {
+        TICKS->TIMER1_CTRL = 0;
         TICKS->TIMER1_CYCLES = CLOCK_XOSC / MHZ(1);
         TICKS->TIMER1_CTRL = TICKS_TIMER1_CTRL_ENABLE_BITS;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Part of the ongoing "wait people actually use the pico2, oh god why" series. This implements timer support, hooray. Timers are surprisingly not that complicated, I just never looked at them when adding support because I didn't have a proper use outside of xosc_sleep which was enough for my needs. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

`cd examples/guides/timers`
`sudo BOARD=rpi-pico-2-arm make flash term PORT=/dev/ttyUSB0`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- Claude Fable 5, mostly to experiment with it, I cross checked its claims with the datasheet at all times. As said the timers stuff on the pico 2 is not as complicated as I imagined, chapter 12.8 and related timer tables are fairly understandable.
