### PR TITLE
pkg/lwip: fix netbuf leak in sock sendv

### DIFF
--- a/pkg/lwip/contrib/sock/lwip_sock.c
+++ b/pkg/lwip/contrib/sock/lwip_sock.c
@@ -681,6 +681,7 @@ ssize_t lwip_sock_sendv(struct netconn *conn, const iolist_t *snips,
                 DEBUG("[lwip_sock_sendv] lwip_sock_bind_addr_to_netif() "
                       "returned %u, but expected %u\n",
                       (unsigned)netif, (unsigned)remote->netif);
+                netbuf_delete(buf);
                 return -EINVAL;
             }
         }


### PR DESCRIPTION
### Contribution description

`lwip_sock_sendv()` allocates and fills a `netbuf` before checking whether an existing connection's bound netif matches `remote->netif`.

The netif-mismatch branch returned `-EINVAL` directly, bypassing the common `netbuf_delete(buf)` at the end of the function. This releases the allocated `netbuf` before that early return. No temporary `netconn` is created in this branch, so only `buf` needs cleanup.

### Testing procedure

Static/local checks performed:

- `git diff --check`
- `git ls-files --eol pkg/lwip/contrib/sock/lwip_sock.c`
- reviewed the `lwip_sock_sendv()` allocation and cleanup paths around `netbuf_new()`, `_create()`, and the final `netbuf_delete(buf)` / `netconn_delete(tmp)` cleanup.

Not run: RIOT build/tests, because this Windows PATH has no `make`, `gcc`, `clang`, `cmake`, or `docker` available.

### Issues/PRs references

Fixes #22422

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- OpenAI Codex for code generation and local static review, with user-directed agent workflow.