### PR TITLE
makefiles: filter stdio_default with STDIO_MODULES

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -2,11 +2,6 @@
 -include $(APPDIR)/Makefile.board.dep
 -include $(APPDIR)/Makefile.$(TOOLCHAIN).dep
 
-# select default stdio provider if no other is selected
-ifeq (,$(filter stdio_%,$(USEMODULE)))
-  USEMODULE += stdio_default
-endif
-
 # include board dependencies
 -include $(BOARDDIR)/Makefile.dep
 

--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -29,6 +29,12 @@ ifneq (,$(filter periph_usbdev,$(FEATURES_USED)))
   endif
 endif
 
+# always require periph_uart when using periph_lpuart because they share code
+# internally
+ifneq (,$(filter periph_lpuart,$(FEATURES_USED)))
+  FEATURES_REQUIRED += periph_uart
+endif
+
 ifneq (,$(filter periph_uart_nonblocking,$(USEMODULE)))
   USEMODULE += tsrb
 endif

--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -1,29 +1,28 @@
+include $(RIOTMAKE)/utils/strings.mk
+
+# List of available stdio backend modules.
 STDIO_MODULES = \
   stdio_cdc_acm \
   stdio_ethos \
+  stdio_fb \
   stdio_native \
   stdio_nimble \
   stdio_null \
   stdio_rtt \
   stdio_semihosting \
   stdio_slipdev \
-  stdio_uart \
-  stdio_udp \
   stdio_telnet \
   stdio_tinyusb_cdc_acm \
+  stdio_uart \
+  stdio_udp \
   stdio_usb_serial_jtag \
-  stdio_fb \
   #
 
+# List of available legacy stdio backend modules.
 STDIO_LEGACY_MODULES = \
   ethos_stdio \
   stdio_ethos \
   #
-
-# select stdio_uart if no other stdio module is slected
-ifeq (,$(filter $(STDIO_MODULES),$(USEMODULE)))
-  USEMODULE += stdio_uart
-endif
 
 ifeq (,$(filter $(STDIO_LEGACY_MODULES),$(USEMODULE)))
   USEMODULE += stdio
@@ -33,7 +32,9 @@ ifneq (,$(filter stdin,$(USEMODULE)))
   USEMODULE += isrpipe
 endif
 
-ifneq (1, $(words $(sort $(filter $(STDIO_MODULES),$(USEMODULE)))))
+# Check if more than one STDIO has been selected, if so add stdio_dispatch.
+# This check will fail if 10 or more modules are selected.
+ifeq (1, $(call _is_greater,$(words $(sort $(filter $(STDIO_MODULES),$(USEMODULE)))),1))
   USEMODULE += stdio_dispatch
 endif
 
@@ -99,9 +100,20 @@ ifneq (,$(filter stdio_udp,$(USEMODULE)))
   USEMODULE += sock_async
 endif
 
-# enable stdout buffering for modules that benefit from sending out buffers in larger chunks
+# Enable stdout buffering for modules that benefit from sending out buffers in
+# larger chunks.
 ifneq (,$(filter picolibc,$(USEMODULE)))
   ifneq (,$(filter stdio_cdc_acm stdio_ethos stdio_slipdev stdio_semihosting stdio_tinyusb_cdc_acm,$(USEMODULE)))
     USEMODULE += picolibc_stdout_buffered
   endif
+endif
+
+# Select stdio_default if no other STDIO backend has been selected so far.
+# If no STDIO backend has been selected in the second round of dependency
+# resolution, then select stdio_uart.
+ifeq (,$(filter $(STDIO_MODULES),$(USEMODULE)))
+  ifneq (,$(filter stdio_default,$(USEMODULE)))
+    USEMODULE += stdio_uart
+  endif
+  USEMODULE += stdio_default
 endif

--- a/sys/stdio/doc.md
+++ b/sys/stdio/doc.md
@@ -35,11 +35,51 @@ USEMODULE += printf_float
 
 The various transports supported by RIOT are enabled by selecting the
 corresponding modules, such as @ref sys_stdio_uart, @ref usbus_cdc_acm_stdio,
-or @ref sys_stdio_rtt. All available options can are shown as mdoules in the
-list below.
+or @ref sys_stdio_rtt. All available options are shown as modules in the
+list below:
 
-As with the additional features, you can specify the STDIO backend to be used in your application Makefile:
+| Module                  | Description                                              |
+|:----------------------- |:-------------------------------------------------------- |
+| `stdio_cdc_acm`         | USB CDC ACM STDIO, see @ref usbus_cdc_acm_stdio          |
+| `stdio_ethos`           | Ethernet-over-serial STDIO (legacy, see `ethos`)         |
+| `stdio_fb`              | Framebuffer STDIO                                        |
+| `stdio_native`          | Native board STDIO, forwarded to the host terminal       |
+| `stdio_nimble`          | Bluetooth LE STDIO on top of NimBLE                      |
+| `stdio_null`            | Discards all output, no input support                    |
+| `stdio_rtt`             | Segger RTT STDIO, see @ref sys_stdio_rtt                 |
+| `stdio_semihosting`     | ARM/RISC-V semihosting STDIO                             |
+| `stdio_slipdev`         | SLIP STDIO                                               |
+| `stdio_telnet`          | Telnet STDIO                                             |
+| `stdio_tinyusb_cdc_acm` | USB CDC ACM STDIO on top of the tinyUSB stack            |
+| `stdio_uart`            | UART STDIO, see @ref sys_stdio_uart                      |
+| `stdio_udp`             | UDP STDIO                                                |
+| `stdio_usb_serial_jtag` | USB Serial/JTAG STDIO (e.g. on some ESP32 variants)      |
+
+As with the additional features, you can specify the STDIO backend to be used
+in your application Makefile:
 
 ```Makefile
 USEMODULE += stdio_cdc_acm
 ```
+
+@note   More than one backend can be selected at the same time. In that
+        case, `stdio_dispatch` is pulled in automatically. It forwards
+        `stdio_write()` to every selected backend and merges the input of
+        all of them into a single stream. A maximum of 9 backends can be
+        selected at the same time.
+
+@note   Not selecting any of the above backends will result in `stdio_uart`
+        being selected as a fallback, so that a usable STDIO is always
+        available. This happens in a two-stage dependency selection mechanism
+        where first `stdio_default` is selected, and if no other backend is
+        selected in the second round of dependency resolution, `stdio_uart` is
+        selected as a fallback. Refer to `makefiles/stdio.inc.mk` for the
+        details.
+
+## Additional features
+
+### stdio_available
+
+The pseudomodule `stdio_available` exists to mark that the selected STDIO
+backend supports @ref stdio_available, the function used to query how many
+bytes are currently buffered for reading.


### PR DESCRIPTION
### Contribution description

Filtering only on `stdio_%` is too greedy, and will match several pseudomodules such as `stdio_available` or `stdio_nimble_debug`. By moving the list of backends to a single source, the inclusion of `stdio_default` can be filtered correctly.

Noticed this while adding a new pseudomodule to the stdio module.

### Testing procedure

Verify that `USEMODULE=stdio_available make -C examples/basic/hello-world` is not working (it does not print 'Hello World!' ).

Then apply this patch, and verify that it does work.

Verified this to work on `native` (defaults to `stdio_native`), `sltb001a` (defaults to `stdio_uart`) and `pro-micro-nrf52840` (defaults to `stdio_cdc_acm`).

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- Claude Opus 4.8 to identify the root cause and potential fix, which I then performed myself.
