### PR TITLE
dist/tools: fix devopen strncat bounds

### DIFF
--- a/dist/tools/sliptty/sliptty.c
+++ b/dist/tools/sliptty/sliptty.c
@@ -67,7 +67,7 @@ static int devopen(const char *dev, int flags)
     char devpath[1024];
 
     strcpy(devpath, "/dev/");
-    strncat(devpath, dev, sizeof(devpath) - (sizeof("/dev/") - 1));
+    strncat(devpath, dev, sizeof(devpath) - sizeof("/dev/"));
     return open(devpath, flags);
 }
 #endif

--- a/dist/tools/tunslip/tunslip6.c
+++ b/dist/tools/tunslip/tunslip6.c
@@ -650,7 +650,7 @@ devopen(const char *dev, int flags)
     strcpy(t, "/dev/");
     /* cppcheck-suppress bufferAccessOutOfBounds
      * (reason: seems to be a bug in cppcheck 1.7x) */
-    strncat(t, dev, sizeof(t) - 5);
+    strncat(t, dev, sizeof(t) - sizeof("/dev/"));
     return open(t, flags);
 }
 


### PR DESCRIPTION
### Contribution description

The non-Linux devopen() helpers build /dev/ paths in fixed-size stack buffers. strncat() copies up to the given count and then appends a terminating NUL, so using the full remaining character count after the /dev/ prefix can write one byte past the end when the device name is long enough.

Use sizeof(/dev/) for the reserved prefix-plus-NUL space in both helpers.

### Testing procedure

- git diff --check HEAD~1..HEAD
- git ls-files --eol dist/tools/sliptty/sliptty.c dist/tools/tunslip/tunslip6.c
- Static bound check: old worst case was 1025 bytes including NUL for a 1024-byte buffer; new worst case is 1024 bytes including NUL.

A local build was not run because this environment does not have make/gcc installed.

### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- OpenAI Codex for code generation and local static review, with user-directed agent workflow.