### PR TITLE
boards/nucleo-g031k8: Add LED and button (SAUL) support for the NUCLEO-G031K8 board.

### DIFF
--- a/boards/common/nucleo32/include/board.h
+++ b/boards/common/nucleo32/include/board.h
@@ -27,15 +27,9 @@ extern "C" {
  * @name Macros for controlling the on-board LED (LD3).
  * @{
  */
-#ifdef BOARD_NUCLEO_G031K8
-#  define LED0_PIN_NUM        6
-#  define LED0_PORT           GPIO_PORT_C /**< GPIO port of LED 3 */
-#  define LED0_PORT_NUM       PORT_C
-#else
-#  define LED0_PIN_NUM        3
-#  define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
-#  define LED0_PORT_NUM       PORT_B
-#endif
+#define LED0_PIN_NUM        3
+#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
+#define LED0_PORT_NUM       PORT_B
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-g031k8/doc.md
+++ b/boards/nucleo-g031k8/doc.md
@@ -51,15 +51,15 @@ The board name for the Nucleo-G031K8 is `nucleo-g031k8`.
 ## Reset configuration
 
 Some boards ship with the `NRST_MODE` option byte set to `2` (the documented
-default is `3`), which turns the NRST pin into the `PF2` GPIO and disables its
-reset function, so the reset button, the NRST pin and the ST-Link reset no
-longer reset the MCU. RIOT works around this by resetting over SWD
+default is `3`), i.e. in **User button mode** below. In this case, hardware
+reset via NRST is unavailable, but RIOT works around this by resetting over SWD
 (`reset_config none`), so `make flash` always works.
 
-To restore the hardware reset, set `NRST_MODE` to `1` or `3`. The easiest way
-to do this is to use STM32CubeProgrammer, which is available for Linux,
-Mac (x86 and ARM) and Windows on the
-[ST website](https://www.st.com/en/development-tools/stm32cubeprog.html).
+- **User button mode** (`NRST_MODE = 2`): PF2 is available as button BTN0 for
+applications, but hardware reset via NRST is disabled. See warning below.
+
+- **Reset mode** (`NRST_MODE = 1 or 3`): PF2 remains a hardware reset button,
+but it cannot be used as an application user button.
 
 @warning If your program crashes after startup, it might become impossible to
          reset and flash the microcontroller if the software reset
@@ -68,6 +68,11 @@ Mac (x86 and ARM) and Windows on the
          high to enter the bootloader and then connect with e.g.
          STM32CubeProgrammer to erase the flash memory. This suggestion
          is not tested yet!
+
+To restore the hardware reset, set `NRST_MODE` to `1` or `3`. The easiest way
+to do this is to use STM32CubeProgrammer, which is available for Linux,
+Mac (x86 and ARM) and Windows on the
+[ST website](https://www.st.com/en/development-tools/stm32cubeprog.html).
 
 @note STM32CubeProgrammer v2.22 from February 2026 has a bug that prevents
 writing the Option Bytes. Use an older or newer version instead!

--- a/boards/nucleo-g031k8/include/arduino_iomap.h
+++ b/boards/nucleo-g031k8/include/arduino_iomap.h
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Hudson C. Dalpra
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_nucleo-g031k8
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      Hudson C. Dalpra <dalpra.hcd@gmail.com>
+ *
+ */
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0           GPIO_PIN(PORT_B, 7)
+#define ARDUINO_PIN_1           GPIO_PIN(PORT_B, 6)
+#define ARDUINO_PIN_2           GPIO_PIN(PORT_A, 15)
+#define ARDUINO_PIN_3           GPIO_PIN(PORT_B, 1)
+#define ARDUINO_PIN_4           GPIO_PIN(PORT_A, 10)
+#define ARDUINO_PIN_5           GPIO_PIN(PORT_A, 9)
+#define ARDUINO_PIN_6           GPIO_PIN(PORT_B, 0)
+#define ARDUINO_PIN_7           GPIO_PIN(PORT_B, 2)
+#define ARDUINO_PIN_8           GPIO_PIN(PORT_B, 8)
+#define ARDUINO_PIN_9           GPIO_PIN(PORT_A, 8)
+#define ARDUINO_PIN_10          GPIO_PIN(PORT_B, 9)
+#define ARDUINO_PIN_11          GPIO_PIN(PORT_B, 5)
+#define ARDUINO_PIN_12          GPIO_PIN(PORT_B, 4)
+#define ARDUINO_PIN_13          GPIO_PIN(PORT_B, 3)
+
+/* analog pins in digital mode: */
+#define ARDUINO_PIN_14          GPIO_PIN(PORT_A, 0)
+#define ARDUINO_PIN_15          GPIO_PIN(PORT_A, 1)
+#define ARDUINO_PIN_16          GPIO_PIN(PORT_A, 4)
+#define ARDUINO_PIN_17          GPIO_PIN(PORT_A, 5)
+#define ARDUINO_PIN_18          GPIO_PIN(PORT_A, 12)
+#define ARDUINO_PIN_19          GPIO_PIN(PORT_A, 11)
+#define ARDUINO_PIN_20          GPIO_PIN(PORT_A, 6)
+#define ARDUINO_PIN_21          GPIO_PIN(PORT_A, 7)
+
+#define ARDUINO_PIN_LAST        21
+/** @} */
+
+/**
+ * @brief   Aliases for analog pins
+ * @{
+ */
+#define ARDUINO_PIN_A0          ARDUINO_PIN_14
+#define ARDUINO_PIN_A1          ARDUINO_PIN_15
+#define ARDUINO_PIN_A2          ARDUINO_PIN_16
+#define ARDUINO_PIN_A3          ARDUINO_PIN_17
+#define ARDUINO_PIN_A4          ARDUINO_PIN_18
+#define ARDUINO_PIN_A5          ARDUINO_PIN_19
+#define ARDUINO_PIN_A6          ARDUINO_PIN_20
+#define ARDUINO_PIN_A7          ARDUINO_PIN_21
+/** @} */
+
+/**
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
+ * @{
+ */
+#define ARDUINO_A0              ADC_LINE(0)
+#define ARDUINO_A1              ADC_LINE(1)
+#define ARDUINO_A2              ADC_LINE(2)
+#define ARDUINO_A3              ADC_LINE(3)
+#define ARDUINO_A4              ADC_LINE(4)
+#define ARDUINO_A5              ADC_LINE(5)
+#define ARDUINO_A6              ADC_LINE(6)
+#define ARDUINO_A7              ADC_LINE(7)
+
+#define ARDUINO_ANALOG_PIN_LAST 7
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/boards/nucleo-g031k8/include/board.h
+++ b/boards/nucleo-g031k8/include/board.h
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Hudson C. Dalpra
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_nucleo-g031k8
+ * @{
+ *
+ * @file
+ * @brief       Pin definitions and board configuration options
+ *
+ * @author      Hudson C. Dalpra <dalpra.hcd@gmail.com>
+ */
+
+#include "board_nucleo.h"
+#include "arduino_pinmap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Macros for controlling the on-board LED (LD3).
+ * @{
+ */
+#define LED0_PIN_NUM        6
+#define LED0_PORT           GPIO_PORT_C /**< GPIO port of LED 3 */
+#define LED0_PORT_NUM       PORT_C
+/** @} */
+
+/**
+ * @name Macros for controlling the on-board button (B1).
+ *
+ * @note PF2 is shared with NRST so the behaviour depends on `NRST_MODE`.
+ *       See `boards/nucleo-g031k8/doc.md` (Reset configuration).
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(PORT_F, 2)  /**< Button B1 pin  */
+#define BTN0_MODE           GPIO_IN_PU           /**< Button B1 mode (released = HIGH) */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#include "stm32_leds.h"
+
+/** @} */

--- a/boards/nucleo-g031k8/include/gpio_params.h
+++ b/boards/nucleo-g031k8/include/gpio_params.h
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Hudson C. Dalpra
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_nucleo-g031k8
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Hudson C. Dalpra <dalpra.hcd@gmail.com>
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+#ifdef MODULE_PERIPH_INIT_LED0
+    {
+        .name = "LD3(green)",
+        .pin  = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+#endif
+    {
+        .name  = "Button(B1)",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */


### PR DESCRIPTION
### Contribution description

Adding support for button and led using saul.

Based on the boards/nucleo-wl55jc.


### Testing procedure

Ran the following tests:

```
BOARD=nucleo-g031k8 make -C tests/drivers/saul flash term

...omitted...

2026-06-28 11:36:04,099 # Dev: LD3(green)       Type: ACT_SWITCH
2026-06-28 11:36:04,101 # Data:               0 
2026-06-28 11:36:04,101 # 
2026-06-28 11:36:04,103 # Dev: Button(B1)       Type: SENSE_BTN
2026-06-28 11:36:04,106 # Data:               0 
2026-06-28 11:36:04,106 # 
2026-06-28 11:36:04,108 # ##########################
```

```
BOARD=nucleo-g031k8 make -C examples/basic/saul flash term

... omitted ...

saul
2026-06-28 11:36:51,685 #                     0saul
2026-06-28 11:36:51,686 # ID    Class           Name
2026-06-28 11:36:51,688 # #0    ACT_SWITCH      LD3(green)
2026-06-28 11:36:51,690 # #1    SENSE_BTN       Button(B1)
> saul write 0 1
2026-06-28 11:36:59,170 # saul write 0 1
2026-06-28 11:36:59,173 # Writing to device #0 - LD3(green)
2026-06-28 11:36:59,175 # Data:               1 
2026-06-28 11:36:59,179 # data successfully written to device #0
> saul read 1
2026-06-28 11:37:07,000 # saul read 1
2026-06-28 11:37:07,004 # Reading from #1 (Button(B1)|SENSE_BTN)
2026-06-28 11:37:07,007 # Data:               0 
> saul read 1
2026-06-28 11:37:11,716 # saul read 1
2026-06-28 11:37:11,719 # Reading from #1 (Button(B1)|SENSE_BTN)
2026-06-28 11:37:11,721 # Data:               1 
```

One caveat, I try testing the interrupt on the button (PF2), but it only fired once,
no matter how much I pressed the button.

I don't have enough knowledge to understand what is happening, maybe I should test with
another gpio.

```
BOARD=nucleo-g031k8 make -C tests/periph/gpio flash term

... omitted ...

init_int 5 2 falling pu
2026-06-28 11:45:25,765 # init_int 5 2 falling pu
2026-06-28 11:45:25,769 # GPIO_PIN(5, 2) successfully initialized as ext int
> 2026-06-28 11:45:28,712 # INT: external interrupt from pin 2
```

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
