### PR TITLE
tests/sys/cpp11_thread: use less stack for boards with low RAM memory

### DIFF
--- a/tests/Makefile.tests_common
+++ b/tests/Makefile.tests_common
@@ -1,6 +1,7 @@
 APPLICATION ?= tests_$(notdir $(patsubst %/,%,$(CURDIR)))
 BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
+RIOTMAKE ?= $(RIOTBASE)/makefiles
 QUIET ?= 1
 # DEVELHELP enabled by default for all tests, set 0 to disable
 DEVELHELP ?= 1

--- a/tests/sys/cpp11_thread/Makefile
+++ b/tests/sys/cpp11_thread/Makefile
@@ -1,7 +1,32 @@
 include ../Makefile.sys_common
 
+# include color echo macros
+include $(RIOTMAKE)/utils/ansi.mk
+include $(RIOTMAKE)/color.inc.mk
+
 USEMODULE += cpp11-compat
 USEMODULE += ztimer64_usec
 USEMODULE += timex
+
+# Boards with little RAM (~8KB) can't handle threads with the large default
+# stack size.
+# Beware: The reduced stack size will also suppress the thread stack usage
+#         printout!
+LOW_MEMORY_BOARDS := \
+    nucleo-c031c6 \
+    nucleo-f042k6 \
+    nucleo-g031k8 \
+    nucleo-l031k6 \
+    stm32g0316-disco \
+    weact-g030f6 \
+    #
+
+ifneq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
+  $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)Using a reduced stack size for low" \
+                        "memory board \"$(BOARD)\"!$(COLOR_RESET)" 1>&2)
+
+  CFLAGS += -DTHREAD_STACKSIZE_MAIN=512
+  DISABLE_MODULE += test_utils_print_stack_usage
+endif
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/sys/cpp11_thread/Makefile.ci
+++ b/tests/sys/cpp11_thread/Makefile.ci
@@ -1,11 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    nucleo-c031c6 \
-    nucleo-f042k6 \
     nucleo-l011k4 \
-    nucleo-l031k6 \
     samd10-xmini \
     stk3200 \
     stm32f030f4-demo \
-    stm32g0316-disco \
-    weact-g030f6 \
     #


### PR DESCRIPTION
### Contribution description

Following #22404, I ran `dist/tools/compile_and_test_for_board/compile_and_test_for_board.py` and noticed that `tests/sys/cpp11_thread` would crash. The reason is that the amount of stack used just exceeds the RAM available in the microcontroller.

Instead of reducing it globally, which would disable printing the stack usage for all microcontrollers, I adapted the `LOW_MEMORY_BOARDS` variable known from other tests and examples.

To get the additional boards that work now which didn't before, I set the stack to 512 bytes and ran `make generate-Makefile.ci` and copied the boards over afterwards.
It is possible that there are boards that would fail the test because they have enough memory for the static compilation check but not for the actual execution though, but without testing them it's kinda hard to know.

One way to find out would be to check the `RAM_LEN` somewhere and compile for all boards and add the ones that have <16KB of RAM, but I didn't want to go that far...

### Testing procedure

Unfortunately I don't have all the hardware for this, but now it works with the `nucleo-g031k8` where it previously crashed.

With #22404 applied, this is the result from `master`:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ BOARD=nucleo-g031k8 make -C tests/sys/cpp11_thread/ flash test -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/cpp11_thread'
Building application "tests_cpp11_thread" for "nucleo-g031k8" with CPU "stm32".

"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/pkg/cmsis/
...
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/ztimer64
   text    data     bss     dec     hex filename
  34040     192    2468   36700    8f5c /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/cpp11_thread/bin/nucleo-g031k8/tests_cpp11_thread.elf
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/openocd/openocd.sh flash /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/cpp11_thread/bin/nucleo-g031k8/tests_cpp11_thread.elf
### Flashing Target ###
Open On-Chip Debugger 0.12.0+dev-00645-g49ef1d010 (2026-05-28-14:54)
...
Done flashing
r
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" -ln "/tmp/pyterm-cbuec" -rn "2026-06-24_16.49.07-tests_cpp11_thread-nucleo-g031k8" --no-reconnect --noprefix --no-repeat-command-on-empty-line
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2026.07-devel-388-g9ae8f-timer-nucleo-g031k8)

************ C++ thread test ***********
Creating one thread and passing an argument ...
Done

tests/sys/cpp11_thread/main.cpp:56 => failed condition
*** RIOT kernel panic:
CONDITION FAILED.

*** halted.

Timeout in expect script at "child.expect_exact("Creating detached thread ...")" (tests/sys/cpp11_thread/tests/01-run.py:18)

make: *** [/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/makefiles/tests/tests.inc.mk:32: test] Error 1
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/cpp11_thread'
```

With #22404 applied and this PR:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ BOARD=nucleo-g031k8 make -C tests/sys/cpp11_thread/ flash test -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/cpp11_thread'
Using a reduced stack size for low memory board "nucleo-g031k8"!
Building application "tests_cpp11_thread" for "nucleo-g031k8" with CPU "stm32".

"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/pkg/cmsis/
...
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/ztimer64
   text    data     bss     dec     hex filename
  33896     192    1444   35532    8acc /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/cpp11_thread/bin/nucleo-g031k8/tests_cpp11_thread.elf
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/openocd/openocd.sh flash /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/cpp11_thread/bin/nucleo-g031k8/tests_cpp11_thread.elf
### Flashing Target ###
Open On-Chip Debugger 0.12.0+dev-00645-g49ef1d010 (2026-05-28-14:54)
...
Done flashing
r
Using a reduced stack size for low memory board "nucleo-g031k8"!
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" -ln "/tmp/pyterm-cbuec" -rn "2026-06-24_16.51.50-tests_cpp11_thread-nucleo-g031k8" --no-reconnect --noprefix --no-repeat-command-on-empty-line
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2026.07-devel-391-g04ff9-pr/cpp11_thread_low_memory_boards)

************ C++ thread test ***********
Creating one thread and passing an argument ...
Done

Creating detached thread ...
Done

Join on 'finished' thread ...
Done

Join on 'running' thread ...
Done

Testing sleep_for ...
Done

Testing sleep_until ...
Done

Swapping two threads ...
Done

Move constructor ...
Done

Bye, bye.
******************************************

make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/cpp11_thread'
```

### Issues/PRs references

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
