### PR TITLE
boards/nucleo-g031k8: Add timer support for the NUCLEO-G031K8 board.

### DIFF
--- a/boards/nucleo-g031k8/Makefile.features
+++ b/boards/nucleo-g031k8/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32g031k8
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # load the common Makefile.features for Nucleo-32 boards

--- a/boards/nucleo-g031k8/include/periph_conf.h
+++ b/boards/nucleo-g031k8/include/periph_conf.h
@@ -23,6 +23,25 @@ extern "C" {
 #endif
 
 /**
+ * @name    Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIM3,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APBENR1_TIM3EN,
+        .bus      = APB1,
+        .irqn     = TIM3_IRQn
+    }
+};
+
+#define TIMER_0_ISR         isr_tim3
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
  * @name    UART configuration
  * @{
  */

--- a/examples/advanced/posix_select/Makefile.ci
+++ b/examples/advanced/posix_select/Makefile.ci
@@ -18,6 +18,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/advanced/psa_crypto/Makefile.ci
+++ b/examples/advanced/psa_crypto/Makefile.ci
@@ -15,6 +15,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/guides/coap/client/Makefile.ci
+++ b/examples/guides/coap/client/Makefile.ci
@@ -19,6 +19,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/guides/coap/server/Makefile.ci
+++ b/examples/guides/coap/server/Makefile.ci
@@ -17,6 +17,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/lang_support/community/lua_REPL/Makefile.ci
+++ b/examples/lang_support/community/lua_REPL/Makefile.ci
@@ -53,6 +53,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-f410rb \
+    nucleo-g031k8 \
     nucleo-g070rb \
     nucleo-g071rb \
     nucleo-g431rb \

--- a/examples/lang_support/community/lua_basic/Makefile.ci
+++ b/examples/lang_support/community/lua_basic/Makefile.ci
@@ -27,6 +27,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-f410rb \
+    nucleo-g031k8 \
     nucleo-g070rb \
     nucleo-g071rb \
     nucleo-g431rb \

--- a/examples/lang_support/community/micropython/Makefile.ci
+++ b/examples/lang_support/community/micropython/Makefile.ci
@@ -18,6 +18,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-g070rb \
     nucleo-g071rb \
     nucleo-l011k4 \

--- a/examples/lang_support/community/wasm/Makefile.ci
+++ b/examples/lang_support/community/wasm/Makefile.ci
@@ -10,6 +10,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/lang_support/official/rust-gcoap/Makefile.ci
+++ b/examples/lang_support/official/rust-gcoap/Makefile.ci
@@ -36,6 +36,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-f410rb \
+    nucleo-g031k8 \
     nucleo-g070rb \
     nucleo-g071rb \
     nucleo-g431rb \

--- a/examples/networking/coap/gcoap/Makefile.ci
+++ b/examples/networking/coap/gcoap/Makefile.ci
@@ -23,6 +23,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/coap/gcoap_block_server/Makefile.ci
+++ b/examples/networking/coap/gcoap_block_server/Makefile.ci
@@ -19,6 +19,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/coap/gcoap_dtls/Makefile.ci
+++ b/examples/networking/coap/gcoap_dtls/Makefile.ci
@@ -40,6 +40,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/coap/gcoap_fileserver/Makefile.ci
+++ b/examples/networking/coap/gcoap_fileserver/Makefile.ci
@@ -22,6 +22,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/coap/nanocoap_server/Makefile.ci
+++ b/examples/networking/coap/nanocoap_server/Makefile.ci
@@ -16,6 +16,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-f303k8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/cord/cord_ep/Makefile.ci
+++ b/examples/networking/cord/cord_ep/Makefile.ci
@@ -24,6 +24,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/cord/cord_epsim/Makefile.ci
+++ b/examples/networking/cord/cord_epsim/Makefile.ci
@@ -17,6 +17,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/cord/cord_lc/Makefile.ci
+++ b/examples/networking/cord/cord_lc/Makefile.ci
@@ -20,6 +20,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/dtls/dtls-echo/Makefile.ci
+++ b/examples/networking/dtls/dtls-echo/Makefile.ci
@@ -36,6 +36,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/dtls/dtls-sock/Makefile.ci
+++ b/examples/networking/dtls/dtls-sock/Makefile.ci
@@ -39,6 +39,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/dtls/dtls-wolfssl/Makefile.ci
+++ b/examples/networking/dtls/dtls-wolfssl/Makefile.ci
@@ -30,6 +30,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-f410rb \
+    nucleo-g031k8 \
     nucleo-g070rb \
     nucleo-g071rb \
     nucleo-g431rb \

--- a/examples/networking/dtn/bplib_cla_udp/Makefile.ci
+++ b/examples/networking/dtn/bplib_cla_udp/Makefile.ci
@@ -55,6 +55,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-f410rb \
+    nucleo-g031k8 \
     nucleo-g431rb \
     nucleo-l011k4 \
     nucleo-l031k6 \

--- a/examples/networking/gnrc/border_router/Makefile.ci
+++ b/examples/networking/gnrc/border_router/Makefile.ci
@@ -44,6 +44,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/gnrc/networking/Makefile.ci
+++ b/examples/networking/gnrc/networking/Makefile.ci
@@ -27,6 +27,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/gnrc/networking_subnets/Makefile.ci
+++ b/examples/networking/gnrc/networking_subnets/Makefile.ci
@@ -20,6 +20,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/misc/benchmark_udp/Makefile.ci
+++ b/examples/networking/misc/benchmark_udp/Makefile.ci
@@ -23,6 +23,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/misc/lwip_ipv4/Makefile.ci
+++ b/examples/networking/misc/lwip_ipv4/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/misc/lwiperf/Makefile.ci
+++ b/examples/networking/misc/lwiperf/Makefile.ci
@@ -5,6 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/misc/lwm2m/Makefile.ci
+++ b/examples/networking/misc/lwm2m/Makefile.ci
@@ -42,6 +42,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-f410rb \
+    nucleo-g031k8 \
     nucleo-g070rb \
     nucleo-g071rb \
     nucleo-g431rb \

--- a/examples/networking/misc/posix_sockets/Makefile.ci
+++ b/examples/networking/misc/posix_sockets/Makefile.ci
@@ -24,6 +24,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/misc/sniffer/Makefile.ci
+++ b/examples/networking/misc/sniffer/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/misc/sock_tcp_echo/Makefile.ci
+++ b/examples/networking/misc/sock_tcp_echo/Makefile.ci
@@ -22,6 +22,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/misc/spectrum-scanner/Makefile.ci
+++ b/examples/networking/misc/spectrum-scanner/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/misc/telnet_server/Makefile.ci
+++ b/examples/networking/misc/telnet_server/Makefile.ci
@@ -18,6 +18,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/mqtt/asymcute_mqttsn/Makefile.ci
+++ b/examples/networking/mqtt/asymcute_mqttsn/Makefile.ci
@@ -28,6 +28,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/mqtt/emcute_mqttsn/Makefile.ci
+++ b/examples/networking/mqtt/emcute_mqttsn/Makefile.ci
@@ -24,6 +24,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/examples/networking/mqtt/paho-mqtt/Makefile.ci
+++ b/examples/networking/mqtt/paho-mqtt/Makefile.ci
@@ -36,6 +36,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/bench/xtimer/Makefile.ci
+++ b/tests/bench/xtimer/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-stm32f030c8 \
     im880b \
     nucleo-c031c6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     olimex-msp430-h1611 \
     olimex-msp430-h2618 \

--- a/tests/bench/ztimer/Makefile.ci
+++ b/tests/bench/ztimer/Makefile.ci
@@ -3,6 +3,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     bluepill-stm32f030c8 \
     im880b \
     nucleo-c031c6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     olimex-msp430-h1611 \
     olimex-msp430-h2618 \

--- a/tests/net/emcute/Makefile.ci
+++ b/tests/net/emcute/Makefile.ci
@@ -41,6 +41,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f103rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gcoap_dns/Makefile.ci
+++ b/tests/net/gcoap_dns/Makefile.ci
@@ -34,6 +34,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gcoap_fileserver/Makefile.ci
+++ b/tests/net/gcoap_fileserver/Makefile.ci
@@ -31,6 +31,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gcoap_forward_proxy/Makefile.ci
+++ b/tests/net/gcoap_forward_proxy/Makefile.ci
@@ -34,6 +34,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_dhcpv6_client/Makefile.ci
+++ b/tests/net/gnrc_dhcpv6_client/Makefile.ci
@@ -23,6 +23,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_dhcpv6_client_6lbr/Makefile.ci
+++ b/tests/net/gnrc_dhcpv6_client_6lbr/Makefile.ci
@@ -45,6 +45,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_dhcpv6_client_stateless/Makefile.ci
+++ b/tests/net/gnrc_dhcpv6_client_stateless/Makefile.ci
@@ -31,6 +31,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_dhcpv6_relay/Makefile.ci
+++ b/tests/net/gnrc_dhcpv6_relay/Makefile.ci
@@ -21,6 +21,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_ipv6_ext/Makefile.ci
+++ b/tests/net/gnrc_ipv6_ext/Makefile.ci
@@ -21,6 +21,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_ipv6_ext_frag/Makefile.ci
+++ b/tests/net/gnrc_ipv6_ext_frag/Makefile.ci
@@ -30,6 +30,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_ipv6_ext_opt/Makefile.ci
+++ b/tests/net/gnrc_ipv6_ext_opt/Makefile.ci
@@ -18,6 +18,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_ipv6_fwd_w_sub/Makefile.ci
+++ b/tests/net/gnrc_ipv6_fwd_w_sub/Makefile.ci
@@ -14,6 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_ipv6_nib_6ln/Makefile.ci
+++ b/tests/net/gnrc_ipv6_nib_6ln/Makefile.ci
@@ -15,6 +15,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_ipv6_nib_dns/Makefile.ci
+++ b/tests/net/gnrc_ipv6_nib_dns/Makefile.ci
@@ -17,6 +17,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-f303k8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_netif/Makefile.ci
+++ b/tests/net/gnrc_netif/Makefile.ci
@@ -47,6 +47,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_netif_ipv6_wait_for_global_address/Makefile.ci
+++ b/tests/net/gnrc_netif_ipv6_wait_for_global_address/Makefile.ci
@@ -19,6 +19,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_rpl/Makefile.ci
+++ b/tests/net/gnrc_rpl/Makefile.ci
@@ -22,6 +22,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_rpl_p2p/Makefile.ci
+++ b/tests/net/gnrc_rpl_p2p/Makefile.ci
@@ -21,6 +21,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_rpl_srh/Makefile.ci
+++ b/tests/net/gnrc_rpl_srh/Makefile.ci
@@ -21,6 +21,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_sixlowpan/Makefile.ci
+++ b/tests/net/gnrc_sixlowpan/Makefile.ci
@@ -22,6 +22,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_sixlowpan_frag_minfwd/Makefile.ci
+++ b/tests/net/gnrc_sixlowpan_frag_minfwd/Makefile.ci
@@ -30,6 +30,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_sixlowpan_frag_sfr/Makefile.ci
+++ b/tests/net/gnrc_sixlowpan_frag_sfr/Makefile.ci
@@ -32,6 +32,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_sixlowpan_frag_sfr_congure/Makefile.ci
+++ b/tests/net/gnrc_sixlowpan_frag_sfr_congure/Makefile.ci
@@ -32,6 +32,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_sixlowpan_frag_sfr_congure_impl/Makefile.ci
+++ b/tests/net/gnrc_sixlowpan_frag_sfr_congure_impl/Makefile.ci
@@ -36,6 +36,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_sixlowpan_iphc_w_vrb/Makefile.ci
+++ b/tests/net/gnrc_sixlowpan_iphc_w_vrb/Makefile.ci
@@ -15,6 +15,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_sock_dns/Makefile.ci
+++ b/tests/net/gnrc_sock_dns/Makefile.ci
@@ -17,6 +17,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-f303k8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_sock_dodtls/Makefile.ci
+++ b/tests/net/gnrc_sock_dodtls/Makefile.ci
@@ -30,6 +30,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_sock_tcp/Makefile.ci
+++ b/tests/net/gnrc_sock_tcp/Makefile.ci
@@ -26,6 +26,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_tcp/Makefile.ci
+++ b/tests/net/gnrc_tcp/Makefile.ci
@@ -27,6 +27,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_tx_sync/Makefile.ci
+++ b/tests/net/gnrc_tx_sync/Makefile.ci
@@ -30,6 +30,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f072rb \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/gnrc_udp/Makefile.ci
+++ b/tests/net/gnrc_udp/Makefile.ci
@@ -33,6 +33,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/ieee802154_security/Makefile.ci
+++ b/tests/net/ieee802154_security/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/nanocoap_cli/Makefile.ci
+++ b/tests/net/nanocoap_cli/Makefile.ci
@@ -23,6 +23,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/nanocoap_fs/Makefile.ci
+++ b/tests/net/nanocoap_fs/Makefile.ci
@@ -18,6 +18,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/netdev_common/Makefile.ci
+++ b/tests/net/netdev_common/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/netstats_neighbor/Makefile.ci
+++ b/tests/net/netstats_neighbor/Makefile.ci
@@ -13,6 +13,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/netutils/Makefile.ci
+++ b/tests/net/netutils/Makefile.ci
@@ -15,6 +15,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/slip/Makefile.ci
+++ b/tests/net/slip/Makefile.ci
@@ -18,6 +18,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/sntp/Makefile.ci
+++ b/tests/net/sntp/Makefile.ci
@@ -17,6 +17,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/net/sock_udp_aux/Makefile.ci
+++ b/tests/net/sock_udp_aux/Makefile.ci
@@ -20,6 +20,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-f410rb \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/pkg/lvgl/Makefile.ci
+++ b/tests/pkg/lvgl/Makefile.ci
@@ -10,6 +10,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/pkg/lvgl_touch/Makefile.ci
+++ b/tests/pkg/lvgl_touch/Makefile.ci
@@ -10,6 +10,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/pkg/lwip/Makefile.ci
+++ b/tests/pkg/lwip/Makefile.ci
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/pkg/lwip_sock_ip/Makefile.ci
+++ b/tests/pkg/lwip_sock_ip/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/pkg/lwip_sock_tcp/Makefile.ci
+++ b/tests/pkg/lwip_sock_tcp/Makefile.ci
@@ -10,6 +10,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/pkg/lwip_sock_udp/Makefile.ci
+++ b/tests/pkg/lwip_sock_udp/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/pkg/microcoap/Makefile.ci
+++ b/tests/pkg/microcoap/Makefile.ci
@@ -16,6 +16,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-f303k8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/pkg/tflite-micro/Makefile.ci
+++ b/tests/pkg/tflite-micro/Makefile.ci
@@ -10,6 +10,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/pkg/tinydtls_sock_async/Makefile.ci
+++ b/tests/pkg/tinydtls_sock_async/Makefile.ci
@@ -45,6 +45,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/pkg/wolfssl/Makefile.ci
+++ b/tests/pkg/wolfssl/Makefile.ci
@@ -15,6 +15,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-g070rb \
     nucleo-g071rb \
     nucleo-l011k4 \

--- a/tests/sys/posix_semaphore/Makefile.ci
+++ b/tests/sys/posix_semaphore/Makefile.ci
@@ -16,6 +16,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/sys/ps_schedstatistics/Makefile.ci
+++ b/tests/sys/ps_schedstatistics/Makefile.ci
@@ -12,6 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/sys/pthread_rwlock/Makefile.ci
+++ b/tests/sys/pthread_rwlock/Makefile.ci
@@ -16,6 +16,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -57,6 +57,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-f410rb \
+    nucleo-g031k8 \
     nucleo-g070rb \
     nucleo-g071rb \
     nucleo-g431rb \


### PR DESCRIPTION
### Contribution description

Added timer support for the NUCLEO-G031K8 board, using same time as other NUCLEO-G0 boards.

### Testing procedure

BOARD=nucleo-g031k8 make -C examples/basic/timer_periodic_wakeup/ flash term

<img width="1920" height="1080" alt="Screenshot_20260623_103048" src="https://github.com/user-attachments/assets/dd128570-28c3-4079-aa5a-c5badc521f63" />

### Issues/PRs references

Follow-up of #22354

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
