### PR TITLE
sys/isrpipe: add convenience helpers to improve sys/stdio

### DIFF
--- a/sys/include/isrpipe.h
+++ b/sys/include/isrpipe.h
@@ -86,12 +86,41 @@ int isrpipe_write(isrpipe_t *isrpipe, const uint8_t *buf, size_t n);
  * @brief   Read data from isrpipe (blocking)
  *
  * @param[in]   isrpipe    isrpipe object to operate on
- * @param[in]   buf        buffer to write to
+ * @param[out]  buf        buffer to write to
  * @param[in]   count      number of bytes to read
  *
  * @returns     number of bytes read
  */
 int isrpipe_read(isrpipe_t *isrpipe, uint8_t *buf, size_t count);
+
+/**
+ * @brief   Read a single byte from isrpipe (blocking)
+ *
+ * @param[in]   isrpipe    isrpipe object to operate on
+ *
+ * @returns     the byte read
+ */
+uint8_t isrpipe_read_one(isrpipe_t *isrpipe);
+
+/**
+ * @brief   Clear the isrpipe's buffer
+ *
+ * @param[in]   isrpipe    isrpipe object to operate on
+ *
+ * @note    If a write has already unlocked the internal mutex, the first
+ *          blocking read after this call will consume that pending wakeup
+ *          before blocking normally.
+ */
+void isrpipe_clear(isrpipe_t *isrpipe);
+
+/**
+ * @brief   Get the number of bytes available for reading from the isrpipe
+ *
+ * @param[in]   isrpipe    isrpipe object to operate on
+ *
+ * @returns     number of bytes available in the isrpipe's buffer
+ */
+unsigned int isrpipe_available(isrpipe_t *isrpipe);
 
 #ifdef __cplusplus
 }

--- a/sys/isrpipe/isrpipe.c
+++ b/sys/isrpipe/isrpipe.c
@@ -60,3 +60,24 @@ int isrpipe_read(isrpipe_t *isrpipe, uint8_t *buffer, size_t count)
 
     return res;
 }
+
+uint8_t isrpipe_read_one(isrpipe_t *isrpipe)
+{
+    int res;
+
+    while ((res = tsrb_get_one(&isrpipe->tsrb)) < 0) {
+        mutex_lock(&isrpipe->mutex);
+    }
+
+    return res;
+}
+
+void isrpipe_clear(isrpipe_t *isrpipe)
+{
+    tsrb_clear(&isrpipe->tsrb);
+}
+
+unsigned int isrpipe_available(isrpipe_t *isrpipe)
+{
+    return tsrb_avail(&isrpipe->tsrb);
+}

--- a/sys/stdio/stdio.c
+++ b/sys/stdio/stdio.c
@@ -78,13 +78,13 @@ int stdio_available(void)
     if (!IS_USED(MODULE_STDIN)) {
         return 0;
     }
-    return tsrb_avail(&stdin_isrpipe.tsrb);
+    return isrpipe_available(&stdin_isrpipe);
 }
 #endif
 
 void stdio_clear_stdin(void)
 {
     if (IS_USED(MODULE_STDIN)) {
-        tsrb_clear(&stdin_isrpipe.tsrb);
+        isrpipe_clear(&stdin_isrpipe);
     }
 }

--- a/tests/unittests/tests-isrpipe/tests-isrpipe.c
+++ b/tests/unittests/tests-isrpipe/tests-isrpipe.c
@@ -223,6 +223,60 @@ static void test_write_one(void)
     /* pipe now empty */
 }
 
+static void test_read_one(void)
+{
+    /* fill the pipe so isrpipe_read_one() never blocks */
+    TEST_ASSERT_EQUAL_INT(0, isrpipe_write_one(&_pipe, 1));
+    TEST_ASSERT_EQUAL_INT(0, isrpipe_write_one(&_pipe, 2));
+    TEST_ASSERT_EQUAL_INT(0, isrpipe_write_one(&_pipe, 200));
+
+    /* pipe now holds 1, 2, 200, the bytes should be returned in FIFO order */
+    TEST_ASSERT_EQUAL_INT(1, isrpipe_read_one(&_pipe));
+    TEST_ASSERT_EQUAL_INT(2, isrpipe_read_one(&_pipe));
+
+    /* a byte with the high bit set must not be confused with an error code */
+    TEST_ASSERT_EQUAL_INT(200, isrpipe_read_one(&_pipe));
+}
+
+static void test_available(void)
+{
+    const uint8_t write_buf[] = {1, 2, 3};
+    uint8_t read_buf[2];
+
+    /* freshly initialized pipe is empty */
+    TEST_ASSERT_EQUAL_INT(0, isrpipe_available(&_pipe));
+
+    TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(write_buf),
+                          isrpipe_write(&_pipe, write_buf, ARRAY_SIZE(write_buf)));
+    TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(write_buf), isrpipe_available(&_pipe));
+
+    /* reading reduces the number of available bytes accordingly */
+    TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(read_buf),
+                          isrpipe_read(&_pipe, read_buf, ARRAY_SIZE(read_buf)));
+    TEST_ASSERT_EQUAL_INT(1, isrpipe_available(&_pipe));
+}
+
+static void test_clear(void)
+{
+    const uint8_t write_buf[] = {1, 2, 3};
+
+    TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(write_buf),
+                          isrpipe_write(&_pipe, write_buf, ARRAY_SIZE(write_buf)));
+    TEST_ASSERT_EQUAL_INT(ARRAY_SIZE(write_buf), isrpipe_available(&_pipe));
+
+    /* clearing discards all buffered data */
+    isrpipe_clear(&_pipe);
+    TEST_ASSERT_EQUAL_INT(0, isrpipe_available(&_pipe));
+
+    /* clearing an empty pipe is a no-op */
+    isrpipe_clear(&_pipe);
+    TEST_ASSERT_EQUAL_INT(0, isrpipe_available(&_pipe));
+
+    /* the pipe is still usable after a clear */
+    TEST_ASSERT_EQUAL_INT(0, isrpipe_write_one(&_pipe, 42));
+    TEST_ASSERT_EQUAL_INT(1, isrpipe_available(&_pipe));
+}
+
 Test *tests_isrpipe_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -233,6 +287,9 @@ Test *tests_isrpipe_tests(void)
         new_TestFixture(test_overflow),
         new_TestFixture(test_underflow),
         new_TestFixture(test_write_one),
+        new_TestFixture(test_read_one),
+        new_TestFixture(test_available),
+        new_TestFixture(test_clear),
     };
 
     EMB_UNIT_TESTCALLER(isrpipe_tests, setup_up, NULL, fixtures);


### PR DESCRIPTION
### Contribution description

`sys/stdio` directly accesses the thread-safe ringbuffer of `sys/isrpipe`, but that should remain an implementation detail of `sys/isrpipe`. Added additional methods to `sys/isrpipe`, to prevent this. These methods can also be useful in other situations.

### Testing procedure

The methods perform the same work as before, but from another module. I added additional unit tests though.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
