### PR TITLE
sys/stdio: add stdio_notify to emit callback on write

### DIFF
--- a/cpu/esp32/stdio_usb_serial_jtag/usb_serial_jtag.c
+++ b/cpu/esp32/stdio_usb_serial_jtag/usb_serial_jtag.c
@@ -56,7 +56,7 @@ static void _serial_intr_handler(void *arg)
     /* read data if available */
     while (IS_USED(MODULE_STDIO_USB_SERIAL_JTAG_RX) &&
            usb_serial_jtag_ll_rxfifo_data_available()) {
-        isrpipe_write_one(&stdin_isrpipe, USB_SERIAL_JTAG.ep1.rdwr_byte);
+        stdio_rx_write_one(USB_SERIAL_JTAG.ep1.rdwr_byte);
     }
 
     /* write data if there is a free stop */

--- a/cpu/native/stdio_native/stdio_native.c
+++ b/cpu/native/stdio_native/stdio_native.c
@@ -15,12 +15,15 @@
 
 #include "stdio_base.h"
 
-static void _async_read_wrapper(int fd, void *arg) {
+static void _async_read_wrapper(int fd, void *arg)
+{
+    (void)arg;
+
     uint8_t buf[STDIO_RX_BUFSIZE];
 
     int res = real_read(fd, &buf, sizeof(buf));
     if (res > 0) {
-        isrpipe_write(arg, buf, res);
+        stdio_rx_write(buf, res);
     }
 
     native_async_read_continue(fd);
@@ -30,7 +33,7 @@ static void _init(void)
 {
     native_async_read_setup();
     if (IS_USED(MODULE_STDIN)) {
-        native_async_read_add_int_handler(STDIN_FILENO, &stdin_isrpipe,
+        native_async_read_add_int_handler(STDIN_FILENO, NULL,
                                           _async_read_wrapper);
     }
 }

--- a/drivers/slipmux/slipdev.c
+++ b/drivers/slipmux/slipdev.c
@@ -46,7 +46,7 @@ static inline void _slipdev_stdio_add_to_frame(slipdev_t *dev, uint8_t byte)
         dev->config.uart != slipdev_params[0].uart) {
         return;
     }
-    isrpipe_write_one(&stdin_isrpipe, byte);
+    stdio_rx_write_one(byte);
 }
 
 static inline bool _slipdev_config_start_frame(slipdev_t *dev)

--- a/drivers/slipmux/stdio.c
+++ b/drivers/slipmux/stdio.c
@@ -11,7 +11,6 @@
  */
 
 #include "board.h"
-#include "isrpipe.h"
 #include "periph/uart.h"
 
 #include "slipdev.h"
@@ -35,9 +34,10 @@ static inline void _slipdev_unlock(void)
     }
 }
 
-static void _isrpipe_write(void *arg, uint8_t data)
+static void _stdio_rx_write(void *arg, uint8_t data)
 {
-    isrpipe_write_one(arg, (char)data);
+    (void)arg;
+    stdio_rx_write_one(data);
 }
 
 static void _init(void)
@@ -45,7 +45,7 @@ static void _init(void)
     /* intentionally overwritten in netdev init so we have stdio before
      * the network device is initialized */
     uart_init(slipdev_params[0].uart, slipdev_params[0].baudrate,
-              _isrpipe_write, &stdin_isrpipe);
+              _stdio_rx_write, NULL);
 
     slipdev_write_byte(slipdev_params[0].uart, SLIPDEV_END);
 }

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -579,6 +579,7 @@ PSEUDOMODULES += stdio_default
 PSEUDOMODULES += stdio_dispatch
 PSEUDOMODULES += stdio_ethos
 PSEUDOMODULES += stdio_nimble_debug
+PSEUDOMODULES += stdio_notify
 PSEUDOMODULES += stdio_slipdev
 PSEUDOMODULES += stdio_telnet
 ## @defgroup sys_stdio_uart_onlcr   Support for DOS line endings in STDIO-UART

--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -28,10 +28,6 @@ ifeq (,$(filter $(STDIO_LEGACY_MODULES),$(USEMODULE)))
   USEMODULE += stdio
 endif
 
-ifneq (,$(filter stdin,$(USEMODULE)))
-  USEMODULE += isrpipe
-endif
-
 # Check if more than one STDIO has been selected, if so add stdio_dispatch.
 # This check will fail if 10 or more modules are selected.
 ifeq (1, $(call _is_greater,$(words $(sort $(filter $(STDIO_MODULES),$(USEMODULE)))),1))
@@ -40,7 +36,7 @@ endif
 
 ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))
   USEMODULE += usbus_cdc_acm
-  USEMODULE += isrpipe
+  USEMODULE += stdin
   USEMODULE += stdio_available
 endif
 
@@ -61,7 +57,7 @@ ifneq (,$(filter stdio_nimble,$(USEMODULE)))
   USEMODULE += stdio_available
   USEPKG += nimble
   USEMODULE += tsrb
-  USEMODULE += isrpipe
+  USEMODULE += stdin
   USEMODULE += nimble_svc_gap
   USEMODULE += nimble_svc_gatt
   ifneq (,$(filter stdio_nimble_debug,$(USEMODULE)))
@@ -76,7 +72,7 @@ ifneq (,$(filter stdin,$(USEMODULE)))
 endif
 
 ifneq (,$(filter stdio_uart_rx,$(USEMODULE)))
-  USEMODULE += isrpipe
+  USEMODULE += stdin
   USEMODULE += stdio_uart
   USEMODULE += stdio_available
 endif
@@ -98,6 +94,14 @@ endif
 ifneq (,$(filter stdio_udp,$(USEMODULE)))
   USEMODULE += sock_udp
   USEMODULE += sock_async
+endif
+
+ifneq (,$(filter stdio_notify,$(USEMODULE)))
+  USEMODULE += stdin
+endif
+
+ifneq (,$(filter stdin,$(USEMODULE)))
+  USEMODULE += isrpipe
 endif
 
 # Enable stdout buffering for modules that benefit from sending out buffers in

--- a/pkg/tinyusb/cdc_acm_stdio/cdc_acm_stdio.c
+++ b/pkg/tinyusb/cdc_acm_stdio/cdc_acm_stdio.c
@@ -51,7 +51,7 @@ void tud_cdc_rx_cb(uint8_t itf)
 
     uint8_t buffer[64];
     unsigned res = tud_cdc_read(buffer, sizeof(buffer));
-    isrpipe_write(&stdin_isrpipe, buffer, res);
+    stdio_rx_write(buffer, res);
 }
 #endif
 

--- a/sys/include/stdio_base.h
+++ b/sys/include/stdio_base.h
@@ -79,8 +79,91 @@ typedef struct {
 
 /**
  * @brief   isrpipe for writing stdin input to
+ *
+ * @deprecated  Use @ref stdio_rx_write or @ref stdio_rx_write_one. This
+ *              isrpipe will become private and should not be used directly.
+ *              Using this isrpipe directly will not work with the
+ *              `stdio_notify` module. Will be removed after the 2027.01
+ *              release.
  */
 extern isrpipe_t stdin_isrpipe;
+
+/**
+ * @brief   Push a single received byte into stdin
+ *
+ * This is the entry point stdio backends use to hand received data to stdin.
+ * It buffers the byte for @ref stdio_read and, when the `stdio_notify` module
+ * is used, invokes the registered notify callback (see @ref stdio_set_notify).
+ *
+ * @note    Safe to call from ISR context.
+ *
+ * @param[in]   c       received byte to push into stdin
+ *
+ * @retval      0       on success
+ * @retval      -1      if the stdin buffer was full
+ */
+#if IS_USED(MODULE_STDIO_NOTIFY) || DOXYGEN
+int stdio_rx_write_one(uint8_t c);
+#else
+static inline int stdio_rx_write_one(uint8_t c)
+{
+    return isrpipe_write_one(&stdin_isrpipe, c);
+}
+#endif
+
+/**
+ * @brief   Push received bytes into stdin
+ *
+ * This is the entry point stdio backends use to hand received data to stdin.
+ * It buffers the data for @ref stdio_read and, when the `stdio_notify` module
+ * is used, invokes the registered notify callback (see @ref stdio_set_notify).
+ *
+ * @note    Safe to call from ISR context.
+ *
+ * @param[in]   buf     received bytes to push into stdin
+ * @param[in]   len     number of bytes in @p buf
+ *
+ * @return  number of bytes pushed into stdin, which may be less than @p len if
+ *          the stdin buffer was full
+ */
+#if IS_USED(MODULE_STDIO_NOTIFY) || DOXYGEN
+int stdio_rx_write(const uint8_t *buf, size_t len);
+#else
+static inline int stdio_rx_write(const uint8_t *buf, size_t len)
+{
+    return isrpipe_write(&stdin_isrpipe, buf, len);
+}
+#endif
+
+#if IS_USED(MODULE_STDIO_NOTIFY) || DOXYGEN
+/**
+ * @brief   Definition of a stdio notify callback
+ *
+ * Invoked once data becomes available on stdin (see @ref stdio_set_notify), in
+ * the (ISR) context of the stdio backend feeding stdin. It must therefore be
+ * ISR-safe and non-blocking.
+ *
+ * @param[in]   arg     argument registered with the callback
+ */
+typedef void (*stdio_notify_cb_t)(void *arg);
+
+/**
+ * @brief   Register a callback fired when data is available on stdin
+ *
+ * The callback is invoked by the stdio backend once new data has been pushed
+ * to stdin, in (ISR) context. It must therefore be ISR-safe and non-blocking.
+ * This allows a consumer to be woken by means other than a blocking
+ * @ref stdio_read (e.g. thread flags), so it can also react to other events.
+ *
+ * There can only be one notify callback registered at a time.
+ *
+ * @note    Only available with the `stdio_notify` module.
+ *
+ * @param[in]   cb      callback to invoke, or `NULL` to disable
+ * @param[in]   arg     argument passed to @p cb
+ */
+void stdio_set_notify(stdio_notify_cb_t cb, void *arg);
+#endif
 
 /**
  * @brief initialize the module

--- a/sys/net/application_layer/telnet/telnet_server.c
+++ b/sys/net/application_layer/telnet/telnet_server.c
@@ -275,7 +275,7 @@ static void *telnet_thread(void *arg)
                 }
 write:
                 if (IS_USED(MODULE_STDIO_TELNET)) {
-                    isrpipe_write_one(&stdin_isrpipe, c);
+                    stdio_rx_write_one(c);
                 }
                 else {
                     pipe_write(&_stdin_pipe, &c, 1);

--- a/sys/stdio/stdio.c
+++ b/sys/stdio/stdio.c
@@ -27,6 +27,45 @@
 static uint8_t _rx_buf_mem[STDIO_RX_BUFSIZE];
 isrpipe_t stdin_isrpipe = ISRPIPE_INIT(_rx_buf_mem);
 
+#if IS_USED(MODULE_STDIO_NOTIFY)
+static stdio_notify_cb_t _notify_cb;
+static void *_notify_arg;
+
+void stdio_set_notify(stdio_notify_cb_t cb, void *arg)
+{
+    unsigned irqstate = irq_disable();
+
+    _notify_arg = arg;
+    _notify_cb = cb;
+
+    irq_restore(irqstate);
+}
+
+int stdio_rx_write_one(uint8_t c)
+{
+    int res = isrpipe_write_one(&stdin_isrpipe, c);
+
+    /* notify even if the pipe is full, isrpipe_read() would unblock anyway */
+    if (_notify_cb) {
+        _notify_cb(_notify_arg);
+    }
+
+    return res;
+}
+
+int stdio_rx_write(const uint8_t *buf, size_t len)
+{
+    int res = isrpipe_write(&stdin_isrpipe, buf, len);
+
+    /* notify even if the pipe is full, isrpipe_read() would unblock anyway */
+    if (_notify_cb) {
+        _notify_cb(_notify_arg);
+    }
+
+    return res;
+}
+#endif
+
 #ifdef MODULE_STDIO_DISPATCH
 XFA_INIT_CONST(stdio_provider_t, stdio_provider_xfa);
 

--- a/sys/stdio_nimble/stdio_nimble.c
+++ b/sys/stdio_nimble/stdio_nimble.c
@@ -171,11 +171,11 @@ static const struct ble_gatt_svc_def _gatt_svr_svcs[] =
 
 static void _purge_buffer(void)
 {
-    tsrb_clear(&stdin_isrpipe.tsrb);
+    stdio_clear_stdin();
 
 #if IS_USED(MODULE_SHELL)
     /* send Ctrl-C to the shell to reset the input */
-    isrpipe_write_one(&stdin_isrpipe, '\x03');
+    stdio_rx_write_one('\x03');
 #endif
 
     tsrb_clear(&_tsrb_stdout);
@@ -290,7 +290,7 @@ static int gatt_svr_chr_access_stdin(
     /* read sent data */
     int rc = ble_hs_mbuf_to_flat(ctxt->om, _stdin_read_buf, sizeof(_stdin_read_buf), &om_len);
 
-    isrpipe_write(&stdin_isrpipe, _stdin_read_buf, om_len);
+    stdio_rx_write(_stdin_read_buf, om_len);
 
     return rc;
 }

--- a/sys/stdio_rtt/stdio_rtt.c
+++ b/sys/stdio_rtt/stdio_rtt.c
@@ -283,12 +283,14 @@ int rtt_write(const char* buf_ptr, unsigned num_bytes) {
 
 static bool _rtt_read_cb(void *arg)
 {
+    (void)arg;
+
     int bytes = rtt_read_bytes_avail();
     uint8_t buffer[STDIO_RX_BUFSIZE];
 
     if (bytes) {
         bytes = rtt_read(buffer, sizeof(buffer));
-        isrpipe_write(arg, buffer, bytes);
+        stdio_rx_write(buffer, bytes);
     }
 
     return true;
@@ -304,7 +306,7 @@ static void _init(void) {
         return;
     }
 
-    ztimer_periodic_init(ZTIMER_MSEC, &stdin_timer, _rtt_read_cb, &stdin_isrpipe,
+    ztimer_periodic_init(ZTIMER_MSEC, &stdin_timer, _rtt_read_cb, NULL,
                          STDIO_POLL_INTERVAL_MS);
     ztimer_periodic_start(&stdin_timer);
     _init_done = true;

--- a/sys/stdio_semihosting/stdio_semihosting.c
+++ b/sys/stdio_semihosting/stdio_semihosting.c
@@ -144,6 +144,8 @@ static ssize_t _semihosting_read(uint8_t *buffer, size_t len)
 
 static bool _read_cb(void *arg)
 {
+    (void)arg;
+
     uint8_t buffer[STDIO_RX_BUFSIZE];
 
     if (!_semihosting_connected()) {
@@ -152,7 +154,7 @@ static bool _read_cb(void *arg)
 
     int bytes = _semihosting_read(buffer, sizeof(buffer));
     if (bytes > 0) {
-        isrpipe_write(arg, buffer, bytes);
+        stdio_rx_write(buffer, bytes);
     }
 
     return true;
@@ -169,7 +171,7 @@ static void _init(void) {
         return;
     }
 
-    ztimer_periodic_init(ZTIMER_MSEC, &stdin_timer, _read_cb, &stdin_isrpipe,
+    ztimer_periodic_init(ZTIMER_MSEC, &stdin_timer, _read_cb, NULL,
                          STDIO_SEMIHOSTING_POLL_RATE_MS);
     ztimer_periodic_start(&stdin_timer);
     _init_done = true;

--- a/sys/stdio_uart/stdio_uart.c
+++ b/sys/stdio_uart/stdio_uart.c
@@ -39,22 +39,21 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-static void _isrpipe_write_one_wrapper(void *arg, uint8_t value)
+static void _stdio_rx_write_one_wrapper(void *arg, uint8_t value)
 {
-    isrpipe_write_one(arg, value);
+    (void)arg;
+    stdio_rx_write_one(value);
 }
 
 static void _init(void)
 {
     uart_rx_cb_t cb = NULL;
-    void *arg = NULL;
 
     if (IS_USED(MODULE_STDIO_UART_RX)) {
-        cb = _isrpipe_write_one_wrapper;
-        arg = &stdin_isrpipe;
+        cb = _stdio_rx_write_one_wrapper;
     }
 
-    uart_init(STDIO_UART_DEV, STDIO_UART_BAUDRATE, cb, arg);
+    uart_init(STDIO_UART_DEV, STDIO_UART_BAUDRATE, cb, NULL);
 }
 
 static ssize_t _write(const void *buffer, size_t len)

--- a/sys/stdio_udp/stdio_udp.c
+++ b/sys/stdio_udp/stdio_udp.c
@@ -49,7 +49,7 @@ static void _sock_cb(sock_udp_t *sock, sock_async_flags_t flags, void *arg)
 
     int res;
     while ((res = sock_udp_recv_buf(sock, &data, &ctx, 0, &remote)) > 0) {
-        isrpipe_write(&stdin_isrpipe, data, res);
+        stdio_rx_write(data, res);
 
         /* detach remote */
         if (res == 1 && *(int8_t *)data == EOT) {

--- a/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
@@ -25,7 +25,6 @@
 #include <sys/types.h>
 
 #include "log.h"
-#include "isrpipe.h"
 #include "stdio_base.h"
 
 #include "usb/usbus.h"
@@ -51,7 +50,7 @@ static void _cdc_acm_rx_pipe(usbus_cdcacm_device_t *cdcacm,
                              uint8_t *data, size_t len)
 {
     (void)cdcacm;
-    isrpipe_write(&stdin_isrpipe, data, len);
+    stdio_rx_write(data, len);
 }
 
 void usb_cdc_acm_stdio_init(usbus_t *usbus)

--- a/tests/sys/stdio_notify/Makefile
+++ b/tests/sys/stdio_notify/Makefile
@@ -1,0 +1,14 @@
+include ../Makefile.sys_common
+
+# the feature under test
+USEMODULE += stdio_notify
+
+# used to drain stdin once notified
+USEMODULE += stdio_available
+
+# used to wake the main thread from the notify and timer callbacks
+USEMODULE += core_thread_flags
+USEMODULE += ztimer
+USEMODULE += ztimer_sec
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/sys/stdio_notify/Makefile.ci
+++ b/tests/sys/stdio_notify/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    atmega8 \
+    #

--- a/tests/sys/stdio_notify/README.md
+++ b/tests/sys/stdio_notify/README.md
@@ -1,0 +1,18 @@
+# stdio_notify test application
+
+## Introduction
+
+This application tests and demonstrates the functionality of the
+`stdio_notify` module, which can be used to invoke a callback whenever data is
+available on the stdin stream. The application has a single thread that handles
+two tasks:
+
+- Echo any data received on stdin back to stdout.
+- Print a message to stdout every five seconds.
+
+The main loop unblocks if any of the two tasks needs to be executed.
+
+## Expected result
+
+Data that is sent to stdin is echoed back to stdout, while a message is printed
+to stdout every five seconds.

--- a/tests/sys/stdio_notify/main.c
+++ b/tests/sys/stdio_notify/main.c
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the stdio_notify module
+ *
+ * This demonstrates how the `stdio_notify` module can be used to wait on stdin
+ * input without blocking on @ref stdio_read. A notify callback raises a thread
+ * flag once data is available, so the main thread can sleep until either new
+ * input arrives or a periodic timer fires, and service both events from a
+ * single @ref thread_flags_wait_any.
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "stdio_base.h"
+#include "thread.h"
+#include "thread_flags.h"
+#include "ztimer.h"
+
+#define FLAG_STDIN          (1U << 0)
+#define FLAG_TIMER          (THREAD_FLAG_TIMEOUT)
+
+#define TIMER_INTERVAL_SEC  (5U)
+
+static thread_t *_main_thread;
+static ztimer_t _timer;
+
+/**
+ * @brief   Invoked in (ISR) context by the stdio backend once data is
+ *          available on stdin.
+ */
+static void _stdin_notify(void *arg)
+{
+    (void)arg;
+
+    if (_main_thread) {
+        thread_flags_set(_main_thread, FLAG_STDIN);
+    }
+}
+
+int main(void)
+{
+    _main_thread = thread_get_active();
+
+    /* register the notify callback that wakes us when stdin has data */
+    stdio_set_notify(_stdin_notify, NULL);
+
+    /* schedule the periodic timer */
+    ztimer_set_timeout_flag(ZTIMER_SEC, &_timer, TIMER_INTERVAL_SEC);
+
+    puts("Type characters to echo them, or wait for the periodic timer.");
+
+    while (1) {
+        /* sleep until either stdin has data or the timer fired; this avoids
+         * busy-polling stdio_available() and avoids blocking in stdio_read() */
+        thread_flags_t flags = thread_flags_wait_any(FLAG_STDIN | FLAG_TIMER);
+
+        if (flags & FLAG_TIMER) {
+            /* handle the timer and re-arm it */
+            puts("*** Woken up! ***");
+            ztimer_set_timeout_flag(ZTIMER_SEC, &_timer, TIMER_INTERVAL_SEC);
+        }
+
+        if (flags & FLAG_STDIN) {
+            /* drain everything that is currently buffered */
+            int available = stdio_available();
+
+            while (available > 0) {
+                char buf[16];
+                size_t len = (size_t)available < sizeof(buf)
+                           ? (size_t)available : sizeof(buf);
+                ssize_t res = stdio_read(buf, len);
+
+                if (res <= 0) {
+                    break;
+                }
+
+                /* echo back to stdio */
+                stdio_write(buf, (size_t)res);
+
+                available -= (int)res;
+            }
+        }
+    }
+
+    return 0;
+}

--- a/tests/sys/stdio_notify/tests/01-run.py
+++ b/tests/sys/stdio_notify/tests/01-run.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+# SPDX-License-Identifier: LGPL-2.1-only
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact(
+        "Type characters to echo them, or wait for the periodic timer.")
+
+    # sending input should wake the thread through the notify callback and
+    # echo the bytes back via stdio_read
+    child.sendline("hello 123")
+    child.expect("hello 123")
+
+    # without any input, the periodic timer should still wake the thread
+    child.expect_exact("*** Woken up! ***", timeout=10)
+
+    # sending more input to assert that thread is still capable of waking up
+    child.sendline("world 456")
+    child.expect("world 456")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

For #22350 I need to be able to execute scheduled work on the same thread that runs and executes the REPL. With the `stdio` module proving an `stdin_isrpipe`, this is not possible, unless you run a second thread to read and rebuffer, then waking up the main thread with something like thread flags. This definitely costs more memory and flash than this proposed solution.

After some experimentation, I came up with `stdio_notify`. This provides a way to register a write callback, that can be used in an application for aforementioned reason.

I made three deliberate choices (which are not set in stone though):

- I did not implement this as part of `isrpipe`, which I could have done too. With #22426 providing `isrpipe_available`, this would be feasible. However, if you have the option to choose for `isrpipe` to begin with, then there are probably other methods to solve the same issue. With the `stdio` module, you cannot. It keeps `isrpipe` lightweight.
- I only add support for a single callback, because stdin is typically read by a single consumer.
- I debated whether it should be called `stdio_notify` or `stdin_notify`, but given that `stdio_available` is not called `stdio_stdin_available`, I went with `stdio_notify`.

`stdio` backends now have to route incoming bytes via `stdio_rx_write()`/`stdio_rx_write_one()`. When `stdio_notify` is disabled, it inlines directly. Public access to `stdin_isrpipe` has been marked as deprecated, and writing to it directly will not invoke the callback (which is still backwards compatible when disable). I set it to 2027.01 for now.

### Testing procedure

A test application has been provided in `tests/sys/stdio_notify`, which exactly shows one of its main intended uses.

### Issues/PRs references

This PR builds for `stdio_uart`, but not for others due to #22424. #22426 was split off as another improvement.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- Claude Opus 4.8 for documentation and test generation
- Claude Opus 4.8 code review
