### PR TITLE
sys/cpp_new_delete: handle allocation failures

### DIFF
--- a/sys/cpp_new_delete/new_delete.cpp
+++ b/sys/cpp_new_delete/new_delete.cpp
@@ -1,50 +1,74 @@
 /*
- * Copyright (c) 2014 Arduino.  All right reserved.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
+ * SPDX-FileCopyrightText: Copyright (c) 2014 Arduino.  All right reserved.
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #include <stdlib.h>
 
-void *operator new(size_t size) {
-    return malloc(size);
+#include "compiler_hints.h"
+
+#ifndef __EXCEPTIONS
+#  include "panic.h"
+#else
+#  include <new>
+#endif
+
+namespace
+{
+void *_new_helper(size_t size)
+{
+    if (size == 0) {
+        /* C++ requires new to return unique ptrs. If we allocate at least 1
+         * byte, we can do so */
+        size = 1;
+    }
+    void *result = malloc(size);
+    if (unlikely(result == NULL)) {
+#ifdef __EXCEPTIONS
+        throw std::bad_alloc();
+#else
+        core_panic(PANIC_MEM_MANAGE, "C++ new alloc failure");
+#endif
+    }
+
+    return result;
+}
+} /* end anonymous namespace */
+
+__attribute__((weak))
+void *operator new(size_t size)
+{
+    return _new_helper(size);
 }
 
-void *operator new[](size_t size) {
-    return malloc(size);
+__attribute__((weak))
+void *operator new[](size_t size)
+{
+    return _new_helper(size);
 }
 
-void *operator new(size_t size, void *ptr) noexcept {
-    (void)size;
-    return ptr;
-}
-
-void operator delete(void *ptr) noexcept {
+__attribute__((weak))
+void operator delete(void *ptr) noexcept
+{
     free(ptr);
 }
 
-void operator delete(void *ptr, size_t) noexcept {
+__attribute__((weak))
+void operator delete(void *ptr, size_t unused) noexcept
+{
+    (void)unused;
     free(ptr);
 }
 
-void operator delete[](void *ptr) noexcept {
+__attribute__((weak))
+void operator delete[](void *ptr) noexcept
+{
     free(ptr);
 }
 
-void operator delete [](void *ptr, size_t) noexcept {
+__attribute__((weak))
+void operator delete[](void *ptr, size_t unused) noexcept
+{
+    (void)unused;
     free(ptr);
 }

--- a/sys/newlib_syscalls_default/syscalls.c
+++ b/sys/newlib_syscalls_default/syscalls.c
@@ -167,7 +167,12 @@ __attribute__((used)) void _fini(void)
  */
 __attribute__((used)) void _exit(int n)
 {
-    LOG_INFO("#! exit %i: powering off\n", n);
+    if (n > 0) {
+        LOG_ERROR("ERR: program failed with exit code %i\n", n);
+    }
+    else {
+        LOG_WARNING("WARN: program exited\n");
+    }
 #ifdef MODULE_PERIPH_PM
     pm_off();
 #endif

--- a/sys/picolibc_syscalls_default/syscalls.c
+++ b/sys/picolibc_syscalls_default/syscalls.c
@@ -116,7 +116,12 @@ static const struct heap heaps[NUM_HEAPS] = {
 void __attribute__((__noreturn__))
 _exit(int n)
 {
-    LOG_INFO("#! exit %i: powering off\n", n);
+    if (n > 0) {
+        LOG_ERROR("ERR: program failed with exit code %i\n", n);
+    }
+    else {
+        LOG_WARNING("WARN: program exited\n");
+    }
 #ifdef MODULE_PERIPH_PM
     pm_off();
 #endif /* MODULE_PERIPH_PM */

--- a/tests/sys/cpp11_thread/Makefile
+++ b/tests/sys/cpp11_thread/Makefile
@@ -5,3 +5,16 @@ USEMODULE += ztimer64_usec
 USEMODULE += timex
 
 include $(RIOTBASE)/Makefile.include
+
+# Boards with little RAM (<=8KB) can't handle threads with the large default
+# stack size. Since cpp11_thread allocates that at runtime, the allocation
+# failure will either cause a panic (no exception supported) or exit with
+# error (exceptions supported)
+BOARDS_UNSUPPORTED := \
+    nucleo-c031c6 \
+    nucleo-f042k6 \
+    nucleo-g031k8 \
+    nucleo-l031k6 \
+    stm32g0316-disco \
+    weact-g030f6 \
+    #

--- a/tests/sys/cpp11_thread/Makefile.ci
+++ b/tests/sys/cpp11_thread/Makefile.ci
@@ -1,11 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
-    nucleo-c031c6 \
-    nucleo-f042k6 \
     nucleo-l011k4 \
-    nucleo-l031k6 \
     samd10-xmini \
     stk3200 \
     stm32f030f4-demo \
-    stm32g0316-disco \
-    weact-g030f6 \
     #


### PR DESCRIPTION
### Contribution description

If exceptions are supported, throw an `std::bad_alloc` on allocation failure.

If not, panic on allocation failure.

### Testing procedure

Allocations should now fail as expected. E.g. the test in `tests/sys/cpp11_thread` can both easily trigger allocation failures and has a very interesting failure mode.

With this fix, the failure mode should be more boring.

### Issues/PRs references

Found in https://github.com/RIOT-OS/RIOT/pull/22417

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
