### PR TITLE
drivers/periph/timer: document timer_init re-initialization precondition

### DIFF
--- a/drivers/include/periph/doc.txt
+++ b/drivers/include/periph/doc.txt
@@ -64,7 +64,7 @@
  * | `periph_rtc`       | `periph_init`     | None (no concurrency whatsoever)                                              |
  * | `periph_rtt`       | `periph_init`     | None (no concurrency whatsoever)                                              |
  * | `periph_spi`       | `periph_init`     | Full Thread Safety (except for initialization)                                |
- * | `periph_timer`     | user / driver     | Yes, except for concurrent initialization of the same timer                   |
+ * | `periph_timer`     | user / driver     | Yes, except for re-initialization of an active timer                         |
  * | `periph_uart`      | user / driver     | Partial (no concurrent use of the same UART device allowed)                   |
  * | `periph_usbdev`    | user / driver (*) | Full Thread Safety (except for initialization)                                |
  * | `periph_vbat`      | `periph_init`     | None (no concurrency whatsoever)                                              |

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -131,6 +131,10 @@ typedef struct {
  * The timer will be started automatically after initialization with interrupts
  * enabled.
  *
+ * @pre     The timer must not be active when calling `timer_init()`. It must
+ *          either not have been initialized before or it must be stopped with
+ *          @ref timer_stop before calling `timer_init()` again.
+ *
  * @param[in] dev   the timer to initialize
  * @param[in] freq  requested number of ticks per second
  * @param[in] cb    this callback is called in interrupt context, the


### PR DESCRIPTION

### Contribution description

This PR documents the usage model of `timer_init()` for the same timer device.

The discussion in #22384 pointed out that the `periph_timer` API did not clearly
state whether calling `timer_init()` again on an already active timer is
supported.

This PR clarifies that callers must not call `timer_init()` again on the same
timer while it is active. A timer must either not have been initialized before,
or it must be stopped with `timer_stop()` before calling `timer_init()` again.

The change is documentation-only. It does not change any timer implementation.

### Testing procedure

Documentation-only change.

To review:

1. Check the new `@pre` entry in `drivers/include/periph/timer.h`.
2. Check the updated `periph_timer` entry in
   `drivers/include/periph/doc.txt`.
3. Verify that no driver implementation is changed.

### Issues/PRs references

Refs #22384

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- OpenAI Codex for drafting the documentation wording and pull request text, with user review
