### PR TITLE
doc/doxygen: do not include RIOTBASE in EXAMPLE_PATH

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -1116,21 +1116,28 @@ EXCLUDE_SYMBOLS        = *CMSIS* \
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           = ../../
+EXAMPLE_PATH           = ../../doc.txt \
+                         ../../core \
+                         ../../cpu \
+                         ../../boards \
+                         ../../bootloaders \
+                         ../../drivers \
+                         ../../pkg \
+                         ../../sys
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and
 # *.h) to filter out the source-files in the directories. If left blank all
 # files are included.
 
-EXAMPLE_PATTERNS       =
+EXAMPLE_PATTERNS       = README.md
 
 # If the EXAMPLE_RECURSIVE tag is set to YES then subdirectories will be
 # searched for input files to be used with the \include or \dontinclude commands
 # irrespective of the value of the RECURSIVE tag.
 # The default value is: NO.
 
-EXAMPLE_RECURSIVE      = NO
+EXAMPLE_RECURSIVE      = YES
 
 # The IMAGE_PATH tag can be used to specify one or more files or directories
 # that contain images that are to be included in the documentation (see the

--- a/pkg/uwb-dw1000/doc.md
+++ b/pkg/uwb-dw1000/doc.md
@@ -3,4 +3,4 @@
 @brief    uwb-core driver for Decawave DW1000 transceiver
 @see      https://github.com/Decawave/uwb-dw1000
 
-@includedoc pkg/uwb-dw1000/README.md
+@include{doc} pkg/uwb-dw1000/README.md


### PR DESCRIPTION
### Contribution description

The PR #17572 from @kfessel added the RIOTBASE to the EXAMPLE_PATH in Doxygen. This caused the undesired behavior of Doxygen to ignore the `EXCLUDE_*` commands in it's Doxyfile and search *everywhere* for files, including the `build` directory as well as the `{tests,examples}/*/bin` directories.

This is bad because we neither want to include manufacturer provided docs nor build generated docs (from Micropython) for example.

```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ make doc-ci
"make" -C doc/doxygen doc-ci
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/doc/doxygen'
make[2]: Nothing to be done for 'all'.
make[2]: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/doc/doxygen'
( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/doxygen/doxygen -
warning: source '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/examples/lang_support/community/micropython/bin/nucleo-g031k8/pkg/micropython/ports/esp32/modules/umqtt/simple.py' is not a readable file or directory... skipping.
warning: source '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/examples/lang_support/community/micropython/bin/nucleo-g031k8/pkg/micropython/ports/esp32/modules/umqtt/robust.py' is not a readable file or directory... skipping.
warning: source '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/examples/lang_support/community/micropython/bin/nucleo-g031k8/pkg/micropython/ports/esp32/modules/upysh.py' is not a readable file or directory... skipping.
warning: source '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/examples/lang_support/community/micropython/bin/nucleo-g031k8/pkg/micropython/ports/esp32/modules/urequests.py' is not a readable file or directory... skipping.
warning: source '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/build/pkg/u8g2/sys/arm-linux/drivers' is not a readable file or directory... skipping.
warning: source '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/build/pkg/corejson/test/cbmc/stubs/README.md' is not a readable file or directory... skipping.
warning: source '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/build/pkg/corejson/test/cbmc/sources/README.md' is not a readable file or directory... skipping.
warning: source '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/build/pkg/corejson/test/cbmc/include/README.md' is not a readable file or directory... skipping.
warning: source '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/build/pkg/corejson/test/cbmc/proofs/run-cbmc-proofs.py' is not a readable file or directory... skipping.
warning: source '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/build/pkg/corejson/test/cbmc/proofs/Makefile.common' is not a readable file or directory... skipping.
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/include/net/gnrc/netif/pktq.h:16: warning: Potential recursion while resolving \ref command!
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/include/net/gnrc/netif/pktq/type.h:15: warning: Potential recursion while resolving \ref command!
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/include/net/gnrc/netif/pktq.h:0: warning: Potential recursion while resolving \ref command!
```

Reverting that PR will break the CI preview for some packages again, but considering Doxygen 1.9.1 at this point is OLD AF, it's a price worth paying. Also more motivation to finally migrate the Doxygen generation command to `make doc-ci`.

<img width="1871" height="949" alt="image" src="https://github.com/user-attachments/assets/8d5906a6-cc2a-4275-aeac-d0ed940b01c5" />

Note that `EXAMPLE_PATH` can't be empty either, because the `@include` commands only work for files specified in this path. I set it to use the same directories as `INPUT` currently does.

```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ make doc-ci
"make" -C doc/doxygen doc-ci
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/doc/doxygen'
make[2]: Nothing to be done for 'all'.
make[2]: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/doc/doxygen'
( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/doxygen/doxygen -
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/pkg/uwb-dw1000/doc.md:6: warning: \include{doc} file 'pkg/uwb-dw1000/README.md' not found
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/include/net/gnrc/netif/pktq.h:16: warning: Potential recursion while resolving \ref command!
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/include/net/gnrc/netif/pktq/type.h:15: warning: Potential recursion while resolving \ref command!
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/include/net/gnrc/netif/pktq.h:0: warning: Potential recursion while resolving \ref command!
```


In PR #21290 I changed the `@include` command in the `pkg/uwb-dw1000/doc.md` file to `@includedoc`. That command is deprecated, so I changed it to `@include{doc}`.



### Testing procedure

The generated documentation with and without this PR is identical:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ diff doc/doxygen/html doc/doxygen/html-with-pr/
diff doc/doxygen/html/_formulas.log doc/doxygen/html-with-pr/_formulas.log
1c1
< This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2022/dev/Debian) (preloaded format=latex 2026.2.4)  24 JUN 2026 16:22
---
> This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2022/dev/Debian) (preloaded format=latex 2026.2.4)  24 JUN 2026 16:18
diff doc/doxygen/html/doxygen.css doc/doxygen/html-with-pr/doxygen.css
2071c2071
< --datetime: 'Wed Jun 24 2026 16:22:46';
---
> --datetime: 'Wed Jun 24 2026 16:18:32';
2073c2073
< --time: '16:22:46';
---
> --time: '16:18:32';
Common subdirectories: doc/doxygen/html/search and doc/doxygen/html-with-pr/search
```


### Issues/PRs references

Partly reverts https://github.com/RIOT-OS/RIOT/pull/17572 from @kfessel 
Partly reverts https://github.com/RIOT-OS/RIOT/pull/21290 from @crasbe

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
