### PR TITLE
sys/isrpipe: fix blocking on zero bytes

### DIFF
--- a/sys/include/isrpipe/read_timeout.h
+++ b/sys/include/isrpipe/read_timeout.h
@@ -52,7 +52,8 @@ int isrpipe_read_timeout(isrpipe_t *isrpipe, uint8_t *buf, size_t count, uint32_
  * timeout or when @p count bytes have been received.
  *
  * A timeout only occurs if no data is received within @p timeout microseconds.
- * Each time a byte or burst of bytes is received, the timeout is reset.
+ * Each time a byte or burst of bytes is received, the timeout is reset. This
+ * means the worst-case total wait is @p count times @p timeout microseconds.
  *
  * @note If a timeout occurs, some bytes may have been read out of the pipe and
  * placed into @p buf.

--- a/sys/isrpipe/isrpipe.c
+++ b/sys/isrpipe/isrpipe.c
@@ -50,8 +50,13 @@ int isrpipe_read(isrpipe_t *isrpipe, uint8_t *buffer, size_t count)
 {
     int res;
 
+    if (!count) {
+        return 0;
+    }
+
     while (!(res = tsrb_get(&isrpipe->tsrb, buffer, count))) {
         mutex_lock(&isrpipe->mutex);
     }
+
     return res;
 }

--- a/sys/isrpipe/read_timeout/read_timeout.c
+++ b/sys/isrpipe/read_timeout/read_timeout.c
@@ -37,6 +37,10 @@ static void _cb(void *arg)
 
 int isrpipe_read_timeout(isrpipe_t *isrpipe, uint8_t *buffer, size_t count, uint32_t timeout)
 {
+    if (!count) {
+        return 0;
+    }
+
     int res = tsrb_get(&isrpipe->tsrb, buffer, count);
     if (res > 0) {
         return res;

--- a/tests/unittests/tests-isrpipe/tests-isrpipe-read_timeout.c
+++ b/tests/unittests/tests-isrpipe/tests-isrpipe-read_timeout.c
@@ -45,6 +45,17 @@ static void test_read_timeout(void)
     TEST_ASSERT_EQUAL_INT(1, res);
 }
 
+static void test_read_timeout_zero(void)
+{
+    uint8_t buffer[2] = {0};
+    isrpipe_t pipe;
+
+    isrpipe_init(&pipe, buffer, ARRAY_SIZE(buffer));
+
+    /* reading zero bytes is a no-op and should not time-out */
+    TEST_ASSERT_EQUAL_INT(0, isrpipe_read_timeout(&pipe, NULL, 0, 1));
+}
+
 static void test_read_all_timeout(void)
 {
     uint8_t buffer[2] = {0};
@@ -79,11 +90,24 @@ static void test_read_all_timeout(void)
     TEST_ASSERT_EQUAL_INT(-ETIMEDOUT, res);
 }
 
+static void test_read_all_timeout_zero(void)
+{
+    uint8_t buffer[2] = {0};
+    isrpipe_t pipe;
+
+    isrpipe_init(&pipe, buffer, ARRAY_SIZE(buffer));
+
+    /* reading zero bytes is a no-op and should not time-out */
+    TEST_ASSERT_EQUAL_INT(0, isrpipe_read_all_timeout(&pipe, NULL, 0, 1));
+}
+
 Test *tests_isrpipe_read_timeout_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_read_timeout),
+        new_TestFixture(test_read_timeout_zero),
         new_TestFixture(test_read_all_timeout),
+        new_TestFixture(test_read_all_timeout_zero),
     };
 
     EMB_UNIT_TESTCALLER(isrpipe_tests, NULL, NULL, fixtures);

--- a/tests/unittests/tests-isrpipe/tests-isrpipe.c
+++ b/tests/unittests/tests-isrpipe/tests-isrpipe.c
@@ -140,6 +140,12 @@ static void test_read_then_write(void)
     TEST_ASSERT_EQUAL_INT(1, thread_kill_zombie(reader_pid));
 }
 
+static void test_read_zero(void)
+{
+    /* reading zero bytes is a no-op and should not block */
+    TEST_ASSERT_EQUAL_INT(0, isrpipe_read(&_pipe, NULL, 0));
+}
+
 static void test_overflow(void)
 {
     int res;
@@ -223,6 +229,7 @@ Test *tests_isrpipe_tests(void)
         new_TestFixture(test_init),
         new_TestFixture(test_write_then_read),
         new_TestFixture(test_read_then_write),
+        new_TestFixture(test_read_zero),
         new_TestFixture(test_overflow),
         new_TestFixture(test_underflow),
         new_TestFixture(test_write_one),


### PR DESCRIPTION
### Contribution description

Reading zero bytes has the potential to block forever via `isrpipe_read`. `isrpipe_read_timeout` and `isrpipe_read_all_timeout` will wait for the timeout to expire. 

The loop condition in `isrpipe_read` is `!(res = tsrb_get(...))`. `tsrb_get` returns 0 when it copied zero bytes, but it does not distinguish between the buffer was empty or because `count == 0`.

The documentation does not state that reading zero bytes is not allowed (or will block). I would presume this is an edge case that is undesired :-)

### Testing procedure

Run `make -C tests/unittests tests-isrpipe term` without the unit tests commits only (c46cb9a077a26fcee1ca77a9a60c1335ee8e9e4f). Observe that the test will hang indefinitely.

Then check-out the full branch and run the tests again. This time they should pass.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
* Claude Fable 5 to find the issues. I checked and fixed them manually.
