### PR TITLE
boards/elecrow-crowpanel-esp32s3-rotary-128: add support

### DIFF
--- a/boards/elecrow-crowpanel-esp32s3-rotary-128/Kconfig
+++ b/boards/elecrow-crowpanel-esp32s3-rotary-128/Kconfig
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
+
+config BOARD
+    default "boards_elecrow-crowpanel-esp32s3-rotary-128" if BOARD_ELECROW_CROWPANEL_ESP32S3_ROTARY_128
+
+config BOARD_ELECROW_CROWPANEL_ESP32S3_ROTARY_128
+    bool
+    default y
+    select BOARD_COMMON_ESP32S3
+    select CPU_MODEL_ESP32S3R8
+
+source "$(RIOTBOARD)/common/esp32s3/Kconfig"

--- a/boards/elecrow-crowpanel-esp32s3-rotary-128/Makefile
+++ b/boards/elecrow-crowpanel-esp32s3-rotary-128/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/elecrow-crowpanel-esp32s3-rotary-128/Makefile.dep
+++ b/boards/elecrow-crowpanel-esp32s3-rotary-128/Makefile.dep
@@ -1,0 +1,16 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+ifneq (,$(filter disp_dev,$(USEMODULE)))
+  USEMODULE += gc9a01
+endif
+
+ifneq (,$(filter touch_dev,$(USEMODULE)))
+  USEMODULE += cst816s
+endif
+
+include $(RIOTBOARD)/common/esp32s3/stdio_esp32s3_default.dep.mk
+include $(RIOTBOARD)/common/esp32s3/Makefile.dep
+
+USEMODULE += boards_common_esp32s3

--- a/boards/elecrow-crowpanel-esp32s3-rotary-128/Makefile.features
+++ b/boards/elecrow-crowpanel-esp32s3-rotary-128/Makefile.features
@@ -1,0 +1,15 @@
+# the board uses an ESP32-S3R80 with 8 MB embedded SPI RAM and 16MB flash
+CPU_MODEL = esp32s3r8
+
+# common board and CPU features
+include $(RIOTBOARD)/common/esp32s3/Makefile.features
+
+# peripherals provided by the board
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_usbdev
+
+# other features provided by the board
+FEATURES_PROVIDED += esp_spi_ram

--- a/boards/elecrow-crowpanel-esp32s3-rotary-128/Makefile.include
+++ b/boards/elecrow-crowpanel-esp32s3-rotary-128/Makefile.include
@@ -1,0 +1,5 @@
+PORT_LINUX ?= /dev/ttyACM0
+
+OPENOCD_CONFIG ?= board/esp32s3-builtin.cfg
+
+include $(RIOTBOARD)/common/esp32s3/Makefile.include

--- a/boards/elecrow-crowpanel-esp32s3-rotary-128/board.c
+++ b/boards/elecrow-crowpanel-esp32s3-rotary-128/board.c
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     boards_elecrow-crowpanel-esp32s3-rotary-128
+ * @{
+ *
+ * @file
+ * @brief       Board specific initializations for the Elecrow CrowPanel
+ *              ESP32-S3 1.28-inch rotary round display board (Touch version)
+ *
+ * @author      Christopher Büchse <christopher.buechse@tuhh.de>
+ */
+
+#include "board.h"
+
+void board_init(void)
+{
+#if MODULE_GC9A01
+    gpio_init(LCD_BACKLIGHT, GPIO_OUT);
+    gpio_clear(LCD_BACKLIGHT);
+#endif
+
+#if MODULE_GC9A01 || MODULE_CST816S
+    gpio_init(POWER_LCD_3V3_PIN, GPIO_OUT);
+    gpio_set(POWER_LCD_3V3_PIN);
+#endif
+}

--- a/boards/elecrow-crowpanel-esp32s3-rotary-128/doc.md
+++ b/boards/elecrow-crowpanel-esp32s3-rotary-128/doc.md
@@ -1,0 +1,115 @@
+<!--
+SPDX-FileCopyrightText: 2023 Gunar Schorcht
+SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+SPDX-License-Identifier: LGPL-2.1-only
+-->
+
+@defgroup   boards_elecrow-crowpanel-esp32s3-rotary-128 Elecrow CrowPanel ESP32-S3 Rotary LCD 1.28"
+@ingroup    boards_esp32s3
+@brief      Support for the Elecrow ESP32-S3 Rotary LCD 1.28" Board
+
+## Overview
+
+The Elecrow ESP32-S3 Rotary LCD 1.28" board is a compact development board
+built around the ESP32-S3 microcontroller with an integrated 1.28"
+round TFT LCD display, capacitive touch panel and a knurled rotary knob around
+the display.
+
+The main features of the board are:
+
+- ESP32-S3R8 SoC with 2.4 GHz WiFi (802.11 b/g/n) and Bluetooth 5/BLE
+- 16 MB Flash
+- 2 MB PSRAM
+- 1.28-inch 240x240 round IPS LCD (GC9A01 driver)
+- Capacitive touch panel (CST816D controller)
+- BOOT button (active low, directly usable as user button)
+- Display Button
+- Rotary knob around the display (currently unsupported, no `periph_qdec` for
+  ESP32 implemented yet)
+- Red LED, 5x WS281x compatible NeoPixels
+
+## Hardware
+
+### MCU
+
+Most features of the board are provided by the ESP32-S3 SoC. For detailed
+information about the ESP32-S3 SoC variant (family) and ESP32x SoCs,
+see section @ref esp32_mcu_esp32 "ESP32 SoC Series".
+
+### Board Configuration
+
+The board integrates a 1.28-inch round IPS LCD driven by a GC9A01 display
+controller via SPI and a CST816D capacitive touch controller connected via I2C.
+A BOOT button on GPIO0 as well as the display button are directly usable
+as user buttons.
+
+The default board configuration provides:
+
+- 2 x ADC channel (available on the external flat flex connector)
+- 1 x SPI (display)
+- 2 x I2C (touch controller and external flat flex connector)
+- 1 x UART (console)
+- 1 x LED Red via PWM Channel
+
+The following table shows the default board configuration sorted by
+peripheral function. This configuration can be overridden by
+@ref esp32_application_specific_configurations
+"application-specific configurations".
+
+Function         | GPIOs  | Remarks                                         | Configuration
+:----------------|:-------|:------------------------------------------------|:------------------------------------------
+BTN0             | GPIO0  |                                                 |
+BTN1             | GPIO41 | Display Button                                  |
+ADC_LINE(0)      | GPIO4  | Flat Flex Connector                             | @ref esp32_adc_channels "ADC Channels"
+ADC_LINE(1)      | GPIO12 | Flat Flex Connector                             | @ref esp32_adc_channels "ADC Channels"
+RGB-LED          | GPIO48 | supported by the `ws281x` module                |
+LED Red          | GPIO40 | Integrated Red LED                              |
+SPI_DEV(0) CLK   | GPIO10 | LCD SCLK, GC9A01                                | @ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0) MOSI  | GPIO11 | LCD SDA, GC9A01                                 | @ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0) MISO  | UNDEF  | The LCD has no MISO output and can not be read. |
+SPI_DEV(0) CS0   | GPIO9  | LCD CS, GC9A01                                  | @ref esp32_spi_interfaces "SPI Interfaces"
+LCD DC           | GPIO3  | GC9A01 data/command                             |
+LCD RST          | GPIO14 | GC9A01 reset                                    |
+LCD BL           | GPIO46 | Backlight control (active high)                 |
+I2C_DEV(0) SCL   | GPIO7  | Touch + IMU                                     | @ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(0) SDA   | GPIO6  | Touch + IMU                                     | @ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(1) SCL   | GPIO39 | Flat Flex Connector                             | @ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(1) SDA   | GPIO38 | Flat Flex Connector                             | @ref esp32_i2c_interfaces "I2C Interfaces"
+Touch IRQ        | GPIO5  | CST816D interrupt                               |
+Touch RST        | GPIO13 | CST816D reset                                   |
+UART_DEV(0) TxD  | GPIO43 | Console (fixed)                                 | @ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(0) RxD  | GPIO44 | Console (fixed)                                 | @ref esp32_uart_interfaces "UART interfaces"
+<br>
+
+For detailed information about the peripheral configurations of ESP32-S3
+boards, see section @ref esp32_peripherals "Common Peripherals".
+
+### Powering Peripherals
+
+The LCD and touch controller are power gated with a MOSFET, controlled by
+GPIO1. To use it, the GPIO pin has to be set high. When using the `GC9A01` or
+`CST816S` modules, the power is automatically activated.
+
+Likewise, the +5V outputs on the external connectors for UART and I2C are
+power gated by a MOSFET controlled by GPIO2. The +5V pin on the flat flex
+connector has a direct connection and is not switched.
+If the power pin on the UART and I2C connectors is used by your application,
+make sure to set the `POWER_EXTERNAL_5V_PIN` GPIO.
+
+### Board Pinout
+
+The board schematic and additional documentation can be found on the
+[Elecrow Wiki](https://www.elecrow.com/wiki/CrowPanel_1.28inch-HMI_ESP32_Rotary_Display.html).
+
+## Flashing the Device
+
+Flashing RIOT is quite easy. The board has a custom USB cable with a JST
+connector with to be used for the reset/boot/flash logic. Just connect the
+board to your host computer and run:
+
+```shell
+BOARD=elecrow-esp32s3-rotary-lcd-128 make flash ...
+```
+
+For detailed information about ESP32-S3 as well as configuring and compiling
+RIOT for ESP32-S3 boards, see @ref esp32_riot.

--- a/boards/elecrow-crowpanel-esp32s3-rotary-128/include/board.h
+++ b/boards/elecrow-crowpanel-esp32s3-rotary-128/include/board.h
@@ -1,0 +1,162 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_elecrow-crowpanel-esp32s3-rotary-128
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Elecrow CrowPanel
+ *              ESP32-S3 1.28-inch rotary round display board (Touch version)
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Yahia Abdella <yahia.abdella@tuhh.de>
+ * @author      Christopher Büchse <christopher.buechse@tuhh.de>
+ */
+
+/**
+ * @name    Button pin definitions
+ * @{
+ */
+
+/**
+ * @brief   Default button GPIO pin definition
+ *
+ * The board has a BOOT button connected to GPIO0, which can be
+ * used as button during normal operation. Since the GPIO0 pin is pulled up,
+ * the button signal is inverted, i.e., pressing the button will give a
+ * low signal.
+ */
+#define BTN0_PIN        GPIO0
+
+/** Default button GPIO mode definition */
+#define BTN0_MODE       GPIO_IN_PU
+
+/** Default interrupt flank definition for the BOOT button */
+#ifndef BTN0_INT_FLANK
+#  define BTN0_INT_FLANK    GPIO_FALLING
+#endif
+
+/** Definition for compatibility with previous versions */
+#define BUTTON0_PIN     BTN0_PIN
+
+/**
+ * @brief   Display push button
+ *
+ * The display itself can be pressed down (apart from the touch functionality),
+ * which activates a button. The button signal is low active.
+ */
+#define BTN1_PIN        GPIO41
+
+/** Default button GPIO mode definition */
+#define BTN1_MODE       GPIO_IN_PU
+
+/** Default interrupt flank definition for the display button */
+#ifndef BTN1_INT_FLANK
+#  define BTN1_INT_FLANK    GPIO_FALLING
+#endif
+
+/** Definition for compatibility with previous versions */
+#define BUTTON1_PIN     BTN1_PIN
+/** @} */
+
+/**
+ * @name    LCD configuration
+ *
+ * The board features a 240x240 TFT display being driven by a GC9A01 LCD driver.
+ * The display driver is connected via SPI.
+ *
+ * @{
+ */
+#if MODULE_GC9A01
+#  define LCD_DC              GPIO3     /**< LCD DC signal */
+#  define LCD_CS              GPIO9     /**< LCD CS signal */
+#  define LCD_RST             GPIO14    /**< LCD RST signal */
+#  define LCD_BACKLIGHT       GPIO46    /**< LCD BL signal */
+
+#  define GC9A01_PARAM_CS               LCD_CS
+#  define GC9A01_PARAM_DCX              LCD_DC
+#  define GC9A01_PARAM_RST              LCD_RST
+#  define GC9A01_PARAM_NUM_LINES        240
+#  define GC9A01_PARAM_RGB_CHANNELS     240
+#  define GC9A01_PARAM_INVERTED         1
+#  define GC9A01_PARAM_RGB              0
+#  ifndef GC9A01_PARAM_ROTATION
+#    define GC9A01_PARAM_ROTATION       GC9A01_ROTATION_VERT
+#  endif
+#  ifndef GC9A01_PARAM_SPI_CLK
+#    define GC9A01_PARAM_SPI_CLK        SPI_CLK_1MHZ
+#  endif
+
+#  define BACKLIGHT_ON                gpio_set(LCD_BACKLIGHT)
+#  define BACKLIGHT_OFF               gpio_clear(LCD_BACKLIGHT)
+#endif
+/** @} */
+
+/**
+ * @name    Touch panel configuration
+ *
+ * The board features a CST816D touch display driver connected via I2C.
+ *
+ * @note The CST816D is fully register compatible with the CST816S.
+ *
+ * @{
+ */
+#if MODULE_CST816S
+#  define CST816S_PARAM_I2C_DEV       I2C_DEV(0)
+#  define CST816S_PARAM_IRQ           GPIO5
+#  define CST816S_PARAM_RESET         GPIO13
+#endif
+/** @} */
+
+/**
+ * @name    Power Control configuration
+ *
+ * The Elecrow rotary display has two MOSFETs that control the power domains,
+ * one for the LCD's 3.3V domain and one for the external 5V supply of the
+ * UART and I2C headers.
+ *
+ * @{
+ */
+/** Enable power for the LCD (active high) */
+#define POWER_LCD_3V3_PIN       GPIO1
+/** Enable power for the external UART and I2C headers (active high) */
+#define POWER_EXTERNAL_5V_PIN   GPIO2
+/** @} */
+
+/**
+ * @name    Neopixel LEDs (WS281x compatible)
+ * @{
+ */
+/** GPIO pin connected to the data pin of the first LED */
+#define WS281X_PARAM_PIN    GPIO48
+/** Number of LEDs chained */
+#define WS281X_PARAM_NUMOF  (5U)
+/** @} */
+
+/**
+ * @name    LED (on-board) configuration
+ *
+ * @{
+ */
+#define LED0_PIN        GPIO40  /**< Red LED */
+#define LED0_ACTIVE     (0)     /**< Red LED is active low */
+/** @} */
+
+/* include common board definitions as last step */
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/elecrow-crowpanel-esp32s3-rotary-128/include/gpio_params.h
+++ b/boards/elecrow-crowpanel-esp32s3-rotary-128/include/gpio_params.h
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_elecrow-crowpanel-esp32s3-rotary-128
+ * @brief       Board specific configuration of direct mapped GPIOs for the
+ *              Elecrow CrowPanel ESP32-S3 1.28-inch rotary round display
+ *              board (Touch version)
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Christopher Büchse <christopher.buechse@tuhh.de>
+ * @{
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Boot button configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "BOOT",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+    {
+        .name = "DISPLAY_BTN",
+        .pin = BTN1_PIN,
+        .mode = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+    {
+        .name = "LED Red",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/elecrow-crowpanel-esp32s3-rotary-128/include/periph_conf.h
+++ b/boards/elecrow-crowpanel-esp32s3-rotary-128/include/periph_conf.h
@@ -1,0 +1,122 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Gunar Schorcht
+ * SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_elecrow-crowpanel-esp32s3-rotary-128
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for the Elecrow CrowPanel
+ *              ESP32-S3 1.28-inch rotary round display board (Touch version)
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Christopher Büchse <christopher.buechse@tuhh.de>
+ */
+
+#include <stdint.h>
+
+#include "board.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    ADC channel configuration
+ * @{
+ */
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ *
+ * GPIO4 and GPIO12 are connected to the external flat flex header.
+ */
+#ifndef ADC_GPIOS
+#  define ADC_GPIOS     { GPIO4, GPIO12 }
+#endif
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * SPI_DEV(0) is used for the LCD display
+ *
+ * @note The GPIOs listed in the configuration are first initialized as SPI
+ *       signals when the corresponding SPI interface is used for the first
+ *       time by either calling the `spi_init_cs` function or the `spi_acquire`
+ *       function. Otherwise they are not allocated as SPI signals before and
+ *       can be used for other purposes as long as the SPI interface is not
+ *       used.
+ * @{
+ */
+#ifndef SPI0_CTRL
+#  define SPI0_CTRL   SPI2_HOST     /**< SPI2 (FSPI) is configured as SPI_DEV(0) */
+#endif
+#ifndef SPI0_SCK
+#  define SPI0_SCK    GPIO10        /**< LCD SCLK */
+#endif
+#ifndef SPI0_MOSI
+#  define SPI0_MOSI   GPIO11        /**< LCD SDA */
+#endif
+#ifndef SPI0_MISO
+#  define SPI0_MISO   GPIO_UNDEF    /**< LCD SDO (not connected) */
+#endif
+#ifndef SPI0_CS0
+#  define SPI0_CS0    GPIO9         /**< LCD CS */
+#endif
+/** @} */
+
+/**
+ * @name   I2C configuration
+ *
+ * I2C_DEV(0) is used for the touch controller.<br/>
+ * I2C_DEV(1) is connected to the external I2C header. It has a level shifter
+ * and is therefore 5V tolerant.
+ *
+ * @note The GPIOs listed in the configuration are only initialized as I2C
+ *       signals when module `periph_i2c` is used. Otherwise they are not
+ *       allocated and can be used for other purposes.
+ *
+ * @{
+ */
+#ifndef I2C0_SPEED
+#  define I2C0_SPEED      I2C_SPEED_FAST  /**< I2C bus speed of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SCL
+#  define I2C0_SCL        GPIO7           /**< SCL signal of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SDA
+#  define I2C0_SDA        GPIO6           /**< SDA signal of I2C_DEV(0) */
+#endif
+#ifndef I2C1_SPEED
+#  define I2C1_SPEED      I2C_SPEED_FAST  /**< I2C bus speed of I2C_DEV(1) */
+#endif
+#ifndef I2C1_SCL
+#  define I2C1_SCL        GPIO39          /**< SCL signal of I2C_DEV(1) */
+#endif
+#ifndef I2C1_SDA
+#  define I2C1_SDA        GPIO38          /**< SDA signal of I2C_DEV(1) */
+#endif
+/** @} */
+
+/**
+ * @brief Declaration of the channels for device PWM_DEV(0)
+ *
+ * LED pins are used as PWM channels.
+ */
+#ifndef PWM0_GPIOS
+#  define PWM0_GPIOS    { LED0_PIN }
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/* include common peripheral definitions as last step */
+#include "periph_conf_common.h"
+
+/** @} */


### PR DESCRIPTION
### Contribution description

This PR adds support for the Elecrow CrowPanel Rotary Display:
https://www.elecrow.com/wiki/CrowPanel_1.28inch-HMI_ESP32_Rotary_Display.html
https://www.elecrow.com/crowpanel-1-28inch-hmi-esp32-rotary-display-240-240-ips-round-touch-knob-screen.html?srsltid=AfmBOoribq2Z0j8YFKGz3WgEhGm1bpw2CAWBhQbS-0yif5_NXP7TQpwi


The rotary button is not implemented yet, because there is no `periph_qdec` implementation for the ESP32 yet.


### Testing procedure

Since probably nobody has the board, here are some test traces:

Display:
<img width="1700" height="956" alt="image" src="https://github.com/user-attachments/assets/bd45061e-359c-48fc-851f-5d812ce2d5f2" />

Touch screen test application:
```
2026-06-22 15:31:34,693 # CST816S test application
2026-06-22 15:31:34,693 #
2026-06-22 15:31:35,113 # Init successful
2026-06-22 15:31:35,114 #
2026-06-22 15:31:36,294 # Callback!
2026-06-22 15:31:36,295 #
2026-06-22 15:31:36,295 # Reading data:
2026-06-22 15:31:36,296 # Touch at 103, 115 with gesture type "none"
2026-06-22 15:31:36,306 # Callback!
2026-06-22 15:31:36,307 #
2026-06-22 15:31:36,307 # Reading data:
2026-06-22 15:31:36,310 # Touch at 103, 115 with gesture type "none"
2026-06-22 15:31:36,318 # Callback!
2026-06-22 15:31:36,318 #
2026-06-22 15:31:36,318 # Reading data:
2026-06-22 15:31:36,319 # Touch at 103, 115 with gesture type "none"
```

NeoPixels:

<img width="1700" height="956" alt="image" src="https://github.com/user-attachments/assets/fc4f7f89-64c4-482e-adea-0da2e88ea58a" />



SAUL:
```
> saul
2026-06-22 15:33:31,378 # saul
2026-06-22 15:33:31,379 # ID    Class           Name
2026-06-22 15:33:31,379 # #0    SENSE_BTN       BOOT
2026-06-22 15:33:31,380 # #1    SENSE_BTN       DISPLAY_BTN
2026-06-22 15:33:31,380 # #2    ACT_SWITCH      LED Red
> saul read 0
2026-06-22 15:33:35,880 # saul read 0
2026-06-22 15:33:35,881 # Reading from #0 (BOOT|SENSE_BTN)
2026-06-22 15:33:35,882 # Data:               0
> saul read 0
2026-06-22 15:33:42,462 # saul read 0
2026-06-22 15:33:42,464 # Reading from #0 (BOOT|SENSE_BTN)
2026-06-22 15:33:42,464 # Data:               1
> saul read 1
2026-06-22 15:33:47,512 # saul read 1
2026-06-22 15:33:47,512 # Reading from #1 (DISPLAY_BTN|SENSE_BTN)
2026-06-22 15:33:47,513 # Data:               0
> saul read 1
2026-06-22 15:33:50,166 # saul read 1
2026-06-22 15:33:50,168 # Reading from #1 (DISPLAY_BTN|SENSE_BTN)
2026-06-22 15:33:50,168 # Data:               1
> saul write 2 1
2026-06-22 15:34:37,990 # saul write 2 1
2026-06-22 15:34:37,990 # Writing to device #2 - LED Red
2026-06-22 15:34:37,991 # Data:               1
2026-06-22 15:34:37,991 # data successfully written to device #2
```

<img width="1700" height="956" alt="image" src="https://github.com/user-attachments/assets/caa138fb-96f0-483a-beb5-de8d285b048b" />


PWM also works (trust me bro).

### Issues/PRs references

Partly based on #22231, Copyright notices retained where applicable.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
