### PR TITLE
cpu/stm32: add STM32U3 peripheral driver support

### DIFF
--- a/boards/nucleo-u385rg-q/Makefile.features
+++ b/boards/nucleo-u385rg-q/Makefile.features
@@ -2,8 +2,14 @@ CPU = stm32
 CPU_MODEL = stm32u385rg
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart periph_lpuart
+FEATURES_PROVIDED += periph_usbdev
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features

--- a/boards/nucleo-u385rg-q/doc.md
+++ b/boards/nucleo-u385rg-q/doc.md
@@ -77,12 +77,12 @@ verified on hardware:
 | Flash page | working | program/erase + verify (VCORE voltage range 1)               |
 | VBAT       | working | internal VBAT channel (scaling fixed)                        |
 | ADC        | working | ADC1, Arduino A0–A5 plus internal VREFINT (verified with a potentiometer sweep) |
+| USB device | working | USB DRD FS, D+/D− on PA12/PA11 (user USB Type-C) — verified with a CDC-ACM shell |
 | I2C        | WIP     | I2C1 on PB8/PB9 (SCL/SDA), Arduino D15/D14 — bus scan can hang, under investigation |
-| USB device | WIP     | USB DRD FS, D+/D− on PA12/PA11 — not yet functional, under investigation |
 
-@note   I2C and USB are configured and compile, but are not yet working
-        correctly on hardware (known bugs are being worked on). The remaining
-        peripherals above have been confirmed working.
+@note   I2C is configured and compiles, but is not yet working correctly on
+        hardware (a known bug is being worked on). The remaining peripherals
+        above have been confirmed working.
 
 Arduino-style abstractions inherited from the common Nucleo-64 support are also
 provided: `arduino_pins`, `arduino_analog`, `arduino_i2c`, `arduino_spi`,

--- a/boards/nucleo-u385rg-q/doc.md
+++ b/boards/nucleo-u385rg-q/doc.md
@@ -78,11 +78,9 @@ verified on hardware:
 | VBAT       | working | internal VBAT channel (scaling fixed)                        |
 | ADC        | working | ADC1, Arduino A0–A5 plus internal VREFINT (verified with a potentiometer sweep) |
 | USB device | working | USB DRD FS, D+/D− on PA12/PA11 (user USB Type-C) — verified with a CDC-ACM shell |
-| I2C        | WIP     | I2C1 on PB8/PB9 (SCL/SDA), Arduino D15/D14 — bus scan can hang, under investigation |
+| I2C        | working | I2C1 on PB6/PB7 (SCL/SDA), Arduino D15/D14 — verified with a full bus scan (no devices attached) |
 
-@note   I2C is configured and compiles, but is not yet working correctly on
-        hardware (a known bug is being worked on). The remaining peripherals
-        above have been confirmed working.
+@note   All peripherals listed above have been verified on hardware.
 
 Arduino-style abstractions inherited from the common Nucleo-64 support are also
 provided: `arduino_pins`, `arduino_analog`, `arduino_i2c`, `arduino_spi`,

--- a/boards/nucleo-u385rg-q/doc.md
+++ b/boards/nucleo-u385rg-q/doc.md
@@ -76,11 +76,11 @@ verified on hardware:
 | SPI        | working | SPI1 on PA7/PA6/PA5 (MOSI/MISO/SCK), Arduino D11/D12/D13 — verified via loopback test |
 | Flash page | working | program/erase + verify (VCORE voltage range 1)               |
 | VBAT       | working | internal VBAT channel (scaling fixed)                        |
-| ADC        | WIP     | ADC1, Arduino A0–A5 plus internal VREFINT — external channels not reading correctly, under investigation |
+| ADC        | working | ADC1, Arduino A0–A5 plus internal VREFINT (verified with a potentiometer sweep) |
 | I2C        | WIP     | I2C1 on PB8/PB9 (SCL/SDA), Arduino D15/D14 — bus scan can hang, under investigation |
 | USB device | WIP     | USB DRD FS, D+/D− on PA12/PA11 — not yet functional, under investigation |
 
-@note   ADC, I2C, and USB are configured and compile, but are not yet working
+@note   I2C and USB are configured and compile, but are not yet working
         correctly on hardware (known bugs are being worked on). The remaining
         peripherals above have been confirmed working.
 

--- a/boards/nucleo-u385rg-q/doc.md
+++ b/boards/nucleo-u385rg-q/doc.md
@@ -11,8 +11,8 @@ with TrustZone, 256KiB of RAM, and 1MiB of Flash.
 You can find general information about the Nucleo-64 boards on the
 @ref boards_common_nucleo64 page.
 
-This is the initial bring-up of the STM32U3 family and the Nucleo-U385RG-Q
-board: CPU and clock setup, GPIO, and the serial console (UART/LPUART).
+This RIOT port has moved past initial bring-up and now supports a range of the
+MCU's peripherals (see the Supported Features section below).
 
 ## Hardware
 
@@ -58,3 +58,36 @@ The default baud rate is 115200.
 
 If a physical connection to USART1 is needed, connect a UART interface to pins
 PA9 (USART1 TX) and PA10 (USART1 RX).
+
+## Supported Features
+
+The peripherals below are configured for this board (see `Makefile.features`
+and `include/periph_conf.h`). "Status" reflects whether the peripheral has been
+verified on hardware:
+
+| Peripheral | Status  | Configuration on this board                                  |
+|:-----------|:--------|:-------------------------------------------------------------|
+| GPIO       | working | including external interrupts (EXTI)                         |
+| UART       | working | USART1 on PA9/PA10 (ST-LINK VCP, STDIO)                       |
+| LPUART     | working | LPUART1 on PA2/PA3                                            |
+| Timer      | working | TIM3 (general-purpose RIOT timer backend)                    |
+| PWM        | working | TIM2 — CH1 User LED (PA5), CH2 PB3 (D3), CH3 PB10 (D6), CH4 PB11 |
+| RTC        | working | uses on-board 32.768 kHz LSE                                 |
+| SPI        | working | SPI1 on PA7/PA6/PA5 (MOSI/MISO/SCK), Arduino D11/D12/D13 — verified via loopback test |
+| Flash page | working | program/erase + verify (VCORE voltage range 1)               |
+| VBAT       | working | internal VBAT channel (scaling fixed)                        |
+| ADC        | WIP     | ADC1, Arduino A0–A5 plus internal VREFINT — external channels not reading correctly, under investigation |
+| I2C        | WIP     | I2C1 on PB8/PB9 (SCL/SDA), Arduino D15/D14 — bus scan can hang, under investigation |
+| USB device | WIP     | USB DRD FS, D+/D− on PA12/PA11 — not yet functional, under investigation |
+
+@note   ADC, I2C, and USB are configured and compile, but are not yet working
+        correctly on hardware (known bugs are being worked on). The remaining
+        peripherals above have been confirmed working.
+
+Arduino-style abstractions inherited from the common Nucleo-64 support are also
+provided: `arduino_pins`, `arduino_analog`, `arduino_i2c`, `arduino_spi`,
+`arduino_uart`, and `arduino_shield_uno`.
+
+@note   TIM2 is reserved for PWM (User LED on TIM2_CH1/PA5), so TIM3 is used as
+        the RIOT timer backend. PWM CH1 and SPI1 share the green User LED pin
+        (PA5); avoid using both simultaneously.

--- a/boards/nucleo-u385rg-q/include/periph_conf.h
+++ b/boards/nucleo-u385rg-q/include/periph_conf.h
@@ -28,9 +28,63 @@ extern "C" {
 #endif
 
 /**
+ * @name   SPI configuration
+ * @{
+ * @note  Arduino D11/D12/D13 (MOSI/MISO/SCK) on Nucleo-U: PA7/PA6/PA5. SPI1 on
+ *        APB2; clock gate @ref RCC_APB2ENR_SPI1EN in stm32u385xx.h. Alternate
+ *        function AF5 for SPI1 on port A (RM0487 AF table).
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_A, 7),
+        .miso_pin = GPIO_PIN(PORT_A, 6),
+        .sclk_pin = GPIO_PIN(PORT_A, 5),
+        .cs_pin = GPIO_UNDEF,
+        .mosi_af = GPIO_AF5,
+        .miso_af = GPIO_AF5,
+        .sclk_af = GPIO_AF5,
+        .cs_af = GPIO_AF5,
+        .rccmask = RCC_APB2ENR_SPI1EN,
+        .apbbus = APB2,
+    },
+};
+
+#define SPI_NUMOF ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name I2C configuration
+ * @{
+ * @note Nucleo Arduino connector D14/D15 = PB9/PB8 (SDA/SCL). I2C1 on APB1,
+ *       AF4 per RM0487 / alternate-function tables (same convention as other
+ *       STM32 Nucleo boards). Kernel clock: RCC CCIPR1 I2C1SEL — leave @c 0 to
+ *       keep reset default (typically PCLK1); OR @ref RCC_CCIPR1_I2C1SEL if a
+ *       different RM0487 setting is required.
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = I2C1,
+        .speed = I2C_SPEED_NORMAL,
+        .scl_pin = GPIO_PIN(PORT_B, 8),
+        .sda_pin = GPIO_PIN(PORT_B, 9),
+        .scl_af = GPIO_AF4,
+        .sda_af = GPIO_AF4,
+        .bus = APB1,
+        .rcc_mask = RCC_APB1ENR1_I2C1EN,
+        .rcc_sw_mask = 0,
+        .irqn = I2C1_ER_IRQn,
+    },
+};
+
+#define I2C_0_ISR isr_i2c1_er
+#define I2C_NUMOF ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**
  * @name    Timer configuration
  * @{
- * @note    TIM2 is reserved for PWM (User LED / TIM2_CH1 on PA5).
+ * @note    TIM2 is reserved for @ref pwm_config (User LED / TIM2_CH1 on PA5).
  *          TIM3 is used here as the RIOT timer backend (general-purpose timer).
  */
 static const timer_conf_t timer_config[] = {
@@ -46,6 +100,33 @@ static const timer_conf_t timer_config[] = {
 #define TIMER_NUMOF        ARRAY_SIZE(timer_config)
 
 #define TIMER_0_ISR        isr_tim3
+/** @} */
+
+/**
+ * @name    PWM configuration
+ *
+ * TIM2 channel mapping follows the MCU alternate-function table (RM0487).
+ * TIM2_CH1 on PA5 uses AF1 and connects to the green User LED (same pin as
+ * Arduino D13 when SPI1 is not in use; see boards/common/nucleo64/doc.md).
+ *
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev = TIM2,
+        .rcc_mask = RCC_APB1ENR1_TIM2EN,
+        .chan = { { .pin = GPIO_PIN(PORT_A, 5) /* User LED */, .cc_chan = 0 },
+                  { .pin = GPIO_PIN(PORT_B, 3),  .cc_chan = 1 }, /* CH2: Arduino D3 */
+                  { .pin = GPIO_PIN(PORT_B, 10), .cc_chan = 2 }, /* CH3: Arduino D6 */
+                  { .pin = GPIO_PIN(PORT_B, 11), .cc_chan = 3 }  /* CH4: Standard extension */
+                },
+        .af = GPIO_AF1,
+        .bus = APB1,
+    },
+};
+
+#define PWM_NUMOF ARRAY_SIZE(pwm_config)
+
 /** @} */
 
 /**
@@ -84,6 +165,66 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart1)
 #define UART_1_ISR          (isr_lpuart1)
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name    ADC configuration
+ * @{
+ * @note Arduino CN8 (A0–A5) pinout for NUCLEO-U385RG-Q per ST UM3062 Table 14:
+ *       A0=PA0/IN5, A1=PA1/IN6, A2=PA4/IN9, A3=PB0/IN15, A4=PC1/IN2, A5=PC0/IN1.
+ *       All lines use ADC1 (@c dev 0). PC0/PC1 are also Arduino I2C3 on the
+ *       connector; this board’s default I2C is I2C1 on PB8/PB9.
+ */
+/**
+ * @brief   Internal ADC1 channel for VREFINT on STM32U3.
+ *          Per CubeU3 stm32u3xx_ll_adc.h, LL_ADC_CHANNEL_VREFINT is channel 0.
+ */
+#ifndef VREFINT_ADC_CHAN
+#  define VREFINT_ADC_CHAN  0
+#endif
+
+static const adc_conf_t adc_config[] = {
+    { .pin = GPIO_PIN(PORT_A, 0), .dev = 0, .chan = 5 },   /* A0  ADC1_IN5  */
+    { .pin = GPIO_PIN(PORT_A, 1), .dev = 0, .chan = 6 },   /* A1  ADC1_IN6  */
+    { .pin = GPIO_PIN(PORT_A, 4), .dev = 0, .chan = 9 },   /* A2  ADC1_IN9  */
+    { .pin = GPIO_PIN(PORT_B, 0), .dev = 0, .chan = 15 },  /* A3  ADC1_IN15 */
+    { .pin = GPIO_PIN(PORT_C, 1), .dev = 0, .chan = 2 },   /* A4  ADC1_IN2  */
+    { .pin = GPIO_PIN(PORT_C, 0), .dev = 0, .chan = 1 },   /* A5  ADC1_IN1  */
+    { .pin = GPIO_UNDEF, .dev = 0, .chan = 16 },           /* VBAT/4 internal (RM0487: VBAT is IN16, IN18 is VDDCORE) */
+    { .pin = GPIO_UNDEF, .dev = 0, .chan = VREFINT_ADC_CHAN }, /* VREFINT (internal channel 0) */
+};
+
+#define VBAT_ADC            ADC_LINE(6) /**< VBAT ADC line */
+#define VREFINT_ADC         ADC_LINE(7) /**< VREFINT ADC line (for vref_mv()) */
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+/** @} */
+
+/**
+ * @name    USB device (USB DRD FS) configuration
+ * @note    D+/D- on ST morpho: PA12 / PA11, alternate function as per
+ *          the STM32U385 and Nucleo documentation.
+ * @note    48MHz USB digital clock must be provided by the clock tree in
+ *          @ref cpu_stm32 "stmclk" when using this peripheral.
+ * @note    On STM32U3, USB is on APB2 and gated via @c RCC->APB2ENR
+ *          (see RM0487, memory map + RCC section).
+ * @{
+ */
+static const stm32_usbdev_fs_config_t stm32_usbdev_fs_config[] = {
+    {
+        .base_addr  = (uintptr_t)USB,
+        .rcc_mask   = RCC_U3_USBDEV_FS_RMASK,
+        .dm         = GPIO_PIN(PORT_A, 11),
+        .dp         = GPIO_PIN(PORT_A, 12),
+        .af         = GPIO_AF10,
+        .disconn    = GPIO_UNDEF,
+        .irqn       = USB_FS_IRQn,
+        .apb        = APB2,
+    },
+};
+
+#define USBDEV_ISR          isr_usb_fs
+#define USBDEV_NUMOF        ARRAY_SIZE(stm32_usbdev_fs_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-u385rg-q/include/periph_conf.h
+++ b/boards/nucleo-u385rg-q/include/periph_conf.h
@@ -204,8 +204,9 @@ static const adc_conf_t adc_config[] = {
 
 /**
  * @name    USB device (USB DRD FS) configuration
- * @note    D+/D- on ST morpho: PA12 / PA11, alternate function as per
- *          the STM32U385 and Nucleo documentation.
+ * @note    D+/D- on PA12/PA11 (user USB Type-C connector). The USB DRD FS
+ *          PHY drives the pads directly, so no alternate function is used;
+ *          the driver keeps the pins in analog mode.
  * @note    48MHz USB digital clock must be provided by the clock tree in
  *          @ref cpu_stm32 "stmclk" when using this peripheral.
  * @note    On STM32U3, USB is on APB2 and gated via @c RCC->APB2ENR
@@ -218,7 +219,7 @@ static const stm32_usbdev_fs_config_t stm32_usbdev_fs_config[] = {
         .rcc_mask   = RCC_U3_USBDEV_FS_RMASK,
         .dm         = GPIO_PIN(PORT_A, 11),
         .dp         = GPIO_PIN(PORT_A, 12),
-        .af         = GPIO_AF10,
+        .af         = GPIO_AF_UNDEF,
         .disconn    = GPIO_UNDEF,
         .irqn       = USB_FS_IRQn,
         .apb        = APB2,

--- a/boards/nucleo-u385rg-q/include/periph_conf.h
+++ b/boards/nucleo-u385rg-q/include/periph_conf.h
@@ -54,20 +54,18 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @name I2C configuration
+ * @name    I2C configuration
  * @{
- * @note Nucleo Arduino connector D14/D15 = PB9/PB8 (SDA/SCL). I2C1 on APB1,
- *       AF4 per RM0487 / alternate-function tables (same convention as other
- *       STM32 Nucleo boards). Kernel clock: RCC CCIPR1 I2C1SEL — leave @c 0 to
- *       keep reset default (typically PCLK1); OR @ref RCC_CCIPR1_I2C1SEL if a
- *       different RM0487 setting is required.
+ * @note    I2C1 on PB6/PB7 (SCL/SDA), the Arduino connector pins D15/D14
+ *          on this board (see UM3062). The I2C1 kernel clock is left at its
+ *          reset default (PCLK1).
  */
 static const i2c_conf_t i2c_config[] = {
     {
         .dev = I2C1,
         .speed = I2C_SPEED_NORMAL,
-        .scl_pin = GPIO_PIN(PORT_B, 8),
-        .sda_pin = GPIO_PIN(PORT_B, 9),
+        .scl_pin = GPIO_PIN(PORT_B, 6),
+        .sda_pin = GPIO_PIN(PORT_B, 7),
         .scl_af = GPIO_AF4,
         .sda_af = GPIO_AF4,
         .bus = APB1,

--- a/boards/nucleo-u385rg-q/include/periph_conf.h
+++ b/boards/nucleo-u385rg-q/include/periph_conf.h
@@ -176,21 +176,23 @@ static const uart_conf_t uart_config[] = {
  *       connector; this board’s default I2C is I2C1 on PB8/PB9.
  */
 /**
- * @brief   Internal ADC1 channel for VREFINT on STM32U3.
- *          Per CubeU3 stm32u3xx_ll_adc.h, LL_ADC_CHANNEL_VREFINT is channel 0.
+ * @brief   Internal ADC1 channel for VREFINT on STM32U3 (channel 0).
  */
 #ifndef VREFINT_ADC_CHAN
 #  define VREFINT_ADC_CHAN  0
 #endif
 
+/* ADC1 channel numbers below are verified on hardware (potentiometer sweep on
+ * each Arduino analog pin). The STM32U385 ADC1 input mux maps
+ *   PC0=IN1, PC1=IN2, PA0=IN3, PA1=IN4, PA2=IN5, PA3=IN6, PA4=IN7, PB0=IN13. */
 static const adc_conf_t adc_config[] = {
-    { .pin = GPIO_PIN(PORT_A, 0), .dev = 0, .chan = 5 },   /* A0  ADC1_IN5  */
-    { .pin = GPIO_PIN(PORT_A, 1), .dev = 0, .chan = 6 },   /* A1  ADC1_IN6  */
-    { .pin = GPIO_PIN(PORT_A, 4), .dev = 0, .chan = 9 },   /* A2  ADC1_IN9  */
-    { .pin = GPIO_PIN(PORT_B, 0), .dev = 0, .chan = 15 },  /* A3  ADC1_IN15 */
+    { .pin = GPIO_PIN(PORT_A, 0), .dev = 0, .chan = 3 },   /* A0  ADC1_IN3  */
+    { .pin = GPIO_PIN(PORT_A, 1), .dev = 0, .chan = 4 },   /* A1  ADC1_IN4  */
+    { .pin = GPIO_PIN(PORT_A, 4), .dev = 0, .chan = 7 },   /* A2  ADC1_IN7  */
+    { .pin = GPIO_PIN(PORT_B, 0), .dev = 0, .chan = 13 },  /* A3  ADC1_IN13 */
     { .pin = GPIO_PIN(PORT_C, 1), .dev = 0, .chan = 2 },   /* A4  ADC1_IN2  */
     { .pin = GPIO_PIN(PORT_C, 0), .dev = 0, .chan = 1 },   /* A5  ADC1_IN1  */
-    { .pin = GPIO_UNDEF, .dev = 0, .chan = 16 },           /* VBAT/4 internal (RM0487: VBAT is IN16, IN18 is VDDCORE) */
+    { .pin = GPIO_UNDEF, .dev = 0, .chan = 16 },           /* VBAT/4 internal (RM0487: VBAT is IN16) */
     { .pin = GPIO_UNDEF, .dev = 0, .chan = VREFINT_ADC_CHAN }, /* VREFINT (internal channel 0) */
 };
 

--- a/boards/nucleo-u385rg-q/include/periph_conf.h
+++ b/boards/nucleo-u385rg-q/include/periph_conf.h
@@ -10,7 +10,7 @@
  * @{
  *
  * @file
- * @brief       Minimal peripheral configuration for STM32U385 (bring-up)
+ * @brief       Peripheral configuration for the STM32 Nucleo-U385RG-Q
  *
  * @author      Adarsh Nair Mullachery <adarsh.mullachery@tuhh.de>
  */
@@ -31,7 +31,7 @@ extern "C" {
  * @name   SPI configuration
  * @{
  * @note  Arduino D11/D12/D13 (MOSI/MISO/SCK) on Nucleo-U: PA7/PA6/PA5. SPI1 on
- *        APB2; clock gate @ref RCC_APB2ENR_SPI1EN in stm32u385xx.h. Alternate
+ *        APB2; clock gate @c RCC_APB2ENR_SPI1EN in stm32u385xx.h. Alternate
  *        function AF5 for SPI1 on port A (RM0487 AF table).
  */
 static const spi_conf_t spi_config[] = {
@@ -82,7 +82,7 @@ static const i2c_conf_t i2c_config[] = {
 /**
  * @name    Timer configuration
  * @{
- * @note    TIM2 is reserved for @ref pwm_config (User LED / TIM2_CH1 on PA5).
+ * @note    TIM2 is reserved for @c pwm_config (User LED / TIM2_CH1 on PA5).
  *          TIM3 is used here as the RIOT timer backend (general-purpose timer).
  */
 static const timer_conf_t timer_config[] = {
@@ -168,10 +168,8 @@ static const uart_conf_t uart_config[] = {
 /**
  * @name    ADC configuration
  * @{
- * @note Arduino CN8 (A0–A5) pinout for NUCLEO-U385RG-Q per ST UM3062 Table 14:
- *       A0=PA0/IN5, A1=PA1/IN6, A2=PA4/IN9, A3=PB0/IN15, A4=PC1/IN2, A5=PC0/IN1.
- *       All lines use ADC1 (@c dev 0). PC0/PC1 are also Arduino I2C3 on the
- *       connector; this board’s default I2C is I2C1 on PB8/PB9.
+ * @note Arduino CN8 analog pins A0-A5 on ADC1, plus the internal VBAT and
+ *       VREFINT channels.
  */
 /**
  * @brief   Internal ADC1 channel for VREFINT on STM32U3 (channel 0).
@@ -180,8 +178,7 @@ static const uart_conf_t uart_config[] = {
 #  define VREFINT_ADC_CHAN  0
 #endif
 
-/* ADC1 channel numbers below are verified on hardware (potentiometer sweep on
- * each Arduino analog pin). The STM32U385 ADC1 input mux maps
+/* STM32U385 ADC1 input mux mapping:
  *   PC0=IN1, PC1=IN2, PA0=IN3, PA1=IN4, PA2=IN5, PA3=IN6, PA4=IN7, PB0=IN13. */
 static const adc_conf_t adc_config[] = {
     { .pin = GPIO_PIN(PORT_A, 0), .dev = 0, .chan = 3 },   /* A0  ADC1_IN3  */
@@ -202,6 +199,7 @@ static const adc_conf_t adc_config[] = {
 
 /**
  * @name    USB device (USB DRD FS) configuration
+ * @{
  * @note    D+/D- on PA12/PA11 (user USB Type-C connector). The USB DRD FS
  *          PHY drives the pads directly, so no alternate function is used;
  *          the driver keeps the pins in analog mode.
@@ -209,8 +207,8 @@ static const adc_conf_t adc_config[] = {
  *          @ref cpu_stm32 "stmclk" when using this peripheral.
  * @note    On STM32U3, USB is on APB2 and gated via @c RCC->APB2ENR
  *          (see RM0487, memory map + RCC section).
- * @{
  */
+/** @brief USB DRD FS device configuration */
 static const stm32_usbdev_fs_config_t stm32_usbdev_fs_config[] = {
     {
         .base_addr  = (uintptr_t)USB,
@@ -224,8 +222,8 @@ static const stm32_usbdev_fs_config_t stm32_usbdev_fs_config[] = {
     },
 };
 
-#define USBDEV_ISR          isr_usb_fs
-#define USBDEV_NUMOF        ARRAY_SIZE(stm32_usbdev_fs_config)
+#define USBDEV_ISR          isr_usb_fs                        /**< USB FS interrupt service routine */
+#define USBDEV_NUMOF        ARRAY_SIZE(stm32_usbdev_fs_config) /**< Number of configured USB devices */
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -28,7 +28,7 @@ ifneq (f1,$(CPU_FAM))
   FEATURES_PROVIDED += periph_gpio_ll_switch_dir
 endif
 
-ifneq (,$(filter $(CPU_FAM),c0 f0 f1 f3 g0 g4 l0 l1 l4 l5 u5 wb wl))
+ifneq (,$(filter $(CPU_FAM),c0 f0 f1 f3 g0 g4 l0 l1 l4 l5 u3 u5 wb wl))
   # The STM32G491 has "Category 4" flash which is currently not supported by
   # the flashpage peripheral driver.
   ifeq (,$(filter stm32g491%,$(CPU_MODEL)))
@@ -38,7 +38,7 @@ ifneq (,$(filter $(CPU_FAM),c0 f0 f1 f3 g0 g4 l0 l1 l4 l5 u5 wb wl))
   endif
 endif
 
-ifneq (,$(filter $(CPU_FAM),f0 f2 f3 f4 f7 l0 l1 l4 l5 u5 wb wl))
+ifneq (,$(filter $(CPU_FAM),f0 f2 f3 f4 f7 l0 l1 l4 l5 u3 u5 wb wl))
   CPU_MODELS_WITHOUT_RTC_BKPR += stm32f030% stm32f070% \
                                  stm32f302%
   ifeq (,$(filter $(CPU_MODELS_WITHOUT_RTC_BKPR),$(CPU_MODEL)))
@@ -67,6 +67,7 @@ STM32_WITH_VBAT = stm32f031% stm32f038% stm32f042% stm32f048% \
                   stm32g4% stm32gbk1cb \
                   stm32l412% stm32l433% stm32l45% stm32l47% stm32l49% stm32l4r% \
                   stm32l5% \
+                  stm32u3% \
                   stm32u5% \
                   stm32wb% \
                   stm32wl%
@@ -92,7 +93,7 @@ endif
 
 # Not all F4 and L0 parts implement a RNG.
 CPU_MODELS_WITHOUT_HWRNG = stm32f401% stm32f411% stm32f446% stm32l031% stm32l011%
-ifneq (,$(filter $(CPU_FAM),f2 f4 f7 g4 h7 l0 l4 l5 u5 wb))
+ifneq (,$(filter $(CPU_FAM),f2 f4 f7 g4 h7 l0 l4 l5 u3 u5 wb))
   ifeq (,$(filter $(CPU_MODELS_WITHOUT_HWRNG),$(CPU_MODEL)))
     FEATURES_PROVIDED += periph_hwrng
   endif

--- a/cpu/stm32/include/cpu_conf.h
+++ b/cpu/stm32/include/cpu_conf.h
@@ -81,7 +81,7 @@ extern "C" {
  */
 #if defined(CPU_FAM_STM32U5)
 #define FLASHPAGE_SIZE                  (8192U)
-#elif defined(CPU_FAM_STM32WB)
+#elif defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32U3)
 #define FLASHPAGE_SIZE                  (4096U)
 #elif defined(CPU_LINE_STM32F091xC) || defined(CPU_LINE_STM32F072xB) \
    || defined(CPU_LINE_STM32F030xC) || defined(CPU_LINE_STM32F103xE) \
@@ -178,8 +178,9 @@ extern "C" {
  */
 #if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
     defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32G0) || \
-    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0)
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32C0) || \
+    defined(CPU_FAM_STM32WL)
 #define FLASHPAGE_WRITE_BLOCK_SIZE            (8U)
 typedef uint64_t stm32_flashpage_block_t;
 #elif defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || \
@@ -194,8 +195,9 @@ typedef uint16_t stm32_flashpage_block_t;
 
 #if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
     defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32G0) || \
-    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0)
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32C0) || \
+    defined(CPU_FAM_STM32WL)
 #define FLASHPAGE_WRITE_BLOCK_ALIGNMENT       (8U)
 #else
 /* Writing should be always 4 bytes aligned */

--- a/cpu/stm32/include/periph/cpu_i2c.h
+++ b/cpu/stm32/include/periph/cpu_i2c.h
@@ -62,9 +62,9 @@ typedef enum {
     defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L0) || \
     defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
     defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32G0) || \
-    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0) || \
-    defined(CPU_FAM_STM32H7)
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32WL) || \
+    defined(CPU_FAM_STM32C0) || defined(CPU_FAM_STM32H7)
     I2C_SPEED_FAST_PLUS,    /**< fast plus mode: ~1Mbit/s */
 #endif
 } i2c_speed_t;
@@ -89,8 +89,9 @@ typedef struct {
     defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32G0) || \
     defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32L4) || \
     defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32WB) || \
-    defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32WL) || \
-    defined(CPU_FAM_STM32C0) || defined(CPU_FAM_STM32H7)
+    defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32U5) || \
+    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0) || \
+    defined(CPU_FAM_STM32H7)
     uint32_t rcc_sw_mask;   /**< bit to switch I2C clock */
 #endif
 #if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || \
@@ -105,9 +106,9 @@ typedef struct {
     defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L0) || \
     defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32L5) || \
     defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32G4) || \
-    defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32WB) || \
-    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0) || \
-    defined(CPU_FAM_STM32H7)
+    defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32U5) || \
+    defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32WL) || \
+    defined(CPU_FAM_STM32C0) || defined(CPU_FAM_STM32H7)
 /**
  * @brief   Structure for I2C timing register settings
  */
@@ -182,17 +183,17 @@ static const i2c_timing_param_t timing_params[] = {
 };
 #endif  /* CPU_FAM_STM32F0 || CPU_FAM_STM32F3 || CPU_FAM_STM32F7 ||
             CPU_FAM_STM32L0 || CPU_FAM_STM32L4 || CPU_FAM_STM32L5 ||
-            CPU_FAM_STM32G0 || CPU_FAM_STM32G4 || CPU_FAM_STM32U5 ||
-            CPU_FAM_STM32WB || CPU_FAM_STM32WL || CPU_FAM_STM32C0 ||
-            CPU_FAM_STM32H7 */
+            CPU_FAM_STM32G0 || CPU_FAM_STM32G4 || CPU_FAM_STM32U3 ||
+            CPU_FAM_STM32U5 || CPU_FAM_STM32WB || CPU_FAM_STM32WL ||
+            CPU_FAM_STM32C0 || CPU_FAM_STM32H7 */
 
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3) || \
     defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32G0) || \
     defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32L0) || \
     defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32L5) || \
-    defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32WB) || \
-    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0) || \
-    defined(CPU_FAM_STM32H7)
+    defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32U5) || \
+    defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32WL) || \
+    defined(CPU_FAM_STM32C0) || defined(CPU_FAM_STM32H7)
 /**
  * @brief   The I2C implementation supports only a limited frame size.
  *          See i2c_1.c

--- a/cpu/stm32/include/periph/u3/periph_cpu.h
+++ b/cpu/stm32/include/periph/u3/periph_cpu.h
@@ -80,6 +80,58 @@ typedef enum {
 #define VBAT_ADC_MAX        4095
 /** @} */
 
+/**
+ * @name   RCC clock gating for USB full-speed (USB DRD FS) on STM32U3
+ * @{
+ * @note RM0487, memory map: USB is on the **APB2** bus; the enable bit is in
+ * @c RCC->APB2ENR. ST CMSIS usually uses @c RCC_APB2ENR_USBEN (or similar).
+ * The APB1 variants below are only fallbacks for unusual header pack versions.
+ * Board @c apb in @c stm32_usbdev_fs_config_t must match (typically @c APB2).
+ */
+#if !defined(RCC_U3_USBDEV_FS_RMASK)
+#  if defined(RCC_APB2ENR_USB1EN)
+#    /* STM32U3 CMSIS: USB DRD FS (bit name includes instance "1" — see stm32u385xx.h) */
+#    define RCC_U3_USBDEV_FS_RMASK  RCC_APB2ENR_USB1EN
+#  elif defined(RCC_APB2ENR_USBEN)
+#    define RCC_U3_USBDEV_FS_RMASK  RCC_APB2ENR_USBEN
+#  elif defined(RCC_APB2ENR_USBFSDEN)
+#    define RCC_U3_USBDEV_FS_RMASK  RCC_APB2ENR_USBFSDEN
+#  elif defined(RCC_APB2ENR_USBFSEN)
+#    define RCC_U3_USBDEV_FS_RMASK  RCC_APB2ENR_USBFSEN
+#  elif defined(RCC_APB2ENR1_USBEN)
+#    define RCC_U3_USBDEV_FS_RMASK  RCC_APB2ENR1_USBEN
+#  elif defined(RCC_APB1ENR1_USBEN)
+#    define RCC_U3_USBDEV_FS_RMASK  RCC_APB1ENR1_USBEN
+#  elif defined(RCC_APB1ENR1_USBFSDEN)
+#    define RCC_U3_USBDEV_FS_RMASK  RCC_APB1ENR1_USBFSDEN
+#  elif defined(RCC_APB1ENR1_USBFSEN)
+#    define RCC_U3_USBDEV_FS_RMASK  RCC_APB1ENR1_USBFSEN
+#  elif defined(RCC_APB1ENR1_USBDEN)
+#    define RCC_U3_USBDEV_FS_RMASK  RCC_APB1ENR1_USBDEN
+#  else
+#    error "Add USB full-speed clock enable: grep RCC_ *USB* in your stm32u3xx.h (APB2ENR in RM0487) and set RCC_U3_USBDEV_FS_RMASK in board Makefile CFLAGS, or add the macro name here"
+#  endif
+#endif
+/** @} */
+
+/**
+ * @name   USB DRD FS peripheral handle for driver code
+ * @{
+ * STM32U3 CMSIS may expose the instance as @c USB, @c USB_DRD, @c USB_DRD_FS, or
+ * a base address macro only. Provide @c USB when missing so @c periph_conf.h can
+ * use a single @c (uintptr_t)USB like other boards.
+ */
+#if !defined(USB)
+#  if defined(USB_DRD)
+#    define USB  USB_DRD
+#  elif defined(USB_DRD_FS)
+#    define USB  USB_DRD_FS
+#  elif defined(USB_DRD_BASE)
+#    define USB  ((USB_DRD_TypeDef *)USB_DRD_BASE)
+#  endif
+#endif
+/** @} */
+
 #endif /* DOXYGEN */
 
 #ifdef __cplusplus

--- a/cpu/stm32/periph/Makefile
+++ b/cpu/stm32/periph/Makefile
@@ -2,7 +2,7 @@ MODULE = periph
 
 # Select the specific implementation for `periph_i2c`
 ifneq (,$(filter periph_i2c,$(USEMODULE)))
-  ifneq (,$(filter $(CPU_FAM),f0 f3 f7 g0 g4 h7 l0 l4 l5 u5 wb wl c0))
+  ifneq (,$(filter $(CPU_FAM),f0 f3 f7 g0 g4 h7 l0 l4 l5 u3 u5 wb wl c0))
     SRC += i2c_1.c
   else ifneq (,$(filter $(CPU_FAM),f1 f2 f4 l1))
     SRC += i2c_2.c
@@ -13,8 +13,8 @@ endif
 
 # Select the specific implementation for `periph_adc`
 ifneq (,$(filter periph_adc,$(USEMODULE)))
-  ifneq (,$(filter $(CPU_FAM),f3 h7))
-    SRC += adc_f3_h7.c
+  ifneq (,$(filter $(CPU_FAM),f3 h7 u3))
+    SRC += adc_f3_h7_u3.c
   else ifneq (,$(filter $(CPU_FAM),f4 f7))
     SRC += adc_f4_f7.c
   else ifneq (,$(filter $(CPU_FAM),f0 g0 c0))

--- a/cpu/stm32/periph/adc_f3_h7_u3.c
+++ b/cpu/stm32/periph/adc_f3_h7_u3.c
@@ -35,7 +35,7 @@
 #endif
 
 #if defined(CPU_FAM_STM32U3)
-/* Give internal VBAT path time to settle before conversion. */
+/* Settling time for internal channels before conversion */
 #  define ADC_T_VBAT_STAB_US   (10U)
 #endif
 
@@ -121,9 +121,9 @@ int adc_init(adc_t line)
     }
 
 #if defined(CPU_FAM_STM32U3)
-    /* Independent analog supply for ADC analog front-end */
+    /* Enable the ADC analog supply */
     PWR->SVMCR |= PWR_SVMCR_ASV;
-    /* ADC kernel clock: clear ADCDACSEL so HCLK is selected */
+    /* Select HCLK as ADC kernel clock */
     RCC->CCIPR2 &= ~RCC_CCIPR2_ADCDACSEL;
 #endif
 
@@ -163,12 +163,10 @@ int adc_init(adc_t line)
 #endif
 
 #if defined(CPU_FAM_STM32U3)
-    /* STM32U3 ADC kernel clock is derived directly from HCLK without a CKMODE 
-     * divider. To ensure sufficient sample-and-hold time for high-impedance 
-     * internal channels (VBAT, VREFINT, TSENSE) at maximum HCLK frequencies, 
-     * a clock prescaler is applied. */
+    /* U3 has no CKMODE divider; prescale the kernel clock (HCLK/8) to keep
+     * enough sample time on high-impedance channels at high HCLK */
     ADC_INSTANCE->CCR = (ADC_INSTANCE->CCR & ~ADC_CCR_PRESC)
-                      | ADC_CCR_PRESC_2; /* divide ADC clock by 8 */
+                      | ADC_CCR_PRESC_2;
 #endif
 
 #if !defined(CPU_FAM_STM32U3)
@@ -204,7 +202,7 @@ int adc_init(adc_t line)
 #endif
         }
     }
-#endif /* !defined(CPU_FAM_STM32U3) — U3: no CKMODE in ADC_CCR; clock from RCC->CCIPR2 */
+#endif /* !CPU_FAM_STM32U3 (U3 has no CKMODE field in ADC_CCR) */
 
     /* Configure the pin */
     if (adc_config[line].pin != GPIO_UNDEF) {
@@ -218,11 +216,12 @@ int adc_init(adc_t line)
         dev(line)->CR &= ~(ADC_CR_DEEPPWD);
 #endif
 #if defined(CPU_FAM_STM32U3)
-        /* take ADC out of deep sleep */
+        /* Exit ADC deep-power-down mode */
         dev(line)->CR &= ~(ADC_CR_DEEPPWD);
 #endif
         /* Enable ADC internal voltage regulator and wait for startup period */
 #if defined(CPU_FAM_STM32U3)
+        /* Clear LDO-ready flag before enabling the regulator */
         dev(line)->ISR |= ADC_ISR_LDORDY;
 #endif
         dev(line)->CR |= ADC_CR_ADVREGEN;
@@ -254,6 +253,18 @@ int adc_init(adc_t line)
         dev(line)->CR |= ADC_CR_ADCAL;
         while (dev(line)->CR & ADC_CR_ADCAL) {}
 
+#if defined(CPU_FAM_STM32U3)
+        /* PCSEL is writable only while ADEN=0 (RM0487), so pre-select all
+         * external channels of this ADC here. Internal channels are routed
+         * via ADC_CCR and need no pre-selection. */
+        for (unsigned i = 0; i < ADC_NUMOF; i++) {
+            if ((adc_config[i].dev == adc_config[line].dev)
+                && (adc_config[i].pin != GPIO_UNDEF)) {
+                dev(line)->PCSEL |= (ADC_PCSEL_PCSEL_0 << adc_config[i].chan);
+            }
+        }
+#endif
+
         /* Clear ADRDY by writing it */
         dev(line)->ISR |= ADC_ISR_ADRDY;
 
@@ -261,7 +272,7 @@ int adc_init(adc_t line)
         dev(line)->CR |= ADC_CR_ADEN;
         while ((dev(line)->ISR & ADC_ISR_ADRDY) == 0) {}
 #if defined(CPU_FAM_STM32U3)
-        /* STM32U3 may drop ADEN once during enable; re-assert if needed */
+        /* Re-assert ADEN if it did not latch on the first write */
         if (!(dev(line)->CR & ADC_CR_ADEN)) {
             dev(line)->ISR |= ADC_ISR_ADRDY;
             dev(line)->CR |= ADC_CR_ADEN;
@@ -286,9 +297,6 @@ int adc_init(adc_t line)
 
 #if CPU_FAM_STM32H7
     /* Enable the ADC channel's analog switch */
-    dev(line)->PCSEL |= ADC_PCSEL_PCSEL_0 << adc_config[line].chan;
-#endif
-#if defined(CPU_FAM_STM32U3)
     dev(line)->PCSEL |= ADC_PCSEL_PCSEL_0 << adc_config[line].chan;
 #endif
 
@@ -354,7 +362,7 @@ int32_t adc_sample(adc_t line, adc_res_t res)
 
 #if defined(CPU_FAM_STM32U3)
     if (IS_USED(MODULE_PERIPH_VBAT) && line == VBAT_ADC) {
-        /* Discard dummy conversion to clear residual charge after enabling path */
+        /* Dummy conversion to flush residual charge after enabling VBAT */
         dev(line)->ISR |= ADC_ISR_EOC;
         dev(line)->CR |= ADC_CR_ADSTART;
         while (!(dev(line)->ISR & ADC_ISR_EOC)) {}

--- a/cpu/stm32/periph/adc_f3_h7_u3.c
+++ b/cpu/stm32/periph/adc_f3_h7_u3.c
@@ -26,12 +26,17 @@
 #define ADC_SMP_MIN_VAL     (0x2) /*< Sampling time for slow channels
                                       (0x2 = 4.5 ADC clock cycles) */
 
-#ifdef CPU_FAM_STM32H7
+#if defined(CPU_FAM_STM32H7) || defined(CPU_FAM_STM32U3)
 #  define ADC_SMP_VBAT_VAL    (0x7) /*< Sampling time when the VBat channel
                                       is read (0x7 = 810.5 ADC clock cycles) */
 #else
 #  define ADC_SMP_VBAT_VAL    (0x5) /*< Sampling time when the VBat channel
                                       is read (0x5 = 61.5 ADC clock cycles) */
+#endif
+
+#if defined(CPU_FAM_STM32U3)
+/* Give internal VBAT path time to settle before conversion. */
+#  define ADC_T_VBAT_STAB_US   (10U)
 #endif
 
 /* The sampling time width is 3 bit */
@@ -115,6 +120,13 @@ int adc_init(adc_t line)
         return -1;
     }
 
+#if defined(CPU_FAM_STM32U3)
+    /* Independent analog supply for ADC analog front-end */
+    PWR->SVMCR |= PWR_SVMCR_ASV;
+    /* ADC kernel clock: clear ADCDACSEL so HCLK is selected */
+    RCC->CCIPR2 &= ~RCC_CCIPR2_ADCDACSEL;
+#endif
+
 #if CPU_FAM_STM32H7
     /* Set per_ck (HSI - 64MHz) as ADC kernel peripheral clock */
     RCC->D3CCIPR |= RCC_D3CCIPR_ADCSEL_1;
@@ -144,7 +156,22 @@ int adc_init(adc_t line)
         periph_clk_en(AHB4, RCC_AHB4ENR_ADC3EN);
     }
 #endif
+#if defined(RCC_AHB2ENR1_ADC12EN) /* STM32U3 */
+    if (adc_config[line].dev <= 1) {
+        periph_clk_en(AHB2, RCC_AHB2ENR1_ADC12EN);
+    }
+#endif
 
+#if defined(CPU_FAM_STM32U3)
+    /* STM32U3 ADC kernel clock is derived directly from HCLK without a CKMODE 
+     * divider. To ensure sufficient sample-and-hold time for high-impedance 
+     * internal channels (VBAT, VREFINT, TSENSE) at maximum HCLK frequencies, 
+     * a clock prescaler is applied. */
+    ADC_INSTANCE->CCR = (ADC_INSTANCE->CCR & ~ADC_CCR_PRESC)
+                      | ADC_CCR_PRESC_2; /* divide ADC clock by 8 */
+#endif
+
+#if !defined(CPU_FAM_STM32U3)
     /* Setting ADC clock to HCLK/1 is only allowed if AHB clock
      * prescaler is 1 */
 #ifdef RCC_D1CFGR_HPRE
@@ -177,6 +204,7 @@ int adc_init(adc_t line)
 #endif
         }
     }
+#endif /* !defined(CPU_FAM_STM32U3) — U3: no CKMODE in ADC_CCR; clock from RCC->CCIPR2 */
 
     /* Configure the pin */
     if (adc_config[line].pin != GPIO_UNDEF) {
@@ -189,10 +217,22 @@ int adc_init(adc_t line)
         /* take ADC out of deep sleep */
         dev(line)->CR &= ~(ADC_CR_DEEPPWD);
 #endif
+#if defined(CPU_FAM_STM32U3)
+        /* take ADC out of deep sleep */
+        dev(line)->CR &= ~(ADC_CR_DEEPPWD);
+#endif
         /* Enable ADC internal voltage regulator and wait for startup period */
+#if defined(CPU_FAM_STM32U3)
+        dev(line)->ISR |= ADC_ISR_LDORDY;
+#endif
         dev(line)->CR |= ADC_CR_ADVREGEN;
+#if defined(CPU_FAM_STM32U3)
+        while (!(dev(line)->ISR & ADC_ISR_LDORDY)) {}
+#else
         busy_wait_us(ADC_T_ADCVREG_STUP_US * 2);
+#endif
 
+#if defined(ADC_CR_ADCALDIF) && !defined(CPU_FAM_STM32U3)
         if (dev(line)->DIFSEL & (1 << adc_config[line].chan)) {
             /* Configure calibration for differential inputs */
             dev(line)->CR |= ADC_CR_ADCALDIF;
@@ -201,6 +241,7 @@ int adc_init(adc_t line)
             /* Configure calibration for single ended inputs */
             dev(line)->CR &= ~ADC_CR_ADCALDIF;
         }
+#endif
 
 #if CPU_FAM_STM32H7
         /* enable linearity cal, and turn on boost supply */
@@ -219,6 +260,14 @@ int adc_init(adc_t line)
         /* Enable ADC and wait for it to be ready */
         dev(line)->CR |= ADC_CR_ADEN;
         while ((dev(line)->ISR & ADC_ISR_ADRDY) == 0) {}
+#if defined(CPU_FAM_STM32U3)
+        /* STM32U3 may drop ADEN once during enable; re-assert if needed */
+        if (!(dev(line)->CR & ADC_CR_ADEN)) {
+            dev(line)->ISR |= ADC_ISR_ADRDY;
+            dev(line)->CR |= ADC_CR_ADEN;
+            while ((dev(line)->ISR & ADC_ISR_ADRDY) == 0) {}
+        }
+#endif
 
         /* Set sequence length to 1 conversion */
         dev(line)->SQR1 |= (0 & ADC_SQR1_L);
@@ -228,9 +277,18 @@ int adc_init(adc_t line)
     if (IS_USED(MODULE_PERIPH_VBAT) && line == VBAT_ADC) {
         smp_time = ADC_SMP_VBAT_VAL;
     }
+#if defined(VREFINT_ADC)
+    /* VREFINT requires maximum sampling time due to high internal impedance */
+    if (line == VREFINT_ADC) {
+        smp_time = ADC_SMP_VBAT_VAL;
+    }
+#endif
 
 #if CPU_FAM_STM32H7
     /* Enable the ADC channel's analog switch */
+    dev(line)->PCSEL |= ADC_PCSEL_PCSEL_0 << adc_config[line].chan;
+#endif
+#if defined(CPU_FAM_STM32U3)
     dev(line)->PCSEL |= ADC_PCSEL_PCSEL_0 << adc_config[line].chan;
 #endif
 
@@ -268,14 +326,41 @@ int32_t adc_sample(adc_t line, adc_res_t res)
     /* check if this is the VBAT line */
     if (IS_USED(MODULE_PERIPH_VBAT) && line == VBAT_ADC) {
         vbat_enable();
+#if defined(CPU_FAM_STM32U3)
+        busy_wait_us(ADC_T_VBAT_STAB_US);
+#endif
     }
+#if defined(VREFINT_ADC) && defined(ADC_CCR_VREFEN)
+    /* Enable internal voltage reference path (VREFINT) */
+    if (line == VREFINT_ADC) {
+        ADC_INSTANCE->CCR |= ADC_CCR_VREFEN;
+#if defined(CPU_FAM_STM32U3)
+        busy_wait_us(ADC_T_VBAT_STAB_US);
+#endif
+    }
+#endif
 
     /* Set resolution */
+#if defined(CPU_FAM_STM32U3)
+    dev(line)->CFGR1 &= ~(uint32_t)ADC_CFGR_RES;
+    dev(line)->CFGR1 |= (uint32_t)res;
+#else
     dev(line)->CFGR &= ~ADC_CFGR_RES;
     dev(line)->CFGR |= res;
+#endif
 
     /* Specify channel for regular conversion */
     dev(line)->SQR1 = adc_config[line].chan << ADC_SQR1_SQ1_Pos;
+
+#if defined(CPU_FAM_STM32U3)
+    if (IS_USED(MODULE_PERIPH_VBAT) && line == VBAT_ADC) {
+        /* Discard dummy conversion to clear residual charge after enabling path */
+        dev(line)->ISR |= ADC_ISR_EOC;
+        dev(line)->CR |= ADC_CR_ADSTART;
+        while (!(dev(line)->ISR & ADC_ISR_EOC)) {}
+        (void)dev(line)->DR;
+    }
+#endif
 
     /* Start conversion and wait for it to complete */
     dev(line)->ISR |= ADC_ISR_EOC;
@@ -289,6 +374,11 @@ int32_t adc_sample(adc_t line, adc_res_t res)
     if (IS_USED(MODULE_PERIPH_VBAT) && line == VBAT_ADC) {
         vbat_disable();
     }
+#if defined(VREFINT_ADC) && defined(ADC_CCR_VREFEN)
+    if (line == VREFINT_ADC) {
+        ADC_INSTANCE->CCR &= ~ADC_CCR_VREFEN;
+    }
+#endif
 
     /* Power off and unlock device again */
     done(line);

--- a/cpu/stm32/periph/adc_f3_h7_u3.c
+++ b/cpu/stm32/periph/adc_f3_h7_u3.c
@@ -254,9 +254,9 @@ int adc_init(adc_t line)
         while (dev(line)->CR & ADC_CR_ADCAL) {}
 
 #if defined(CPU_FAM_STM32U3)
-        /* PCSEL is writable only while ADEN=0 (RM0487), so pre-select all
+        /* PCSEL is writable only while ADEN=0 (RM0487), so preselect all
          * external channels of this ADC here. Internal channels are routed
-         * via ADC_CCR and need no pre-selection. */
+         * via ADC_CCR and need no preselection. */
         for (unsigned i = 0; i < ADC_NUMOF; i++) {
             if ((adc_config[i].dev == adc_config[line].dev)
                 && (adc_config[i].pin != GPIO_UNDEF)) {

--- a/cpu/stm32/periph/flash_common.c
+++ b/cpu/stm32/periph/flash_common.c
@@ -17,6 +17,7 @@
  */
 
 #include "cpu.h"
+#include "periph_cpu.h"
 
 #define ENABLE_DEBUG           0
 #include "debug.h"
@@ -41,6 +42,22 @@
 #define KEY_REG                (FLASH->NSKEYR)
 #define FLASH_SR_EOP           (FLASH_NSSR_NSEOP)
 #endif
+#elif defined(CPU_FAM_STM32U3)
+/* STM32U3: non-secure flash uses KEYR / CR / SR (see CMSIS FLASH_TypeDef).
+ * Some packs expose unlock constants as FLASH_NSKEY1/2; fall back to ST key pair. */
+#  if defined(FLASH_NSKEY1) && defined(FLASH_NSKEY2)
+#    define FLASH_KEY1         (FLASH_NSKEY1)
+#    define FLASH_KEY2         (FLASH_NSKEY2)
+#  elif defined(FLASH_KEY1_NS) && defined(FLASH_KEY2_NS)
+#    define FLASH_KEY1         (FLASH_KEY1_NS)
+#    define FLASH_KEY2         (FLASH_KEY2_NS)
+#  else
+#    define FLASH_KEY1         ((uint32_t)0x45670123)
+#    define FLASH_KEY2         ((uint32_t)0xCDEF89AB)
+#  endif
+#  define CNTRL_REG            (FLASH->CR)
+#  define CNTRL_REG_LOCK       (FLASH_CR_LOCK)
+#  define KEY_REG              (FLASH->KEYR)
 #else
 #if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
     defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32G0) || \

--- a/cpu/stm32/periph/flashpage.c
+++ b/cpu/stm32/periph/flashpage.c
@@ -61,6 +61,7 @@
 #define FLASH_CR_PNB_Pos       (FLASH_CR_SNB_Pos)
 #define CNTRL_REG              (FLASH->CR)
 #else
+/* L4, WB, G4, G0, WL, C0, STM32U3, …: FLASH->CR; bit macros are FLASH_CR_* in CMSIS*/
 #define CNTRL_REG              (FLASH->CR)
 #define CNTRL_REG_LOCK         (FLASH_CR_LOCK)
 #endif
@@ -70,7 +71,7 @@ extern void _unlock(void);
 extern void _wait_for_pending_operations(void);
 
 #if defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32L5) || \
-    defined(CPU_FAM_STM32U5)
+    defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32U5)
 #define MAX_PAGES_PER_BANK      (128)
 #else /* CPU_FAM_STM32L4 */
 #define MAX_PAGES_PER_BANK      (256)
@@ -118,8 +119,8 @@ static void _erase_page(void *page_addr)
       defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32G0) || \
       defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32F2) || \
       defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32F7) || \
-      defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32WL) || \
-      defined(CPU_FAM_STM32C0)
+      defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32U5) || \
+      defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0)
     DEBUG("[flashpage] erase: setting the page address\n");
     uint8_t pn;
 #if (FLASHPAGE_NUMOF <= MAX_PAGES_PER_BANK) || defined(CPU_FAM_STM32WB) || \
@@ -151,7 +152,9 @@ static void _erase_page(void *page_addr)
     DEBUG("[flashpage] erase: the page address is set and started\n");
 #else /* CPU_FAM_STM32F0 || CPU_FAM_STM32F1 || CPU_FAM_STM32F3 */
     DEBUG("[flashpage] erase: setting the page address\n");
+#if !defined(CPU_FAM_STM32U3)
     FLASH->AR = (uint32_t)page_addr;
+#endif
     /* trigger the page erase and wait for it to be finished */
     DEBUG("[flashpage] erase: trigger the page erase\n");
     CNTRL_REG |= FLASH_CR_STRT;
@@ -270,8 +273,9 @@ void flashpage_write(void *target_addr, const void *data, size_t len)
     defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32G4) || \
     defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32L5) || \
     defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) || \
-    defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0)
+    defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32WL) || \
+    defined(CPU_FAM_STM32C0)
     /* set PG bit and program page to flash */
     CNTRL_REG |= FLASH_CR_PG;
 #endif
@@ -291,8 +295,9 @@ void flashpage_write(void *target_addr, const void *data, size_t len)
     defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32G4) || \
     defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32L5) || \
     defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) || \
-    defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32C0)
+    defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32WL) || \
+    defined(CPU_FAM_STM32C0)
     CNTRL_REG &= ~(FLASH_CR_PG);
 #endif
     DEBUG("[flashpage_raw] write: done writing data\n");

--- a/cpu/stm32/periph/hwrng.c
+++ b/cpu/stm32/periph/hwrng.c
@@ -47,7 +47,7 @@ void hwrng_read(void *buf, unsigned int num)
     periph_clk_en(AHB, RCC_AHBENR_RNGEN);
 #elif defined(CPU_FAM_STM32WB)
     periph_clk_en(AHB3, RCC_AHB3ENR_RNGEN);
-#elif defined(CPU_FAM_STM32U5)
+#elif defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32U5)
     periph_clk_en(AHB2, RCC_AHB2ENR1_RNGEN);
 #else
     periph_clk_en(AHB2, RCC_AHB2ENR_RNGEN);
@@ -75,7 +75,7 @@ void hwrng_read(void *buf, unsigned int num)
     periph_clk_dis(AHB, RCC_AHBENR_RNGEN);
 #elif defined(CPU_FAM_STM32WB)
     periph_clk_dis(AHB3, RCC_AHB3ENR_RNGEN);
-#elif defined(CPU_FAM_STM32U5)
+#elif defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32U5)
     periph_clk_dis(AHB2, RCC_AHB2ENR1_RNGEN);
 #else
     periph_clk_dis(AHB2, RCC_AHB2ENR_RNGEN);

--- a/cpu/stm32/periph/i2c_1.c
+++ b/cpu/stm32/periph/i2c_1.c
@@ -100,7 +100,7 @@ void i2c_init(i2c_t dev)
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3) || \
     defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L4) || \
     defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32WB) || \
-    defined(CPU_FAM_STM32H7)
+    defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32H7)
     /* select I2C clock source */
     I2C_CLOCK_SRC_REG |= i2c_config[dev].rcc_sw_mask;
 #endif

--- a/cpu/stm32/periph/rtc_all.c
+++ b/cpu/stm32/periph/rtc_all.c
@@ -46,7 +46,8 @@
 #  define EXTI_REG_FTSR     (EXTI->FTSR1)
 #  define EXTI_REG_PR       (EXTI->PR1)
 #  define EXTI_REG_IMR      (EXTI->IMR1)
-#elif defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32WL)
+#elif defined(CPU_FAM_STM32G0) || defined(CPU_FAM_STM32U3) ||  \
+      defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32U5)
 #  define EXTI_REG_RTSR     (EXTI->RTSR1)
 #  define EXTI_REG_FTSR     (EXTI->FTSR1)
 #  define EXTI_REG_PR       (EXTI->RPR1)
@@ -79,7 +80,7 @@
 #  define RTC_ISR_INIT      RTC_ICSR_INIT
 #  define RTC_ISR_INITF     RTC_ICSR_INITF
 #  define RTC_ISR_INITS     RTC_ICSR_INITS
-#elif defined(CPU_FAM_STM32U5)
+#elif defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32U3)
 #  define RTC_REG_ISR       RTC->ICSR
 #  define RTC_REG_SR        RTC->SR
 #  define RTC_REG_SCR       RTC->SCR
@@ -94,7 +95,8 @@
 
 /* interrupt line name mapping */
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0) || \
-    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5)
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5) || \
+    defined(CPU_FAM_STM32U3)
 #  define IRQN              (RTC_IRQn)
 #  define ISR_NAME          isr_rtc
 #elif defined(CPU_FAM_STM32G0)
@@ -123,6 +125,11 @@
 #  define EXTI_FTSR_BIT     (EXTI_FTSR1_FT11)
 #  define EXTI_RTSR_BIT     (EXTI_RTSR1_RT11)
 #  define EXTI_PR_BIT       (EXTI_RPR1_RPIF11)
+#elif defined(CPU_FAM_STM32U3)
+#  define EXTI_IMR_BIT      (EXTI_IMR1_IM17)
+#  define EXTI_FTSR_BIT     (EXTI_FTSR1_FT17)
+#  define EXTI_RTSR_BIT     (EXTI_RTSR1_RT17)
+#  define EXTI_PR_BIT       (EXTI_RPR1_RPIF17)
 #elif defined(CPU_FAM_STM32H7)
 #  define EXTI_IMR_BIT        (EXTI_IMR1_IM17)
 #  define EXTI_RTSR_BIT       (EXTI_RTSR1_TR17)
@@ -293,6 +300,8 @@ void rtc_init(void)
     periph_clk_en(APB1, RCC_APBENR1_RTCAPBEN);
 #elif defined(CPU_FAM_STM32U5)
     periph_clk_en(APB3, RCC_APB3ENR_RTCAPBEN);
+#elif defined(CPU_FAM_STM32U3)
+    periph_clk_en(APB1, RCC_APB1ENR1_RTCAPBEN);
 #elif defined(CPU_FAM_STM32H7)
     periph_clk_en(APB4, RCC_APB4ENR_RTCAPBEN);
 #endif
@@ -428,7 +437,8 @@ void rtc_clear_alarm(void)
 
     RTC->CR &= ~(RTC_CR_ALRAE | RTC_CR_ALRAIE);
 
-#if !(defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32WL))
+#if !(defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U3) || \
+      defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32U5))
     while (!(RTC_REG_ISR & RTC_ISR_ALRAWF)) {}
 #else
     RTC_REG_SCR = RTC_SCR_CALRAF;
@@ -457,7 +467,7 @@ void rtc_poweroff(void)
 void ISR_NAME(void)
 {
 #if !(defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32WL) || defined(CPU_FAM_STM32G0) || \
-      defined(CPU_FAM_STM32U5))
+      defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32U5))
     if (RTC_REG_ISR & RTC_ISR_ALRAF) {
         if (isr_ctx.cb != NULL) {
             isr_ctx.cb(isr_ctx.arg);

--- a/cpu/stm32/periph/spi.c
+++ b/cpu/stm32/periph/spi.c
@@ -36,6 +36,15 @@
 #include "debug.h"
 
 /**
+ * @brief SPI variants with CFG1/CFG2/TXDR/RXDR (not legacy DR + BR in CR1)
+ *
+ * Same programming model as STM32H7; STM32U3 uses this SPI IP as well.
+ */
+#if defined(CPU_FAM_STM32H7) || defined(CPU_FAM_STM32U3)
+#define STM32_SPI_USE_MODERN_REGS   1
+#endif
+
+/**
  * @brief   Number of bits to shift the BR value in the CR1 register
  */
 #define BR_SHIFT            (3U)
@@ -84,7 +93,7 @@ static uint8_t _get_prescaler(const spi_conf_t *conf, uint32_t clock)
 
     uint8_t prescaler = 0;
     uint32_t prescaled_clock = bus_clock >> 1;
-#if CPU_FAM_STM32H7
+#if defined(CPU_FAM_STM32H7) || defined(CPU_FAM_STM32U3)
     const uint8_t prescaler_max = SPI_CFG1_MBR_Msk >> SPI_CFG1_MBR_Pos;
 #else
     const uint8_t prescaler_max = SPI_CR1_BR_Msk >> SPI_CR1_BR_Pos;
@@ -276,7 +285,7 @@ void spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
           periph_apb_clk(spi_config[bus].apbbus) >> (br + 1),
           (unsigned)br);
 
-#if CPU_FAM_STM32H7
+#if defined(CPU_FAM_STM32H7) || defined(CPU_FAM_STM32U3)
 
     uint32_t cr1 = 0;
     if (cs != SPI_HWCS_MASK) {
@@ -364,7 +373,7 @@ void spi_release(spi_t bus)
     /* disable device and release lock */
     dev(bus)->CR1 = 0;
     dev(bus)->CR2 = SPI_CR2_SETTINGS; /* Clear the DMA and SSOE flags */
-#if CPU_FAM_STM32H7
+#if defined(CPU_FAM_STM32H7) || defined(CPU_FAM_STM32U3)
     dev(bus)->CFG1 = 0;
     dev(bus)->CFG2 = 0;
 #endif
@@ -378,7 +387,7 @@ void spi_release(spi_t bus)
 
 static inline void _wait_for_end(spi_t bus)
 {
-#if CPU_FAM_STM32H7
+#if defined(CPU_FAM_STM32H7) || defined(CPU_FAM_STM32U3)
     /* Wait until End Of Transfer */
     while (!(dev(bus)->SR & SPI_SR_EOT)) {}
     /* Clear EOT by writing 1 to IFC register */
@@ -401,7 +410,7 @@ static inline void _wait_for_end(spi_t bus)
 static void _transfer_dma(spi_t bus, const void *out, void *in, size_t len)
 {
     uint8_t tmp = 0;
-#if CPU_FAM_STM32H7
+#if defined(CPU_FAM_STM32H7) || defined(CPU_FAM_STM32U3)
 
     dev(bus)->IFCR = 0xFFFFFFFF;
 
@@ -451,7 +460,7 @@ static void _transfer_dma(spi_t bus, const void *out, void *in, size_t len)
     dma_start(spi_config[bus].rx_dma);
     dma_start(spi_config[bus].tx_dma);
 
-#if CPU_FAM_STM32H7
+#if defined(CPU_FAM_STM32H7) || defined(CPU_FAM_STM32U3)
     dev(bus)->CR1 |= SPI_CR1_SPE;
     dev(bus)->CR1 |= SPI_CR1_CSTART;
 #endif
@@ -459,7 +468,7 @@ static void _transfer_dma(spi_t bus, const void *out, void *in, size_t len)
     dma_wait(spi_config[bus].rx_dma);
     dma_wait(spi_config[bus].tx_dma);
 
-#if defined(DMA_CCR_EN) || defined(CPU_FAM_STM32H7)
+#if defined(DMA_CCR_EN) || defined(CPU_FAM_STM32H7) || defined(CPU_FAM_STM32U3)
     dma_stop(spi_config[bus].rx_dma);
     dma_stop(spi_config[bus].tx_dma);
 #endif
@@ -472,7 +481,53 @@ static void _transfer_no_dma(spi_t bus, const void *out, void *in, size_t len)
     const uint8_t *outbuf = out;
     uint8_t *inbuf = in;
 
-#if CPU_FAM_STM32H7
+#if defined(CPU_FAM_STM32U3)
+
+    dev(bus)->IFCR = 0xFFFFFFFF;
+
+    /* drain any stale RX bytes */
+    while (dev(bus)->SR & SPI_SR_RXP) {
+        (void)*(volatile uint8_t*)&(dev(bus)->RXDR);
+    }
+
+    /* recast to uint8_t to force 8-bit (single frame) access */
+    volatile uint8_t *TXDR = (volatile uint8_t*)&(dev(bus)->TXDR);
+    volatile uint8_t *RXDR = (volatile uint8_t*)&(dev(bus)->RXDR);
+
+    /* Continuous mode (TSIZE = 0): a fixed-count transfer auto-suspends when the
+     * frame counter reaches len, truncating the last received frame. End the
+     * transfer with CSUSP, which stops on a frame boundary. */
+    dev(bus)->CR2 = 0;
+    dev(bus)->CR1 |= SPI_CR1_SPE;
+    dev(bus)->CR1 |= SPI_CR1_CSTART;
+
+    /* RXP drains most frames; the last few (below the FIFO threshold) are
+     * exposed only through the RX FIFO packing level (RXPLVL). */
+    size_t tx = 0, rx = 0;
+    while ((tx < len) || (rx < len)) {
+        if ((tx < len) && (dev(bus)->SR & SPI_SR_TXP)) {
+            *TXDR = outbuf ? outbuf[tx] : 0;
+            tx++;
+        }
+        if (rx < len) {
+            uint32_t sr = dev(bus)->SR;
+            if ((sr & SPI_SR_RXP) ||
+                (((len - rx) < 4) && (sr & SPI_SR_RXPLVL_Msk))) {
+                uint8_t in = *RXDR;
+                if (inbuf) {
+                    inbuf[rx] = in;
+                }
+                rx++;
+            }
+        }
+    }
+
+    dev(bus)->CR1 |= SPI_CR1_CSUSP;
+    while (!(dev(bus)->SR & SPI_SR_SUSP)) {}
+    dev(bus)->IFCR = SPI_IFCR_SUSPC;
+    dev(bus)->CR1 &= ~SPI_CR1_SPE;
+
+#elif defined(CPU_FAM_STM32H7)
 
     dev(bus)->IFCR = 0xFFFFFFFF;
 
@@ -573,7 +628,7 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
         gpio_clear((gpio_t)cs);
     }
     else {
-#if CPU_FAM_STM32H7
+#if defined(CPU_FAM_STM32H7) || defined(CPU_FAM_STM32U3)
         dev(bus)->CFG2 |= SPI_CFG2_SSOE;
 #else
         dev(bus)->CR2 |= SPI_CR2_SSOE;
@@ -597,7 +652,7 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
             gpio_set((gpio_t)cs);
         }
         else {
-#if CPU_FAM_STM32H7
+#if defined(CPU_FAM_STM32H7) || defined(CPU_FAM_STM32U3)
             dev(bus)->CFG2 &= ~(SPI_CFG2_SSOE);
 #else
             dev(bus)->CR2 &= ~(SPI_CR2_SSOE);

--- a/cpu/stm32/periph/usbdev_fs.c
+++ b/cpu/stm32/periph/usbdev_fs.c
@@ -40,9 +40,55 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
+/* STM32U3 CMSIS exposes PMA base as USB_DRD_PMAADDR, not legacy USB_PMAADDR */
+#if defined(CPU_LINE_STM32U385xx)
+#ifndef USB_PMAADDR
+#define USB_PMAADDR             USB_DRD_PMAADDR
+#endif
+#ifndef USB1_PMAADDR
+#define USB1_PMAADDR            USB_DRD_PMAADDR
+#endif
+#endif
+
 #ifndef USB1_PMAADDR
 #define USB1_PMAADDR USB_PMAADDR
 #endif /* ndef USB1_PMAADDR */
+
+/**
+ * @brief   Map legacy F1 USB `USB_EP_*` / `CNTR` / `EPTX` symbol names to USB DRD
+ *          (CHEP / CNTR) names in STM32U3 CMSIS headers.
+ * @{
+ */
+#if defined(CPU_LINE_STM32U385xx)
+#ifndef USB_CNTR_FRES
+#  define USB_CNTR_FRES             USB_CNTR_USBRST
+#endif
+#  ifndef USB_EPTX_DTOG1
+#    define USB_EPTX_DTOG1          USB_CHEP_TX_DTOG1
+#    define USB_EPTX_DTOG2          USB_CHEP_TX_DTOG2
+#    define USB_EPRX_DTOG1          USB_CHEP_RX_DTOG1
+#    define USB_EPRX_DTOG2          USB_CHEP_RX_DTOG2
+#  endif
+#  ifndef USB_EPTX_STAT
+#    define USB_EPTX_STAT           USB_CHEP_TX_STTX
+#  endif
+#  ifndef USB_EPRX_STAT
+#    define USB_EPRX_STAT           USB_CHEP_RX_STRX
+#  endif
+#  ifndef USB_EP_DTOG_TX
+#    define USB_EP_DTOG_TX          USB_CHEP_DTOG_TX
+#  endif
+#  ifndef USB_EP_DTOG_RX
+#    define USB_EP_DTOG_RX          USB_CHEP_DTOG_RX
+#  endif
+#  ifndef USB_EP_CTR_TX
+#    define USB_EP_CTR_TX           USB_CHEP_VTTX
+#  endif
+#  ifndef USB_EP_CTR_RX
+#    define USB_EP_CTR_RX           USB_CHEP_VTRX
+#  endif
+#endif /* U3 / U385 */
+/** @} */
 
 /**
  * There are two schemes for accessing the packet buffer area (PMA) from the CPU:
@@ -74,6 +120,13 @@
 #define _PMA_ACCESS_SCHEME      (1)     /* 1 x 16-bit/word */
 #define _PMA_ACCESS_STEP_SIZE   (2)     /* Step size in 16-bit half-words when
                                          * accessing the PMA SRAM from CPU */
+#elif defined(CPU_LINE_STM32U385xx)
+
+#define _ENDPOINT_NUMOF         (8)
+#define _PMA_SRAM_SIZE          (2048)  /* see USB_DRD_PMA_SIZE in device header */
+#define _PMA_ACCESS_SCHEME      (2)     /* 2 x 16-bit/word (USB DRD FS PMA) */
+#define _PMA_ACCESS_STEP_SIZE   (1)     /* Step in 16-bit half-words when
+                                         * accessing the PMA from CPU */
 #else
 #error "STM32 line is not supported"
 #endif
@@ -97,10 +150,18 @@ static uint8_t* _app_pbuf[_ENDPOINT_NUMOF];
 /* Forward declaration for the usb device driver */
 const usbdev_driver_t driver;
 
+/* STM32U3: USB full-speed is USB DRD (not legacy USB_TypeDef) — only this family */
+#if defined(CPU_LINE_STM32U385xx)
+static USB_DRD_TypeDef *_global_regs(const stm32_usbdev_fs_config_t *conf)
+{
+    return (USB_DRD_TypeDef *)conf->base_addr;
+}
+#else
 static USB_TypeDef *_global_regs(const stm32_usbdev_fs_config_t *conf)
 {
     return (USB_TypeDef *)conf->base_addr;
 }
+#endif
 
 #if _PMA_ACCESS_SCHEME == 1
 
@@ -276,7 +337,10 @@ static inline void _usb_attach(stm32_usbdev_fs_t *usbdev)
 #ifdef USB_BCDR_DPPU
     /* Enable DP pullup to signal connection */
     _global_regs(conf)->BCDR |= USB_BCDR_DPPU;
+#if defined(CRS) && defined(CRS_ISR_ESYNCF) && !defined(CPU_FAM_STM32U3)
+    /* Synchronize 48MHz clock: not all families use CRS the same for USB */
     while (!(CRS->ISR & CRS_ISR_ESYNCF)) {}
+#endif
 #else
     /* If configuration uses a GPIO for USB connect/disconnect */
     if (conf->disconn != GPIO_UNDEF) {
@@ -384,8 +448,12 @@ static void _usbdev_init(usbdev_t *dev)
     _global_regs(conf)->CNTR &= ~USB_CNTR_FRES;
     /* Clear interrupt register */
     _global_regs(conf)->ISTR = 0x0000;
+#if !defined(CPU_LINE_STM32U385xx)
+    /* Legacy USB_FS: BTABLE selects buffer-table offset inside PMA SRAM.
+     * USB DRD FS on STM32U3 has no BTABLE register; table is fixed at PMA base 0 */
     /* Set BTABLE at start of USB SRAM */
     _global_regs(conf)->BTABLE = 0x0000;
+#endif
     /* Set default address after reset */
     _global_regs(conf)->DADDR = USB_DADDR_EF;
     /* Unmask the interrupt in the NVIC */
@@ -399,7 +467,12 @@ static void _usbdev_init(usbdev_t *dev)
     /* Enable USB IRQ */
     NVIC_EnableIRQ(conf->irqn);
     /* fill USB SRAM with zeroes */
-    memset((uint8_t*)USB1_PMAADDR, 0, 1024);
+#if defined(CPU_LINE_STM32U385xx)
+    /* U3 USB DRD PMA is 2 KiB; other lines keep the historical clear size */
+    memset((uint8_t *)USB1_PMAADDR, 0, _PMA_SRAM_SIZE);
+#else
+    memset((uint8_t *)USB1_PMAADDR, 0, 1024);
+#endif
 }
 
 static usbdev_ep_t *_get_ep(stm32_usbdev_fs_t *usbdev, unsigned num,

--- a/cpu/stm32/periph/usbdev_fs.c
+++ b/cpu/stm32/periph/usbdev_fs.c
@@ -41,7 +41,7 @@
 #include "debug.h"
 
 /* STM32U3 CMSIS exposes PMA base as USB_DRD_PMAADDR, not legacy USB_PMAADDR */
-#if defined(CPU_LINE_STM32U385xx)
+#if defined(CPU_FAM_STM32U3)
 #ifndef USB_PMAADDR
 #define USB_PMAADDR             USB_DRD_PMAADDR
 #endif
@@ -59,7 +59,7 @@
  *          (CHEP / CNTR) names in STM32U3 CMSIS headers.
  * @{
  */
-#if defined(CPU_LINE_STM32U385xx)
+#if defined(CPU_FAM_STM32U3)
 #ifndef USB_CNTR_FRES
 #  define USB_CNTR_FRES             USB_CNTR_USBRST
 #endif
@@ -87,7 +87,7 @@
 #  ifndef USB_EP_CTR_RX
 #    define USB_EP_CTR_RX           USB_CHEP_VTRX
 #  endif
-#endif /* U3 / U385 */
+#endif /* CPU_FAM_STM32U3 */
 /** @} */
 
 /**
@@ -120,7 +120,7 @@
 #define _PMA_ACCESS_SCHEME      (1)     /* 1 x 16-bit/word */
 #define _PMA_ACCESS_STEP_SIZE   (2)     /* Step size in 16-bit half-words when
                                          * accessing the PMA SRAM from CPU */
-#elif defined(CPU_LINE_STM32U385xx)
+#elif defined(CPU_FAM_STM32U3)
 
 #define _ENDPOINT_NUMOF         (8)
 #define _PMA_SRAM_SIZE          (2048)  /* see USB_DRD_PMA_SIZE in device header */
@@ -151,7 +151,7 @@ static uint8_t* _app_pbuf[_ENDPOINT_NUMOF];
 const usbdev_driver_t driver;
 
 /* STM32U3: USB full-speed is USB DRD (not legacy USB_TypeDef) — only this family */
-#if defined(CPU_LINE_STM32U385xx)
+#if defined(CPU_FAM_STM32U3)
 static USB_DRD_TypeDef *_global_regs(const stm32_usbdev_fs_config_t *conf)
 {
     return (USB_DRD_TypeDef *)conf->base_addr;
@@ -197,6 +197,27 @@ typedef struct {
 
 #define EP_DESC ((ep_buf_desc_t*)USB1_PMAADDR)
 #define EP_REG(x) (*((volatile uint32_t*) (((uintptr_t)(USB)) + (4*x))))
+
+#if defined(CPU_FAM_STM32U3)
+/* The USB DRD FS packet memory only supports word (32-bit) writes: a
+ * half-word write clears the other half of the addressed word. Merge
+ * half-word writes into a 32-bit read-modify-write instead. */
+static inline void _pma_write16(volatile uint16_t *addr, uint16_t val)
+{
+    volatile uint32_t *word =
+        (volatile uint32_t *)((uintptr_t)addr & ~(uintptr_t)0x3);
+
+    if ((uintptr_t)addr & 0x2) {
+        *word = (*word & 0x0000ffffUL) | ((uint32_t)val << 16);
+    }
+    else {
+        *word = (*word & 0xffff0000UL) | val;
+    }
+}
+#define _pma_set(dst, val)  _pma_write16((volatile uint16_t *)&(dst), (val))
+#else
+#define _pma_set(dst, val)  ((dst) = (val))
+#endif
 
 usbdev_t *usbdev_get_ctx(unsigned num)
 {
@@ -252,6 +273,14 @@ static void _enable_usb_clk(void)
 #if defined(PWR_CR2_USV)
     /* Validate USB Supply */
     PWR->CR2 |= PWR_CR2_USV;
+#elif defined(PWR_SVMCR_USV)
+    /* STM32U3/U5: enable the VDDUSB monitor and wait for the supply to be
+     * ready, then validate it for the FS transceiver */
+    PWR->SVMCR |= PWR_SVMCR_UVMEN;
+    busy_wait_us(100);
+    for (volatile uint32_t to = 0;
+         !(PWR->SVMSR & PWR_SVMSR_VDDUSBRDY) && to < 100000; to++) {}
+    PWR->SVMCR |= PWR_SVMCR_USV;
 #endif
 
 #if defined(RCC_APB1SMENR_USBSMEN)
@@ -268,6 +297,13 @@ static void _enable_usb_clk(void)
 
 static void _enable_gpio(const stm32_usbdev_fs_config_t *conf)
 {
+#if defined(CPU_FAM_STM32U3)
+    /* The USB DRD FS PHY drives the D+/D- pads directly; the GPIOs must be
+     * kept in analog mode instead of an alternate function */
+    gpio_init_analog(conf->dp);
+    gpio_init_analog(conf->dm);
+    return;
+#endif
     if (conf->af == GPIO_AF_UNDEF && conf->disconn == GPIO_UNDEF) {
         /* If the MCU does not have an internal D+ pullup and there is no
          * dedicated GPIO on the board to simulate a USB disconnect, the D+ GPIO
@@ -444,11 +480,15 @@ static void _usbdev_init(usbdev_t *dev)
     _global_regs(conf)->CNTR = USB_CNTR_FRES | USB_CNTR_PDWN;
     /* Clear power down */
     _global_regs(conf)->CNTR &= ~USB_CNTR_PDWN;
+#if defined(CPU_FAM_STM32U3)
+    /* USB DRD transceiver start-up time (tSTARTUP) after leaving power-down */
+    busy_wait_us(1);
+#endif
     /* Clear reset */
     _global_regs(conf)->CNTR &= ~USB_CNTR_FRES;
     /* Clear interrupt register */
     _global_regs(conf)->ISTR = 0x0000;
-#if !defined(CPU_LINE_STM32U385xx)
+#if !defined(CPU_FAM_STM32U3)
     /* Legacy USB_FS: BTABLE selects buffer-table offset inside PMA SRAM.
      * USB DRD FS on STM32U3 has no BTABLE register; table is fixed at PMA base 0 */
     /* Set BTABLE at start of USB SRAM */
@@ -467,7 +507,7 @@ static void _usbdev_init(usbdev_t *dev)
     /* Enable USB IRQ */
     NVIC_EnableIRQ(conf->irqn);
     /* fill USB SRAM with zeroes */
-#if defined(CPU_LINE_STM32U385xx)
+#if defined(CPU_FAM_STM32U3)
     /* U3 USB DRD PMA is 2 KiB; other lines keep the historical clear size */
     memset((uint8_t *)USB1_PMAADDR, 0, _PMA_SRAM_SIZE);
 #else
@@ -680,12 +720,12 @@ static void _usbdev_ep_init(usbdev_ep_t *ep)
     /* Write the configuration to the register */
     EP_REG(ep->num) = reg;
     if (ep->dir == USB_EP_DIR_IN) {
-        EP_DESC[ep->num].addr_tx = _ep_in_buf[ep->num];
-        EP_DESC[ep->num].count_tx = 64;
+        _pma_set(EP_DESC[ep->num].addr_tx, _ep_in_buf[ep->num]);
+        _pma_set(EP_DESC[ep->num].count_tx, 64);
     } else {
-        EP_DESC[ep->num].addr_rx = _ep_out_buf[ep->num];
+        _pma_set(EP_DESC[ep->num].addr_rx, _ep_out_buf[ep->num]);
         /* Set BLSIZE + NUM_BLOCK (1) */
-        EP_DESC[ep->num].count_rx = (1 << 10) | (1 << 15);
+        _pma_set(EP_DESC[ep->num].count_rx, (1 << 10) | (1 << 15));
     }
 }
 
@@ -842,10 +882,10 @@ static int _usbdev_ep_xmit(usbdev_ep_t *ep, uint8_t* buf, size_t len)
         }
         if (len < 63) {
             /* Should write len / 2 in count_rx if len <= 62 */
-            EP_DESC[ep->num].count_rx = (len >> 1) << 10;
+            _pma_set(EP_DESC[ep->num].count_rx, (len >> 1) << 10);
         } else {
             /* BL_SIZE = 1, NUM_BLOCK = 1 */
-            EP_DESC[ep->num].count_rx = 1 << 15 | 1 << 10;
+            _pma_set(EP_DESC[ep->num].count_rx, 1 << 15 | 1 << 10);
         }
         CLRBIT(reg, USB_EP_DTOG_TX | USB_EP_DTOG_RX);
         _app_pbuf[ep->num] = buf;
@@ -856,15 +896,15 @@ static int _usbdev_ep_xmit(usbdev_ep_t *ep, uint8_t* buf, size_t len)
         uint16_t* pma_ptr = (uint16_t *)(USB1_PMAADDR +
                                          (EP_DESC[ep->num].addr_tx * _PMA_ACCESS_STEP_SIZE));
         for (size_t i = 0; i < len; i += 2) {
-            *pma_ptr = (buf[i + 1] << 8) | buf[i];
+            _pma_set(*pma_ptr, (buf[i + 1] << 8) | buf[i]);
             pma_ptr += _PMA_ACCESS_STEP_SIZE;
         }
         /* Manage odd transfer size */
         if (len % 2 == 1) {
-            *pma_ptr =  0x00ff & buf[len - 1];
+            _pma_set(*pma_ptr, 0x00ff & buf[len - 1]);
         }
 
-        EP_DESC[ep->num].count_tx = len;
+        _pma_set(EP_DESC[ep->num].count_tx, len);
         CLRBIT(reg, USB_EP_DTOG_TX | USB_EP_DTOG_RX);
     }
 

--- a/cpu/stm32/periph/vbat.c
+++ b/cpu/stm32/periph/vbat.c
@@ -123,8 +123,9 @@
 #elif defined(CPU_LINE_STM32L552xx) || defined(CPU_LINE_STM32L562xx)
 #  define VBAT_ADC_SCALE      3
 #  define VBAT_ADC_MIN_MV     1550
-/* u5 */
-#elif defined(CPU_LINE_STM32U575xx) || defined(CPU_LINE_STM32U585xx)
+/* u5, u3 (same internal VBAT divider / RM0487 guidance as U5 class) */
+#elif defined(CPU_LINE_STM32U575xx) || defined(CPU_LINE_STM32U585xx) || \
+      defined(CPU_LINE_STM32U385xx)
 #  define VBAT_ADC_SCALE      4
 #  define VBAT_ADC_MIN_MV     1650
 /* wb */
@@ -191,15 +192,69 @@
 #endif
 
 /**
- * @brief   Override this function if you know how to retrieve the accurate
- *          ADC supply voltage in mV for your board. The default behaviour is
- *          to return @ref CONFIG_VBAT_ADC_VREF_MV.
- *          Once there is a driver to sample VREFINT, this function is likely
- *          to be changed.
+ * @brief   VREF+ value (mV) at which VREFINT_CAL was measured in production.
+ *          For the STM32U5/U3 analog family this is 3000 mV (datasheet).
  */
+#ifndef VREFINT_CAL_VREF_MV
+#  define VREFINT_CAL_VREF_MV     3000
+#endif
+
+/**
+ * @brief   Datasheet-typical VREFINT value (mV), used as a fallback.
+ */
+#ifndef VREFINT_TYP_MV
+#  define VREFINT_TYP_MV          1212
+#endif
+
+/**
+ * @brief   Address of the factory VREFINT calibration word.
+ *
+ * For STM32U3 this is 0x0BFA07A5 (calibrated at Vref+ = 3.0 V, 30 degC).
+ * If undefined, vref_mv() uses the datasheet-typical VREFINT.
+ */
+#if defined(CPU_FAM_STM32U3) && !defined(VREFINT_CAL_ADDR)
+#  define VREFINT_CAL_ADDR  ((const uint16_t *)0x0BFA07A5UL)
+#endif
+
+/**
+ * @brief   Return the ADC reference voltage (VREF+ / VDDA) in mV.
+ *
+ * Derives VDDA ratiometrically when VREFINT_ADC is available:
+ * VDDA = VREFINT_CAL_VREF_MV * VREFINT_CAL / VREFINT_DATA
+ *
+ * Falls back to @ref CONFIG_VBAT_ADC_VREF_MV on out-of-bounds error.
+ */
+#if defined(VREFINT_ADC) && defined(ADC_CCR_VREFEN)
+int32_t vref_mv(void)
+{
+    /* Sample internal reference to derive VDDA ratiometrically */
+    int32_t raw = adc_sample(VREFINT_ADC, VBAT_ADC_RES);
+    int32_t vdda = CONFIG_VBAT_ADC_VREF_MV;
+
+    if (raw > 0) {
+#if defined(VREFINT_CAL_ADDR)
+        uint16_t cal = *(volatile uint16_t *)(VREFINT_CAL_ADDR);
+        if (cal != 0 && cal != 0xFFFF) {
+            vdda = ((int32_t)VREFINT_CAL_VREF_MV * cal) / raw;
+        } else {
+            vdda = ((int32_t)VREFINT_TYP_MV * VBAT_ADC_MAX) / raw;
+        }
+#else
+        vdda = ((int32_t)VREFINT_TYP_MV * VBAT_ADC_MAX) / raw;
+#endif
+    }
+
+    /* Clamp to realistic STM32 operating voltage bounds */
+    if (vdda < 2000 || vdda > 3600) {
+        vdda = CONFIG_VBAT_ADC_VREF_MV;
+    }
+    return vdda;
+}
+#else
 int32_t __attribute__((weak)) vref_mv(void) {
     return CONFIG_VBAT_ADC_VREF_MV;
 }
+#endif
 
 #ifndef VBAT_ADC
 #  error "VBAT: Add internal VBAT ADC line to adc_config[] and #define VBAT_ADC."
@@ -207,6 +262,10 @@ int32_t __attribute__((weak)) vref_mv(void) {
 
 int vbat_init(void)
 {
+#if defined(VREFINT_ADC) && defined(ADC_CCR_VREFEN)
+    /* Initialize VREFINT line for vref_mv() sampling */
+    adc_init(VREFINT_ADC);
+#endif
     return adc_init(VBAT_ADC);
 }
 
@@ -222,8 +281,9 @@ void vbat_disable(void)
 
 int32_t vbat_sample_mv(void)
 {
-    int32_t mv = adc_sample(VBAT_ADC, VBAT_ADC_RES);
-    mv = (mv * VBAT_ADC_SCALE * vref_mv()) / VBAT_ADC_MAX;
+    int32_t raw = adc_sample(VBAT_ADC, VBAT_ADC_RES);
+    int32_t vref = vref_mv();
+    int32_t mv = (raw * VBAT_ADC_SCALE * vref) / VBAT_ADC_MAX;
     return mv;
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Follow-up to the STM32U3 / NUCLEO-U385RG-Q bring-up (#22427), **stacked on
that PR**. It adds the remaining MCU peripherals on top of the bring-up base.

Peripherals added (drivers in `cpu/stm32`, board wiring in
`boards/nucleo-u385rg-q`):
- **SPI** — SPI1 on PA7/PA6/PA5; includes a fix for last-frame RX truncation on U3
  (continuous mode + CSUSP). Verified on hardware via loopback test.
- **PWM** — TIM2 (CH1 User LED / PA5, CH2 PB3, CH3 PB10, CH4 PB11).
- **RTC** — register/EXTI mappings for U3; uses the on-board 32.768 kHz LSE.
- **flashpage** — page size / write block / FLASH key for U3; VCORE voltage range 1
  is selected so program/erase does not raise PGSERR.
- **VBAT** — internal VBAT channel, with the U3 scaling/reference fixed.
- **HWRNG** — U3 family whitelisted/routed.
- **ADC** — `adc_f3_h7.c` renamed to `adc_f3_h7_u3.c` and extended with the U3 path;
  ADC1 on Arduino A0–A5 plus internal VREFINT.
- **I2C** — I2C1 on PB6/PB7 (Arduino D15/D14 on MB1841), APB1 routing and register fixups.
- **USB device** — USB DRD FS support in `usbdev_fs` (D+/D− on PA12/PA11).


### Testing procedure

> [!NOTE]
> Depends on #22427  — review/merge that first. Flashing uses
> STM32CubeProgrammer (OpenOCD does not yet support the STM32U3); see the bring-up
> PR / board `doc.md` for the exact command.

Compiled for the NUCLEO-U385RG-Q:

cd tests/periph/spi        && make BOARD=nucleo-u385rg-q
cd tests/periph/pwm        && make BOARD=nucleo-u385rg-q
cd tests/periph/rtc        && make BOARD=nucleo-u385rg-q
cd tests/periph/flashpage  && make BOARD=nucleo-u385rg-q
cd tests/periph/adc        && make BOARD=nucleo-u385rg-q
cd tests/periph/i2c        && make BOARD=nucleo-u385rg-q
cd tests/sys/usbus_cdc_acm_stdio && make BOARD=nucleo-u385rg-q

Per-peripheral status:

| Peripheral | Status   | Notes                                                        |
|:-----------|:---------|:-------------------------------------------------------------|
| SPI        | working  | SPI1; verified via loopback test                             |
| PWM        | working  | TIM2 channels                                                |
| RTC        | working  | on-board LSE                                                 |
| flashpage  | working  | program/erase + verify (VCORE range 1)                       |
| VBAT       | working  | internal VBAT channel, scaling fixed
| ADC        | working   | ADC1 A0–A5; verified with potentiometer sweep after correcting the channel map |
| I2C        | working   | I2C1 on PB6/PB7; full bus scan completes cleanly (verified without attached devices) |
| USB device | working   | USB DRD FS, D+/D− on PA12/PA11 (user USB Type-C) — verified with a CDC-ACM shell    |

How to confirm it's not in master: these peripherals are not provided by the board
on `master` (the board and `stm32u3` family don't exist there); after this PR
`make BOARD=nucleo-u385rg-q` builds the apps above. All peripherals behave as their tests expect.

### Issues/PRs references

Depends on #22427  (initial bring-up). Together these two PRs supersede
the original #22175.Do not merge until #22427  is merged

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- Gemini for documentation generation, with user review