### PR TITLE
sys/base64: minor improvements and documentation updates

### DIFF
--- a/sys/base64/base64.c
+++ b/sys/base64/base64.c
@@ -91,7 +91,6 @@ static int base64_encode_base(const void *data_in, size_t data_in_size,
     const uint8_t *in = data_in;
     const uint8_t *end = in + data_in_size;
     uint8_t *out = base64_out;
-    size_t required_size = base64_estimate_encode_size(data_in_size);
 
     if (in == NULL) {
         return BASE64_ERROR_DATA_IN;
@@ -101,6 +100,12 @@ static int base64_encode_base(const void *data_in, size_t data_in_size,
         *base64_out_size = 0;
         return BASE64_SUCCESS;
     }
+
+    if (!base64_can_estimate_encode_size(data_in_size)) {
+        return BASE64_ERROR_OVERFLOW;
+    }
+
+    size_t required_size = base64_estimate_encode_size(data_in_size);
 
     if (*base64_out_size < required_size) {
         *base64_out_size = required_size;
@@ -224,7 +229,6 @@ int base64_decode(const void *base64_in, size_t base64_in_size,
 {
     uint8_t *out = data_out;
     const uint8_t *in = base64_in;
-    size_t required_size = base64_estimate_decode_size(base64_in_size);
 
     if (in == NULL) {
         return BASE64_ERROR_DATA_IN;
@@ -234,6 +238,8 @@ int base64_decode(const void *base64_in, size_t base64_in_size,
         *data_out_size = 0;
         return BASE64_SUCCESS;
     }
+
+    size_t required_size = base64_estimate_decode_size(base64_in_size);
 
     if (*data_out_size < required_size) {
         *data_out_size = required_size;

--- a/sys/base64/base64.c
+++ b/sys/base64/base64.c
@@ -230,6 +230,11 @@ int base64_decode(const void *base64_in, size_t base64_in_size,
         return BASE64_ERROR_DATA_IN;
     }
 
+    if (base64_in_size == 0) {
+        *data_out_size = 0;
+        return BASE64_SUCCESS;
+    }
+
     if (*data_out_size < required_size) {
         *data_out_size = required_size;
         return BASE64_ERROR_BUFFER_OUT_SIZE;

--- a/sys/base64/base64.c
+++ b/sys/base64/base64.c
@@ -89,7 +89,6 @@ static int base64_encode_base(const void *data_in, size_t data_in_size,
 {
     const uint8_t padding = urlsafe ? 0 : '=';
     const uint8_t *in = data_in;
-    const uint8_t *end = in + data_in_size;
     uint8_t *out = base64_out;
 
     if (in == NULL) {
@@ -117,6 +116,8 @@ static int base64_encode_base(const void *data_in, size_t data_in_size,
     }
 
     *base64_out_size = required_size;
+
+    const uint8_t *end = in + data_in_size;
 
     while (in < end - 2) {
         encode_three_bytes(out, in[0], in[1], in[2], urlsafe);
@@ -227,8 +228,8 @@ static void decode_four_codes(uint8_t *out, const uint8_t *src)
 int base64_decode(const void *base64_in, size_t base64_in_size,
                   void *data_out, size_t *data_out_size)
 {
-    uint8_t *out = data_out;
     const uint8_t *in = base64_in;
+    uint8_t *out = data_out;
 
     if (in == NULL) {
         return BASE64_ERROR_DATA_IN;

--- a/sys/include/base64.h
+++ b/sys/include/base64.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 Hochschule für Angewandte Wissenschaften Hamburg (HAW)
- * Copyright (C) 2014 Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Hochschule für Angewandte Wissenschaften Hamburg (HAW)
+ * SPDX-FileCopyrightText: 2014 Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/base64.h
+++ b/sys/include/base64.h
@@ -10,12 +10,12 @@
 #pragma once
 
 /**
- * @defgroup    sys_base64 base64 encoder decoder
+ * @defgroup    sys_base64 Base64 encoder decoder
  * @ingroup     sys_serialization
- * @brief       base64 encoder and decoder
+ * @brief       Base64 encoder and decoder
  * @{
  *
- * @brief       encoding and decoding functions for base64
+ * @brief       Encoding and decoding functions for base64
  * @author      Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
  */
 
@@ -34,11 +34,12 @@ extern "C" {
 #define BASE64_ERROR_OVERFLOW           (-5) /**< error value for buffer overflow                */
 
 /**
- * @brief Estimates the amount of bytes needed for decoding @p base64_in_size
- * characters from base64.
+ * @brief   Estimates the amount of bytes needed for decoding @p base64_in_size
+ *          characters from base64.
  *
- * @param[in] base64_in_size Size of the string to be decoded
- * @return Amount of bytes estimated to be used after decoding
+ * @param[in]   base64_in_size      Size of the string to be decoded
+ *
+ * @return  Amount of bytes estimated to be used after decoding
  */
 static inline size_t base64_estimate_decode_size(size_t base64_in_size)
 {
@@ -67,8 +68,8 @@ static inline size_t base64_estimate_encode_size(size_t data_in_size)
  *
  * @param[in]   data_in_size        Amount of bytes to be encoded
  *
- * @retval  true if the given size can be encoded to base64.
- * @retval  false if the given size would overflow
+ * @retval  true    if the given size can be encoded to base64
+ * @retval  false   if the given size would overflow
  */
 static inline bool base64_can_estimate_encode_size(size_t data_in_size)
 {
@@ -77,21 +78,23 @@ static inline bool base64_can_estimate_encode_size(size_t data_in_size)
 
 /**
  * @brief           Encodes a given datum to base64 and save the result to the given destination.
- * @param[in]       data_in           pointer to the datum to encode
- * @param[in]       data_in_size      the size of `data_in`
- * @param[out]      base64_out        pointer to store the encoded base64 string
- * @param[in,out]   base64_out_size   pointer to the variable containing the size of `base64_out.`
-                                      This value is overwritten with the estimated size used for
-                                      the encoded base64 string on BASE64_ERROR_BUFFER_OUT_SIZE.
-                                      This value is overwritten with the actual used size for the
-                                      encoded base64 string on BASE64_SUCCESS.
-
- * @returns BASE64_SUCCESS on success,
-            BASE64_ERROR_BUFFER_OUT_SIZE on insufficient size for encoding to `base64_out`,
-            BASE64_ERROR_BUFFER_OUT if `base64_out` equals NULL
-                                    but the `base64_out_size` is sufficient,
-            BASE64_ERROR_DATA_IN if `data_in` equals NULL.
-            BASE64_ERROR_OVERFLOW if `data_in_size` is too large to be encoded to base64.
+ *
+ * @param[in]       data_in         Pointer to the datum to encode
+ * @param[in]       data_in_size    The size of `data_in`
+ * @param[out]      base64_out      Pointer to store the encoded base64 string (may be tainted
+ *                                  on error)
+ * @param[in,out]   base64_out_size Pointer to the variable containing the size of `base64_out.`
+ *                                  This value is overwritten with the estimated size used for
+ *                                  the encoded base64 string on BASE64_ERROR_BUFFER_OUT_SIZE.
+ *                                  This value is overwritten with the actual used size for the
+ *                                  encoded base64 string on BASE64_SUCCESS.
+ *
+ * @retval  BASE64_SUCCESS                  on success
+ * @retval  BASE64_ERROR_BUFFER_OUT_SIZE    on insufficient size for encoding to `base64_out`
+ * @retval  BASE64_ERROR_BUFFER_OUT         if `base64_out` equals NULL but the `base64_out_size`
+ *                                          is sufficient
+ * @retval  BASE64_ERROR_DATA_IN            if `data_in` equals NULL
+ * @retval  BASE64_ERROR_OVERFLOW           if `data_in_size` is too large to be encoded to base64
  */
 int base64_encode(const void *data_in, size_t data_in_size,
                   void *base64_out, size_t *base64_out_size);
@@ -104,42 +107,45 @@ int base64_encode(const void *data_in, size_t data_in_size,
  *
  * @note            Requires the use of the `base64url` module.
  *
- * @param[in]       data_in           pointer to the datum to encode
- * @param[in]       data_in_size      the size of `data_in`
- * @param[out]      base64_out        pointer to store the encoded base64 string
- * @param[in,out]   base64_out_size   pointer to the variable containing the size of `base64_out.`
-                                      This value is overwritten with the estimated size used for
-                                      the encoded base64 string on BASE64_ERROR_BUFFER_OUT_SIZE.
-                                      This value is overwritten with the actual used size for the
-                                      encoded base64 string on BASE64_SUCCESS.
-
- * @returns BASE64_SUCCESS on success,
-            BASE64_ERROR_BUFFER_OUT_SIZE on insufficient size for encoding to `base64_out`,
-            BASE64_ERROR_BUFFER_OUT if `base64_out` equals NULL
-                                    but the `base64_out_size` is sufficient,
-            BASE64_ERROR_DATA_IN if `data_in` equals NULL.
-            BASE64_ERROR_OVERFLOW if `data_in_size` is too large to be encoded to base64.
+ * @param[in]       data_in         Pointer to the datum to encode
+ * @param[in]       data_in_size    The size of `data_in`
+ * @param[out]      base64_out      Pointer to store the encoded base64 string (may be tainted
+ *                                  on error)
+ * @param[in,out]   base64_out_size Pointer to the variable containing the size of `base64_out.`
+ *                                  This value is overwritten with the estimated size used for
+ *                                  the encoded base64 string on BASE64_ERROR_BUFFER_OUT_SIZE.
+ *                                  This value is overwritten with the actual used size for the
+ *                                  encoded base64 string on BASE64_SUCCESS.
+ *
+ * @retval  BASE64_SUCCESS                  on success
+ * @retval  BASE64_ERROR_BUFFER_OUT_SIZE    on insufficient size for encoding to `base64_out`
+ * @retval  BASE64_ERROR_BUFFER_OUT         if `base64_out` equals NULL but the `base64_out_size`
+ *                                          is sufficient
+ * @retval  BASE64_ERROR_DATA_IN            if `data_in` equals NULL
+ * @retval  BASE64_ERROR_OVERFLOW           if `data_in_size` is too large to be encoded to base64
  */
 int base64url_encode(const void *data_in, size_t data_in_size,
                      void *base64_out, size_t *base64_out_size);
 
 /**
  * @brief           Decodes a given base64 string and save the result to the given destination.
- * @param[out]      base64_in        pointer to store the encoded base64 string
- * @param[in]       base64_in_size   pointer to the variable containing the size of `base64_out.`
- * @param[in]       data_out         pointer to the datum to encode
- * @param[in, out]  data_out_size    the size of `data_out`.
-                                     This value is overwritten with the estimated size used for the
-                                     decoded string on BASE64_ERROR_BUFFER_OUT_SIZE.
-                                     This value is overwritten with the actual used size for the
-                                     decoded string on BASE64_SUCCESS.
-
- * @returns BASE64_SUCCESS on success,
-            BASE64_ERROR_BUFFER_OUT_SIZE on insufficient size for decoding to `data_out`,
-            BASE64_ERROR_BUFFER_OUT if `data_out` equals NULL
-                                    but the size for `data_out_size` is sufficient,
-            BASE64_ERROR_DATA_IN if `base64_in` equals NULL,
-            BASE64_ERROR_DATA_IN_SIZE if `base64_in_size` is between 1 and 4.
+ *
+ * @param[in]       base64_in        Pointer to the datum to decode
+ * @param[in]       base64_in_size   The size of `base64_in`
+ * @param[out]      data_out         Pointer to store the decoded base64 string (may be tainted
+ *                                   on error)
+ * @param[in,out]   data_out_size    The size of `data_out`.
+ *                                   This value is overwritten with the estimated size used for the
+ *                                   decoded string on BASE64_ERROR_BUFFER_OUT_SIZE.
+ *                                   This value is overwritten with the actual used size for the
+ *                                   decoded string on BASE64_SUCCESS.
+ *
+ * @retval  BASE64_SUCCESS                  on success
+ * @retval  BASE64_ERROR_BUFFER_OUT_SIZE    on insufficient size for decoding to `data_out`
+ * @retval  BASE64_ERROR_BUFFER_OUT         if `data_out` equals NULL but the size for
+ *                                          `data_out_size` is sufficient
+ * @retval  BASE64_ERROR_DATA_IN            if `base64_in` equals NULL
+ * @retval  BASE64_ERROR_DATA_IN_SIZE       if `base64_in_size` has remainder 1 (mod 4)
  */
 int base64_decode(const void *base64_in, size_t base64_in_size,
                   void *data_out, size_t *data_out_size);

--- a/sys/include/base64.h
+++ b/sys/include/base64.h
@@ -20,16 +20,18 @@
  */
 
 #include <stddef.h> /* for size_t */
+#include <stdbool.h> /* for bool */
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define BASE64_SUCCESS                (0)  /**< return value for success                       */
-#define BASE64_ERROR_BUFFER_OUT       (-1) /**< error value for invalid output buffer pointer  */
-#define BASE64_ERROR_BUFFER_OUT_SIZE  (-2) /**< error value for invalid output buffer size     */
-#define BASE64_ERROR_DATA_IN          (-3) /**< error value for invalid input buffer           */
-#define BASE64_ERROR_DATA_IN_SIZE     (-4) /**< error value for invalid input buffer size      */
+#define BASE64_SUCCESS                  (0)  /**< return value for success                       */
+#define BASE64_ERROR_BUFFER_OUT         (-1) /**< error value for invalid output buffer pointer  */
+#define BASE64_ERROR_BUFFER_OUT_SIZE    (-2) /**< error value for invalid output buffer size     */
+#define BASE64_ERROR_DATA_IN            (-3) /**< error value for invalid input buffer           */
+#define BASE64_ERROR_DATA_IN_SIZE       (-4) /**< error value for invalid input buffer size      */
+#define BASE64_ERROR_OVERFLOW           (-5) /**< error value for buffer overflow                */
 
 /**
  * @brief Estimates the amount of bytes needed for decoding @p base64_in_size
@@ -44,15 +46,33 @@ static inline size_t base64_estimate_decode_size(size_t base64_in_size)
 }
 
 /**
- * @brief Estimates the length of the resulting string after encoding
- * @p data_in_size bytes into base64.
+ * @brief   Estimates the length of the resulting string after encoding
+ *          @p data_in_size bytes into base64.
  *
- * @param[in] data_in_size Amount of bytes to be encoded
+ * @pre     @p data_in_size must be smaller than ~75% of the SIZE_MAX to
+ *          prevent integer overflow in the calculation of the return value.
+ *
+ * @param[in]   data_in_size        Amount of bytes to be encoded
+ *
  * @return Amount of characters the output string is estimated to have
  */
 static inline size_t base64_estimate_encode_size(size_t data_in_size)
 {
     return (4 * ((data_in_size + 2) / 3));
+}
+
+/**
+ * @brief   Checks if the given size of data can return a valid estimate for
+ *          the size without an integer overflow.
+ *
+ * @param[in]   data_in_size        Amount of bytes to be encoded
+ *
+ * @retval  true if the given size can be encoded to base64.
+ * @retval  false if the given size would overflow
+ */
+static inline bool base64_can_estimate_encode_size(size_t data_in_size)
+{
+    return (data_in_size <= (SIZE_MAX / 4) * 3);
 }
 
 /**
@@ -71,6 +91,7 @@ static inline size_t base64_estimate_encode_size(size_t data_in_size)
             BASE64_ERROR_BUFFER_OUT if `base64_out` equals NULL
                                     but the `base64_out_size` is sufficient,
             BASE64_ERROR_DATA_IN if `data_in` equals NULL.
+            BASE64_ERROR_OVERFLOW if `data_in_size` is too large to be encoded to base64.
  */
 int base64_encode(const void *data_in, size_t data_in_size,
                   void *base64_out, size_t *base64_out_size);
@@ -97,6 +118,7 @@ int base64_encode(const void *data_in, size_t data_in_size,
             BASE64_ERROR_BUFFER_OUT if `base64_out` equals NULL
                                     but the `base64_out_size` is sufficient,
             BASE64_ERROR_DATA_IN if `data_in` equals NULL.
+            BASE64_ERROR_OVERFLOW if `data_in_size` is too large to be encoded to base64.
  */
 int base64url_encode(const void *data_in, size_t data_in_size,
                      void *base64_out, size_t *base64_out_size);

--- a/tests/unittests/tests-base64/tests-base64.c
+++ b/tests/unittests/tests-base64/tests-base64.c
@@ -388,7 +388,30 @@ static void test_base64_10_encode_empty(void)
     TEST_ASSERT_EQUAL_INT(0, base64_out_size);
 }
 
-static void test_base64_10_decode_empty(void)
+static void test_base64_11_encode_empty_null_out(void)
+{
+    unsigned char data_in[] = "";
+
+    size_t base64_out_size = 0;
+
+    int ret = base64_encode(data_in, 0, NULL, &base64_out_size);
+
+    TEST_ASSERT_EQUAL_INT(BASE64_SUCCESS, ret);
+    TEST_ASSERT_EQUAL_INT(0, base64_out_size);
+}
+
+static void test_base64_12_encode_overflow(void)
+{
+    unsigned char data_in[] = "";
+
+    size_t base64_out_size = 0;
+
+    int ret = base64_encode(data_in, SIZE_MAX, NULL, &base64_out_size);
+
+    TEST_ASSERT_EQUAL_INT(BASE64_ERROR_OVERFLOW, ret);
+}
+
+static void test_base64_13_decode_empty(void)
 {
     unsigned char data_in[] = "";
 
@@ -401,7 +424,19 @@ static void test_base64_10_decode_empty(void)
     TEST_ASSERT_EQUAL_INT(0, base64_out_size);
 }
 
-static void test_base64_11_urlsafe_encode_int(void)
+static void test_base64_14_decode_empty_null_out(void)
+{
+    unsigned char data_in[] = "";
+
+    size_t data_out_size = 0;
+
+    int ret = base64_decode(data_in, 0, NULL, &data_out_size);
+
+    TEST_ASSERT_EQUAL_INT(BASE64_SUCCESS, ret);
+    TEST_ASSERT_EQUAL_INT(0, data_out_size);
+}
+
+static void test_base64_15_urlsafe_encode_int(void)
 {
     uint32_t data_in = 4345;
     unsigned char expected_encoding[] = "-RAAAA";
@@ -439,7 +474,7 @@ static void test_base64_11_urlsafe_encode_int(void)
 #endif
 }
 
-static void test_base64_12_urlsafe_decode_int(void)
+static void test_base64_16_urlsafe_decode_int(void)
 {
     static const char encoded_base64[]  = "_____wAA";
     static const uint8_t expected[]     = {0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0};
@@ -472,7 +507,7 @@ static void test_base64_12_urlsafe_decode_int(void)
 #endif
 }
 
-static void test_base64_13_size_estimation(void) {
+static void test_base64_17_size_estimation(void) {
     size_t expected = 0;
     for (size_t i = 0; i < 33; i += 3) {
         TEST_ASSERT_EQUAL_INT(expected, base64_estimate_encode_size(i + 0));
@@ -504,10 +539,13 @@ Test *tests_base64_tests(void)
         new_TestFixture(test_base64_08_encode_16_bytes),
         new_TestFixture(test_base64_09_encode_size_determination),
         new_TestFixture(test_base64_10_encode_empty),
-        new_TestFixture(test_base64_10_decode_empty),
-        new_TestFixture(test_base64_11_urlsafe_encode_int),
-        new_TestFixture(test_base64_12_urlsafe_decode_int),
-        new_TestFixture(test_base64_13_size_estimation),
+        new_TestFixture(test_base64_11_encode_empty_null_out),
+        new_TestFixture(test_base64_12_encode_overflow),
+        new_TestFixture(test_base64_13_decode_empty),
+        new_TestFixture(test_base64_14_decode_empty_null_out),
+        new_TestFixture(test_base64_15_urlsafe_encode_int),
+        new_TestFixture(test_base64_16_urlsafe_decode_int),
+        new_TestFixture(test_base64_17_size_estimation),
     };
 
     EMB_UNIT_TESTCALLER(base64_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description

Similar to #22379, I found some ways to improve sys/base64. Again, most is related to documentation and alignment.

Another finding is `base64_estimate_encode_size`. When `data_in_size` is greater than ~75% of `SIZE_MAX`, the result will overflow and `0` will be returned. This will then bypass the check performed  `if (*base64_out_size < required_size) { .. }`. I decided to solve this by adding another check to see if it would fit (opted for returning an error, but 75% of `SIZE_MAX` is still larger than `ssize_t` to return negative values).

Unit tests have been extended too.

### Testing procedure

Running `make -C tests/unittests tests-base64 term` should confirm unit tests still pass.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
* Claude Fable 5 to find the issues. I checked and fixed them manually.
