### PR TITLE
sys/net/l2util: fix false positive compiler warning

### DIFF
--- a/sys/net/link_layer/l2util/l2util.c
+++ b/sys/net/link_layer/l2util/l2util.c
@@ -402,6 +402,8 @@ size_t l2util_addr_from_str_sized(const char *str, void *_addr, size_t addr_size
         return 0;
     }
 
+    assume(addr + addr_size >= addr_end);
+
     /* out is reversed */
     while (addr < --addr_end) {
         uint8_t tmp = *addr_end;

--- a/tests/net/l2util/main.c
+++ b/tests/net/l2util/main.c
@@ -460,10 +460,12 @@ static void test_l2util_addr_from_str(void)
                                                    out));
     TEST_ASSERT_EQUAL_INT(0, memcmp(ieee802154_l2addr_long, out,
                                     sizeof(ieee802154_l2addr_long)));
+    out[6] = canary;
     TEST_ASSERT_EQUAL_INT(0,
                           l2util_addr_from_str_sized("3E:E6:B5:0F:19:22:FD:0A",
                                                      out,
                                                      6));
+    TEST_ASSERT_EQUAL_INT(canary, out[6]);
     TEST_ASSERT_EQUAL_INT(sizeof(ieee802154_l2addr_short),
                           l2util_addr_from_str("FD:0A", out));
     TEST_ASSERT_EQUAL_INT(0, memcmp(ieee802154_l2addr_short, out,


### PR DESCRIPTION
### Contribution description

Add an `assume()` to ensure the bounds. This fixes:

    In function ‘l2util_addr_from_str_sized’,
        inlined from ‘l2util_addr_from_str’ at ../../../sys/net/link_layer/l2util/l2util.c:416:12:
    ../../../sys/net/link_layer/l2util/l2util.c:409:17: warning: writing 16 bytes into a region of size between 0 and 8 [-Wstringop-overflow=]
      409 |         *addr++ = tmp;
          |         ~~~~~~~~^~~~~
    ../../../sys/net/link_layer/l2util/l2util.c: In function ‘l2util_addr_from_str’:
    ../../../sys/net/link_layer/l2util/l2util.c:414:54: note: destination object ‘out’ of size [0, 8]
      414 | size_t l2util_addr_from_str(const char *str, uint8_t out[L2UTIL_ADDR_MAX_LEN])
          |                                              ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~

Note that the unit tests for the overflow has also been spiced up a bit and is automatically run in the CI. We can be pretty sure that if this would not be a false positive, the unit test would detect that the function does overwrite the canary value at the end of the buffer.

### Testing procedure

#### In `master`

```
make -C dist/tools/zep_dispatch
make: Entering directory '/home/maribu/Repos/software/RIOT/master/dist/tools/zep_dispatch'
cc -g -O3 -Wall -Wextra -I../../../core/lib/include -I../../../cpu/native/include -I../../../drivers/include -I../../../sys/include -DNDEBUG   main.c topology.c zep_parser.c ../../../sys/net/link_layer/ieee802154/ieee802154.c ../../../sys/fmt/fmt.c ../../../sys/net/link_layer/l2util/l2util.c ../../../sys/libc/string.c -o bin/zep_dispatch
In function ‘l2util_addr_from_str_sized’,
    inlined from ‘l2util_addr_from_str’ at ../../../sys/net/link_layer/l2util/l2util.c:416:12:
../../../sys/net/link_layer/l2util/l2util.c:409:17: warning: writing 16 bytes into a region of size between 0 and 8 [-Wstringop-overflow=]
  409 |         *addr++ = tmp;
      |         ~~~~~~~~^~~~~
../../../sys/net/link_layer/l2util/l2util.c: In function ‘l2util_addr_from_str’:
../../../sys/net/link_layer/l2util/l2util.c:414:54: note: destination object ‘out’ of size [0, 8]
  414 | size_t l2util_addr_from_str(const char *str, uint8_t out[L2UTIL_ADDR_MAX_LEN])
      |                                              ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
make: Leaving directory '/home/maribu/Repos/software/RIOT/master/dist/tools/zep_dispatch'
```

#### This PR

```
make -C dist/tools/zep_dispatch
make: Entering directory '/home/maribu/Repos/software/RIOT/master/dist/tools/zep_dispatch'
cc -g -O3 -Wall -Wextra -I../../../core/lib/include -I../../../cpu/native/include -I../../../drivers/include -I../../../sys/include -DNDEBUG   main.c topology.c zep_parser.c ../../../sys/net/link_layer/ieee802154/ieee802154.c ../../../sys/fmt/fmt.c ../../../sys/net/link_layer/l2util/l2util.c ../../../sys/libc/string.c -o bin/zep_dispatch
cc -g -O3 -Wall -Wextra -I../../../core/lib/include -I../../../cpu/native/include -I../../../drivers/include -I../../../sys/include -DNDEBUG  topogen.c -o bin/topogen -lm
make: Leaving directory '/home/maribu/Repos/software/RIOT/master/dist/tools/zep_dispatch'
```

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
