### PR TITLE
sys/checksum: add ACCESS() attribute

### DIFF
--- a/dist/tools/riotboot_gen_hdr/Makefile
+++ b/dist/tools/riotboot_gen_hdr/Makefile
@@ -1,11 +1,12 @@
-RIOTBASE       := ../../..
-BUILD_DIR      ?= $(RIOTBASE)/build
-GENHDR_BINDIR  := $(BUILD_DIR)/genhdr
-RIOT_INCLUDE   := $(RIOTBASE)/sys/include
-RIOT_CORE_INC  := $(RIOTBASE)/core/include
-NATIVE_INCLUDE := $(RIOTBASE)/cpu/native/include
-COMMON_SRC     := common.c
-COMMON_HDR     := common.h
+RIOTBASE          := ../../..
+BUILD_DIR         ?= $(RIOTBASE)/build
+GENHDR_BINDIR     := $(BUILD_DIR)/genhdr
+RIOT_INCLUDE      := $(RIOTBASE)/sys/include
+RIOT_CORE_INC     := $(RIOTBASE)/core/include
+RIOT_CORE_LIB_INC := $(RIOTBASE)/core/lib/include
+NATIVE_INCLUDE    := $(RIOTBASE)/cpu/native/include
+COMMON_SRC        := common.c
+COMMON_HDR        := common.h
 
 RIOT_HDR_SRC := \
 	$(RIOTBASE)/sys/checksum/fletcher32.c \
@@ -34,7 +35,7 @@ $(GENHDR_BINDIR)/:
 	$(Q)mkdir -p "$@"
 
 $(GENHDR_BINDIR)/genhdr: $(GENHDR_HDR) $(GENHDR_SRC) Makefile | $(GENHDR_BINDIR)/
-	$(Q)$(CC) $(CFLAGS) -I$(RIOT_INCLUDE) -I$(RIOT_CORE_INC) \
+	$(Q)$(CC) $(CFLAGS) -I$(RIOT_INCLUDE) -I$(RIOT_CORE_INC) -I$(RIOT_CORE_LIB_INC) \
 		-I$(NATIVE_INCLUDE) $(GENHDR_SRC) -o $@
 
 clean:

--- a/sys/checksum/fletcher32.c
+++ b/sys/checksum/fletcher32.c
@@ -42,12 +42,13 @@ uint32_t fletcher32_finish(fletcher32_ctx_t *ctx)
 
 void fletcher32_update(fletcher32_ctx_t *ctx, const void *data, size_t words)
 {
-    const uint16_t *u16_data = (const uint16_t*)data;
+    uintptr_t pos = (uintptr_t)data;
     while (words) {
         unsigned tlen = words > 359 ? 359 : words;
         words -= tlen;
         do {
-            ctx->sum1 += unaligned_get_u16(u16_data++);
+            ctx->sum1 += unaligned_get_u16((void *)pos);
+            pos += sizeof(uint16_t);
             ctx->sum2 += ctx->sum1;
         } while (--tlen);
         _reduce(ctx);

--- a/sys/include/checksum/crc16_ccitt.h
+++ b/sys/include/checksum/crc16_ccitt.h
@@ -34,6 +34,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "compiler_hints.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -50,6 +52,7 @@ extern "C" {
  * @return          Checksum of the specified memory area based on the
  *                  given start value
  */
+ACCESS(read_only, 2, 3)
 uint16_t crc16_ccitt_kermit_update(uint16_t crc, const unsigned char *buf, size_t len);
 
 /**

--- a/sys/include/checksum/fletcher16.h
+++ b/sys/include/checksum/fletcher16.h
@@ -22,6 +22,8 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#include "compiler_hints.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,6 +49,7 @@ typedef struct {
  * @param bytes length of buffer, in bytes
  * @return 16 bit sized hash in the interval [1..65535]
  */
+ACCESS(read_only, 1, 2)
 uint16_t fletcher16(const uint8_t *buf, size_t bytes);
 
 /**
@@ -65,6 +68,7 @@ void fletcher16_init(fletcher16_ctx_t *ctx);
  * @param[in]   data    Data to add to the context
  * @param[in]   len     Length of the data
  */
+ACCESS(read_only, 2, 3)
 void fletcher16_update(fletcher16_ctx_t *ctx, const uint8_t *data, size_t len);
 
 /**

--- a/sys/include/checksum/fletcher32.h
+++ b/sys/include/checksum/fletcher32.h
@@ -23,6 +23,8 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#include "compiler_hints.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -44,11 +46,12 @@ typedef struct {
  * @note the returned sum is never 0
  * @note pay attention to the @p words parameter buffer containing 16 bit words, not bytes.
  *
- * @param buf input buffer to hash
+ * @param data  input buffer to hash
  * @param words length of buffer, in 16 bit words
  * @return 32 bit sized hash in the interval [1..2^32]
  */
-uint32_t fletcher32(const uint16_t *buf, size_t words);
+ACCESS(read_only, 1, 2)
+uint32_t fletcher32(const uint16_t *data, size_t words);
 
 /**
  * @brief Initialize a fletcher32 context
@@ -60,8 +63,8 @@ uint32_t fletcher32(const uint16_t *buf, size_t words);
 void fletcher32_init(fletcher32_ctx_t *ctx);
 
 /**
- * @brief Incrementally update the fletcher32 context with new data. Can be an arbitrary amount of
- * times with new data to checksum.
+ * @brief Incrementally update the fletcher32 context with new data. Can be an
+ *        arbitrary amount of times with new data to checksum.
  *
  * @note @p words is the number of 16 bit words in the buffer
  * @note @p data should contain an integer number of 16 bit words

--- a/sys/include/checksum/ucrc16.h
+++ b/sys/include/checksum/ucrc16.h
@@ -32,6 +32,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "compiler_hints.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -56,6 +58,7 @@ extern "C" {
  *
  * @note    The return value is not the complement of the sum but the sum itself
  */
+ACCESS(read_only, 1, 2)
 uint16_t ucrc16_calc_be(const uint8_t *buf, size_t len, uint16_t poly,
                         uint16_t seed);
 
@@ -71,6 +74,7 @@ uint16_t ucrc16_calc_be(const uint8_t *buf, size_t len, uint16_t poly,
  *
  * @note    The return value is not the complement of the sum but the sum itself
  */
+ACCESS(read_only, 1, 2)
 uint16_t ucrc16_calc_le(const uint8_t *buf, size_t len, uint16_t poly,
                         uint16_t seed);
 


### PR DESCRIPTION
### Contribution description

Annotated a functions in `sys/checksum` with the `access` attribute using the `ACCESS()` macro to allow GCC to perform better `-Wstringop-overflow` diagnostics.

### Testing procedure

The Ci should do the testing here

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/22380

### Declaration of AI-Tools / LLMs usage:

Same as in https://github.com/RIOT-OS/RIOT/pull/22380