### PR TITLE
sys/hashes: minor improvements

### DIFF
--- a/sys/hashes/aes128_cmac.c
+++ b/sys/hashes/aes128_cmac.c
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "crypto/ciphers.h"
+#include "crypto/helper.h"
 #include "hashes/aes128_cmac.h"
 #include "macros/utils.h"
 
@@ -61,6 +62,7 @@ void aes128_cmac_update(aes128_cmac_context_t *ctx,
             _xor128(ctx->M_last, ctx->X);
             cipher_encrypt(&ctx->aes128_ctx, ctx->X, d);
             memcpy(ctx->X, d, AES128_CMAC_BLOCK_SIZE);
+            crypto_secure_wipe(d, sizeof(d));
         }
         c = MIN(AES128_CMAC_BLOCK_SIZE - ctx->M_n, len);
         memcpy(ctx->M_last + ctx->M_n, data, c);
@@ -108,4 +110,10 @@ void aes128_cmac_final(aes128_cmac_context_t *ctx, void *digest)
     _xor128(ctx->M_last, ctx->X);
     cipher_encrypt(&ctx->aes128_ctx, ctx->X, L);
     memcpy(digest, L, AES128_CMAC_BLOCK_SIZE);
+
+    crypto_secure_wipe(K, sizeof(K));
+    crypto_secure_wipe(L, sizeof(L));
+    crypto_secure_wipe(ctx->X, sizeof(ctx->X));
+    crypto_secure_wipe(ctx->M_last, sizeof(ctx->M_last));
+    crypto_secure_wipe(&ctx->aes128_ctx, sizeof(ctx->aes128_ctx));
 }

--- a/sys/hashes/pbkdf2.c
+++ b/sys/hashes/pbkdf2.c
@@ -16,6 +16,7 @@
  * @}
  */
 
+#include <assert.h>
 #include <string.h>
 
 #include "hashes/sha256.h"
@@ -46,6 +47,8 @@ void pbkdf2_sha256(const void *password, size_t password_len,
                    int iterations,
                    uint8_t *output)
 {
+    assert(iterations > 0);
+
     sha256_context_t inner;
     sha256_context_t outer;
     uint8_t tmp_digest[SHA256_DIGEST_LENGTH];

--- a/sys/hashes/sha1.c
+++ b/sys/hashes/sha1.c
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "crypto/helper.h"
 #include "hashes/sha1.h"
 
 #define SHA1_K0  0x5a827999
@@ -197,6 +198,7 @@ void sha1_final_hmac(sha1_context *ctx, void *digest)
 
     /* Complete inner hash */
     sha1_final(ctx, ctx->inner_hash);
+
     /* Calculate outer hash */
     sha1_init(ctx);
     for (i = 0; i < SHA1_BLOCK_LENGTH; i++) {
@@ -206,5 +208,10 @@ void sha1_final_hmac(sha1_context *ctx, void *digest)
         sha1_update_byte(ctx, ctx->inner_hash[i]);
     }
 
+    /* Finalize hash */
     sha1_final(ctx, digest);
+
+    /* Securely wipe sensitive data */
+    crypto_secure_wipe(ctx->key_buffer, sizeof(ctx->key_buffer));
+    crypto_secure_wipe(ctx->inner_hash, sizeof(ctx->inner_hash));
 }

--- a/sys/hashes/sha1.c
+++ b/sys/hashes/sha1.c
@@ -89,7 +89,7 @@ static void sha1_add_uncounted(sha1_context *s, uint8_t data)
 {
     uint8_t *const b = (uint8_t *) s->buffer;
 
-#ifdef __BIG_ENDIAN__
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
     b[s->buffer_offset] = data;
 #else
     b[s->buffer_offset ^ 3] = data;

--- a/sys/hashes/sha256.c
+++ b/sys/hashes/sha256.c
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <assert.h>
 
+#include "crypto/helper.h"
 #include "hashes/sha256.h"
 #include "hashes/sha2xx_common.h"
 
@@ -95,6 +96,10 @@ void hmac_sha256_init(hmac_context_t *ctx, const void *key, size_t key_length)
     sha256_init(&ctx->c_out);
     sha2xx_update(&ctx->c_out, o_key_pad, SHA256_INTERNAL_BLOCK_SIZE);
 
+    /* Securely wipe sensitive data */
+    crypto_secure_wipe(k, sizeof(k));
+    crypto_secure_wipe(i_key_pad, sizeof(i_key_pad));
+    crypto_secure_wipe(o_key_pad, sizeof(o_key_pad));
 }
 
 void hmac_sha256_update(hmac_context_t *ctx, const void *data, size_t len)
@@ -109,6 +114,9 @@ void hmac_sha256_final(hmac_context_t *ctx, void *digest)
     sha256_final(&ctx->c_in, tmp);
     sha2xx_update(&ctx->c_out, tmp, SHA256_DIGEST_LENGTH);
     sha256_final(&ctx->c_out, digest);
+
+    /* Securely wipe sensitive data */
+    crypto_secure_wipe(tmp, sizeof(tmp));
 }
 
 void hmac_sha256(const void *key, size_t key_length,

--- a/sys/hashes/sha2xx_common.c
+++ b/sys/hashes/sha2xx_common.c
@@ -28,13 +28,13 @@
 
 #include "hashes/sha2xx_common.h"
 
-#ifdef __BIG_ENDIAN__
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 /* Copy a vector of big-endian uint32_t into a vector of bytes */
 #define be32enc_vect memcpy
 
 /* Copy a vector of bytes into a vector of big-endian uint32_t */
 #define be32dec_vect memcpy
-#else /* !__BIG_ENDIAN__ */
+#else /* __BYTE_ORDER__ != __ORDER_BIG_ENDIAN__ */
 
 /*
  * Encode a length len/4 vector of (uint32_t) into a length len vector of

--- a/sys/hashes/sha3.c
+++ b/sys/hashes/sha3.c
@@ -42,9 +42,6 @@
     - There is no message queue. The whole message must be ready in a buffer.
     - It is not optimized for performance.
 
-   The implementation is even simpler on a little endian platform. Just define the
-   LITTLE_ENDIAN symbol in that case.
-
    For a more complete set of implementations, please refer to
    the Keccak Code Package at https://github.com/gvanas/KeccakCodePackage
 
@@ -175,11 +172,7 @@ typedef uint8_t UINT8;
 typedef uint64_t UINT64;
 typedef UINT64 tKeccakLane;
 
-#if __BYTE_ORDER__ == __ORDER__LITTLE_ENDIAN__
-#define LITTLE_ENDIAN
-#endif
-
-#ifndef LITTLE_ENDIAN
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 /** Function to load a 64-bit value using the little-endian (LE) convention.
  * On a LE platform, this could be greatly simplified using a cast.
  */
@@ -220,7 +213,7 @@ static void xor64(UINT8 *x, UINT64 u)
         u >>= 8;
     }
 }
-#endif
+#endif /* __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__ */
 
 /*
    ================================================================
@@ -231,15 +224,15 @@ static void xor64(UINT8 *x, UINT64 u)
 #define ROL64(a, offset) ((((UINT64)a) << offset) ^ (((UINT64)a) >> (64 - offset)))
 #define i(x, y) ((x) + 5 * (y))
 
-#ifdef LITTLE_ENDIAN
-    #define readLane(x, y)          (((tKeccakLane *)state)[i(x, y)])
-    #define writeLane(x, y, lane)   (((tKeccakLane *)state)[i(x, y)]) = (lane)
-    #define XORLane(x, y, lane)     (((tKeccakLane *)state)[i(x, y)]) ^= (lane)
-#else
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
     #define readLane(x, y)          load64((UINT8 *)state + sizeof(tKeccakLane) * i(x, y))
     #define writeLane(x, y, lane)   store64((UINT8 *)state + sizeof(tKeccakLane) * i(x, y), lane)
     #define XORLane(x, y, lane)     xor64((UINT8 *)state + sizeof(tKeccakLane) * i(x, y), lane)
-#endif
+#else /* __BYTE_ORDER__ != __ORDER_BIG_ENDIAN__ */
+    #define readLane(x, y)          (((tKeccakLane *)state)[i(x, y)])
+    #define writeLane(x, y, lane)   (((tKeccakLane *)state)[i(x, y)]) = (lane)
+    #define XORLane(x, y, lane)     (((tKeccakLane *)state)[i(x, y)]) ^= (lane)
+#endif /* __BYTE_ORDER__ != __ORDER_BIG_ENDIAN__ */
 
 /**
  * Function that computes the linear feedback shift register (LFSR) used to

--- a/sys/hashes/sha512_common.c
+++ b/sys/hashes/sha512_common.c
@@ -22,13 +22,13 @@
 
 #include "hashes/sha512_common.h"
 
-#ifdef __BIG_ENDIAN__
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 /* Copy a vector of big-endian uint32_t into a vector of bytes */
 #define be64enc_vect memcpy
 
 /* Copy a vector of bytes into a vector of big-endian uint32_t */
 #define be64dec_vect memcpy
-#else /* !__BIG_ENDIAN__ */
+#else /* __BYTE_ORDER__ != __ORDER_BIG_ENDIAN__ */
 
 /*
  * Encode a length ceil(len/8) vector of (uint64_t) into a length len vector of

--- a/sys/include/hashes/aes128_cmac.h
+++ b/sys/include/hashes/aes128_cmac.h
@@ -74,6 +74,8 @@ void aes128_cmac_update(aes128_cmac_context_t *ctx,
 /**
  * @brief Finalizes the CMAC message digest
  *
+ * Internal key material will be wiped after this function is called.
+ *
  * @param[in] ctx     Pointer to the AES128 CMAC context
  * @param[out] digest Result location
  */

--- a/sys/include/hashes/pbkdf2.h
+++ b/sys/include/hashes/pbkdf2.h
@@ -42,7 +42,7 @@ extern "C" {
  * @param[in]   password_len    length of password
  * @param[in]   salt            salt pointer
  * @param[in]   salt_len        salt length, recommended 64bit
- * @param[in]   iterations      number of rounds. Must be >1.
+ * @param[in]   iterations      number of rounds. Must be >0.
  *                              NIST’s detailed guide (Appendix A.2.2),
  *                              recommended 10000
  * @param[out]  output          array of size PBKDF2_KEY_SIZE

--- a/sys/include/hashes/sha1.h
+++ b/sys/include/hashes/sha1.h
@@ -107,6 +107,8 @@ void sha1_init_hmac(sha1_context *ctx, const void *key, size_t key_length);
 /**
  * @brief Finalizes the SHA-1 message digest with MAC
  *
+ * Internal key material will be wiped after this function is called.
+ *
  * @param[in] ctx     Pointer to the SHA-1 context
  * @param[out] digest Result location, must be 20 byte
  */

--- a/sys/include/hashes/sha256.h
+++ b/sys/include/hashes/sha256.h
@@ -150,6 +150,9 @@ void hmac_sha256_update(hmac_context_t *ctx, const void *data, size_t len);
 
 /**
  * @brief hmac_sha256_final HMAC SHA-256 finalization. Finish HMAC calculation and export the value
+ *
+ * Internal key material will be wiped after this function is called.
+ *
  * @param[in] ctx hmac_context_t handle to use
  * @param[out] digest the computed hmac-sha256, length MUST be SHA256_DIGEST_LENGTH
  */

--- a/tests/unittests/tests-hashes/tests-hashes-aes128_cmac.c
+++ b/tests/unittests/tests-hashes/tests-hashes-aes128_cmac.c
@@ -101,11 +101,31 @@ static void test_hashes_cmac_keysize(void)
                           CIPHER_INIT_SUCCESS);
 }
 
+static void test_hashes_cmac_wipe(void)
+{
+    aes128_cmac_context_t ctx;
+    uint8_t digest[AES128_CMAC_BLOCK_SIZE];
+    uint8_t zeros_block[AES128_CMAC_BLOCK_SIZE];
+    uint8_t zeros_cipher[sizeof(ctx.aes128_ctx)];
+
+    memset(zeros_block, 0, sizeof(zeros_block));
+    memset(zeros_cipher, 0, sizeof(zeros_cipher));
+
+    aes128_cmac_init(&ctx, AES128_CMAC_KEY, 16);
+    aes128_cmac_update(&ctx, TEST_1_INP, sizeof(TEST_1_INP));
+    aes128_cmac_final(&ctx, digest);
+
+    TEST_ASSERT(memcmp(ctx.X, zeros_block, sizeof(ctx.X)) == 0);
+    TEST_ASSERT(memcmp(ctx.M_last, zeros_block, sizeof(ctx.M_last)) == 0);
+    TEST_ASSERT(memcmp(&ctx.aes128_ctx, zeros_cipher, sizeof(ctx.aes128_ctx)) == 0);
+}
+
 Test *tests_hashes_cmac_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_hashes_cmac),
         new_TestFixture(test_hashes_cmac_keysize),
+        new_TestFixture(test_hashes_cmac_wipe),
     };
 
     EMB_UNIT_TESTCALLER(test_hashes_cmac, NULL, NULL, fixtures);

--- a/tests/unittests/tests-hashes/tests-hashes-sha1-hmac.c
+++ b/tests/unittests/tests-hashes/tests-hashes-sha1-hmac.c
@@ -111,10 +111,26 @@ static void test_hashes_sha1_hmac(void)
                                            _hmac_key5, sizeof(_hmac_key5)) == 0);
 }
 
+static void test_hashes_sha1_hmac_wipe(void)
+{
+    sha1_context ctx;
+    uint8_t digest[SHA1_DIGEST_LENGTH];
+    static const uint8_t zeros_key[SHA1_BLOCK_LENGTH];
+    static const uint8_t zeros_hash[SHA1_DIGEST_LENGTH];
+
+    sha1_init_hmac(&ctx, _hmac_key1, sizeof(_hmac_key1));
+    sha1_update(&ctx, (unsigned char *)TEST1_HMAC, strlen(TEST1_HMAC));
+    sha1_final_hmac(&ctx, digest);
+
+    TEST_ASSERT(memcmp(ctx.key_buffer, zeros_key, sizeof(ctx.key_buffer)) == 0);
+    TEST_ASSERT(memcmp(ctx.inner_hash, zeros_hash, sizeof(ctx.inner_hash)) == 0);
+}
+
 Test *tests_hashes_sha1_hmac_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_hashes_sha1_hmac),
+        new_TestFixture(test_hashes_sha1_hmac_wipe),
     };
 
     EMB_UNIT_TESTCALLER(test_hashes_sha1_hmac, NULL, NULL, fixtures);

--- a/tests/unittests/tests-hashes/tests-hashes-sha1-hmac.c
+++ b/tests/unittests/tests-hashes/tests-hashes-sha1-hmac.c
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: 2016 Oliver Hahm <oliver.hahm@inria.fr>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     unittests
+ * @{
+ *
+ * @file
+ * @brief       Test cases for the HMAC-SHA-1 implementation
+ *
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ *
+ * @}
+ */
+
+#include <string.h>
+#include <stdio.h>
+
+#include "embUnit/embUnit.h"
+
+#include "hashes/sha1.h"
+
+#include "tests-hashes.h"
+
+#define TEST_CASES_HMAC_NUM      (5)
+
+#define TEST1_HMAC  "Hi There"
+#define TEST2_HMAC  "what do ya want for nothing?"
+#define TEST3_HMAC  "Test With Truncation"
+#define TEST4_HMAC  "Test Using Larger Than Block-Size Key - Hash Key First"
+#define TEST5_HMAC  "Test Using Larger Than Block-Size Key and Larger Than One Block-Size Data"
+
+static const uint8_t _hmac_key1[]={
+    0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+    0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b
+};
+static const uint8_t _hmac_key2[]= "Jefe";
+static const uint8_t _hmac_key3[]={
+    0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c,
+    0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c
+};
+static const uint8_t _hmac_key4[]={
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa
+};
+static const uint8_t _hmac_key5[]={
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa
+};
+
+static const char *_resultarray_hmac[TEST_CASES_HMAC_NUM] =
+{
+    "B6 17 31 86 55 05 72 64 E2 8B C0 B6 FB 37 8C 8E F1 46 BE 00",
+    "EF FC DF 6A E5 EB 2F A2 D2 74 16 D5 F1 84 DF 9C 25 9A 7C 79",
+    "4C 1A 03 42 4B 55 E0 7F E7 F2 7B E1 D5 8B B9 32 4A 9A 5A 04",
+    "AA 4A E5 E1 52 72 D0 0E 95 70 56 37 CE 8A 3B 55 ED 40 21 12",
+    "E8 E9 9D 0F 45 23 7D 78 6D 6B BA A7 96 5C 78 08 BB FF 1A 91 "
+};
+
+static int calc_and_compare_hash_hmac(const char *str, const char *expected,
+                                      const uint8_t *key, size_t key_len)
+{
+    sha1_context ctx;
+
+    uint8_t hash[SHA1_DIGEST_LENGTH];
+    char tmp[(3 * SHA1_DIGEST_LENGTH) + 1];
+
+    /* calculate hash */
+    sha1_init_hmac(&ctx, key, key_len);
+    sha1_update(&ctx, (unsigned char*) str, strlen(str));
+
+    sha1_final_hmac(&ctx, hash);
+    /* copy hash to string */
+    for (size_t i = 0; i < SHA1_DIGEST_LENGTH; i++) {
+        sprintf(&(tmp[i * 3]), "%02X ", (unsigned) hash[i]);
+    }
+    tmp[SHA1_DIGEST_LENGTH* 2] = '\0';
+
+    /* compare with result string */
+    return strncmp(tmp, expected, strlen((char*) tmp));
+}
+
+/* test cases from RFC 2202
+ * https://tools.ietf.org/html/rfc2202
+ */
+static void test_hashes_sha1_hmac(void)
+{
+    TEST_ASSERT(calc_and_compare_hash_hmac(TEST1_HMAC, _resultarray_hmac[0],
+                                           _hmac_key1, sizeof(_hmac_key1)) == 0);
+    TEST_ASSERT(calc_and_compare_hash_hmac(TEST2_HMAC, _resultarray_hmac[1],
+                                           _hmac_key2, sizeof(_hmac_key2)) == 0);
+    TEST_ASSERT(calc_and_compare_hash_hmac(TEST3_HMAC, _resultarray_hmac[2],
+                                           _hmac_key3, sizeof(_hmac_key3)) == 0);
+    TEST_ASSERT(calc_and_compare_hash_hmac(TEST4_HMAC, _resultarray_hmac[3],
+                                           _hmac_key4, sizeof(_hmac_key4)) == 0);
+    TEST_ASSERT(calc_and_compare_hash_hmac(TEST5_HMAC, _resultarray_hmac[4],
+                                           _hmac_key5, sizeof(_hmac_key5)) == 0);
+}
+
+Test *tests_hashes_sha1_hmac_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_hashes_sha1_hmac),
+    };
+
+    EMB_UNIT_TESTCALLER(test_hashes_sha1_hmac, NULL, NULL, fixtures);
+
+    return (Test *)&test_hashes_sha1_hmac;
+}

--- a/tests/unittests/tests-hashes/tests-hashes-sha1.c
+++ b/tests/unittests/tests-hashes/tests-hashes-sha1.c
@@ -22,6 +22,8 @@
 
 #include "hashes/sha1.h"
 
+#include "tests-hashes.h"
+
 #define TEST_CASES_NUM      (4)
 /*
  *  *  Define patterns for testing
@@ -57,53 +59,6 @@ static const char *_resultarray[TEST_CASES_NUM + 2] =
     /* for single runs */
     "86 F7 E4 37 FA A5 A7 FC E1 5D 1D DC B9 EA EA EA 37 76 67 B8",
     "E0 C0 94 E8 67 EF 46 C3 50 EF 54 A7 F5 9D D6 0B ED 92 AE 83"
-};
-
-#define TEST_CASES_HMAC_NUM      (5)
-
-#define TEST1_HMAC  "Hi There"
-#define TEST2_HMAC  "what do ya want for nothing?"
-#define TEST3_HMAC  "Test With Truncation"
-#define TEST4_HMAC  "Test Using Larger Than Block-Size Key - Hash Key First"
-#define TEST5_HMAC  "Test Using Larger Than Block-Size Key and Larger Than One Block-Size Data"
-
-static const uint8_t _hmac_key1[]={
-    0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
-    0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b
-};
-static const uint8_t _hmac_key2[]= "Jefe";
-static const uint8_t _hmac_key3[]={
-    0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c,
-    0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c
-};
-static const uint8_t _hmac_key4[]={
-    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
-    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
-    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
-    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
-    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
-    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
-    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
-    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa
-};
-static const uint8_t _hmac_key5[]={
-    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
-    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
-    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
-    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
-    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
-    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
-    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
-    0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa
-};
-
-static const char *_resultarray_hmac[TEST_CASES_HMAC_NUM] =
-{
-    "B6 17 31 86 55 05 72 64 E2 8B C0 B6 FB 37 8C 8E F1 46 BE 00",
-    "EF FC DF 6A E5 EB 2F A2 D2 74 16 D5 F1 84 DF 9C 25 9A 7C 79",
-    "4C 1A 03 42 4B 55 E0 7F E7 F2 7B E1 D5 8B B9 32 4A 9A 5A 04",
-    "AA 4A E5 E1 52 72 D0 0E 95 70 56 37 CE 8A 3B 55 ED 40 21 12",
-    "E8 E9 9D 0F 45 23 7D 78 6D 6B BA A7 96 5C 78 08 BB FF 1A 91 "
 };
 
 static int calc_and_compare_hash(const char *str, const char *expected,
@@ -144,28 +99,6 @@ static int calc_and_compare_hash2(const char *str, const char *expected)
     return strncmp(tmp, expected, strlen((char*) tmp));
 }
 
-static int calc_and_compare_hash_hmac(const char *str, const char *expected,
-                                      const uint8_t *key, size_t key_len)
-{
-    sha1_context ctx;
-
-    uint8_t hash[SHA1_DIGEST_LENGTH];
-    char tmp[(3 * SHA1_DIGEST_LENGTH) + 1];
-
-    /* calculate hash */
-    sha1_init_hmac(&ctx, key, key_len);
-    sha1_update(&ctx, (unsigned char*) str, strlen(str));
-
-    sha1_final_hmac(&ctx, hash);
-    /* copy hash to string */
-    for (size_t i = 0; i < SHA1_DIGEST_LENGTH; i++) {
-        sprintf(&(tmp[i * 3]), "%02X ", (unsigned) hash[i]);
-    }
-    tmp[SHA1_DIGEST_LENGTH* 2] = '\0';
-
-    /* compare with result string */
-    return strncmp(tmp, expected, strlen((char*) tmp));
-}
 /* test cases copied from section 7.3 of RFC 3174
  * https://tools.ietf.org/html/rfc3174#section-7.3
  */
@@ -179,17 +112,6 @@ static void test_hashes_sha1(void)
     TEST_ASSERT(calc_and_compare_hash2(_testarray[1], _resultarray[1]) == 0);
     TEST_ASSERT(calc_and_compare_hash2(_testarray[2], _resultarray[4]) == 0);
     TEST_ASSERT(calc_and_compare_hash2(_testarray[3], _resultarray[5]) == 0);
-
-    TEST_ASSERT(calc_and_compare_hash_hmac(TEST1_HMAC, _resultarray_hmac[0],
-                                           _hmac_key1, sizeof(_hmac_key1)) == 0);
-    TEST_ASSERT(calc_and_compare_hash_hmac(TEST2_HMAC, _resultarray_hmac[1],
-                                           _hmac_key2, sizeof(_hmac_key2)) == 0);
-    TEST_ASSERT(calc_and_compare_hash_hmac(TEST3_HMAC, _resultarray_hmac[2],
-                                           _hmac_key3, sizeof(_hmac_key3)) == 0);
-    TEST_ASSERT(calc_and_compare_hash_hmac(TEST4_HMAC, _resultarray_hmac[3],
-                                           _hmac_key4, sizeof(_hmac_key4)) == 0);
-    TEST_ASSERT(calc_and_compare_hash_hmac(TEST5_HMAC, _resultarray_hmac[4],
-                                           _hmac_key5, sizeof(_hmac_key5)) == 0);
 }
 
 Test *tests_hashes_sha1_tests(void)

--- a/tests/unittests/tests-hashes/tests-hashes-sha256-hmac.c
+++ b/tests/unittests/tests-hashes/tests-hashes-sha256-hmac.c
@@ -332,6 +332,24 @@ static void test_hashes_hmac_sha256_ite_hash_PRF6_split(void)
                  "9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2", hmac));
 }
 
+static void test_hashes_hmac_sha256_wipe(void)
+{
+    hmac_context_t ctx;
+    unsigned char key[20];
+    static unsigned char hmac[SHA256_DIGEST_LENGTH];
+    static const hmac_context_t zeros;
+
+    memset(key, 0x0b, sizeof(key));
+
+    hmac_sha256_init(&ctx, key, sizeof(key));
+    hmac_sha256_update(&ctx, "Hi There", 8);
+    hmac_sha256_final(&ctx, hmac);
+
+    TEST_ASSERT(compare_str_vs_digest(
+                 "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7", hmac));
+    TEST_ASSERT(memcmp(&ctx, &zeros, sizeof(ctx)) == 0);
+}
+
 Test *tests_hashes_sha256_hmac_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -350,6 +368,7 @@ Test *tests_hashes_sha256_hmac_tests(void)
         new_TestFixture(test_hashes_hmac_sha256_ite_hash_PRF5),
         new_TestFixture(test_hashes_hmac_sha256_ite_hash_PRF6),
         new_TestFixture(test_hashes_hmac_sha256_ite_hash_PRF6_split),
+        new_TestFixture(test_hashes_hmac_sha256_wipe),
     };
 
     EMB_UNIT_TESTCALLER(hashes_sha256_tests, NULL, NULL,

--- a/tests/unittests/tests-hashes/tests-hashes.c
+++ b/tests/unittests/tests-hashes/tests-hashes.c
@@ -22,6 +22,7 @@ void tests_hashes(void)
     TESTS_RUN(tests_hashes_md5_tests());
     TESTS_RUN(tests_hashes_cmac_tests());
     TESTS_RUN(tests_hashes_sha1_tests());
+    TESTS_RUN(tests_hashes_sha1_hmac_tests());
     TESTS_RUN(tests_hashes_sha224_tests());
     TESTS_RUN(tests_hashes_sha256_tests());
     TESTS_RUN(tests_hashes_sha256_hmac_tests());

--- a/tests/unittests/tests-hashes/tests-hashes.h
+++ b/tests/unittests/tests-hashes/tests-hashes.h
@@ -48,6 +48,13 @@ Test *tests_hashes_md5_tests(void);
 Test *tests_hashes_sha1_tests(void);
 
 /**
+ * @brief   Generates tests for hashes/sha1.h - hmac
+ *
+ * @return  embUnit tests if successful, NULL if not.
+ */
+Test *tests_hashes_sha1_hmac_tests(void);
+
+/**
  * @brief   Generates tests for hashes/sha224.h
  *
  * @return  embUnit tests if successful, NULL if not.


### PR DESCRIPTION
### Contribution description

Four minor improvements for sys/hashes. Too small to make separate pull-requests IMHO.

Two improvements fix endianness checks. One additional assertion to guard against incorrect use and one to clear key material after use for {C,H}MAC algorithms. This should make these algorithms a bit more resilient against certain types of attacks and similar practice is also applied to the PBKDF2 algorithm.

I did not focus on the PSA hash implementations.

### Testing procedure

Running `make -C tests/unittests tests-hashes` term should confirm unit tests still pass.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
* Claude Fable 5 to find the issues. I checked and fixed them manually.