### PR TITLE
sys/{x,z}timer: minor bug fixes

### DIFF
--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -173,7 +173,7 @@ static inline void xtimer_spin(xtimer_ticks32_t ticks) {
 
 static inline void xtimer_msleep(uint32_t milliseconds)
 {
-    _xtimer_tsleep64(_xtimer_ticks_from_usec64(milliseconds * US_PER_MS));
+    _xtimer_tsleep64(_xtimer_ticks_from_usec64((uint64_t)milliseconds * US_PER_MS));
 }
 
 static inline void xtimer_usleep(uint32_t microseconds)

--- a/sys/ztimer64/util.c
+++ b/sys/ztimer64/util.c
@@ -103,7 +103,7 @@ int ztimer64_msg_receive_until(ztimer64_clock_t *clock, msg_t *msg,
     }
 
     ztimer64_t t;
-    msg_t m = { .type = MSG_ZTIMER, .content.ptr = &m };
+    msg_t m = { .type = MSG_ZTIMER64, .content.ptr = &m };
 
     ztimer64_set_msg_at(clock, &t, target, &m, thread_getpid());
 


### PR DESCRIPTION
### Contribution description

This PR address two finding in the timer subsystem.

### Testing procedure

I did not test them specifically, other than checking if `examples/basic/default` and `tests/sys/ztimer64_msg` compiled and ran.

The wrong `msg_t` is a copy-paste failure of the regular ztimer module.

The overflow issue can be easily demonstrated: 

```
uint32_t milliseconds = 4294968; /* just over UINT32_MAX / US_PER_MS */
uint64_t before = milliseconds * US_PER_MS; /* overflows uint32_t */
uint64_t after  = (uint64_t)milliseconds * 1000;
```

will print (with `fmt.h`):

```
4294968
704             <-- Wrong (would sleep too short)
4294968000      <-- Correct
```

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
* Claude Fable 5 to find the issues. I checked and fixed them manually.
