### PR TITLE
tests/periph/uart: use busy wait if no timer is available

### DIFF
--- a/tests/periph/uart/Makefile
+++ b/tests/periph/uart/Makefile
@@ -5,10 +5,10 @@ FEATURES_OPTIONAL += periph_lpuart  # STM32 L0 and L4 provides lpuart support
 FEATURES_OPTIONAL += periph_uart_collision
 FEATURES_OPTIONAL += periph_uart_modecfg
 FEATURES_OPTIONAL += periph_uart_rxstart_irq
+FEATURES_OPTIONAL += periph_timer   # Use the timer if available
 
 USEMODULE += bitfield
 USEMODULE += shell
-USEMODULE += ztimer_msec
 
 # avoid running Kconfig by default
 SHOULD_RUN_KCONFIG ?=

--- a/tests/periph/uart/Makefile.board.dep
+++ b/tests/periph/uart/Makefile.board.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter periph_timer,$(FEATURES_USED)))
+  USEMODULE += ztimer_msec
+endif

--- a/tests/periph/uart/main.c
+++ b/tests/periph/uart/main.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include "clk.h"
 #include "bitfield.h"
 #include "msg.h"
 #include "periph/uart.h"
@@ -28,14 +29,14 @@
 #include "ztimer.h"
 
 #ifdef MODULE_STDIO_UART
-#include "stdio_uart.h"
+#  include "stdio_uart.h"
 #endif
 
 #ifndef SHELL_BUFSIZE
-#define SHELL_BUFSIZE       (128U)
+#  define SHELL_BUFSIZE     (128U)
 #endif
 #ifndef UART_BUFSIZE
-#define UART_BUFSIZE        (128U)
+#  define UART_BUFSIZE      (128U)
 #endif
 
 #define PRINTER_PRIO        (THREAD_PRIORITY_MAIN - 1)
@@ -45,15 +46,15 @@
 
 /* if stdio is not done via UART, allow to use the stdio UART for the test */
 #ifndef MODULE_STDIO_UART
-#undef STDIO_UART_DEV
+#  undef STDIO_UART_DEV
 #endif
 
 #ifndef STDIO_UART_DEV
-#define STDIO_UART_DEV      (UART_UNDEF)
+#  define STDIO_UART_DEV    (UART_UNDEF)
 #endif
 
 #ifndef STX
-#define STX 0x2
+#  define STX               (0x2)
 #endif
 
 static char *_endline = "\n";
@@ -61,6 +62,29 @@ static char *_endline = "\n";
 static void _write_newline(uart_t dev)
 {
     uart_write(dev, (uint8_t *)_endline, strlen(_endline));
+}
+
+static void _delay_ms(uint32_t msec)
+{
+    if (IS_USED(MODULE_ZTIMER)) {
+        ztimer_sleep(ZTIMER_MSEC, msec);
+    }
+    else {
+        /*
+         * As fallback for freshly ported boards with no timer drivers written
+         * yet, we just use the CPU to delay execution and assume that roughly
+         * 20 CPU cycles are spend per loop iteration.
+         *
+         * Note that the volatile qualifier disables compiler optimizations for
+         * all accesses to the counter variable. Without volatile, modern
+         * compilers would detect that the loop is only wasting CPU cycles and
+         * optimize it out - but here the wasting of CPU cycles is desired.
+         */
+        uint32_t loops = (coreclk() / 20) / 1000;
+        for (volatile uint32_t j = 0; j < msec; j++) {
+            for (volatile uint32_t i = 0; i < loops; i++) { }
+        }
+    }
 }
 
 typedef struct {
@@ -136,7 +160,7 @@ static int _self_test(uart_t dev, unsigned baud)
 
     uart_write(dev, (uint8_t*)test_string, sizeof(test_string));
     /* wait 1ms for rx callback to be triggered by HW */
-    ztimer_sleep(ZTIMER_MSEC, 1);
+    _delay_ms(1);
     for (unsigned i = 0; i < sizeof(test_string); ++i) {
         int c = ringbuffer_get_one(&ctx[dev].rx_buf);
         if (c == -1) {
@@ -230,7 +254,7 @@ static void sleep_test(int num, uart_t uart)
 {
     printf("UARD_DEV(%i): test uart_poweron() and uart_poweroff()  ->  ", num);
     uart_poweroff(uart);
-    ztimer_sleep(ZTIMER_MSEC, POWEROFF_DELAY_MS);
+    _delay_ms(POWEROFF_DELAY_MS);
     uart_poweron(uart);
     puts("[OK]");
 }
@@ -327,24 +351,24 @@ static int cmd_mode(int argc, char **argv)
 
     argv[3][0] &= ~0x20;
     switch (argv[3][0]) {
-        case 'N':
-            parity = UART_PARITY_NONE;
-            break;
-        case 'E':
-            parity = UART_PARITY_EVEN;
-            break;
-        case 'O':
-            parity = UART_PARITY_ODD;
-            break;
-        case 'M':
-            parity = UART_PARITY_MARK;
-            break;
-        case 'S':
-            parity = UART_PARITY_SPACE;
-            break;
-        default:
-            printf("Error: Invalid parity (%c).\n", argv[3][0]);
-            return 1;
+    case 'N':
+        parity = UART_PARITY_NONE;
+        break;
+    case 'E':
+        parity = UART_PARITY_EVEN;
+        break;
+    case 'O':
+        parity = UART_PARITY_ODD;
+        break;
+    case 'M':
+        parity = UART_PARITY_MARK;
+        break;
+    case 'S':
+        parity = UART_PARITY_SPACE;
+        break;
+    default:
+        printf("Error: Invalid parity (%c).\n", argv[3][0]);
+        return 1;
     }
 
     stop_bits_arg = atoi(argv[4]) - 1;
@@ -468,7 +492,7 @@ int main(void)
          "data will be outputted via STDIO. So the easiest way to test an \n"
          "UART interface, is to simply connect the RX with the TX pin. Then \n"
          "you can send data on that interface and you should see the data \n"
-         "being printed to STDOUT\n\n"
+         "being printed to STDOUT.\n\n"
          "NOTE: all strings need to be '\\n' terminated!\n");
 
     /* do sleep test for UART used as STDIO. There is a possibility that the


### PR DESCRIPTION
### Contribution description

Freshly ported boards often don't have a timer yet, so similar to `examples/basic/blinky`, we use busy waiting to waste some CPU cycles. That's not accurate, but good enough to pass the test.

Also the usual code style beautifications because I can't help myself 🤷 

### Testing procedure

In the current master, the `tests/periph/uart` won't compile for boards that don't have a timer:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ BOARD=nucleo-g031k8 make -C tests/periph/uart
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/periph/uart'
There are unsatisfied feature requirements: periph_timer
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/periph/uart/../../../Makefile.include:1041: *** You can let the build continue on expected errors by setting CONTINUE_ON_EXPECTED_ERRORS=1 to the command line.  Stop.
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/periph/uart'
```

With this PR, it will compile *and* work. You can see that no `ztimer` is added in the compilation:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ BOARD=nucleo-g031k8 make -C tests/periph/uart flash term -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/periph/uart'
Building application "tests_uart" for "nucleo-g031k8" with CPU "stm32".

"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/pkg/cmsis/
...
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/stdio
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/stdio_uart
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/tsrb
   text    data     bss     dec     hex filename
  16916     136    4192   21244    52fc /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/periph/uart/bin/nucleo-g031k8/tests_uart.elf
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/openocd/openocd.sh flash /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/periph/uart/bin/nucleo-g031k8/tests_uart.elf
### Flashing Target ###
Open On-Chip Debugger 0.12.0+dev-00645-g49ef1d010 (2026-05-28-14:54)
...
Done flashing
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" -ln "/tmp/pyterm-cbuec" -rn "2026-06-19_16.11.33-tests_uart-nucleo-g031k8"
2026-06-19 16:11:33,816 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2026-06-19 16:11:34,823 # [OK]
2026-06-19 16:11:34,824 #
2026-06-19 16:11:34,824 # UART INFO:
2026-06-19 16:11:34,824 # Available devices:               2
2026-06-19 16:11:34,825 # UART used for STDIO (the shell): UART_DEV(0)
2026-06-19 16:11:34,825 #
> test 1
2026-06-19 16:11:36,881 # test 1
2026-06-19 16:11:36,881 # [START]
2026-06-19 16:11:36,932 # [SUCCESS]
> init 1 115200
2026-06-19 16:11:40,785 # init 1 115200
2026-06-19 16:11:40,790 # Success: Initialized UART_DEV(1) at BAUD 115200
2026-06-19 16:11:40,945 # UARD_DEV(1): test uart_poweron() and uart_poweroff()  ->  [OK]
> test 1
2026-06-19 16:11:42,481 # test 1
2026-06-19 16:11:42,482 # [START]
2026-06-19 16:11:42,532 # [SUCCESS]
>
```

Of course it also still works with boards that *do* have timer support, those will select `ztimer`. The nRF52840dk was chosen arbitrarily because it was the first one I grabbed:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ BOARD=nrf52840dk make -C tests/periph/uart flash term -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/periph/uart'
Building application "tests_uart" for "nrf52840dk" with CPU "nrf52".

"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/pkg/cmsis/
...
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/stdio
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/stdio_uart
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/tsrb
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/ztimer
   text    data     bss     dec     hex filename
  19456     132    4392   23980    5dac /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/periph/uart/bin/nrf52840dk/tests_uart.elf
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/jlink/jlink.sh flash /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/periph/uart/bin/nrf52840dk/tests_uart.elf
### Flashing Target ###
### Flashing elf file ###
SEGGER J-Link Commander V9.30 (Compiled Mar 25 2026 16:46:25)
...
J-Link>exit

Script processing completed.

/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" -ln "/tmp/pyterm-cbuec" -rn "2026-06-19_16.12.51-tests_uart-nrf52840dk"
2026-06-19 16:12:51,988 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2026-06-19 16:12:52,994 # main(): This is RIOT! (Version: 2026.07-devel-315-g197f4d-nucleo-g031k8)
2026-06-19 16:12:52,994 #
2026-06-19 16:12:52,995 # Manual UART driver test application
2026-06-19 16:12:52,995 # ===================================
2026-06-19 16:12:52,995 # This application is intended for testing additional UART
2026-06-19 16:12:52,996 # interfaces, that might be defined for a board. The 'primary' UART
2026-06-19 16:12:52,996 # interface is tested implicitly, as it is running the shell...
2026-06-19 16:12:52,996 #
2026-06-19 16:12:52,996 # When receiving data on one of the additional UART interfaces, this
2026-06-19 16:12:52,997 # data will be outputted via STDIO. So the easiest way to test an
2026-06-19 16:12:52,997 # UART interface, is to simply connect the RX with the TX pin. Then
2026-06-19 16:12:52,997 # you can send data on that interface and you should see the data
2026-06-19 16:12:52,997 # being printed to STDOUT.
2026-06-19 16:12:52,997 #
2026-06-19 16:12:52,998 # NOTE: all strings need to be '\n' terminated!
2026-06-19 16:12:52,998 #
2026-06-19 16:12:52,998 # UARD_DEV(0): test uart_poweron() and uart_poweroff()  -> [OK]
2026-06-19 16:12:52,998 #
2026-06-19 16:12:52,998 # UART INFO:
2026-06-19 16:12:52,999 # Available devices:               2
2026-06-19 16:12:52,999 # UART used for STDIO (the shell): UART_DEV(0)
2026-06-19 16:12:52,999 #
> test 1
2026-06-19 16:13:11,048 # test 1
2026-06-19 16:13:11,049 # [START]
2026-06-19 16:13:11,081 # warning: unsupported baudrate 48000
2026-06-19 16:13:11,088 # warning: unsupported baudrate 67200
2026-06-19 16:13:11,094 # warning: unsupported baudrate 86400
2026-06-19 16:13:11,097 # warning: unsupported baudrate 96000
2026-06-19 16:13:11,100 # warning: unsupported baudrate 105600
2026-06-19 16:13:11,103 # [SUCCESS]
>

```


### Issues/PRs references

Discovered in #22354. 

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
