### PR TITLE
drivers/periph/timer: documentation and code style improvements

### DIFF
--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -10,7 +10,7 @@
  * @ingroup     drivers_periph
  * @brief       Low-level timer peripheral driver
  *
- * # (Low-) Power Implications
+ * ## (Low-) Power Implications
  *
  * After calling timer_init(), the underlying hardware timer **should** be
  * powered on and running. When a timer is explicitly stopped by calling
@@ -21,6 +21,10 @@
  *
  * While the timer is active, the implementation might need to block certain
  * power modes on specific CPU implementation.
+ *
+ * @note Some platforms return ERRNO values if an error occurred in the
+ *       timer functions. This can be useful for debugging, but keep in mind
+ *       that different platforms may or may not return specific ERRNOs.
  *
  * @{
  * @file
@@ -44,17 +48,17 @@ extern "C" {
 /**
  * @brief   Default timer definition macro
  *
- * Overwrite this in your CPUs periph_cpu.h file if needed
+ * Overwrite this in your CPU's `periph_cpu.h` file if needed
  */
 #ifndef TIMER_DEV
-#define TIMER_DEV(x)        (x)
+#  define TIMER_DEV(x)      (x)
 #endif
 
 /**
  * @brief   Default value for timer not defined
  */
 #ifndef TIMER_UNDEF
-#define TIMER_UNDEF         (UINT_FAST8_MAX)
+#  define TIMER_UNDEF       (UINT_FAST8_MAX)
 #endif
 
 /**
@@ -68,23 +72,24 @@ typedef uint_fast8_t tim_t;
 #endif
 
 /**
- * @brief   Reset the timer when the set() function is called
+ * @brief   Reset the timer when the timer_set() function is called
  *
- * When set, calling the timer_set_periodic() function resets the timer count value.
+ * When set, calling the timer_set_periodic() function resets the timer count
+ * value to zero.
  */
 #ifndef TIM_FLAG_RESET_ON_SET
-#define TIM_FLAG_RESET_ON_SET   (0x01)
+#  define TIM_FLAG_RESET_ON_SET (0x01)
 #endif
 
 /**
  * @brief   Reset the timer on match
  *
- * When set, a match on this channel will reset the timer count value.
+ * When set, a match on this channel will reset the timer count value to zero.
  * When set on multiple channels, only the channel with the lowest match value
  * will be reached.
  */
 #ifndef TIM_FLAG_RESET_ON_MATCH
-#define TIM_FLAG_RESET_ON_MATCH (0x02)
+#  define TIM_FLAG_RESET_ON_MATCH   (0x02)
 #endif
 
 /**
@@ -94,7 +99,7 @@ typedef uint_fast8_t tim_t;
  * can be started manually with timer_start().
  */
 #ifndef TIM_FLAG_SET_STOPPED
-#define TIM_FLAG_SET_STOPPED    (0x04)
+#  define TIM_FLAG_SET_STOPPED  (0x04)
 #endif
 
 /**
@@ -119,21 +124,22 @@ typedef struct {
  * @brief Initialize the given timer
  *
  * Each timer device is running with the given speed. Each can contain one or
- * more channels as defined in periph_conf.h. The timer is configured in
- * up-counting mode and will count until TIMER_x_MAX_VALUE as defined in used
- * board's periph_conf.h until overflowing.
+ * more channels as defined in the board's `periph_conf.h`. The timer is configured
+ * in up-counting mode and will count until `TIMER_x_MAX_VALUE` as defined in the
+ * board's `periph_conf.h`.
  *
  * The timer will be started automatically after initialization with interrupts
  * enabled.
  *
- * @param[in] dev           the timer to initialize
- * @param[in] freq          requested number of ticks per second
- * @param[in] cb            this callback is called in interrupt context, the
- *                          emitting channel is passed as argument
- * @param[in] arg           argument to the callback
+ * @param[in] dev   the timer to initialize
+ * @param[in] freq  requested number of ticks per second
+ * @param[in] cb    this callback is called in interrupt context, the
+ *                  emitting channel is passed as argument
+ * @param[in] arg   argument to the callback
  *
- * @return                  0 on success
- * @return                  -1 if speed not applicable or unknown device given
+ * @retval          0 on success
+ * @retval          <0 on error, e.g. if the speed is not applicable or an
+ *                  unknown device is given
  */
 int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg);
 
@@ -145,27 +151,27 @@ int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg);
  *
  * @param[in] dev           the timer device to set
  * @param[in] channel       the channel to set
- * @param[in] timeout       timeout in ticks after that the registered callback
+ * @param[in] timeout       timeout in ticks after which the registered callback
  *                          is executed
  *
- * @return                  0 on success
- * @return                  -1 on error
+ * @retval                  0 on success
+ * @retval                  <0 on error
  */
 int timer_set(tim_t dev, int channel, unsigned int timeout);
 
 /**
  * @brief Set an absolute timeout value for the given channel of the given timer
  *
- * Timers that are less wide than `unsigned int` accept and truncate overflown
- * values.
+ * Timers that are less wide than `unsigned int` (32-bit on most platforms)
+ * accept and truncate overflown values.
  *
  * @param[in] dev           the timer device to set
  * @param[in] channel       the channel to set
- * @param[in] value         the absolute compare value when the callback will be
- *                          triggered
+ * @param[in] value         the absolute compare value at which the callback
+ *                          will be triggered
  *
- * @return                  0 on success
- * @return                  -1 on error
+ * @retval                  0 on success
+ * @retval                  -1 on error
  */
 int timer_set_absolute(tim_t dev, int channel, unsigned int value);
 
@@ -174,7 +180,8 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value);
  *        The timeout will be called periodically for each iteration.
  *
  * @note  Only one channel with `TIM_FLAG_RESET_ON_MATCH` can be active.
- *        Some platforms (Atmel) only allow to use the first channel as TOP value.
+ *        Some platforms (Atmel AVR) only allow to use the first channel as TOP
+ *        value.
  *
  * @note  Needs to be enabled with `FEATURES_REQUIRED += periph_timer_periodic`.
  *
@@ -184,8 +191,8 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value);
  *                          triggered
  * @param[in] flags         options
  *
- * @return                  0 on success
- * @return                  -1 on error
+ * @retval                  0 on success
+ * @retval                  <0 on error
  */
 int timer_set_periodic(tim_t dev, int channel, unsigned int value, uint8_t flags);
 
@@ -195,8 +202,8 @@ int timer_set_periodic(tim_t dev, int channel, unsigned int value, uint8_t flags
  * @param[in] dev           the timer device to clear
  * @param[in] channel       the channel on the given device to clear
  *
- * @return                  0 on success
- * @return                  -1 on error
+ * @retval                  0 on success
+ * @retval                  <0 on error
  */
 int timer_clear(tim_t dev, int channel);
 
@@ -221,7 +228,7 @@ void timer_start(tim_t dev);
 /**
  * @brief Stop the given timer
  *
- * This will effect all of the timer's channels.
+ * This will stop all of the timer's channels.
  *
  * When the timer is stopped, the underlying timer peripheral should be
  * completely powered off.
@@ -237,11 +244,14 @@ void timer_stop(tim_t dev);
  * If calling @ref timer_query_freqs_numof for the same timer with an index
  * smaller this number, it hence MUST return a frequency (and not zero).
  *
- * @details This function is marked with attribute pure to tell the compiler
- *          that this function has no side affects and will return the same
- *          value when called with the same parameter. (E.g. to not call this
- *          function in every loop iteration when iterating over all
- *          supported frequencies.)
+ * This function is marked with `__attribute__((pure))` to tell the compiler
+ * that this function has no side effects and will return the same
+ * value when called with the same parameter. (E.g. to not call this
+ * function in every loop iteration when iterating over all
+ * supported frequencies.)
+ *
+ * @param[in] dev   The timer to get the number of frequencies of
+ * @return          Number of supported frequencies
  */
 __attribute__((pure))
 uword_t timer_query_freqs_numof(tim_t dev);
@@ -249,13 +259,16 @@ uword_t timer_query_freqs_numof(tim_t dev);
 /**
  * @brief   Get the number of timer channels for the given timer
  *
- * @details This function is marked with attribute pure to tell the compiler
- *          that this function has no side affects and will return the same
- *          value when called with the same timer as parameter.
- * @details There is a weak default implementation that returns the value of
- *          `TIMER_CHANNEL_NUMOF`. For some MCUs the number of supported
- *          channels depends on @p dev - those are expected to provide there
- *          own implementation of this function.
+ * This function is marked with `__attribute__((pure))` to tell the compiler
+ * that this function has no side effects and will return the same
+ * value when called with the same timer as parameter.
+ * There is a weak default implementation that returns the value of
+ * `TIMER_CHANNEL_NUMOF`. For some MCUs the number of supported
+ * channels depends on @p dev - those are expected to provide their
+ * own implementation of this function.
+ *
+ * @param[in] dev   The timer to get the number of channels of
+ * @return          Number of channels
  */
 __attribute__((pure))
 uword_t timer_query_channel_numof(tim_t dev);
@@ -263,32 +276,31 @@ uword_t timer_query_channel_numof(tim_t dev);
 /**
  * @brief   Iterate over supported frequencies
  *
- * @param   dev     The timer to get the next supported frequency of
- * @param   index   Index of the frequency to get
- * @return          The @p index highest frequency supported by the timer
- * @retval  0       @p index is too high
- *
- * @note    Add `FEATURES_REQUIRED += periph_timer_query_freqs` to your `Makefile`.
- *
  * When called with a value of 0 for @p index, the highest supported frequency
  * is returned. For a value 1 the second highest is returned, and so on. For
- * values out of range, 0 is returned. A program hence can iterate over all
+ * indices out of range, 0 is returned. A program hence can iterate over all
  * supported frequencies using:
  *
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+ * ```c
  * uint32_t freq:
  * for (uword_t i = 0; (freq = timer_query_freqs(dev, i)); i++) {
  *     work_with_frequency(freq);
  * }
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * ```
  *
  * Or alternatively:
- *
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+ * ```c
  * for (uword_t i = 0; i < timer_query_freqs_numof(dev); i++) {
  *     work_with_frequency(timer_query_freqs(dev, i));
  * }
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * ```
+ *
+ * @note    Add `FEATURES_REQUIRED += periph_timer_query_freqs` to your `Makefile`.
+ *
+ * @param[in]   dev     The timer to get the next supported frequency of
+ * @param[in]   index   Index of the frequency to get
+ * @return              The @p index highest frequency supported by the timer
+ * @retval      0       if the @p index is too high
  */
 uint32_t timer_query_freqs(tim_t dev, uword_t index);
 
@@ -296,17 +308,17 @@ uint32_t timer_query_freqs(tim_t dev, uword_t index);
  * @brief   Search the frequency supported by the timer that is closest to
  *          a given target frequency, efficiently
  *
+ * This will use binary search internally to have an O(log(n))
+ * runtime. This can be relevant on hardware with 16 bit or 32 bit
+ * prescaler registers.
+ *
+ * @note    Add `FEATURES_REQUIRED += periph_timer_query_freqs` to your
+ *          `Makefile`.
+ *
  * @param   dev     The timer to get the closest supported frequency for
  * @param   target  Ideal frequency to match
  * @return          The frequency supported by the timer @p dev that is
  *                  closest to @p target
- *
- * @details This will use binary search internally to have an O(log(n))
- *          runtime. This can be relevant on hardware with 16 bit or 32 bit
- *          prescaler registers.
- *
- * @note    Add `FEATURES_REQUIRED += periph_timer_query_freqs` to your
- *          `Makefile`.
  */
 uint32_t timer_get_closest_freq(tim_t dev, uint32_t target);
 
@@ -314,24 +326,23 @@ uint32_t timer_get_closest_freq(tim_t dev, uint32_t target);
 /**
  * @brief Check whether a compare channel has matched
  *
- * @return true once after the channel has matched.
- *
  * It is currently not defined whether this keeps returning true after a
  * channel has been polled until that channel is set, or whether later calls
  * return false.
  *
  * This is typically used in spin loops that wait for a timer's completion:
  *
- * ~~~
+ * ```c
  * while (!timer_poll_channel(tim, chan)) {};
- * ~~~
+ * ```
  *
  * This function is only available on platforms that implement the
  * `periph_timer_poll` peripheral in addition to `periph_timer`.
  *
+ * @retval true once after the channel has matched.
  */
 /* As this function is polled, it needs to be inlined, so it is typically
- * provided through timer_arch.h. If a platform ever does not need to go
+ * provided through `timer_arch.h`. If a platform ever does not need to go
  * through static inline here, this declaration's condition can be extended to
  * be `(defined(MODULE_PERIPH_TIMER_POLL) &&
  * !defined(PERIPH_TIMER_PROVIDES_INLINE_POLL_CHANNEL) || defined(DOXYGEN)` or
@@ -340,7 +351,7 @@ bool timer_poll_channel(tim_t dev, int channel);
 #endif
 
 #if defined(MODULE_PERIPH_TIMER_POLL)
-#include "timer_arch.h" /* IWYU pragma: export */
+#  include "timer_arch.h" /* IWYU pragma: export */
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

Just the usual stuff. The only noteworthy addition is the information that `TIM_FLAG_RESET_ON_MATCH` and `TIM_FLAG_RESET_ON_SET` reset the counter to zero. That was unclear which is why I looked at the code and decided to add this piece of information.

Also, since the RP2350 timer implementation uses `ERRNO` return values, I adapted the return value information for the timer functions and added a note that some functions can, but not necessarily will return ERRNOs on error.


### Testing procedure

Look at the docs 👀 

### Issues/PRs references

Noticed while reviewing #22375.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
