### PR TITLE
build-system: write output to both SARIF and stdio

### DIFF
--- a/makefiles/toolchain/gnu.inc.mk
+++ b/makefiles/toolchain/gnu.inc.mk
@@ -40,7 +40,7 @@ include $(RIOTMAKE)/tools/gdb.inc.mk
 CFLAGS_STATIC_ANALYSIS := -fanalyzer
 
 # this needs to be recursively evaluated
-RCFLAGS_WRITE_SARIF = -fdiagnostics-set-output=sarif:file='$$@.sarif'
+RCFLAGS_WRITE_SARIF = -fdiagnostics-add-output=sarif:file='$$@.sarif'
 
 # Data address spaces starts at zero for all supported architectures. This fixes
 # compilation at least on MSP430 and AVR.


### PR DESCRIPTION
### Contribution description

Using `-fdiagnostics-add-output` instead of `-fdiagnostics-set-output` results in the diagnostics to be written to both stdout and SARIF files.

While SARIF is a nice addition, it can be a bit of a footgun when compilation fails with no log output (besides in the SARIF files).

### Testing procedure

Add a syntax error e.g. to `examples/basic/default/main.c` and compile with `make WRITE_SARIF=1 -C examples/basic/default`. In `master`, it will fail with no output at all (but the diagnostics will be present in the sarif file, though).

With this PR, the output will show the error in addition to the diagnostics being in the SARIF file.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
