### PR TITLE
pkg/u8g2: assert I2C buffer size before copy

### DIFF
--- a/pkg/u8g2/contrib/u8x8_riotos.c
+++ b/pkg/u8g2/contrib/u8x8_riotos.c
@@ -186,9 +186,9 @@ uint8_t u8x8_byte_hw_i2c_riotos(u8x8_t *u8g2, uint8_t msg, uint8_t arg_int, void
 
     switch (msg) {
         case U8X8_MSG_BYTE_SEND:
+            assert((index + arg_int) <= sizeof(buffer));
             memcpy(&buffer[index], arg_ptr, arg_int);
             index += arg_int;
-            assert(index <= sizeof(buffer));
             break;
         case U8X8_MSG_BYTE_INIT:
             break;


### PR DESCRIPTION
### Contribution description
The RIOT u8x8 I2C backend accumulates U8X8_MSG_BYTE_SEND chunks into a fixed 32-byte transfer buffer.

The existing assertion checked index only after memcpy() had already written into the buffer. If an oversized chunk ever violates the documented u8x8 transfer-size assumption, the debug assertion fires too late to prevent the out-of-bounds write.

This moves the existing buffer-size invariant check before the copy, keeping the assertion at the single write boundary.

### Testing procedure
- git diff --check
- git show --stat --check --format=fuller HEAD
- git ls-files --eol -- pkg/u8g2/contrib/u8x8_riotos.c

I could not run a RIOT build locally because this Windows environment does not have make installed.

### Issues/PRs references
None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- OpenAI Codex for code generation and local static review, with user-directed agent workflow.