### PR TITLE
doc/doxygen: don't set the checksum for DLCACHE for custom versions

### DIFF
--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -42,6 +42,12 @@ DOXYGEN_CUR_VERSION = $(shell $(DOXYGEN) --version | cut -d ' ' -f1)
 # Valid options are `latest` and version numbers such as `1.13.2`.
 DOXYGEN_VERSION ?= $(DOXYGEN_MIN_VERSION)
 
+# If we don't build the Doxygen version specified here, remove the SHA512 sum
+# to avoid a checksum error from `dist/tools/dlcache.sh`
+ifneq ($(DOXYGEN_VERSION),$(DOXYGEN_MIN_VERSION))
+  DOXYGEN_TGZ_SHA512=
+endif
+
 # include color echo macros
 include $(RIOTMAKE)/utils/ansi.mk
 include $(RIOTMAKE)/color.inc.mk


### PR DESCRIPTION
### Contribution description

In #21372 I added the DLCACHE support for Doxygen. This included adding a SHA512 checksum to the `doc/doxygen/Makefile` to ensure the package integrity.

The issue arises when using the `DOXYGEN_VERSION` enviroment variable to set a different Doxygen version, since the checksum won't be correct and dlcache will complain about a checksum mismatch after downloading.

Therefore, when setting a custom version, the checksum is now removed and dlcache will always redownload the package if there is no `doxygen` binary present with the correct version in the `dist/tools/doxygen` directory.
Not ideal, but given the `DOXYGEN_VERSION` environment variable is only ever used for testing, that's not too bad.

### Testing procedure

Behavior with current `master`:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ DOXYGEN_VERSION=1.13.0 make doc-ci
"make" -C doc/doxygen doc-ci
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/doc/doxygen'
[INFO] Downloading Doxygen binary...
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/doxygen/../dlcache/dlcache.sh: "/home/cbuec/.dlcache/doxygen-1.13.0.linux.bin.tar.gz" has wrong or no checksum, re-downloading
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/doxygen/../dlcache/dlcache.sh: downloading "https://github.com/doxygen/doxygen/releases/download/Release_1_13_0/doxygen-1.13.0.linux.bin.tar.gz"...
2026-06-24 16:31:18 URL:https://release-assets.githubusercontent.com/github-production-release-asset/10160141/b381e848-37ab-488e-9106-cd69ed6d10f6?sp=r&sv=2018-11-09&sr=b&spr=https&se=2026-06-24T15%3A18%3A00Z&rscd=attachment%3B+filename%3Ddoxygen-1.13.0.linux.bin.tar.gz&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2026-06-24T14%3A17%3A50Z&ske=2026-06-24T15%3A18%3A00Z&sks=b&skv=2018-11-09&sig=BXeIGA7NY%2FUfl%2B2V3Nq9nDmIDGQjvQLx7EeQeupB4zs%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc4MjMxMzE2NiwibmJmIjoxNzgyMzExMzY2LCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.1IyzrOhZtXtyECG9ym6CHho1T4MXQzg2vM2BrXvYDJo&response-content-disposition=attachment%3B%20filename%3Ddoxygen-1.13.0.linux.bin.tar.gz&response-content-type=application%2Foctet-stream [78025463/78025463] -> "/home/cbuec/.dlcache/doxygen-1.13.0.linux.bin.tar.gz" [1]
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/doxygen/../dlcache/dlcache.sh: done downloading "https://github.com/doxygen/doxygen/releases/download/Release_1_13_0/doxygen-1.13.0.linux.bin.tar.gz"
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/doxygen/../dlcache/dlcache.sh: checksum mismatch!
[ERROR] Failed to download binary
make[3]: *** [Makefile:83: download_binary] Error 1
make[2]: *** [Makefile:79: /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/doxygen/doxygen] Error 2
make[1]: *** [Makefile:76: doc-ci] Error 2
make[1]: Leaving directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/doc/doxygen'
make: *** [Makefile:11: doc-ci] Error 2
```

Behavior with this PR:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ DOXYGEN_VERSION=1.13.0 make doc-ci
"make" -C doc/doxygen doc-ci
make[1]: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/doc/doxygen'
[INFO] Downloading Doxygen binary...
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/doxygen/../dlcache/dlcache.sh: downloading "https://github.com/doxygen/doxygen/releases/download/Release_1_13_0/doxygen-1.13.0.linux.bin.tar.gz"...
2026-06-24 16:29:34 URL:https://release-assets.githubusercontent.com/github-production-release-asset/10160141/b381e848-37ab-488e-9106-cd69ed6d10f6?sp=r&sv=2018-11-09&sr=b&spr=https&se=2026-06-24T15%3A18%3A00Z&rscd=attachment%3B+filename%3Ddoxygen-1.13.0.linux.bin.tar.gz&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2026-06-24T14%3A17%3A50Z&ske=2026-06-24T15%3A18%3A00Z&sks=b&skv=2018-11-09&sig=BXeIGA7NY%2FUfl%2B2V3Nq9nDmIDGQjvQLx7EeQeupB4zs%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc4MjMxMzE2NiwibmJmIjoxNzgyMzExMzY2LCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.1IyzrOhZtXtyECG9ym6CHho1T4MXQzg2vM2BrXvYDJo&response-content-disposition=attachment%3B%20filename%3Ddoxygen-1.13.0.linux.bin.tar.gz&response-content-type=application%2Foctet-stream [78025463/78025463] -> "/home/cbuec/.dlcache/doxygen-1.13.0.linux.bin.tar.gz" [1]
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/doxygen/../dlcache/dlcache.sh: done downloading "https://github.com/doxygen/doxygen/releases/download/Release_1_13_0/doxygen-1.13.0.linux.bin.tar.gz"
[INFO] Unpacking Doxygen...
make[2]: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/doc/doxygen'
( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/doxygen/doxygen -
...
```

### Issues/PRs references

Fixes a regression introduced in #21372.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
