### PR TITLE
sys/shell: fix iw NETOPT_IS_WIRED value size

### DIFF
--- a/sys/shell/cmds/iw.c
+++ b/sys/shell/cmds/iw.c
@@ -128,7 +128,7 @@ static int _iw_probe(netif_t *iface)
 {
     long ret;
     uint16_t val16;
-    if ((ret = netif_get_opt(iface, NETOPT_IS_WIRED, 0, &val16, sizeof(&val16))) < 0) {
+    if ((ret = netif_get_opt(iface, NETOPT_IS_WIRED, 0, &val16, sizeof(val16))) < 0) {
         if (ret != -ENOTSUP) {  /* -ENOTSUP means wireless */
             return -EIO;
         }


### PR DESCRIPTION
### Contribution description

_iw_probe() passes a uint16_t buffer to 
netif_get_opt() for NETOPT_IS_WIRED, but the length argument used sizeof(&val16). That reports the pointer size instead of the value buffer size.

Use sizeof(val16), matching the following NETOPT_DEVICE_TYPE query and the other shell code paths that pass a uint16_t buffer.

### Testing procedure

- git diff --check
- git show --stat --check --format=fuller HEAD
- git ls-files --eol -- sys\shell\cmds\iw.c

### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- OpenAI Codex for code analysis, patch generation, and PR preparation, with user review