### PR TITLE
boards/seeedstudio-xiao-esp32c6: add initial support

### DIFF
--- a/boards/seeedstudio-xiao-esp32c6/Makefile
+++ b/boards/seeedstudio-xiao-esp32c6/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/seeedstudio-xiao-esp32c6/Makefile.dep
+++ b/boards/seeedstudio-xiao-esp32c6/Makefile.dep
@@ -1,0 +1,5 @@
+ifeq (,$(filter stdio_%,$(USEMODULE)))
+  USEMODULE += stdio_usb_serial_jtag
+endif
+
+USEMODULE += boards_common_esp32c6

--- a/boards/seeedstudio-xiao-esp32c6/Makefile.features
+++ b/boards/seeedstudio-xiao-esp32c6/Makefile.features
@@ -1,0 +1,21 @@
+CPU = esp32
+CPU_MODEL = esp32c6_fh4
+
+# common board and CPU features
+include $(RIOTBOARD)/common/esp32c6/Makefile.features
+
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += arduino_analog
+FEATURES_PROVIDED += arduino_i2c
+FEATURES_PROVIDED += arduino_pins
+FEATURES_PROVIDED += arduino_spi
+FEATURES_PROVIDED += arduino_uart
+
+FEATURES_PROVIDED += highlevel_stdio
+FEATURES_PROVIDED += xiao_shield

--- a/boards/seeedstudio-xiao-esp32c6/Makefile.include
+++ b/boards/seeedstudio-xiao-esp32c6/Makefile.include
@@ -1,0 +1,1 @@
+PORT ?= /dev/ttyACM0

--- a/boards/seeedstudio-xiao-esp32c6/board.c
+++ b/boards/seeedstudio-xiao-esp32c6/board.c
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Stepan Konoplev
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* enable the RF switch (active low) */
+    gpio_init(RF_SWITCH_EN_GPIO, GPIO_OUT);
+    gpio_clear(RF_SWITCH_EN_GPIO);
+
+    /* select antenna */
+    gpio_init(RF_SWITCH_ANT_GPIO, GPIO_OUT);
+    if (IS_ACTIVE(CONFIG_XIAO_ESP32C6_EXT_ANTENNA)) {
+        gpio_set(RF_SWITCH_ANT_GPIO);
+    }
+    else {
+        gpio_clear(RF_SWITCH_ANT_GPIO);
+    }
+}

--- a/boards/seeedstudio-xiao-esp32c6/doc.md
+++ b/boards/seeedstudio-xiao-esp32c6/doc.md
@@ -1,0 +1,171 @@
+<!--
+SPDX-FileCopyrightText: 2025 Gunar Schorcht
+SPDX-FileCopyrightText: 2025 David Picard
+SPDX-FileCopyrightText: 2026 Stepan Konoplev
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+
+@defgroup    boards_seeedstudio-xiao-esp32c6 Seeed Studio Xiao ESP32C6
+@ingroup     boards_esp32c6
+@brief       Support for the Seeed Studio Xiao ESP32-C6 board
+@author      Stepan Konoplev <stepan.konoplev@haw-hamburg.de>
+
+\section seeedstudio-xiao-esp32c6 Seeed Studio Xiao ESP32C6
+
+## Overview
+
+Seeed Studio Xiao ESP32C6 is a small board based on the
+Espressif ESP32-C6 SoC, featuring two 32-bit RISC-V processors: a
+high-performance core running at up to 160 MHz and a low-power core
+clocked up to 20 MHz.
+
+- Wi-Fi 6 2.4 GHz
+- Bluetooth 5 (LE)
+- IEEE 802.15.4 (Zigbee, Thread)
+- Memory: 512KB of SRAM, and 4MB of Flash
+- Size: 21 x 17.8mm
+- Battery charging chip: Supports lithium battery charge and discharge management
+- Ultra-Low Power: Deep sleep power consumption is about 15μA
+- Battery charge indicator red LED
+- RF switch for built-in or external antenna
+- Working temperature: -40°C ~ 85°C
+
+<img src="https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32C6/img/xiaoc6.jpg" alt="Seeed Studio ESP32-C6 Xiao" width=200px />
+
+## Hardware
+
+### MCU
+
+Most features of the board are provided by the ESP32-C6 SoC. For detailed
+information about the ESP32-C6 variant (family) and ESP32x SoCs,
+see section \ref esp32_mcu_esp32 "ESP32 SoC Series".
+
+### Board Configuration
+
+The Seeed Studio ESP32-C6 Xiao board has a reset button and a bootloader
+button, as well as a user LED on GPIO15.
+After reset, the bootloader button may be used by the application.
+
+GPIO overview:
+
+- 1 x UART
+- 1 x LP_UART (not supported)
+- 1 x I2C
+- 1 x LP_I2C (not supported)
+- 1 x SPI
+- 11 x GPIO (only 3 PWM channels are defined by default)
+- 7 x ADC (3 usable)
+- 1 x SDIO (not supported)
+
+The purpose for which a GPIO is used depends on which module
+or function is used first. For example, if the `periph_spi` module is not used,
+the GPIOs listed in SPI configuration can be used for other purposes.
+
+The following table shows the default board configuration.
+This configuration can be overridden by \ref esp32_application_specific_configurations
+"application-specific configurations".
+
+Function        | Pin                 | Configuration
+:---------------|:--------------------|:-------------
+BUTTON0(Boot)   | GPIO9               | GPIO9 is a [strapping pin](https://docs.espressif.com/projects/esptool/en/latest/esp32c6/advanced-topics/boot-mode-selection.html)
+LED0            | GPIO15              | User LED (low active)
+ADC/LP_GPIO     | GPIO0, GPIO1, GPIO2 | \ref esp32_adc_channels "ADC Channels"
+PWM_DEV(0)      | GPIO0, GPIO1, GPIO2 | \ref esp32_pwm_channels "PWM Channels"
+I2C_DEV(0):SDA  | GPIO22              | \ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(0):SCL  | GPIO23              | \ref esp32_i2c_interfaces "I2C Interfaces"
+SPI_DEV(0):SCK  | GPIO19              | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MISO | GPIO20              | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MOSI | GPIO18              | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):CS0  | GPIO21              | \ref esp32_spi_interfaces "SPI Interfaces"
+UART_DEV(0):TxD | GPIO16              | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(0):RxD | GPIO17              | \ref esp32_uart_interfaces "UART interfaces"
+
+For detailed information about the peripheral configurations of ESP32-C6
+boards, see section \ref esp32_peripherals "Common Peripherals".
+
+### RF Antenna Switch
+
+The board has an RF switch to toggle between the built-in
+ceramic antenna and an external U.FL antenna. It is controlled by two GPIOs:
+
+- GPIO3 (RF switch enable, active low) powers the switch.
+- GPIO14 selects the antenna: low for the built-in ceramic antenna (default),
+  high for the external U.FL antenna.
+
+The built-in ceramic antenna is used by default, so no configuration is
+required for the common case. The `board_init` function configures the RF
+switch accordingly at startup.
+
+To use the external U.FL antenna instead, enable the
+`CONFIG_XIAO_ESP32C6_EXT_ANTENNA` option, for example by adding
+the following line to the application's Makefile:
+```Makefile
+CFLAGS += -DCONFIG_XIAO_ESP32C6_EXT_ANTENNA=1
+```
+
+@note The external antenna path has not been tested due to a missing external antenna.
+
+### Battery Usage
+
+The XIAO ESP32C6 series features a built-in power management chip, allowing
+it to be powered independently by a battery or to charge the battery through
+its USB port.
+
+For connecting a battery to your XIAO, it's recommend using a qualified
+rechargeable 3.7V lithium battery. When soldering the battery, carefully
+distinguish between the positive and negative terminals. The negative
+electrode pad should be located on the left side near the silk screen
+marking "D8", while the positive electrode pad should be located on the
+right side near the silk screen marking "D5".
+
+@note When the board is powered from the battery, no voltage is present on
+      the 5V pin.
+
+@note The XIAO ESP32C6 has a red indicator light for battery charging,
+similar to the XIAO ESP32S3:
+The red light behavior for the XIAO ESP32C6 is as follows:
+- When no battery is connected:
+  - The red light turns on when the Type-C cable is connected and turns off after 30 seconds.
+- When a battery is connected and the Type-C cable is plugged in for charging:
+  - The red light flashes.
+- When the battery is fully charged via the Type-C connection:
+  - The red light turns off.
+
+To monitor the battery voltage on the XIAO ESP32C6, similar to the XIAO ESP32C3,
+you'll need to solder a 200k resistor in a 1:2 configuration.
+This setup reduces the voltage by half, allowing safe monitoring through the A0 analog port.
+
+Sample Code can be found in [The Seeed Wiki](https://wiki.seeedstudio.com/xiao_esp32c6_getting_started/#sample-code).
+
+### Deep Sleep and Wake-up
+
+On the XIAO ESP32C6, only GPIO0, GPIO1 and GPIO2 of these RTC-capable pins are broken out
+and can therefore be used as wake-up sources.
+
+### Board Pinout
+
+The following figure shows the pinout as configured by default board
+definition.
+
+<img src="https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32C6/img/XIAO_ESP32-C6_front_pinout.png" alt="Seeed Studio ESP32-C6 Xiao Pinout Front" width=800 />
+<img src="https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32C6/img/XIAO_ESP32-C6_back_pinout.png" alt="Seeed Studio ESP32-C6 Xiao Pinout Back" width=800 />
+
+### Board documentation
+
+- [Schematic](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32C6/XIAO_ESP32_C6_v1.0_SCH_260114.pdf) (PDF)
+- [Pinout](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32C6/res/XIAO_ESP32C6_Pinout.xlsx) (XLSX)
+- [ESP32-C6 Datasheet](https://files.seeedstudio.com/wiki/SeeedStudio-XIAO-ESP32C6/res/esp32-c6_datasheet_en.pdf) (PDF)
+- [ESP32-C6 Technical Reference Manual](https://www.espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf) (PDF)
+- [Product Page](https://www.seeedstudio.com/Seeed-Studio-XIAO-ESP32C6-p-5884.html)
+- [Wiki Page](https://wiki.seeedstudio.com/xiao_esp32c6_getting_started/)
+
+## Flashing the Device
+
+The USB-C connector of the board is directly connected to the USB Serial/JTAG
+interface of the ESP32-C6 SoC. It can be used to program the board and to debug
+the application. Just connect the board to your host computer and use the
+following command:
+
+```shell
+make BOARD=seeedstudio-xiao-esp32c6 flash
+```

--- a/boards/seeedstudio-xiao-esp32c6/include/arduino_iomap.h
+++ b/boards/seeedstudio-xiao-esp32c6/include/arduino_iomap.h
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_seeedstudio-xiao-esp32c6
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * @author      Mikolai Gütschow <mikolai.guetschow@tu-dresden.de>
+ * @author      Stepan Konoplev <stepan.konoplev@haw-hamburg.de>
+ */
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * @name    XIAO's UART buses
+ * @{
+ */
+#define ARDUINO_UART_D0D1   UART_DEV(0) /**< Standard UART bus for general purpose use */
+/** @} */
+
+/**
+ * @name    XIAO's SPI buses
+ * @{
+ */
+#define ARDUINO_SPI_DEV     SPI_DEV(0)  /**< Standard SPI bus for general purpose use */
+/** @} */
+
+/**
+ * @name    XIAO's I2C buses
+ * @{
+ */
+#define ARDUINO_I2C_DEV     I2C_DEV(0)  /**< Standard I2C bus for general purpose use */
+/** @} */
+
+/**
+ * @name    XIAO's USER LED (LED_BUILTIN)
+ * @{
+ */
+#define ARDUINO_LED     (15)            /**< Use the USER LED */
+/** @} */
+
+/**
+ * @name   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+/* Left pins */
+#define ARDUINO_PIN_0       GPIO0   /**< Pin Definition for D0 */
+#define ARDUINO_PIN_1       GPIO1   /**< Pin Definition for D1 */
+#define ARDUINO_PIN_2       GPIO2   /**< Pin Definition for D2 */
+#define ARDUINO_PIN_3       GPIO21  /**< Pin Definition for D3 */
+#define ARDUINO_PIN_4       GPIO22  /**< Pin Definition for D4 */
+#define ARDUINO_PIN_5       GPIO23  /**< Pin Definition for D5 */
+#define ARDUINO_PIN_6       GPIO16  /**< Pin Definition for D6 */
+
+/* Right side */
+#define ARDUINO_PIN_7       GPIO17  /**< Pin Definition for D7 */
+#define ARDUINO_PIN_8       GPIO19  /**< Pin Definition for D8 */
+#define ARDUINO_PIN_9       GPIO20  /**< Pin Definition for D9 */
+#define ARDUINO_PIN_10      GPIO18  /**< Pin Definition for D10 */
+
+#define ARDUINO_PIN_LAST    10      /**< Last Arduino pin index. */
+/** @} */
+
+/**
+ * @name    Aliases for analog pins
+ * @{
+ */
+#define ARDUINO_PIN_A0      ARDUINO_PIN_0   /**< Arduino pin A0 */
+#define ARDUINO_PIN_A1      ARDUINO_PIN_1   /**< Arduino pin A1 */
+#define ARDUINO_PIN_A2      ARDUINO_PIN_2   /**< Arduino pin A2 */
+/** @} */
+
+/**
+ * @name    Aliases for analog pins
+ * @{
+ */
+#define ARDUINO_A0          ADC_LINE(0)     /**< ADC line for Arduino pin A0 */
+#define ARDUINO_A1          ADC_LINE(1)     /**< ADC line for Arduino pin A1 */
+#define ARDUINO_A2          ADC_LINE(2)     /**< ADC line for Arduino pin A2 */
+
+#define ARDUINO_ANALOG_PIN_LAST 2           /**< Last Arduino analog pin index */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+/** @} */

--- a/boards/seeedstudio-xiao-esp32c6/include/board.h
+++ b/boards/seeedstudio-xiao-esp32c6/include/board.h
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: 2025 David Picard
+ * SPDX-FileCopyrightText: 2026 Stepan Konoplev
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_seeedstudio-xiao-esp32c6
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Seeed Studio XIAO ESP32-C6
+ *
+ * @author      Stepan Konoplev <stepan.konoplev@haw-hamburg.de>
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED configuration
+ * @{
+ */
+#define LED0_PIN        GPIO15
+#define LED0_ACTIVE     (0)     /**< LED is low active */
+/** @} */
+
+#if MODULE_PERIPH_INIT_BUTTONS || DOXYGEN
+/**
+ * @name    Button pin definitions
+ * @{
+ */
+/**
+ * @brief   Default button GPIO pin definition
+ *
+ * Pressing the button will give a low signal.
+ *
+ * @note GPIO9 is a strapping pin that must be pulled up at boot time
+ *       in order to boot the user application.
+ *       After boot, it can be used as user button.
+ */
+#  define BTN0_PIN        GPIO9
+/**
+ * @brief   Default button GPIO mode definition
+ *
+ * The pin is actually pulled up by an external resistor on the board.
+ * As a consequence, the pin mode should be GPIO_IN.
+ * The internal pull-up resistor is not enabled on purpose
+ * because it would decrease the total pull-up resistor value.
+ */
+#  define BTN0_MODE       GPIO_IN
+/**
+ * @brief   Default interrupt flank definition for the button GPIO
+ */
+#  ifndef BTN0_INT_FLANK
+#    define BTN0_INT_FLANK  GPIO_FALLING
+#  endif
+/**
+ * @brief   Definition for compatibility with previous versions
+ */
+#  define BUTTON0_PIN     BTN0_PIN
+/** @} */
+#endif
+
+/**
+ * @name    RF antenna switch configuration
+ * @{
+ */
+#define RF_SWITCH_EN_GPIO   GPIO3       /**< RF switch enable, active low */
+#define RF_SWITCH_ANT_GPIO  GPIO14      /**< antenna select: low=internal, high=external */
+/** @} */
+
+#include "board_common.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/seeedstudio-xiao-esp32c6/include/periph_conf.h
+++ b/boards/seeedstudio-xiao-esp32c6/include/periph_conf.h
@@ -1,0 +1,124 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Gunar Schorcht
+ * SPDX-FileCopyrightText: 2026 Stepan Konoplev
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_seeedstudio-xiao-esp32c6
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configurations for the Seeed Studio XIAO ESP32-C6
+ *
+ * @author      Stepan Konoplev <stepan.konoplev@haw-hamburg.de>
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   I2C configuration
+ * @{
+ */
+#ifndef I2C0_SDA
+#  define I2C0_SDA    GPIO22             /**< I2C SDA pin */
+#endif
+
+#ifndef I2C0_SCL
+#  define I2C0_SCL    GPIO23             /**< I2C SCL pin */
+#endif
+
+#ifndef I2C0_SPEED
+#  define I2C0_SPEED  I2C_SPEED_FAST     /**< I2C bus speed */
+#endif
+/** @} */
+
+/**
+ * @name   SPI configuration
+ * @{
+ */
+#ifndef SPI0_CTRL
+#  define SPI0_CTRL   FSPI               /**< SPI controller used */
+#endif
+
+#ifndef SPI0_SCK
+#  define SPI0_SCK    GPIO19             /**< SPI SCK pin */
+#endif
+
+#ifndef SPI0_MOSI
+#  define SPI0_MOSI   GPIO18             /**< SPI MOSI pin */
+#endif
+
+#ifndef SPI0_MISO
+#  define SPI0_MISO   GPIO20             /**< SPI MISO pin */
+#endif
+
+#ifndef SPI0_CS0
+#  define SPI0_CS0    GPIO21             /**< SPI CS0 pin */
+#endif
+/** @} */
+
+/**
+ * @name    ADC channel configuration
+ * @{
+ */
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ *
+ * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
+ * channels with the `adc_init` function, they can be used for other
+ * purposes.
+ */
+#ifndef ADC_GPIOS
+#  define ADC_GPIOS   { GPIO0, GPIO1, GPIO2 }
+#endif
+/** @} */
+
+/**
+ * @name   PWM channel configuration
+ *
+ * PWM_DEV(0) shares its GPIOs with the ADC channels on this board.
+ * Generally, all output pins could be used as PWM channels.
+ *
+ * @note As long as the according PWM device is not initialized with
+ * the `pwm_init`, the GPIOs declared for this device can be used
+ * for other purposes.
+ *
+ * @{
+ */
+/**
+ * @brief Declaration of the channels for device PWM_DEV(0),
+ *        at maximum PWM_CHANNEL_NUM_DEV_MAX.
+ */
+#ifndef PWM0_GPIOS
+#  define PWM0_GPIOS  { GPIO0, GPIO1, GPIO2 }
+#endif
+/** @} */
+
+/**
+ * @name   UART configuration
+ *
+ * Seeed Studio XIAO ESP32-C6 provides only 1 UART interface.
+ *
+ * UART_DEV(0) uses fixed standard configuration.
+ *
+ * @{
+ */
+#define UART0_TXD   GPIO16              /**< UART TxD pin */
+#define UART0_RXD   GPIO17              /**< UART RxD pin */
+/** @} */
+
+/* Include common peripheral definitions */
+#include "periph_conf_common.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */


### PR DESCRIPTION
### Contribution description
This PR adds support for the Seeed Studio XIAO ESP32C6.
This board also offers an external antenna so I added the functionality for
the antenna switch.
What I find kinda disappointing is that as far as I understand the ESP32C6
can support ieee 802.15.4, wifi and ble in a single application via the
coexistence module but in RIOT we only support wifi + ble. Is there any
ongoing work to support all three of them?
I tried to hack it in myself but it doesn't seem to be that trivial at least not for me :(

### Testing procedure
I ran some basic tests:

Module                    | esp32c6
--------------------------|---------
shell                     | OK
periph/adc                | OK
periph/gpio               | OK
periph/i2c                | OK
periph/spi                | OK
periph/timer              | OK
esp_ble_nimble + esp_wifi | OK
esp_ieee802154            | OK

I don't have an external antenna so I couldn't test the antenna switch but the
code follows the sample code on the official page:
[sample code](https://wiki.seeedstudio.com/xiao_esp32c6_getting_started/#front)

### Issues/PRs references
- None

### Declaration of AI-Tools / LLMs usage:
AI-Tools / LLMs that were used are:
- Claude Opus 4.8:
  - reviewing the board definition files (board.h, periph_conf.h, board.c, doc.md, Makefiles)
  - adding and fixing Doxygen documentation comments to satisfy the doc check
  - explanations and research on ESP32 and RIOT for correct implementation