### PR TITLE
sys/checksum: minor improvements to algorithms

### DIFF
--- a/sys/checksum/crc16_ccitt.c
+++ b/sys/checksum/crc16_ccitt.c
@@ -25,7 +25,7 @@
 #include "kernel_defines.h"
 #include "checksum/crc16_ccitt.h"
 
-static const uint16_t crc_ccitt_lookuptable[256] = {
+static const uint16_t _crc_ccitt_lookuptable[256] = {
     0x0000, 0x1189, 0x2312, 0x329b, 0x4624, 0x57ad, 0x6536, 0x74bf,
     0x8c48, 0x9dc1, 0xaf5a, 0xbed3, 0xca6c, 0xdbe5, 0xe97e, 0xf8f7,
     0x1081, 0x0108, 0x3393, 0x221a, 0x56a5, 0x472c, 0x75b7, 0x643e,
@@ -100,7 +100,7 @@ uint16_t crc16_ccitt_kermit_update(uint16_t crc, const unsigned char *buf, size_
     while (len--) {
         uint8_t e = crc ^= *buf++;
         if (IS_USED(MODULE_CRC16_FAST)) {
-            crc = (crc >> 8) ^ crc_ccitt_lookuptable[e];
+            crc = (crc >> 8) ^ _crc_ccitt_lookuptable[e];
         } else {
             uint8_t f = e ^ (e << 4);
             crc = (crc >> 8)

--- a/sys/checksum/crc16_ccitt.c
+++ b/sys/checksum/crc16_ccitt.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2016 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/checksum/crc32.c
+++ b/sys/checksum/crc32.c
@@ -108,7 +108,7 @@ uint32_t crc32(const void *buf, size_t size)
     const uint8_t *p = buf;
     uint32_t crc = ~0U;
 
-    for (unsigned i = 0; i < size; ++i) {
+    for (size_t i = 0; i < size; ++i) {
         crc ^= *p++;
         crc = crc32_for_byte(crc);
 

--- a/sys/checksum/crc32.c
+++ b/sys/checksum/crc32.c
@@ -1,11 +1,6 @@
 /*
- * Copyright (C) 2020 Ayman El Didi
- *
- * To the extent possible under law, the author(s) have dedicated all
- * domain worldwide. This software is distributed without any warranty.
- *
- * You should have received a copy of the CC0 Public Domain Dedication along
- * with this software. If not, see http://creativecommons.org/publicdomain/zero/1.0/
+ * SPDX-FileCopyrightText: 2020 Ayman El Didi
+ * SPDX-License-Identifier: CC0-1.0
  */
 
 /**

--- a/sys/checksum/crc32.c
+++ b/sys/checksum/crc32.c
@@ -9,6 +9,8 @@
  */
 
 /**
+ * @ingroup     sys_checksum_crc32
+ *
  * @{
  *
  * @file

--- a/sys/checksum/crc32.c
+++ b/sys/checksum/crc32.c
@@ -19,7 +19,7 @@
 #include "kernel_defines.h"
 #include "checksum/crc32.h"
 
-const uint32_t crc32_tab[] = {
+static const uint32_t _crc32_tab[] = {
     0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
     0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
     0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91, 0x1db71064, 0x6ab020f2,
@@ -68,7 +68,7 @@ const uint32_t crc32_tab[] = {
 static inline uint32_t crc32_for_byte(uint32_t result)
 {
     if (IS_USED(MODULE_CRC32_FAST)) {
-        return crc32_tab[result & 0xFF] ^ (result >> 8);
+        return _crc32_tab[result & 0xFF] ^ (result >> 8);
     }
 
     const uint32_t polynomial = 0xEDB88320L;

--- a/sys/checksum/crc8.c
+++ b/sys/checksum/crc8.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/checksum/crc8.c
+++ b/sys/checksum/crc8.c
@@ -24,12 +24,10 @@
 uint8_t crc8(const uint8_t *data, size_t len, uint8_t g_polynom, uint8_t crc)
 {
     /* iterate over all bytes */
-    for (size_t i=0; i < len; i++)
-    {
+    for (size_t i = 0; i < len; i++) {
         crc ^= data[i];
 
-        for (int i = 0; i < 8; i++)
-        {
+        for (unsigned j = 0; j < 8; j++) {
             bool xor = crc & 0x80;
             crc = crc << 1;
             crc = xor ? crc ^ g_polynom : crc;
@@ -41,12 +39,10 @@ uint8_t crc8(const uint8_t *data, size_t len, uint8_t g_polynom, uint8_t crc)
 
 uint8_t crc8_lsb(const uint8_t *data, size_t len, uint8_t g_polynom, uint8_t crc)
 {
-    for (size_t i = 0; i < len; i++)
-    {
+    for (size_t i = 0; i < len; i++) {
         crc ^= data[i];
 
-        for (int i = 0; i < 8; i++)
-        {
+        for (unsigned j = 0; j < 8; j++) {
             bool xor = crc & 0x01;
             crc = crc >> 1;
             crc = xor ? crc ^ g_polynom : crc;

--- a/sys/checksum/doc.md
+++ b/sys/checksum/doc.md
@@ -31,3 +31,7 @@ advantage by using a look-up table that provides the checksum for every
 possible byte-value. It thus trades of memory against speed. If your
 platform is rather small equipped in memory you should prefer the
 @ref sys_checksum_ucrc16 version.
+
+It is worth noting that the checksumming algorithms provided should not be used
+for security purposes (e.g. integrity or authentication), since they are not
+cryptographically secure.

--- a/sys/checksum/fletcher16.c
+++ b/sys/checksum/fletcher16.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2015 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/checksum/fletcher32.c
+++ b/sys/checksum/fletcher32.c
@@ -35,7 +35,7 @@ void fletcher32_init(fletcher32_ctx_t *ctx)
 
 uint32_t fletcher32_finish(fletcher32_ctx_t *ctx)
 {
-    /* Second reduction step to reduce sums to 8 bits */
+    /* Second reduction step to reduce sums to 16 bits */
     _reduce(ctx);
     return (ctx->sum2 << 16) | ctx->sum1;
 }

--- a/sys/checksum/fletcher32.c
+++ b/sys/checksum/fletcher32.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2015 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/checksum/ucrc16.c
+++ b/sys/checksum/ucrc16.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/checksum/ucrc16.c
+++ b/sys/checksum/ucrc16.c
@@ -27,7 +27,7 @@ uint16_t ucrc16_calc_be(const uint8_t *buf, size_t len, uint16_t poly,
                         uint16_t seed)
 {
     assert(buf != NULL);
-    for (unsigned c = 0; c < len; c++, buf++) {
+    for (size_t c = 0; c < len; c++, buf++) {
         uint32_t tmp = seed ^ (*buf << (UINT16_BIT_SIZE - UINT8_BIT_SIZE));
         for (unsigned i = 0; i < UINT8_BIT_SIZE; i++) {
             tmp = LEFTMOST_BIT_SET(tmp) ? ((tmp << 1) ^ poly) : (tmp << 1);
@@ -41,7 +41,7 @@ uint16_t ucrc16_calc_le(const uint8_t *buf, size_t len, uint16_t poly,
                         uint16_t seed)
 {
     assert(buf != NULL);
-    for (unsigned c = 0; c < len; c++, buf++) {
+    for (size_t c = 0; c < len; c++, buf++) {
         seed ^= (*buf);
         for (unsigned i = 0; i < UINT8_BIT_SIZE; i++) {
             seed = RIGHTMOST_BIT_SET(seed) ? ((seed >> 1) ^ poly) : (seed >> 1);

--- a/sys/include/checksum/crc16_ccitt.h
+++ b/sys/include/checksum/crc16_ccitt.h
@@ -1,9 +1,6 @@
 /*
- * Copyright 2016 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/checksum/crc32.h
+++ b/sys/include/checksum/crc32.h
@@ -36,7 +36,7 @@ extern "C" {
  * @param[in] buf   The data to checksum
  * @param[in] size  Length of the data in bytes
  *
- * @return 32 bit sized hash in the interval [0..2^32]
+ * @return 32 bit sized hash in the interval [0..2^32-1]
  */
 ACCESS(read_only, 1, 2)
 uint32_t crc32(const void *buf, size_t size);

--- a/sys/include/checksum/fletcher16.h
+++ b/sys/include/checksum/fletcher16.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/checksum/fletcher16.h
+++ b/sys/include/checksum/fletcher16.h
@@ -40,8 +40,9 @@ typedef struct {
  *
  * @note the returned sum is never 0
  *
- * @param buf input buffer to hash
- * @param bytes length of buffer, in bytes
+ * @param[in]       buf     input buffer to hash
+ * @param[in]       bytes   length of buffer, in bytes
+ *
  * @return 16 bit sized hash in the interval [1..65535]
  */
 uint16_t fletcher16(const uint8_t *buf, size_t bytes);
@@ -51,25 +52,25 @@ uint16_t fletcher16(const uint8_t *buf, size_t bytes);
  *
  * Multi-part version of @ref fletcher16_full.
  *
- * @param[in]   ctx     fletcher16 context to initialize
+ * @param[out]      ctx     Fletcher16 context to initialize
  */
 void fletcher16_init(fletcher16_ctx_t *ctx);
 
 /**
  * @brief Update the fletcher16 context with new data
  *
- * @param[in]   ctx     fletcher16 context
- * @param[in]   data    Data to add to the context
- * @param[in]   len     Length of the data
+ * @param[in,out]   ctx     Fletcher16 context
+ * @param[in]       data    Data to add to the context
+ * @param[in]       len     Length of the data
  */
 void fletcher16_update(fletcher16_ctx_t *ctx, const uint8_t *data, size_t len);
 
 /**
  * @brief Finalize the checksum operation and return the checksum
  *
- * @param[in]   ctx     fletcher16 context
+ * @param[in,out]   ctx     Fletcher16 context
  *
- * @return              Checksum of the data
+ * @return  Checksum of the data
  */
 uint16_t fletcher16_finish(fletcher16_ctx_t *ctx);
 

--- a/sys/include/checksum/fletcher32.h
+++ b/sys/include/checksum/fletcher32.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/checksum/fletcher32.h
+++ b/sys/include/checksum/fletcher32.h
@@ -46,7 +46,7 @@ typedef struct {
  *
  * @param buf input buffer to hash
  * @param words length of buffer, in 16 bit words
- * @return 32 bit sized hash in the interval [1..2^32]
+ * @return 32 bit sized hash in the interval [1..2^32-1]
  */
 uint32_t fletcher32(const uint16_t *buf, size_t words);
 

--- a/sys/include/checksum/fletcher32.h
+++ b/sys/include/checksum/fletcher32.h
@@ -35,14 +35,15 @@ typedef struct {
 /**
  * @brief Fletcher's 32 bit checksum
  *
- * found on
+ * Found on
  * http://en.wikipedia.org/w/index.php?title=Fletcher%27s_checksum&oldid=661273016#Optimizations
  *
  * @note the returned sum is never 0
  * @note pay attention to the @p words parameter buffer containing 16 bit words, not bytes.
  *
- * @param buf input buffer to hash
- * @param words length of buffer, in 16 bit words
+ * @param[in]       buf     Input buffer to hash
+ * @param[in]       words   Length of buffer, in 16 bit words
+ *
  * @return 32 bit sized hash in the interval [1..2^32-1]
  */
 uint32_t fletcher32(const uint16_t *buf, size_t words);
@@ -52,7 +53,7 @@ uint32_t fletcher32(const uint16_t *buf, size_t words);
  *
  * Multi-part version of @ref fletcher32.
  *
- * @param[in]   ctx     fletcher32 context to initialize
+ * @param[out]      ctx     Fletcher32 context to initialize
  */
 void fletcher32_init(fletcher32_ctx_t *ctx);
 
@@ -63,16 +64,16 @@ void fletcher32_init(fletcher32_ctx_t *ctx);
  * @note @p words is the number of 16 bit words in the buffer
  * @note @p data should contain an integer number of 16 bit words
  *
- * @param[in]   ctx     fletcher32 context
- * @param[in]   data    Data to add to the context
- * @param[in]   words   Length of the data in 16 bit words
+ * @param[in,out]   ctx     Fletcher32 context
+ * @param[in]       data    Data to add to the context
+ * @param[in]       words   Length of the data in 16 bit words
  */
 void fletcher32_update(fletcher32_ctx_t *ctx, const void *data, size_t words);
 
 /**
  * @brief Finalize the checksum operation and return the checksum
  *
- * @param[in]   ctx     fletcher32 context
+ * @param[in,out]   ctx     Fletcher32 context
  *
  * @return 32 bit sized hash in the interval [1..2^32]
  */

--- a/sys/include/checksum/ucrc16.h
+++ b/sys/include/checksum/ucrc16.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once


### PR DESCRIPTION
### Contribution description

This PR improves the checksum algorithms currently available in sys/checksum. Most fixes are related to documentation.

One finding is related to different sizes of types. `size_t` is 64 bits and `unsigned` is 32 bits on 64 bit platforms. This leads to infinite loops. This can be demonstrated with the following on `native64`:

```c
size_t x = SIZE_MAX;

for (unsigned i = UINT32_MAX - 1; i < x; i++) {  
    if (i == 0) {
        puts("overflowed");
    }
}
```

### Testing procedure

Running `make -C tests/unittests tests-checksum term` should confirm unit tests still pass.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- Claude Fable 5 to find the issues. I checked and fixed them manually.
