### PR TITLE
cpu/stm32: allow custom PLL config for H7

### DIFF
--- a/cpu/stm32/include/clk/h7/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/h7/cfg_clock_default.h
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @brief           Main header for STM32H7 clock configuration (STM32H753ZI)
+ * @brief           Main header for STM32H7 clock configuration
  *
  * @note
  * This configuration supports:
@@ -58,7 +58,7 @@ extern "C" {
 #    define CONFIG_USE_HSI_PLL       0
 #  else
 #    define CONFIG_USE_HSI_PLL       1
-#endif
+#  endif
 #endif
 
 /**
@@ -188,9 +188,12 @@ extern "C" {
 #   endif
 
 #  else
-#    error "Unsupported clock input for PLL configuration."
+     /* only error out when the board didn't configure the PLL itself */
+#    ifndef CONFIG_CLOCK_PLL1_M
+#      error "Unsupported clock input for PLL configuration."
+#    endif
 #  endif
-#endif /* CONFIG_USE_HSI_DIRECT */
+#endif /* CONFIG_USE_HSI_PLL CONFIG_USE_HSE_PLL CONFIG_USE_CSI_PLL */
 
 #include "clk/h7/lse.h"
 #include "clk/h7/lsi.h"


### PR DESCRIPTION
### Contribution description

The default clock configuration currently errors out when a non-standard clock rate is used. As the PLL settings can be overridden in a board definition, a check was added before aborting the compilation with an error message.

### Testing procedure

Trust me bro.

Or if you *really* want to, you can try to compile for the Nucleo-H753ZI with custom clock configuration.

Current `master`:
```
CFLAGS="-DCONFIG_CLOCK_HSE='32' -DCONFIG_CLOCK_BOARD_HAS_HSE='1' -DCONFIG_USE_HSE_PLL='1' -DCONFIG_CLOCK_PLL1_M='2' -DCONFIG_CLOCK_PLL1_N='60' -DCONFIG_CLOCK_PLL1_P='2' -DCONFIG_CLOCK_PLL1_P='2' -DCONFIG_CLOCK_PLL1_Q='20' -DCONFIG_CLOCK_PLL1_R='2' -DCONFIG_CLOCK_PLL2_M='2' -DCONFIG_CLOCK_PLL2_N='60' -DCONFIG_CLOCK_PLL2_P='2' -DCONFIG_CLOCK_PLL2_P='2' -DCONFIG_CLOCK_PLL2_Q='20' -DCONFIG_CLOCK_PLL2_R='2' -DCONFIG_CLOCK_PLL3_M='2' -DCONFIG_CLOCK_PLL3_N='60' -DCONFIG_CLOCK_PLL3_P='2' -DCONFIG_CLOCK_PLL3_P='2' -DCONFIG_CLOCK_PLL3_Q='20' -DCONFIG_CLOCK_PLL3_R='2'" BOARD=nucleo-h753zi make -C tests/sys/shell
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell'
Building application "tests_shell" for "nucleo-h753zi" with CPU "stm32".

"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/pkg/cmsis/
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/pkg/mpaland-printf/
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/build/pkg/mpaland-printf -f /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/pkg/mpaland-printf/mpaland-printf.mk
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/boards
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/boards/common/init
In file included from /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/cpu/stm32/include/clk/clk_conf.h:27,
                 from /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/boards/nucleo-h753zi/include/periph_conf.h:27,
                 from /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/drivers/include/periph/gpio.h:78,
                 from /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/boards/common/nucleo144/include/arduino_iomap.h:21,
                 from /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/drivers/include/arduino_pinmap.h:20,
                 from /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/boards/common/nucleo144/include/board.h:23,
                 from /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/boards/common/init/board_common.c:17:
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/cpu/stm32/include/clk/h7/cfg_clock_default.h:191:6: error: #error "Unsupported clock input for PLL configuration."
  191 | #    error "Unsupported clock input for PLL configuration."
      |      ^~~~~
make[3]: *** [/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/Makefile.base:162: /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell/bin/nucleo-h753zi/board_common_init/board_common.o] Error 1
make[2]: *** [/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/Makefile.base:31: ALL--/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/boards/common/init] Error 2
make[1]: *** [/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/Makefile.base:31: ALL--/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/boards] Error 2
make: *** [/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell/../../../Makefile.include:743: application_tests_shell.module] Error 2
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell'
```


This PR:
```
CFLAGS="-DCONFIG_CLOCK_HSE='32' -DCONFIG_CLOCK_BOARD_HAS_HSE='1' -DCONFIG_USE_HSE_PLL='1' -DCONFIG_CLOCK_PLL1_M='2' -DCONFIG_CLOCK_PLL1_N='60' -DCONFIG_CLOCK_PLL1_P='2' -DCONFIG_CLOCK_PLL1_P='2' -DCONFIG_CLOCK_PLL1_Q='20' -DCONFIG_CLOCK_PLL1_R='2' -DCONFIG_CLOCK_PLL2_M='2' -
DCONFIG_CLOCK_PLL2_N='60' -DCONFIG_CLOCK_PLL2_P='2' -DCONFIG_CLOCK_PLL2_P='2' -DCONFIG_CLOCK_PLL2_Q='20' -DC
ONFIG_CLOCK_PLL2_R='2' -DCONFIG_CLOCK_PLL3_M='2' -DCONFIG_CLOCK_PLL3_N='60' -DCONFIG_CLOCK_PLL3_P='2' -DCONF
IG_CLOCK_PLL3_P='2' -DCONFIG_CLOCK_PLL3_Q='20' -DCONFIG_CLOCK_PLL3_R='2'" BOARD=nucleo-h753zi make -C tests/
sys/shell
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell'
Building application "tests_shell" for "nucleo-h753zi" with CPU "stm32".

"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/pkg/cmsis/
...
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/ztimer
   text    data     bss     dec     hex filename
  17808     180    2532   20520    5028 /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell/bin/nucleo-h753zi/tests_shell.elf
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell'
```

### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
