### PR TITLE
cpu/stm32: add initial STM32U3 and nucleo-u385rg-q support

### DIFF
--- a/boards/common/nucleo64/include/board.h
+++ b/boards/common/nucleo64/include/board.h
@@ -44,7 +44,8 @@ extern "C" {
  */
 #define BTN0_PIN            GPIO_PIN(PORT_C, 13)
 #if defined(CPU_MODEL_STM32L433RC) || defined(CPU_MODEL_STM32G431RB) || \
-    defined(CPU_MODEL_STM32G474RE) || defined(CPU_MODEL_STM32G491RE)
+    defined(CPU_MODEL_STM32G474RE) || defined(CPU_MODEL_STM32G491RE) || \
+    defined(CPU_MODEL_STM32U385RG)
 #  define BTN0_MODE         GPIO_IN_PD
 #else
 #  define BTN0_MODE         GPIO_IN_PU

--- a/boards/common/stm32/dist/stm32u3.cfg
+++ b/boards/common/stm32/dist/stm32u3.cfg
@@ -1,0 +1,3 @@
+source [find target/stm32u3x.cfg]
+reset_config srst_only
+$_TARGETNAME configure -rtos auto

--- a/boards/nucleo-u385rg-q/Makefile
+++ b/boards/nucleo-u385rg-q/Makefile
@@ -1,0 +1,4 @@
+MODULE = board
+DIRS = $(RIOTBOARD)/common/nucleo
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/nucleo-u385rg-q/Makefile.dep
+++ b/boards/nucleo-u385rg-q/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-u385rg-q/Makefile.features
+++ b/boards/nucleo-u385rg-q/Makefile.features
@@ -1,0 +1,9 @@
+CPU = stm32
+CPU_MODEL = stm32u385rg
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart periph_lpuart
+
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/common/nucleo64/Makefile.features

--- a/boards/nucleo-u385rg-q/Makefile.include
+++ b/boards/nucleo-u385rg-q/Makefile.include
@@ -1,0 +1,2 @@
+# load the common Makefile.include for Nucleo boards
+include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-u385rg-q/doc.md
+++ b/boards/nucleo-u385rg-q/doc.md
@@ -1,0 +1,60 @@
+@defgroup    boards_nucleo-u385rg-q STM32 Nucleo-U385RG-Q
+@ingroup     boards_common_nucleo64
+@brief       Support for the STM32 Nucleo-U385RG-Q
+
+## Overview
+
+The NUCLEO-U385RG-Q is a board from ST's Nucleo-64 family supporting the
+STM32U385RG ultra-low-power microcontroller based on an ARM Cortex-M33 core
+with TrustZone, 256KiB of RAM, and 1MiB of Flash.
+
+You can find general information about the Nucleo-64 boards on the
+@ref boards_common_nucleo64 page.
+
+This is the initial bring-up of the STM32U3 family and the Nucleo-U385RG-Q
+board: CPU and clock setup, GPIO, and the serial console (UART/LPUART).
+
+## Hardware
+
+### MCU
+
+| MCU               | STM32U385RG          |
+|:------------------|:---------------------|
+| Family            | ARM Cortex-M33       |
+| Vendor            | STMicroelectronics   |
+| RAM               | 256KiB               |
+| Flash             | 1MiB                 |
+| Frequency         | up to 96MHz (currently clocked at 16MHz) |
+| FPU               | yes                  |
+| TrustZone         | yes                  |
+| Datasheet         | [Datasheet](https://www.st.com/resource/en/datasheet/stm32u375ce.pdf) |
+| Reference Manual  | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0487-stm32u3-series-armbased-32bit-mcus-stmicroelectronics.pdf) |
+| Programming Manual| [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0264-stm32-cortexm33-mcus-and-mpus-programming-manual-stmicroelectronics.pdf) |
+| Board Manual      | [Board Manual](https://www.st.com/resource/en/user_manual/um3062-stm32u3u5-nucleo64-boards-mb1841-stmicroelectronics.pdf) |
+
+## Flashing the Board
+
+A detailed description of the flashing process can be found on the
+[guides page](https://guide.riot-os.org/board_specific/stm32/).
+
+The board name for the NUCLEO-U385RG-Q is `nucleo-u385rg-q`.
+
+@note   OpenOCD does not yet support the STM32U3, so the default
+        `make BOARD=nucleo-u385rg-q flash` (which uses OpenOCD) does not work
+        for this board. Until OpenOCD support is available, build with
+        `make BOARD=nucleo-u385rg-q` and flash the resulting ELF with the
+        STM32CubeProgrammer CLI, e.g.:
+@code
+STM32_Programmer_CLI -c port=SWD -w bin/nucleo-u385rg-q/<application>.elf -rst
+@endcode
+
+## Accessing RIOT shell
+
+Default RIOT shell access uses the VCP (Virtual COM Port) over the USB interface
+provided by the on-board ST-LINK programmer. The ST-LINK is connected to the
+microcontroller's USART1 (`UART_DEV(0)`, STDIO).
+
+The default baud rate is 115200.
+
+If a physical connection to USART1 is needed, connect a UART interface to pins
+PA9 (USART1 TX) and PA10 (USART1 RX).

--- a/boards/nucleo-u385rg-q/include/periph_conf.h
+++ b/boards/nucleo-u385rg-q/include/periph_conf.h
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_nucleo-u385rg-q
+ * @{
+ *
+ * @file
+ * @brief       Minimal peripheral configuration for STM32U385 (bring-up)
+ *
+ * @author      Adarsh Nair Mullachery <adarsh.mullachery@tuhh.de>
+ */
+
+/* Nucleo board provides 32.768 kHz LSE for RTC (same as other Nucleo-U boards) */
+#ifndef CONFIG_BOARD_HAS_LSE
+#  define CONFIG_BOARD_HAS_LSE 1
+#endif
+
+#include "periph_cpu.h"
+#include "clk_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Timer configuration
+ * @{
+ * @note    TIM2 is reserved for PWM (User LED / TIM2_CH1 on PA5).
+ *          TIM3 is used here as the RIOT timer backend (general-purpose timer).
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev = TIM3,
+        .max = 0xffffffff,
+        .rcc_mask = RCC_APB1ENR1_TIM3EN,
+        .bus = APB1,
+        .irqn = TIM3_IRQn,
+    }
+};
+
+#define TIMER_NUMOF        ARRAY_SIZE(timer_config)
+
+#define TIMER_0_ISR        isr_tim3
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        /* ST-Link Virtual COM Port (STDIO, UART_DEV(0)) — USART1 on PA9/PA10 */
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 10),
+        .tx_pin     = GPIO_PIN(PORT_A, 9),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
+    },
+    {
+        /* LPUART1 on PA2/PA3 */
+        .dev        = LPUART1,
+        .rcc_mask   = RCC_APB3ENR_LPUART1EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 3),
+        .tx_pin     = GPIO_PIN(PORT_A, 2),
+        .rx_af      = GPIO_AF8,
+        .tx_af      = GPIO_AF8,
+        .bus        = APB3,
+        .irqn       = LPUART1_IRQn,
+        .type       = STM32_LPUART,
+        .clk_src    = 0,
+    }
+};
+
+#define UART_0_ISR          (isr_usart1)
+#define UART_1_ISR          (isr_lpuart1)
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/cpu/stm32/Makefile.cmsis
+++ b/cpu/stm32/Makefile.cmsis
@@ -1,7 +1,7 @@
 PKG_NAME=stm32cmsis
 
 # The package URL depends on the family of the target STM32
-PKG_URL=https://github.com/STMicroelectronics/cmsis_device_$(CPU_FAM)
+PKG_URL=https://github.com/STMicroelectronics/cmsis-device-$(CPU_FAM)
 
 # v1.3.0
 PKG_VERSION_c0=517611273f835ffe95318947647bc1408f69120d
@@ -31,6 +31,8 @@ PKG_VERSION_l1=dafdef897e29b4f5934f1e2b9de9957410435476
 PKG_VERSION_l4=013bf0e41256ffbc2b539676f2007d08b297a86a
 # v1.0.5
 PKG_VERSION_l5=a43f959bdb1e7449cbabe14356ca9309dbd48ad3
+# v1.2.0
+PKG_VERSION_u3=8b05f32016213eaf818fbceb01fab4c8347b15c3
 # v1.3.0
 PKG_VERSION_u5=06d7edade7167b0eafdd550bf77cfc4fa98eae2e
 # v1.12.0

--- a/cpu/stm32/cpu_common.c
+++ b/cpu/stm32/cpu_common.c
@@ -62,24 +62,33 @@ static const uint8_t apbmul[] = {
     [APB1] = 2,
 #if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
     defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32G4) || \
-    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0)
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32C0) || \
+    defined(CPU_FAM_STM32WL)
     [APB12] = 2,
 #endif
 #else
     [APB1] = 1,
 #if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
     defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32G4) || \
-    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0)
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32C0) || \
+    defined(CPU_FAM_STM32WL)
     [APB12] = 1,
 #endif
 #endif
 #if defined(APB2_PERIPH_EN)
 #if (CLOCK_APB2 < CLOCK_CORECLOCK)
-    [APB2] = 2
+    [APB2] = 2,
 #else
-    [APB2] = 1
+    [APB2] = 1,
+#endif
+#endif
+#if defined(APB3_PERIPH_EN) && defined(CLOCK_APB3)
+#if (CLOCK_APB3 < CLOCK_CORECLOCK)
+    [APB3] = 2,
+#else
+    [APB3] = 1,
 #endif
 #endif
 };
@@ -118,6 +127,10 @@ static volatile uint32_t* _rcc_en_reg(bus_t bus)
 #ifdef AHB1_PERIPH_EN
     case AHB1:
         return &AHB1_PERIPH_EN;
+#endif
+#ifdef AHB12_PERIPH_EN
+    case AHB12:
+        return &AHB12_PERIPH_EN;
 #endif
 #ifdef AHB2_PERIPH_EN
     case AHB2:
@@ -366,9 +379,14 @@ uint32_t periph_apb_clk(bus_t bus)
     if (bus == APB2) {
         return CLOCK_APB2;
     }
+#ifdef CLOCK_APB3
+    if (bus == APB3) {
+        return CLOCK_APB3;
+    }
+#endif /* CLOCK_APB3 */
 #else
     (void)bus;
-#endif
+#endif /* CLOCK_APB2 */
     return CLOCK_APB1;
 }
 

--- a/cpu/stm32/cpu_init.c
+++ b/cpu/stm32/cpu_init.c
@@ -358,6 +358,8 @@ void cpu_init(void)
     /* enable PWR module */
 #if defined(CPU_FAM_STM32U5)
     periph_clk_en(AHB3, RCC_AHB3ENR_PWREN);
+#elif defined(CPU_FAM_STM32U3)
+    periph_clk_en(AHB12, RCC_AHB1ENR2_PWREN);
 #elif !defined(CPU_FAM_STM32WB) && !defined(CPU_FAM_STM32MP1) &&  \
     !defined(CPU_FAM_STM32WL)
     periph_clk_en(APB1, BIT_APB_PWREN);
@@ -401,6 +403,8 @@ void backup_ram_init(void)
     periph_clk_en(APB1, RCC_APB1ENR1_PWREN);
 #elif defined(RCC_AHB3ENR_PWREN)
     periph_clk_en(AHB3, RCC_AHB3ENR_PWREN);
+#elif defined(RCC_AHB1ENR2_PWREN)
+    periph_clk_en(AHB12, RCC_AHB1ENR2_PWREN);
 #endif
     stmclk_dbp_unlock();
 #if defined(RCC_AHB1ENR_BKPSRAMEN)

--- a/cpu/stm32/dist/irqs/gen_irqs.py
+++ b/cpu/stm32/dist/irqs/gen_irqs.py
@@ -56,6 +56,8 @@ def list_cpu_lines(cmsis_dir, cpu_fam):
         headers.remove("partition_stm32l5xx.h")
     if "partition_stm32u5xx.h" in headers:
         headers.remove("partition_stm32u5xx.h")
+    if "partition_stm32u3xx.h" in headers:
+        headers.remove("partition_stm32u3xx.h")
     headers.remove("stm32{}xx.h".format(cpu_fam))
     headers.remove("system_stm32{}xx.h".format(cpu_fam))
     return sorted([header.split(".")[0] for header in headers])

--- a/cpu/stm32/include/clk/clk_conf.h
+++ b/cpu/stm32/include/clk/clk_conf.h
@@ -32,6 +32,8 @@
 #elif defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32L5) || \
       defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32WL)
 #include "l4l5wx/cfg_clock_default.h"
+#elif defined(CPU_FAM_STM32U3)
+#include "u3/cfg_clock_default.h"
 #elif defined(CPU_FAM_STM32U5)
 #include "u5/cfg_clock_default.h"
 #elif defined(CPU_FAM_STM32MP1)

--- a/cpu/stm32/include/clk/u3/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/u3/cfg_clock_default.h
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     cpu_stm32
+ * @{
+ *
+ * @file
+ * @brief       Default STM32U3 clock configuration (bring-up)
+ *
+ * This configuration is intentionally conservative for early bring-up.
+ * By default it uses HSI (16 MHz) as SYSCLK and disables PLL usage.
+ *
+ * @author      Adarsh Nair Mullachery <adarsh.mullachery@tuhh.de>
+ */
+
+#include "cfg_clock_common_lx_u5_wx.h"
+#include "kernel_defines.h"
+#include "macros/units.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock system configuration (STM32U3)
+ * @{
+ */
+/** Set to 1 to use the PLL as system clock source (STM32U3 has no main PLL) */
+#ifndef CONFIG_USE_CLOCK_PLL
+#  define CONFIG_USE_CLOCK_PLL 0
+#endif
+
+/** Set to 1 to use HSI as system clock source (default for bring-up) */
+#ifndef CONFIG_USE_CLOCK_HSI
+#  define CONFIG_USE_CLOCK_HSI 1
+#endif
+
+/** HSI (high-speed internal) oscillator frequency */
+#ifndef CONFIG_CLOCK_HSI
+#  define CONFIG_CLOCK_HSI MHZ(16)
+#endif
+
+/** HSE (high-speed external) oscillator frequency */
+#ifndef CONFIG_CLOCK_HSE
+#  define CONFIG_CLOCK_HSE MHZ(8)
+#endif
+
+/** MSIS (multi-speed internal) oscillator frequency, used when MSI is selected */
+#ifndef CONFIG_CLOCK_MSI
+#  define CONFIG_CLOCK_MSI MHZ(12)
+#endif
+
+#if IS_ACTIVE(CONFIG_USE_CLOCK_HSE)
+#  define CLOCK_CORECLOCK CONFIG_CLOCK_HSE
+#elif IS_ACTIVE(CONFIG_USE_CLOCK_MSI)
+#  define CLOCK_CORECLOCK CONFIG_CLOCK_MSI
+#else
+#  define CLOCK_CORECLOCK CONFIG_CLOCK_HSI
+#endif
+
+/** Maximum system core clock (SYSCLK) allowed on the STM32U3 */
+#define CLOCK_CORECLOCK_MAX MHZ(96)
+
+#if CLOCK_CORECLOCK > CLOCK_CORECLOCK_MAX
+#  error "SYSCLK cannot exceed 96MHz on STM32U3"
+#endif
+
+#define CLOCK_AHB CLOCK_CORECLOCK
+
+#ifndef CONFIG_CLOCK_APB1_DIV
+#  define CONFIG_CLOCK_APB1_DIV (1)
+#endif
+
+#ifndef CONFIG_CLOCK_APB2_DIV
+#  define CONFIG_CLOCK_APB2_DIV (1)
+#endif
+
+#ifndef CONFIG_CLOCK_APB3_DIV
+#  define CONFIG_CLOCK_APB3_DIV (1)
+#endif
+
+#define CLOCK_APB1 (CLOCK_AHB / CONFIG_CLOCK_APB1_DIV)
+#define CLOCK_APB2 (CLOCK_AHB / CONFIG_CLOCK_APB2_DIV)
+/** APB3 peripheral clock */
+#define CLOCK_APB3 (CLOCK_AHB / CONFIG_CLOCK_APB3_DIV)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/cpu/stm32/include/periph/cpu_common.h
+++ b/cpu/stm32/include/periph/cpu_common.h
@@ -59,9 +59,9 @@ extern "C" {
       defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L4) || \
       defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32G4) || \
       defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32L5) || \
-      defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32MP1) || \
+      defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32MP1) || \
       defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0) || \
-      defined(CPU_FAM_STM32H7)
+      defined(CPU_FAM_STM32H7) || defined(CPU_FAM_STM32U5)
 #define CLOCK_LSI           (32000U)
 #else
 #error "error: LSI clock speed not defined for your target CPU"
@@ -71,6 +71,7 @@ extern "C" {
 #if     defined(CPU_FAM_STM32G4) || \
         defined(CPU_FAM_STM32L4) || \
         defined(CPU_FAM_STM32L5) || \
+        defined(CPU_FAM_STM32U3) || \
         defined(CPU_FAM_STM32U5) || \
         defined(CPU_FAM_STM32WB) || \
         defined(CPU_FAM_STM32WL)
@@ -99,7 +100,8 @@ extern "C" {
 #elif   defined(APB2PERIPH_BASE) || \
         defined(CPU_FAM_STM32F0) || \
         defined(CPU_FAM_STM32L0) || \
-        defined(CPU_FAM_STM32H7)
+        defined(CPU_FAM_STM32H7) || \
+        defined(CPU_FAM_STM32U3)
             #define APB2_PERIPH_EN              RCC->APB2ENR
 #endif
 
@@ -108,8 +110,10 @@ extern "C" {
             /* CPU has APB3, but no periph enable registers for the bus. */
             #undef APB3_PERIPH_EN               /* not defined */
 #elif   defined(APB3PERIPH_BASE) || \
+        defined(APB3PERIPH_BASE_NS) || \
         defined(APB3PERIPH_BASE_S) || \
-        defined(CPU_FAM_STM32H7)
+        defined(CPU_FAM_STM32H7) || \
+        defined(CPU_FAM_STM32U3)
             #define APB3_PERIPH_EN              RCC->APB3ENR
 #endif
 
@@ -122,6 +126,9 @@ extern "C" {
 #if     defined(AHBPERIPH_BASE) || \
         defined(CPU_FAM_STM32F3)
             #define AHB_PERIPH_EN               RCC->AHBENR
+#elif   defined(CPU_FAM_STM32U3)
+            #define AHB1_PERIPH_EN              RCC->AHB1ENR1
+            #define AHB12_PERIPH_EN             RCC->AHB1ENR2
 #elif   defined(CPU_FAM_STM32MP1)
             /* CPU has AHB1, but no periph enable registers for the bus. */
             #undef AHB1_PERIPH_EN               /* not defined */
@@ -136,7 +143,8 @@ extern "C" {
         defined(CPU_FAM_STM32F3)
             /* CPU has AHB2, but no periph enable registers for the bus. */
             #undef AHB2_PERIPH_EN               /* not defined */
-#elif   defined(CPU_FAM_STM32U5)
+#elif   defined(CPU_FAM_STM32U3) || \
+        defined(CPU_FAM_STM32U5)
             #define AHB2_PERIPH_EN              RCC->AHB2ENR1
             #define AHB22_PERIPH_EN             RCC->AHB2ENR2
 #elif   defined(CPU_FAM_STM32F4) && defined(RCC_AHB2_SUPPORT)
@@ -194,7 +202,7 @@ typedef enum {
     APB1,           /**< APB1 bus */
 #endif
 #if defined(APB12_PERIPH_EN)
-    APB12,          /**< AHB1 bus, second register */
+    APB12,          /**< APB1 bus, second register */
 #endif
 #if defined(APB2_PERIPH_EN)
     APB2,           /**< APB2 bus */
@@ -210,6 +218,9 @@ typedef enum {
 #endif
 #if defined(AHB1_PERIPH_EN)
     AHB1,           /**< AHB1 bus */
+#endif
+#if defined(AHB12_PERIPH_EN)
+    AHB12,           /**< AHB12 bus */
 #endif
 #if defined(AHB2_PERIPH_EN)
     AHB2,           /**< AHB2 bus */

--- a/cpu/stm32/include/periph/cpu_uart.h
+++ b/cpu/stm32/include/periph/cpu_uart.h
@@ -118,8 +118,9 @@ typedef struct {
 #endif
 #if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L4) || \
     defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32G4) || \
-    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32MP1) || defined(CPU_FAM_STM32WL)
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32MP1) || defined(CPU_FAM_STM32U5) || \
+    defined(CPU_FAM_STM32WL)
     uart_type_t type;       /**< hardware module type (USART or LPUART) */
     uint32_t clk_src;       /**< clock source used for UART */
 #endif

--- a/cpu/stm32/include/periph/u3/periph_cpu.h
+++ b/cpu/stm32/include/periph/u3/periph_cpu.h
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     cpu_stm32
+ * @{
+ *
+ * @file
+ * @brief       STM32U3 family specific peripheral CPU definitions
+ *
+ * @author      Adarsh Nair Mullachery <adarsh.mullachery@tuhh.de>
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef DOXYGEN
+
+/**
+ * @brief   Starting address of the ROM bootloader
+ *          see application note AN2606
+ */
+#define STM32_BOOTLOADER_ADDR   (0x0BF8F000)
+
+/**
+ * @brief   Number of ADC controller instances (CMSIS @c ADCx_BASE symbols)
+ */
+#if defined(ADC4)
+#  define ADC_DEVS          (4U)
+#elif defined(ADC3)
+#  define ADC_DEVS          (3U)
+#elif defined(ADC2)
+#  define ADC_DEVS          (2U)
+#elif defined(ADC1)
+#  define ADC_DEVS          (1U)
+#endif
+
+/**
+ * @brief   ADC voltage regulator start-up time [µs] (RM0487, @c t_ADCVREG_STUP)
+ */
+#define ADC_T_ADCVREG_STUP_US   (20U)
+
+/**
+ * @brief   Mask of @c ADC_CFGR1.RES bits — used by @ref adc_f3_h7_u3.c @c adc_sample()
+ */
+#define ADC_CFGR_RES            ADC_CFGR1_RES_Msk
+
+/**
+ * @brief   Highest ADC channel index described in SMPR/SQR bit maps (RM0487)
+ */
+#define ADC_CONF_CHAN_MAX       (19U)
+
+/**
+ * @name   ADC resolution (@c ADC_CFGR1.RES)
+ * @{
+ * @note 14-bit and 16-bit values are RIOT placeholders; @c adc_sample() rejects
+ *       them unless a future driver adds oversampling / precision modes.
+ */
+#define HAVE_ADC_RES_T
+typedef enum {
+    ADC_RES_6BIT  = (ADC_CFGR1_RES),           /**< 6 bit */
+    ADC_RES_8BIT  = (ADC_CFGR1_RES_1),         /**< 8 bit */
+    ADC_RES_10BIT = (ADC_CFGR1_RES_0),         /**< 10 bit */
+    ADC_RES_12BIT = (0x00),                    /**< 12 bit */
+    ADC_RES_14BIT = (0xfe),                    /**< not supported via CFGR1 alone */
+    ADC_RES_16BIT = (0xff)                     /**< not supported via CFGR1 alone */
+} adc_res_t;
+/** @} */
+
+/**
+ * @name   Constants for internal VBAT ADC line
+ * @{
+ */
+#define VBAT_ADC_RES        ADC_RES_12BIT
+#define VBAT_ADC_MAX        4095
+/** @} */
+
+#endif /* DOXYGEN */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -50,6 +50,8 @@
 #include "periph/l4/periph_cpu.h"
 #elif defined(CPU_FAM_STM32L5)
 #include "periph/l5/periph_cpu.h"
+#elif defined(CPU_FAM_STM32U3)
+#include "periph/u3/periph_cpu.h"
 #elif defined(CPU_FAM_STM32U5)
 #include "periph/u5/periph_cpu.h"
 #elif defined(CPU_FAM_STM32WB)

--- a/cpu/stm32/include/vendor/patches/u3/0001-stm32u3xx-remove-ErrorStatus.patch
+++ b/cpu/stm32/include/vendor/patches/u3/0001-stm32u3xx-remove-ErrorStatus.patch
@@ -1,0 +1,29 @@
+From 0e955b27f0714e6d5c47fb4e379eacd034086a9b Mon Sep 17 00:00:00 2001
+From: Adarsh Nair Mullachery <adarsh.mullachery@tuhh.de>
+Date: Tue, 28 Jul 2026 19:48:41 +0200
+Subject: [PATCH] stm32u3xx: remove ErrorStatus
+
+---
+ Include/stm32u3xx.h | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/Include/stm32u3xx.h b/Include/stm32u3xx.h
+index 83ef39d..b007b47 100644
+--- a/Include/stm32u3xx.h
++++ b/Include/stm32u3xx.h
+@@ -120,12 +120,6 @@ typedef enum
+ } FunctionalState;
+ #define IS_FUNCTIONAL_STATE(STATE) (((STATE) == DISABLE) || ((STATE) == ENABLE))
+ 
+-typedef enum
+-{
+-  SUCCESS = 0,
+-  ERROR = !SUCCESS
+-} ErrorStatus;
+-
+ /**
+   * @}
+   */
+-- 
+2.43.0
+

--- a/cpu/stm32/kconfigs/u3/Kconfig
+++ b/cpu/stm32/kconfigs/u3/Kconfig
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
+
+config CPU_FAM_U3
+    bool
+    select CPU_STM32
+    select CPU_CORE_CORTEX_M33
+
+config CPU_FAM
+    default "u3" if CPU_FAM_U3

--- a/cpu/stm32/kconfigs/u3/Kconfig.lines
+++ b/cpu/stm32/kconfigs/u3/Kconfig.lines
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
+
+# CPU lines
+config CPU_LINE_STM32U385XX
+    bool
+    select CPU_FAM_U3

--- a/cpu/stm32/kconfigs/u3/Kconfig.models
+++ b/cpu/stm32/kconfigs/u3/Kconfig.models
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
+
+# CPU models
+
+config CPU_MODEL_STM32U385CG
+    bool
+    select CPU_LINE_STM32U385XX
+
+config CPU_MODEL_STM32U385KG
+    bool
+    select CPU_LINE_STM32U385XX
+
+config CPU_MODEL_STM32U385RG
+    bool
+    select CPU_LINE_STM32U385XX
+
+config CPU_MODEL_STM32U385VG
+    bool
+    select CPU_LINE_STM32U385XX
+
+# Configure CPU model
+
+config CPU_MODEL
+    default "stm32u385cg" if CPU_MODEL_STM32U385CG
+    default "stm32u385kg" if CPU_MODEL_STM32U385KG
+    default "stm32u385rg" if CPU_MODEL_STM32U385RG
+    default "stm32u385vg" if CPU_MODEL_STM32U385VG

--- a/cpu/stm32/periph/gpio_all.c
+++ b/cpu/stm32/periph/gpio_all.c
@@ -40,13 +40,22 @@
  * @brief   Allocate memory for one callback and argument per EXTI channel
  */
 static gpio_isr_ctx_t isr_ctx[EXTI_NUMOF];
+#if defined(CPU_FAM_STM32U3)
+/* STM32U3: one IRQn per EXTI line (stm32u3xxxx.h: EXTI0_IRQn - EXTI15_IRQn) */
+static const IRQn_Type _stm32u3_exti_irqn[EXTI_NUMOF] = {
+    EXTI0_IRQn,  EXTI1_IRQn,  EXTI2_IRQn,  EXTI3_IRQn,
+    EXTI4_IRQn,  EXTI5_IRQn,  EXTI6_IRQn,  EXTI7_IRQn,
+    EXTI8_IRQn,  EXTI9_IRQn,  EXTI10_IRQn, EXTI11_IRQn,
+    EXTI12_IRQn, EXTI13_IRQn, EXTI14_IRQn, EXTI15_IRQn,
+};
+#endif
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 
 #if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
     defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32G0) || \
-    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5) || \
+    defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32U5) || \
     defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0) || \
-    defined(CPU_FAM_STM32H7)
+    defined(CPU_FAM_STM32H7) || defined(CPU_FAM_STM32L5)
 #define EXTI_REG_RTSR       (EXTI->RTSR1)
 #define EXTI_REG_FTSR       (EXTI->FTSR1)
 #define EXTI_REG_PR         (EXTI->PR1)
@@ -256,6 +265,8 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     periph_clk_en(APB2, RCC_APB2ENR_SYSCFGCOMPEN);
 #elif defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32C0)
     periph_clk_en(APB12, RCC_APBENR2_SYSCFGEN);
+#elif defined(CPU_FAM_STM32U3)
+    periph_clk_en(APB3, RCC_APB3ENR_SYSCFGEN);
 #elif defined(CPU_FAM_STM32U5)
     periph_clk_en(APB3, RCC_APB3ENR_SYSCFGEN);
 #elif defined(CPU_FAM_STM32H7)
@@ -271,6 +282,8 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     /* enable global pin interrupt */
 #if defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5)
     NVIC_EnableIRQ(EXTI0_IRQn + pin_num);
+#elif defined(CPU_FAM_STM32U3)
+    NVIC_EnableIRQ(_stm32u3_exti_irqn[pin_num]);
 #elif defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0) || \
     defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32C0)
     if (pin_num < 2) {
@@ -325,7 +338,8 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     EXTI_REG_FTSR |=  ((flank >> 1) << pin_num);
 
 #if defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32L5) || \
-    defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32C0)
+    defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32C0) || \
+    defined(CPU_FAM_STM32U5)
     /* enable specific pin as exti sources */
     EXTI->EXTICR[pin_num >> 2] &= ~(0xf << ((pin_num & 0x03) * 8));
     EXTI->EXTICR[pin_num >> 2] |= (port_num << ((pin_num & 0x03) * 8));
@@ -340,8 +354,8 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
 #endif
 
 #if defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32L5) || \
-    defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32MP1) || \
-    defined(CPU_FAM_STM32C0)
+    defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32MP1) || \
+    defined(CPU_FAM_STM32C0) || defined(CPU_FAM_STM32U5)
     /* clear any pending requests */
     EXTI->RPR1 = (1 << pin_num);
     EXTI->FPR1 = (1 << pin_num);
@@ -358,8 +372,8 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
 void isr_exti(void)
 {
 #if defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32L5) || \
-    defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32MP1) || \
-    defined(CPU_FAM_STM32C0)
+    defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32MP1) || \
+    defined(CPU_FAM_STM32C0) || defined(CPU_FAM_STM32U5)
     /* get all interrupts handled by this ISR */
     uint32_t pending_rising_isr = (EXTI->RPR1 & EXTI_MASK);
     uint32_t pending_falling_isr = (EXTI->FPR1 & EXTI_MASK);

--- a/cpu/stm32/periph/gpio_ll_irq.c
+++ b/cpu/stm32/periph/gpio_ll_irq.c
@@ -72,7 +72,11 @@
 #  define EXTI_REG_IMR          (EXTI->IMR1)
 #endif
 
-#if defined(RCC_APB2ENR_SYSCFGCOMPEN)
+/* STM32U3: SYSCFG is on APB3, RCC_APB3ENR_SYSCFGEN in CMSIS (e.g. stm32u385xx.h) */
+#if defined(CPU_FAM_STM32U3) && defined(RCC_APB3ENR_SYSCFGEN)
+#  define SYSFG_CLOCK           APB3
+#  define SYSFG_ENABLE_MASK     RCC_APB3ENR_SYSCFGEN
+#elif defined(RCC_APB2ENR_SYSCFGCOMPEN)
 #  define SYSFG_CLOCK           APB2
 #  define SYSFG_ENABLE_MASK     RCC_APB2ENR_SYSCFGCOMPEN
 #elif defined(RCC_APB2ENR_SYSCFGEN)
@@ -126,7 +130,8 @@ static IRQn_Type get_irqn(uint8_t pin)
 {
     /* TODO: Come up with a way that this doesn't need updates whenever a new
      * MCU family gets added */
-#if defined(CPU_FAM_STM32L5) ||  defined(CPU_FAM_STM32U5)
+#if defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32U5)
     return EXTI0_IRQn + pin;
 #elif defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0) || \
     defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32C0)

--- a/cpu/stm32/periph/pm.c
+++ b/cpu/stm32/periph/pm.c
@@ -54,6 +54,8 @@
 #define PM_STOP_CONFIG  (PWR_CR1_LPDS | PWR_CR1_FPDS | PWR_CR1_LPUDS)
 #elif defined(CPU_FAM_STM32MP1)
 #define PM_STOP_CONFIG  (0)
+#elif defined(CPU_FAM_STM32U3)
+#define PM_STOP_CONFIG  (PWR_CR1_LPMS_0)
 #elif defined(CPU_FAM_STM32U5)
 #define PM_STOP_CONFIG  (0)
 #elif defined(CPU_FAM_STM32H7)
@@ -82,7 +84,7 @@
 #define PM_STANDBY_CONFIG   (PWR_CR1_PDDS | PWR_CR1_CSBF)
 #elif defined(CPU_FAM_STM32MP1)
 #define PM_STANDBY_CONFIG   (0)
-#elif defined(CPU_FAM_STM32U5)
+#elif defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32U5)
 #define PM_STANDBY_CONFIG   (0)
 #elif defined(CPU_FAM_STM32H7)
     /* Set D1 and D2 domains to enter DStandby */
@@ -95,7 +97,8 @@
 #if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
     defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32G0) || \
     defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0)
+    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32C0)
 #define PWR_CR_REG     PWR->CR1
 #define PWR_WUP_REG    PWR->CR3
 /* Allow overridable SRAM2 retention mode using CFLAGS */

--- a/cpu/stm32/periph/uart.c
+++ b/cpu/stm32/periph/uart.c
@@ -32,8 +32,9 @@
 #include "pm_layered.h"
 
 #if defined(CPU_LINE_STM32L4R5xx) || defined(CPU_FAM_STM32G0) || \
-    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0)
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0) || \
+    defined(CPU_FAM_STM32U5)
 #define ISR_REG     ISR
 #define ISR_TXE     USART_ISR_TXE_TXFNF
 #define ISR_RXNE    USART_ISR_RXNE_RXFNE
@@ -67,8 +68,9 @@
 #endif
 
 #if defined(CPU_LINE_STM32L4R5xx) || defined(CPU_FAM_STM32G0) || \
-    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0)
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0) || \
+    defined(CPU_FAM_STM32U5)
 #define RXENABLE            (USART_CR1_RE | USART_CR1_RXNEIE_RXFNEIE)
 #else
 #define RXENABLE            (USART_CR1_RE | USART_CR1_RXNEIE)
@@ -104,8 +106,8 @@ static inline USART_TypeDef *dev(uart_t uart)
 static inline void uart_init_usart(uart_t uart, uint32_t baudrate);
 #if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L4) || \
     defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32G4) || \
-    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32WL)
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32U5)
 #ifdef MODULE_PERIPH_LPUART
 static inline void uart_init_lpuart(uart_t uart, uint32_t baudrate);
 #endif
@@ -199,8 +201,8 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 
 #if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L4) || \
     defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32G4) || \
-    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32WL)
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32U5)
     switch (uart_config[uart].type) {
         case STM32_USART:
             uart_init_usart(uart, baudrate);
@@ -330,12 +332,16 @@ static inline void uart_init_usart(uart_t uart, uint32_t baudrate)
 
 #if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L4) || \
     defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32G4) || \
-    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32WL)
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32U5)
 #ifdef CPU_FAM_STM32L5
 #define RCC_CCIPR_LPUART1SEL_0  RCC_CCIPR1_LPUART1SEL_0
 #define RCC_CCIPR_LPUART1SEL_1  RCC_CCIPR1_LPUART1SEL_1
 #define CCIPR                   CCIPR1
+#elif CPU_FAM_STM32U3
+#define RCC_CCIPR_LPUART1SEL_0  RCC_CCIPR3_LPUART1SEL_0
+#define RCC_CCIPR_LPUART1SEL_1  RCC_CCIPR3_LPUART1SEL_1
+#define CCIPR                   CCIPR3
 #elif CPU_FAM_STM32U5
 #define RCC_CCIPR_LPUART1SEL_0  RCC_CCIPR3_LPUART1SEL_0
 #define RCC_CCIPR_LPUART1SEL_1  RCC_CCIPR3_LPUART1SEL_1

--- a/cpu/stm32/stm32_info.mk
+++ b/cpu/stm32/stm32_info.mk
@@ -86,6 +86,9 @@ else ifeq (c0,$(CPU_FAM))
 else ifeq (l5,$(CPU_FAM))
   CPU_CORE = cortex-m33
   SVD_MODEL := STM32L$(STM32_MODEL)
+else ifeq (u3,$(CPU_FAM))
+  CPU_CORE = cortex-m33
+  SVD_MODEL := STM32U$(STM32_MODEL)
 else ifeq (u5,$(CPU_FAM))
   CPU_CORE = cortex-m33
   SVD_MODEL := STM32U$(STM32_MODEL)

--- a/cpu/stm32/stm32_mem_lengths.mk
+++ b/cpu/stm32/stm32_mem_lengths.mk
@@ -294,7 +294,11 @@ else ifeq ($(STM32_TYPE), L)
     endif
   endif
 else ifeq ($(STM32_TYPE), U)
-  ifeq ($(STM32_FAMILY), 5)
+  ifeq ($(STM32_FAMILY), 3)
+    ifneq (, $(filter $(STM32_MODEL2), 7 8))
+      RAM_LEN = 256K
+    endif
+  else ifeq ($(STM32_FAMILY), 5)
     ifneq (, $(filter $(STM32_MODEL2), 7 8))
       RAM_LEN = 768K
       SRAM4_LEN = 16K

--- a/cpu/stm32/stmclk/Makefile
+++ b/cpu/stm32/stmclk/Makefile
@@ -16,6 +16,8 @@ else ifneq (,$(filter $(CPU_FAM),l4 wb wl))
   SRC += stmclk_l4wx.c
 else ifneq (,$(filter $(CPU_FAM),l5))
   SRC += stmclk_l5.c
+else ifneq (,$(filter $(CPU_FAM),u3))
+  SRC += stmclk_u3.c
 else ifneq (,$(filter $(CPU_FAM),u5))
   SRC += stmclk_u5.c
 else ifneq (,$(filter $(CPU_FAM),g0 g4))

--- a/cpu/stm32/stmclk/stmclk_common.c
+++ b/cpu/stm32/stmclk/stmclk_common.c
@@ -26,7 +26,7 @@
     defined(CPU_FAM_STM32WL)
 #define REG_PWR_CR          CR1
 #define BIT_CR_DBP          PWR_CR1_DBP
-#elif defined(CPU_FAM_STM32U5)
+#elif defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32U5)
 #define REG_PWR_CR          DBPR
 #define BIT_CR_DBP          PWR_DBPR_DBP
 #elif defined(CPU_FAM_STM32H7)
@@ -95,7 +95,7 @@ void stmclk_enable_lfclk(void)
     /* Set LSE system clock enable bit. This is required if LSE is to be used by
        USARTx, LPUARTx, LPTIMx, TIMx, RNG, system LSCO, MCO, MSI PLL mode */
 #if defined(CPU_FAM_STM32WL) || defined (CPU_FAM_STM32L5) || \
-    defined(CPU_FAM_STM32U5)
+    defined(CPU_FAM_STM32U3) || defined (CPU_FAM_STM32U5)
         RCC->BDCR |= RCC_BDCR_LSESYSEN;
         while (!(RCC->BDCR & RCC_BDCR_LSESYSRDY)) {}
 #endif

--- a/cpu/stm32/stmclk/stmclk_u3.c
+++ b/cpu/stm32/stmclk/stmclk_u3.c
@@ -1,0 +1,224 @@
+/*
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2017 HAW-Hamburg
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     cpu_stm32
+ * @{
+ *
+ * @file
+ * @brief       STM32U3 clock initialization
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Nick van IJzendoorn <nijzendoorn@engineering-spirit.nl>
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Adarsh Nair Mullachery <adarsh.mullachery@tuhh.de>
+ * @}
+ */
+
+#include "cpu.h"
+#include "stmclk.h"
+#include "periph_conf.h"
+
+#if !defined(CPU_FAM_STM32U3)
+#  error "stmclk_u3.c compiled for non-STM32U3 CPU"
+#endif
+
+#define RCC_CFGR1_SW_MSI            (0x00000000U)
+#define RCC_CFGR1_SW_HSI            (RCC_CFGR1_SW_0)
+#define RCC_CFGR1_SW_HSE            (RCC_CFGR1_SW_1)
+
+#define RCC_CFGR1_SWS_MSI           (0x00000000U)
+#define RCC_CFGR1_SWS_HSI           (RCC_CFGR1_SWS_0)
+#define RCC_CFGR1_SWS_HSE           (RCC_CFGR1_SWS_1)
+
+/* Define MSI range bitfields for STM32U3
+ * Configure MSI range and divider per RM0487 */
+#if CONFIG_CLOCK_MSI == MHZ(48)
+#  define CLOCK_MSIRANGE              (0) /* MSISRANGE 0, MSISDIV 0 */
+#elif CONFIG_CLOCK_MSI == MHZ(24)
+#  define CLOCK_MSIRANGE              (RCC_ICSCR1_MSISDIV_0) /* Range 0, Div 2 */
+#elif CONFIG_CLOCK_MSI == MHZ(16)
+#  define CLOCK_MSIRANGE              (0x1UL << 16)
+#elif CONFIG_CLOCK_MSI == MHZ(12)
+#  define CLOCK_MSIRANGE              (RCC_ICSCR1_MSISDIV_1) /* Range 0, Div 4 */
+#elif CONFIG_CLOCK_MSI == MHZ(4)
+#  define CLOCK_MSIRANGE              (0x2UL << 16) /* Range 2, Div 1 */
+#else
+#  error "Invalid MSI clock for STM32U3 - check manual for supported LDO frequencies"
+#endif
+
+/* Configure the AHB and APB buses prescalers */
+#define CLOCK_AHB_DIV               (0)
+
+#if CONFIG_CLOCK_APB1_DIV == 1
+#  define CLOCK_APB1_DIV              (0)
+#elif CONFIG_CLOCK_APB1_DIV == 2
+#  define CLOCK_APB1_DIV              (RCC_CFGR2_PPRE1_2)
+#elif CONFIG_CLOCK_APB1_DIV == 4
+#  define CLOCK_APB1_DIV              (RCC_CFGR2_PPRE1_2 | RCC_CFGR2_PPRE1_0)
+#elif CONFIG_CLOCK_APB1_DIV == 8
+#  define CLOCK_APB1_DIV              (RCC_CFGR2_PPRE1_2 | RCC_CFGR2_PPRE1_1)
+#elif CONFIG_CLOCK_APB1_DIV == 16
+#  define CLOCK_APB1_DIV              (RCC_CFGR2_PPRE1_2 | RCC_CFGR2_PPRE1_1 | RCC_CFGR2_PPRE1_0)
+#endif
+
+#if CONFIG_CLOCK_APB2_DIV == 1
+#  define CLOCK_APB2_DIV              (0)
+#elif CONFIG_CLOCK_APB2_DIV == 2
+#  define CLOCK_APB2_DIV              (RCC_CFGR2_PPRE2_2)
+#elif CONFIG_CLOCK_APB2_DIV == 4
+#  define CLOCK_APB2_DIV              (RCC_CFGR2_PPRE2_2 | RCC_CFGR2_PPRE2_0)
+#elif CONFIG_CLOCK_APB2_DIV == 8
+#  define CLOCK_APB2_DIV              (RCC_CFGR2_PPRE2_2 | RCC_CFGR2_PPRE2_1)
+#elif CONFIG_CLOCK_APB2_DIV == 16
+#  define CLOCK_APB2_DIV              (RCC_CFGR2_PPRE2_2 | RCC_CFGR2_PPRE2_1 | RCC_CFGR2_PPRE2_0)
+#endif
+
+/* Only periph_hwrng and periph_usbdev require HSI RC with 48MHz for the moment */
+#if IS_USED(MODULE_PERIPH_HWRNG) || IS_USED(MODULE_PERIPH_USBDEV_CLK)
+#  define CLOCK_ENABLE_HSI48          1
+#else
+#  define CLOCK_ENABLE_HSI48          0
+#endif
+
+/* Check if HSE is required:
+ * - When used as system clock
+ */
+#if IS_ACTIVE(CONFIG_USE_CLOCK_HSE) || \
+    (IS_ACTIVE(CLOCK_ENABLE_PLL) && IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_HSE))
+#  define CLOCK_ENABLE_HSE            1
+#else
+#  define CLOCK_ENABLE_HSE            0
+#endif
+
+/* HSE cannot be enabled if not provided by the board */
+#if IS_ACTIVE(CLOCK_ENABLE_HSE) && !IS_ACTIVE(CONFIG_BOARD_HAS_HSE)
+#  error "HSE is required by the clock configuration but is not provided by the board."
+#endif
+
+/* Check if HSI RC with 16 MHz is required:
+ * - When used as system clock
+ */
+#if IS_ACTIVE(CONFIG_USE_CLOCK_HSI) || \
+    (IS_ACTIVE(CLOCK_ENABLE_PLL) && IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_HSI))
+#  define CLOCK_ENABLE_HSI            1
+#else
+#  define CLOCK_ENABLE_HSI            0
+#endif
+
+/* Check if MSI is required
+ * - When used as system clock
+ * - When used for 48MHz clock domain
+ */
+#if IS_ACTIVE(CONFIG_USE_CLOCK_MSI) || \
+    (IS_ACTIVE(CLOCK_ENABLE_PLL) && IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_MSI)) || \
+    (IS_ACTIVE(CLOCK_ENABLE_48MHZ) && IS_ACTIVE(CLOCK48MHZ_USE_MSI))
+#  define CLOCK_ENABLE_MSI            1
+#else
+#  define CLOCK_ENABLE_MSI            0
+#endif
+
+/* Define the required flash wait states based on the core clock frequency */
+#define FLASH_WAITSTATES FLASH_ACR_LATENCY_2
+
+void stmclk_init_sysclk(void)
+{
+    /* Bring-up safe clock init for STM32U3:
+     * - SYSCLK = HSI16
+     * - AHB = SYSCLK
+     * - APB1/APB2 prescalers from CONFIG_CLOCK_APB{1,2}_DIV
+     * - Enable PWR clock (needed by other code paths)
+     * - Conservative Flash latency
+     */
+    unsigned is = irq_disable();
+
+    /* Disable RCC clock interrupts */
+    RCC->CIER = 0;
+
+    //* 1) Enable required oscillators based on configuration */
+#if IS_ACTIVE(CLOCK_ENABLE_HSE)
+    RCC->CR |= RCC_CR_HSEON;
+    while (!(RCC->CR & RCC_CR_HSERDY)) {}
+#endif
+
+#if IS_ACTIVE(CLOCK_ENABLE_HSI)
+    RCC->CR |= RCC_CR_HSION;
+    while (!(RCC->CR & RCC_CR_HSIRDY)) {}
+#endif
+
+#if IS_ACTIVE(CLOCK_ENABLE_MSI)
+    /* Apply MSI range to ICSCR1 before enabling */
+    RCC->ICSCR1 = (RCC->ICSCR1 &~(RCC_ICSCR1_MSISRANGE_Msk | RCC_ICSCR1_MSISDIV_Msk)) \
+                  | CLOCK_MSIRANGE;
+    RCC->CR |= RCC_CR_MSISON;
+    while (!(RCC->CR & RCC_CR_MSIRDY)) {}
+#endif
+
+    /* 2) Enable PWR interface clock (STM32U3: RCC_AHB1ENR2.PWREN) */
+    RCC->AHB1ENR2 |= RCC_AHB1ENR2_PWREN;
+    (void)RCC->AHB1ENR2; /* read-back */
+
+    /* select VCORE voltage scaling range 1 */
+    PWR->VOSR = (PWR->VOSR & ~(PWR_VOSR_R1EN | PWR_VOSR_R2EN)) | PWR_VOSR_R1EN;
+    for (volatile uint32_t to = 0; !(PWR->VOSR & PWR_VOSR_R1RDY) && to < 100000;
+         to++) {}
+
+    /* 3) Set Flash wait states BEFORE any clock increase */
+    FLASH->ACR = (FLASH->ACR & ~FLASH_ACR_LATENCY) | FLASH_WAITSTATES;
+
+    /* 4) Configure AHB/APB prescalers */
+    RCC->CFGR2 &= ~(RCC_CFGR2_HPRE_Msk |
+                    RCC_CFGR2_PPRE1_Msk |
+                    RCC_CFGR2_PPRE2_Msk);
+    RCC->CFGR2 |= (CLOCK_APB1_DIV | CLOCK_APB2_DIV);
+
+    /* 5) Switch SYSCLK to the configured source */
+#if IS_ACTIVE(CONFIG_USE_CLOCK_HSE)
+    RCC->CFGR1 = (RCC->CFGR1 & ~RCC_CFGR1_SW_Msk) | RCC_CFGR1_SW_HSE;
+    while ((RCC->CFGR1 & RCC_CFGR1_SWS_Msk) != RCC_CFGR1_SWS_HSE) {}
+#elif IS_ACTIVE(CONFIG_USE_CLOCK_MSI)
+    RCC->CFGR1 = (RCC->CFGR1 & ~RCC_CFGR1_SW_Msk) | RCC_CFGR1_SW_MSI;
+    while ((RCC->CFGR1 & RCC_CFGR1_SWS_Msk) != RCC_CFGR1_SWS_MSI) {}
+#elif IS_ACTIVE(CONFIG_USE_CLOCK_HSI)
+    RCC->CFGR1 = (RCC->CFGR1 & ~RCC_CFGR1_SW_Msk) | RCC_CFGR1_SW_HSI;
+    while ((RCC->CFGR1 & RCC_CFGR1_SWS_Msk) != RCC_CFGR1_SWS_HSI) {}
+#else
+#  error "No valid system clock source defined in board configuration!"
+#endif
+
+    /* 4) Configure AHB/APB prescalers */
+#ifdef ICACHE
+    ICACHE->CR |= ICACHE_CR_EN;
+#endif
+
+    /* 7) Configure 48 MHz domain for HWRNG / USB FS */
+    if (IS_ACTIVE(CLOCK_ENABLE_HSI48)) {
+        RCC->CR |= RCC_CR_HSI48ON;
+        while (!(RCC->CR & RCC_CR_HSI48RDY)) {}
+
+        /* Route HSI48 to ICLK and USB1 */
+#if defined(RCC_CCIPR1_ICLKSEL)
+        RCC->CCIPR1 &= (uint32_t) ~RCC_CCIPR1_ICLKSEL;
+#endif
+#if defined(RCC_CCIPR1_USB1SEL)
+        RCC->CCIPR1 &= (uint32_t) ~RCC_CCIPR1_USB1SEL;
+#endif
+        /* Ensure RNG kernel clock source is HSI48 per RM0487 */
+#if defined(RCC_CCIPR2_RNGSEL)
+        RCC->CCIPR2 &= (uint32_t) ~RCC_CCIPR2_RNGSEL;
+#endif
+    }
+
+    irq_restore(is);
+}
+
+/** @} */

--- a/features.yaml
+++ b/features.yaml
@@ -336,6 +336,8 @@ groups:
           help: The MCU has an STM32 L5 MCU
         - name: cpu_stm32mp1
           help: The MCU has an STM32 MP1 MCU
+        - name: cpu_stm32u3
+          help: The MCU has an STM32 U3 MCU
         - name: cpu_stm32u5
           help: The MCU has an STM32 U5 MCU
         - name: cpu_stm32wb

--- a/makefiles/features_existing.inc.mk
+++ b/makefiles/features_existing.inc.mk
@@ -111,6 +111,7 @@ FEATURES_EXISTING := \
     cpu_stm32l4 \
     cpu_stm32l5 \
     cpu_stm32mp1 \
+    cpu_stm32u3 \
     cpu_stm32u5 \
     cpu_stm32wb \
     cpu_stm32wl \


### PR DESCRIPTION
### Contribution description


This PR adds initial support for the **STM32U3 MCU family** (Cortex-M33, TrustZone)
and the **NUCLEO-U385RG-Q** board, covering the minimum needed to boot RIOT and
interact with it over a serial console.

Parts of RIOT involved:
- `cpu/stm32`: new `u3` CPU family — `CPU_FAM`/line/RAM/ROM detection
  (`stm32_info.mk`, `stm32_mem_lengths.mk`), CMSIS header selection, Kconfig
  family/model definitions, and the `cpu_stm32u3` feature.
- Clock: `stmclk_u3.c` + `clk/u3/cfg_clock_default.h`. The U3 reaches high SYSCLK
  via the MSI oscillator (no PLL bring-up needed); FLASH wait states are wired to
  the ACR register to avoid HardFaults at higher frequencies.
- Core register fixups so the family compiles: APB3 / AHB1ENR1-2 enable routing,
  FLASH key, EXTI/SYSCFG, and `CLOCK_LSI` (`periph/cpu_common.h`, `periph_cpu.h`,
  `periph/u3/periph_cpu.h`).
- Peripherals in this PR: **GPIO** (incl. EXTI external interrupts) and
  **UART/LPUART** (USART1 = ST-LINK VCP / STDIO, LPUART1), plus the general-purpose
  **timer** backend.
- `boards/nucleo-u385rg-q`: new thin Nucleo-64 board (LED/button, clock selection,
  serial console pins).

Additional peripherals (ADC, SPI, I2C, PWM, USB, RTC, VBAT, HWRNG, flashpage) are
added in a follow-up PR stacked on top of this one.


### Testing procedure


These apps were compiled for the NUCLEO-U385RG-Q and run on hardware:

cd examples/basic/blinky        && make BOARD=nucleo-u385rg-q
cd examples/basic/default       && make BOARD=nucleo-u385rg-q
cd tests/periph/uart            && make BOARD=nucleo-u385rg-q
cd tests/periph/timer_periodic  && make BOARD=nucleo-u385rg-q
cd tests/periph/gpio_ll         && make BOARD=nucleo-u385rg-q

> [!NOTE]
> OpenOCD does not yet support the STM32U3, so `make flash` (default programmer:
> openocd) does not work for this board. Until OpenOCD support lands, flash the
> built ELF with the STM32CubeProgrammer CLI, e.g.:
>
> ```
> STM32_Programmer_CLI -c port=SWD mode=Normal reset=HWrst freq=8000 \
>     -e all \
>     -w bin/nucleo-u385rg-q/<application>.elf \
>     -v -rst
> ```

After flashing, open the serial console (ST-LINK VCP, 115200 baud) with
`make BOARD=nucleo-u385rg-q term`.

Expected results:
- `blinky` — the green User LED (LD2) blinks, confirming clock + GPIO bring-up.
- `default` — the RIOT shell comes up on the VCP and responds to commands,
  confirming the UART/STDIO console.
- `tests/periph/uart` — UART/LPUART behaves as the test expects.
- `tests/periph/timer_periodic` — the periodic timer fires at the expected intervals.
- `tests/periph/gpio_ll` — GPIO including external interrupts (EXTI) works.

None of this is available in `master` today — the `stm32u3` CPU family and the
`nucleo-u385rg-q` board do not exist there, so `make BOARD=nucleo-u385rg-q` fails
on master with an unknown board.



### Issues/PRs references


Supersedes #22175 (that PR is being split into this focused bring-up PR plus a
peripherals PR for easier review). The peripherals follow-up is stacked on this
branch and depends on it.


### Declaration of AI-Tools / LLMs usage:


AI-Tools / LLMs that were used are:
-Claude for code generation but reviewed by user.
-Gemini for planning and review.


