### PR TITLE
sys/can: annotate functions with ACCESS()

### DIFF
--- a/sys/can/conn/raw.c
+++ b/sys/can/conn/raw.c
@@ -39,7 +39,7 @@
 #define CONN_CAN_ISOTP_TIMEOUT_TX_CONF_US   (1 * US_PER_SEC)
 #endif
 
-int conn_can_raw_create(conn_can_raw_t *conn, struct can_filter *filter, size_t count,
+int conn_can_raw_create(conn_can_raw_t *conn, const struct can_filter *filter, size_t count,
                         int ifnum, int flags)
 {
     assert(conn != NULL);
@@ -71,7 +71,7 @@ int conn_can_raw_create(conn_can_raw_t *conn, struct can_filter *filter, size_t 
     return conn_can_raw_set_filter(conn, filter, count);
 }
 
-int conn_can_raw_set_filter(conn_can_raw_t *conn, struct can_filter *filter, size_t count)
+int conn_can_raw_set_filter(conn_can_raw_t *conn, const struct can_filter *filter, size_t count)
 {
     assert(conn != NULL);
     assert(filter != NULL || count == 0);

--- a/sys/can/dll.c
+++ b/sys/can/dll.c
@@ -166,9 +166,11 @@ int raw_can_abort(int ifnum, int handle)
     return 0;
 }
 
-static int register_filter_entry(can_reg_entry_t *entry, struct can_filter *filter, void *param)
+static int register_filter_entry(can_reg_entry_t *entry,
+                                 const struct can_filter *filter, void *param)
 {
-    msg_t msg, reply;
+    msg_t msg;
+    msg_t reply;
     int ret;
 
     DEBUG("register_filter_entry: ifnum=%d, filter=0x%" PRIx32 ", mask=0x%" PRIx32 ", param=%p\n",
@@ -178,13 +180,13 @@ static int register_filter_entry(can_reg_entry_t *entry, struct can_filter *filt
     if (ret < 0) {
         return -ENOMEM;
     }
-    else if (ret == 1) {
+    if (ret == 1) {
         DEBUG("raw_can_subscribe_rx: filter=0x%" PRIx32 " already in use\n", filter->can_id);
         return 0;
     }
 
     msg.type = CAN_MSG_SET_FILTER;
-    msg.content.ptr = filter;
+    msg.content.ptr = (void *)filter;
     msg_send_receive(&msg, &reply, candev_list[entry->ifnum]->pid);
 
     if ((int) reply.content.value < 0) {
@@ -195,9 +197,11 @@ static int register_filter_entry(can_reg_entry_t *entry, struct can_filter *filt
     return 0;
 }
 
-static int unregister_filter_entry(can_reg_entry_t *entry, struct can_filter *filter, void *param)
+static int unregister_filter_entry(can_reg_entry_t *entry,
+                                   const struct can_filter *filter, void *param)
 {
-    msg_t msg, reply;
+    msg_t msg;
+    msg_t reply;
     int ret;
 
     DEBUG("unregister_filter_entry: ifnum=%d, filter=0x%" PRIx32 ", mask=0x%" PRIx32 ", param=%p\n",
@@ -207,13 +211,13 @@ static int unregister_filter_entry(can_reg_entry_t *entry, struct can_filter *fi
     if (ret < 0) {
         return -ENOMEM;
     }
-    else if (ret == 1) {
+    if (ret == 1) {
         DEBUG("raw_can_unsubscribe_rx: filter=0x%" PRIx32 " still in use\n", filter->can_id);
         return 0;
     }
 
     msg.type = CAN_MSG_REMOVE_FILTER;
-    msg.content.ptr = filter;
+    msg.content.ptr = (void *)filter;
     msg_send_receive(&msg, &reply, candev_list[entry->ifnum]->pid);
 
     if ((int) reply.content.value < 0) {
@@ -223,7 +227,8 @@ static int unregister_filter_entry(can_reg_entry_t *entry, struct can_filter *fi
     return 0;
 }
 
-int raw_can_subscribe_rx(int ifnum, struct can_filter *filter, kernel_pid_t pid, void *param)
+int raw_can_subscribe_rx(int ifnum, const struct can_filter *filter,
+                         kernel_pid_t pid, void *param)
 {
     assert(ifnum < candev_nb);
     assert(filter);
@@ -239,7 +244,8 @@ int raw_can_subscribe_rx(int ifnum, struct can_filter *filter, kernel_pid_t pid,
 }
 
 #ifdef MODULE_CAN_MBOX
-int raw_can_subscribe_rx_mbox(int ifnum, struct can_filter *filter, mbox_t *mbox, void *param)
+int raw_can_subscribe_rx_mbox(int ifnum, const struct can_filter *filter,
+                              mbox_t *mbox, void *param)
 {
     assert(ifnum < candev_nb);
     assert(filter);
@@ -253,7 +259,7 @@ int raw_can_subscribe_rx_mbox(int ifnum, struct can_filter *filter, mbox_t *mbox
 }
 #endif
 
-int raw_can_unsubscribe_rx(int ifnum, struct can_filter *filter, kernel_pid_t pid, void *param)
+int raw_can_unsubscribe_rx(int ifnum, const struct can_filter *filter, kernel_pid_t pid, void *param)
 {
     assert(ifnum < candev_nb);
     assert(filter);
@@ -269,7 +275,8 @@ int raw_can_unsubscribe_rx(int ifnum, struct can_filter *filter, kernel_pid_t pi
 }
 
 #ifdef MODULE_CAN_MBOX
-int raw_can_unsubscribe_rx_mbox(int ifnum, struct can_filter *filter, mbox_t *mbox, void *param)
+int raw_can_unsubscribe_rx_mbox(int ifnum, const struct can_filter *filter,
+                                mbox_t *mbox, void *param)
 {
     assert(ifnum < candev_nb);
     assert(filter);

--- a/sys/include/can/conn/isotp.h
+++ b/sys/include/can/conn/isotp.h
@@ -23,6 +23,7 @@
 extern "C" {
 #endif
 
+#include "compiler_hints.h"
 #include "can/can.h"
 #include "can/isotp.h"
 #include "mbox.h"
@@ -92,7 +93,8 @@ struct conn_can_isotp_master {
  * @param[in]       master      the master connection
  * @param[in,out]   slave       the slave connection to initialize
  */
-static inline void conn_can_isotp_init_slave(conn_can_isotp_t *master, conn_can_isotp_slave_t *slave)
+static inline void conn_can_isotp_init_slave(conn_can_isotp_t *master,
+                                             conn_can_isotp_slave_t *slave)
 {
     slave->next = NULL;
     slave->master = master;
@@ -164,6 +166,7 @@ int conn_can_isotp_close(conn_can_isotp_t *conn);
  * @return the number of bytes received
  * @return any other negative number in case of an error
  */
+ACCESS(write_only, 2, 3)
 int conn_can_isotp_recv(conn_can_isotp_t *conn, void *buf, size_t size, uint32_t timeout);
 
 /**
@@ -178,6 +181,7 @@ int conn_can_isotp_recv(conn_can_isotp_t *conn, void *buf, size_t size, uint32_t
  * @return the number of bytes sent
  * @return any other negative number in case of an error
  */
+ACCESS(read_only, 2, 3)
 int conn_can_isotp_send(conn_can_isotp_t *conn, const void *buf, size_t size, int flags);
 
 #if defined(MODULE_CONN_CAN_ISOTP_MULTI) || defined(DOXYGEN)
@@ -190,7 +194,8 @@ int conn_can_isotp_send(conn_can_isotp_t *conn, const void *buf, size_t size, in
  *
  * @return 0 if OK, < 0 if error
  */
-int conn_can_isotp_select(conn_can_isotp_slave_t **conn, conn_can_isotp_t *master, uint32_t timeout);
+int conn_can_isotp_select(conn_can_isotp_slave_t **conn, conn_can_isotp_t *master,
+                          uint32_t timeout);
 #endif
 
 #ifdef __cplusplus

--- a/sys/include/can/conn/raw.h
+++ b/sys/include/can/conn/raw.h
@@ -28,6 +28,7 @@
 extern "C" {
 #endif
 
+#include "compiler_hints.h"
 #include "can/can.h"
 #include "can/raw.h"
 #include "mbox.h"
@@ -51,11 +52,11 @@ extern "C" {
  * @brief   RAW CAN connection
  */
 typedef struct conn_can_raw {
-    int ifnum;                 /**< Interface number of the can device */
-    int flags;                 /**< Config flags for that conn object */
-    size_t count;              /**< number of filters set */
-    struct can_filter *filter; /**< list of filter */
-    mbox_t mbox;               /**< mbox */
+    int ifnum;                          /**< Interface number of the can device */
+    int flags;                          /**< Config flags for that conn object */
+    size_t count;                       /**< number of filters set */
+    const struct can_filter *filter;    /**< list of filter */
+    mbox_t mbox;                        /**< mbox */
     /**
      * message queue
      */
@@ -76,7 +77,8 @@ typedef struct conn_can_raw {
  * @return 0 if socket was successfully connected
  * @return any other negative number in case of an error
  */
-int conn_can_raw_create(conn_can_raw_t *conn, struct can_filter *filter, size_t count,
+ACCESS(read_only, 2, 3)
+int conn_can_raw_create(conn_can_raw_t *conn, const struct can_filter *filter, size_t count,
                         int ifnum, int flags);
 
 /**
@@ -131,7 +133,8 @@ int conn_can_raw_send(conn_can_raw_t *conn, const can_frame_t *frame, int flags)
  * @return 0 if can filters were successfully set
  * @return any other negative number in case of an error
  */
-int conn_can_raw_set_filter(conn_can_raw_t *conn, struct can_filter *filter, size_t count);
+ACCESS(read_only, 2, 3)
+int conn_can_raw_set_filter(conn_can_raw_t *conn, const struct can_filter *filter, size_t count);
 
 #ifdef __cplusplus
 }

--- a/sys/include/can/isotp.h
+++ b/sys/include/can/isotp.h
@@ -26,29 +26,30 @@ extern "C" {
 
 #include "can/can.h"
 #include "can/common.h"
+#include "compiler_hints.h"
+#include "net/gnrc/pktbuf.h"
 #include "thread.h"
 #include "ztimer.h"
-#include "net/gnrc/pktbuf.h"
 
 #ifndef CAN_ISOTP_BS
 /**
  * @brief   Default Block Size for RX Flow Control frames
  */
-#define CAN_ISOTP_BS        (10)
+#  define CAN_ISOTP_BS (10)
 #endif
 
 #ifndef CAN_ISOTP_STMIN
 /**
  * @brief   Default STmin for RX Flow Control frames
  */
-#define CAN_ISOTP_STMIN     (5)
+#  define CAN_ISOTP_STMIN (5)
 #endif
 
 #ifndef CAN_ISOTP_WFTMAX
 /**
  * @brief   Default maximum WFT for TX Flow Control
  */
-#define CAN_ISOTP_WFTMAX    (1)
+#  define CAN_ISOTP_WFTMAX (1)
 #endif
 
 /**
@@ -168,6 +169,7 @@ kernel_pid_t isotp_init(char *stack, int stacksize, char priority, const char *n
  * @return the number of bytes sent
  * @return < 0 if an error occurred  (-EBUSY, -ENOMEM)
  */
+ACCESS(read_only, 2, 3)
 int isotp_send(struct isotp *isotp, const void *buf, int len, int flags);
 
 /**

--- a/sys/include/can/raw.h
+++ b/sys/include/can/raw.h
@@ -80,7 +80,8 @@ int raw_can_abort(int ifnum, int handle);
  * @brief Subscribe to a CAN filter
  *
  * This function must be called if a user thread @p pid wants to receive the CAN frame matching @p filter
- * on the interface @p ifnum.
+ * This function must be called if a user thread @p pid wants to receive the
+ * CAN frame matching @p filter on the interface @p ifnum.
  * The user thread will then receive msg via IPC on reception of frame matching @p filters.
  *
  * @param[in] ifnum      the interface number to listen
@@ -91,7 +92,8 @@ int raw_can_abort(int ifnum, int handle);
  * @return the @p ifnum on success
  * @return < 0 on error
  */
-int raw_can_subscribe_rx(int ifnum, struct can_filter *filter, kernel_pid_t pid, void *param);
+int raw_can_subscribe_rx(int ifnum, const struct can_filter *filter,
+                         kernel_pid_t pid, void *param);
 
 /**
  * @brief Unsubscribe from reception for the given CAN @p filter on @p pid thread
@@ -104,7 +106,7 @@ int raw_can_subscribe_rx(int ifnum, struct can_filter *filter, kernel_pid_t pid,
  * @return 0 on success
  * @return < 0 on error
  */
-int raw_can_unsubscribe_rx(int ifnum, struct can_filter *filter, kernel_pid_t pid, void *param);
+int raw_can_unsubscribe_rx(int ifnum, const struct can_filter *filter, kernel_pid_t pid, void *param);
 
 /**
  * @brief Free a received frame
@@ -162,7 +164,8 @@ int raw_can_send_mbox(int ifnum, const can_frame_t *frame, mbox_t *mbox);
  *
  * This function must be called if a user thread waiting on @p mbox wants to receive
  * the CAN frame matching @p filter on the interface @p ifnum.
- * The user thread will then receive msg via mailbox IPC on reception of frame matching @p filters.
+ * The user thread will then receive msg via mailbox IPC on reception of
+ * frame matching @p filters.
  *
  * Currently only single frame ID (i.e. filters->can_mask = 0xFFFFFFFF) are supported.
  *
@@ -174,7 +177,8 @@ int raw_can_send_mbox(int ifnum, const can_frame_t *frame, mbox_t *mbox);
  * @return the @p ifnum on success
  * @return < 0 on error
  */
-int raw_can_subscribe_rx_mbox(int ifnum, struct can_filter *filter, mbox_t *mbox, void *param);
+int raw_can_subscribe_rx_mbox(int ifnum, const struct can_filter *filter,
+                              mbox_t *mbox, void *param);
 
 /**
  * @brief Unsubscribe from reception for the given CAN @p filter and @p mbox
@@ -187,7 +191,8 @@ int raw_can_subscribe_rx_mbox(int ifnum, struct can_filter *filter, mbox_t *mbox
  * @return 0 on success
  * @return < 0 on error
  */
-int raw_can_unsubscribe_rx_mbox(int ifnum, struct can_filter *filter, mbox_t *mbox, void *param);
+int raw_can_unsubscribe_rx_mbox(int ifnum, const struct can_filter *filter,
+                                mbox_t *mbox, void *param);
 #endif
 
 /**
@@ -251,7 +256,10 @@ candev_dev_t *raw_can_get_dev_by_ifnum(int ifnum);
  *                           if not set, the default value of 87.5% is used
  * @return 0 on success
  * @return 1 if the bitrate/sample_point couple can not be reached precisely but the bitrate is set
- * @return < 0  on error
+ * @retval 0    on success
+ * @retval 1    if the bitrate/sample_point couple can not be reached precisely
+ *              but the bitrate is set
+ * @retval <0   on error
  */
 int raw_can_set_bitrate(int ifnum, uint32_t bitrate, uint32_t sample_point);
 


### PR DESCRIPTION
### Contribution description

Use the `ACCESS()` macro to annotate functions so that GCC can provide better diagnostics for `-Wstringop-overflow`.

### Testing procedure

The CI will do this

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/22380

### Declaration of AI-Tools / LLMs usage:

Same as in https://github.com/RIOT-OS/RIOT/pull/22380