### PR TITLE
build-system: use better default for cache dirs

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -52,12 +52,13 @@ RIOTPKG                         ?= $(RIOTBASE)/pkg
 EXTERNAL_PKG_DIRS               ?=
 RIOTTOOLS                       ?= $(RIOTBASE)/dist/tools
 RIOTPROJECT                     ?= $(shell git rev-parse --show-toplevel 2>/dev/null || pwd)
-BUILD_DIR                       ?= $(RIOTBASE)/build
+XDG_CACHE_HOME                  ?= $(HOME)/.cache
+BUILD_DIR                       ?= $(XDG_CACHE_HOME)/RIOT
 APPDIR                          ?= $(CURDIR)
 BINDIRBASE                      ?= $(APPDIR)/bin
 PKGDIRBASE                      ?= $(BUILD_DIR)/pkg
 DLCACHE                         ?= $(RIOTTOOLS)/dlcache/dlcache.sh
-DLCACHE_DIR                     ?= $(RIOTBASE)/.dlcache
+DLCACHE_DIR                     ?= $(BUILD_DIR)/.dlcache
 RIOT_VERSION_DUMMY_CODE         ?= RIOT_VERSION_NUM\(2042,5,23,0\)
 
 # Resolve potential BOARD alias to canonical name before defining BINDIR

--- a/dist/tools/dlcache/dlcache.sh
+++ b/dist/tools/dlcache/dlcache.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env sh
+set -eu
 
 # local is not POSIX standard, but all practical shells (even busybox) have it
 # shellcheck disable=SC3043
 
-DLCACHE_DIR=${DLCACHE_DIR:-~/.dlcache}
+XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+DLCACHE_DIR="${DLCACHE_DIR:-${XDG_CACHE_HOME}/RIOT/dlcache}""
 
 mkdir -p "$DLCACHE_DIR"
 


### PR DESCRIPTION
### Contribution description

Following https://specifications.freedesktop.org/basedir/latest/
the correct folder to use for caches `$XDG_CACHE_HOME` which should
default to `$HOME/.cache` if not defined. Both `$(BUILD_DIR)` and
`$(DL_CACHE_DIR)` should therefore use that as default.

This makes common workflows such as git worktree much more efficient,
as instead of having duplicated data to download to
`~/repos/RIOT/master/.dlcache` and `~/repos/RIOT/feat/.dlcache`, we now
only need to download into `~/.cache/RIOT/dlcache`.

### Testing procedure

With `master` and RIOT mounted read-only into `/data/ext/RIOT`, not setting `DLCACHE_DIR` by hand, and having `BUILD_DIR` mounted read-write into the container:

```
/data/ext/RIOT/dist/tools/dlcache/dlcache.sh: line 34: can't create /data/ext/RIOT/.dlcache/c25519-2017-10-05.zip.locked: Read-only file system
read EC key
make[1]: *** [Makefile:29: /build/pkg/c25519-2017-10-05.zip] Error 2
writing EC key
/data/ext/RIOT/dist/tools/dlcache/dlcache.sh: line 34: can't create /data/ext/RIOT/.dlcache/c25519-2017-10-05.zip.locked: Read-only file system
```

Same situation with this PR:

```
/data/ext/RIOT/dist/tools/dlcache/dlcache.sh: downloading "https://www.dlbeer.co.nz/downloads/c25519-2017-10-05.zip"...
Connecting to www.dlbeer.co.nz (120.138.18.251:443)
saving to '/build/dlcache/c25519-2017-10-05.zip'
c25519-2017-10-05.zi  47% |***************                 | 32457  0:00:01 ETA
c25519-2017-10-05.zi 100% |********************************| 68419  0:00:00 ETA
'/build/dlcache/c25519-2017-10-05.zip' saved
/data/ext/RIOT/dist/tools/dlcache/dlcache.sh: done downloading "https://www.dlbeer.co.nz/downloads/c25519-2017-10-05.zip"
```

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
