### PR TITLE
tests/unittests: fix failure on read-only system

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -93,3 +93,10 @@ endif
 ifeq (,$(filter gnrc_sock,$(USEMODULE)))
   CFLAGS +=-I$(RIOTBASE)/sys/net/gnrc/sock/include
 endif
+
+# Don't require write access to the current folder just for the MTD test on
+# native
+ifneq (,$(filter native%,$(BOARD)))
+  MTD_NATIVE_FILENAME ?= $(BINDIR)/MEMORY.bin
+  CFLAGS += -DMTD_NATIVE_FILENAME=\"$(MTD_NATIVE_FILENAME)\"
+endif


### PR DESCRIPTION
### Contribution description

When running the unit tests e.g. in a container with the source repo mounted as read-only, the failure to create `MEMORY.bin` in the unittests folder results in the unit tests to fail.

This injects the `CFLAGS` needed to create the file in the `$(BINDIR)`, which must be read-writeable for the compilation to work. Since the unit tests wipe the MTD device anyway, there is little reason to keep the `MEMORY.bin` around anyway.

### Testing procedure

The CI should still pass.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
