### PR TITLE
tests/sys/shell: escape backslash in test input

### DIFF
--- a/tests/sys/shell/tests/01-run.py
+++ b/tests/sys/shell/tests/01-run.py
@@ -85,7 +85,7 @@ CMDS = (
     ('echo escaped\\ space', '"echo""escaped space"'),
     ('echo escape within \'\\s\\i\\n\\g\\l\\e\\q\\u\\o\\t\\e\'', '"echo""escape""within""singlequote"'),
     ('echo escape within "\\d\\o\\u\\b\\l\\e\\q\\u\\o\\t\\e"', '"echo""escape""within""doublequote"'),
-    ("""echo "t\\e st" "\\"" '\\'' a\ b""", '"echo""te st"""""\'""a b"'),  # noqa: W605
+    ("""echo "t\\e st" "\\"" '\\'' a\\ b""", '"echo""te st"""""\'""a b"'),
 
     # test correct quoting
     ('echo "hello"world', '"echo""helloworld"'),


### PR DESCRIPTION
## Summary
- escape the backslash in the shell escaping test input so Python no longer treats `\ ` as an invalid escape sequence
- remove the now-unneeded `# noqa: W605` suppression

## Verification
- `python` compile check with `SyntaxWarning` captured for `tests/sys/shell/tests/01-run.py` reports `TOTAL 0`
- `git diff --check`
- `git ls-files --eol tests/sys/shell/tests/01-run.py`

I also checked for open duplicate PRs/issues mentioning `invalid escape`, `W605`, and this test file, and found no matches.

I did not run the full shell test because it depends on a RIOT board/terminal test environment that is not available locally.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- OpenAI Codex for code generation and local static review, with user-directed agent workflow.