### PR TITLE
drivers/ads1x1x: fix return value for SAUL on read error [backport 2026.07]

### DIFF
--- a/drivers/ads1x1x/ads1x1x_saul.c
+++ b/drivers/ads1x1x/ads1x1x_saul.c
@@ -32,7 +32,7 @@ static int read_adc(const void *dev, phydat_t *res)
     int16_t raw;
 
     if (ads1x1x_read_raw(mydev, &raw) < 0) {
-        return ECANCELED;
+        return -ECANCELED;
     }
 
     *res->val = (int16_t)(ads1x1x_convert_to_mv(mydev, raw));


### PR DESCRIPTION
# Backport of #22435

### Contribution description

Error return values should be negative, the macro itself is positive, so a minus sign has to be added.


### Testing procedure

Not sure? Perhaps @baptleduc can test it, it is pretty obvious though.


### Issues/PRs references

Bug introduced in #21694.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
