### PR TITLE
net/emcute: unlock txlock on connect errors

### DIFF
--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -224,6 +224,7 @@ int emcute_con(sock_udp_ep_t *remote, bool clean, const char *will_topic,
 
     /* check for existing connections and copy given UDP endpoint */
     if (gateway.port != 0) {
+        mutex_unlock(&txlock);
         return EMCUTE_NOGW;
     }
     memcpy(&gateway, remote, sizeof(sock_udp_ep_t));
@@ -249,12 +250,14 @@ int emcute_con(sock_udp_ep_t *remote, bool clean, const char *will_topic,
         if ((topic_len > CONFIG_EMCUTE_TOPIC_MAXLEN) ||
             ((will_msg_len + 4) > CONFIG_EMCUTE_BUFSIZE)) {
             gateway.port = 0;
+            mutex_unlock(&txlock);
             return EMCUTE_OVERFLOW;
         }
 
         res = syncsend(WILLTOPICREQ, len, false);
         if (res != EMCUTE_OK) {
             gateway.port = 0;
+            mutex_unlock(&txlock);
             return res;
         }
 
@@ -268,6 +271,7 @@ int emcute_con(sock_udp_ep_t *remote, bool clean, const char *will_topic,
         res = syncsend(WILLMSGREQ, len, false);
         if (res != EMCUTE_OK) {
             gateway.port = 0;
+            mutex_unlock(&txlock);
             return res;
         }
 

--- a/tests/net/emcute/tests-as-root/01-run.py
+++ b/tests/net/emcute/tests-as-root/01-run.py
@@ -27,6 +27,7 @@ SERVER_PORT = 1883
 MODES = set(["pub", "sub", "sub_w_reg"])
 INTER_PACKET_GAP = 0.07
 TIMEOUT = 1
+TOPIC_MAX_LEN = 249
 
 
 class MQTTSNServer(Automaton):
@@ -456,13 +457,24 @@ def get_host_lladdr(tap):
         return res
 
 
+def check_will_topic_overflow_releases_txlock(child, gw_addr):
+    utils.test_utils_interactive_sync_shell(child,
+                                            TEST_INTERACTIVE_RETRIES,
+                                            TEST_INTERACTIVE_DELAY)
+    will_topic = "/" + ("x" * TOPIC_MAX_LEN)
+    for _ in range(2):
+        child.sendline("con {} {} msg".format(gw_addr, will_topic))
+        child.expect_exact("error: unable to connect to {}".format(gw_addr))
+
+
 def testfunc(child):
     tap = get_bridge(os.environ["TAP"])
     lladdr = get_host_lladdr(tap)
+    gw_addr = "[{}%{}]:{}".format(lladdr, tap, SERVER_PORT)
 
     time.sleep(1)
     DATA_MAX_LEN = 512 - 9  # PUBLISH + 2 byte extra for length
-    TOPIC_MAX_LEN = 249     # see Makefile
+    check_will_topic_overflow_releases_txlock(child, gw_addr)
     for test_params in [
         {"qos_level": 0, "mode": "sub", "topic_name": "/test",
          "data_len_start": 0, "data_len_end": DATA_MAX_LEN,


### PR DESCRIPTION
### Contribution description

`emcute_con()` locks `txlock` before checking the current gateway state and before running the optional last-will handshake. Several error paths returned after that lock was acquired without unlocking it.

This fixes the connect error paths by unlocking `txlock` before returning when:

- a gateway is already connected
- the last-will topic/message does not fit
- `WILLTOPICREQ` fails
- `WILLMSGREQ` fails

The change is intentionally limited to releasing the existing lock on paths that already return an error. It does not change MQTT-SN packet encoding or the existing client ID length validation.

### Testing procedure

A regression scenario was added to `tests/net/emcute/tests-as-root/01-run.py`.

The new `check_will_topic_overflow_releases_txlock()` step constructs a will topic that is one byte longer than the test's `CONFIG_EMCUTE_TOPIC_MAXLEN=249`, then sends this shell command twice:

```sh
con <gateway> <overlong-will-topic> msg
```

Expected result with this fix: both attempts print `error: unable to connect to <gateway>` and the test continues.

Expected result before this fix: the first attempt reaches the `EMCUTE_OVERFLOW` path after `txlock` has been acquired and returns without unlocking it, so the second attempt blocks waiting for the same lock. The repeated command is what turns the missing unlock into an observable test hang.

The local checks I can run from this Windows checkout are only sanity checks for the patch and the modified Python test harness:

```sh
python -m py_compile tests/net/emcute/tests-as-root/01-run.py
git diff --check
```

`py_compile` is not meant as behavioral validation for emcute; it only verifies that the edited Python test file still parses in this local environment.

I still cannot run the full RIOT native build locally because this checkout has no `make` and no installed WSL distribution. With a RIOT build environment, the relevant target is:

```sh
make -C tests/net/emcute BOARD=native all
```

The PR Murdock run passed with 11124 successful jobs and 0 failures.

### Issues/PRs references

None found.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- OpenAI Codex with GPT-5 for code inspection, patch generation, and validation command orchestration, with user-directed scope and review.
