### PR TITLE
pkg/nimble: clear full statconn peer address

### DIFF
--- a/pkg/nimble/statconn/nimble_statconn.c
+++ b/pkg/nimble/statconn/nimble_statconn.c
@@ -263,7 +263,7 @@ int nimble_statconn_rm(const uint8_t *addr)
         nimble_netif_accept_stop();
     }
     s->state = UNUSED;
-    memset(s->addr, 0, sizeof(BLE_ADDR_LEN));
+    memset(s->addr, 0, sizeof(s->addr));
     mutex_unlock(&_lock);
 
     nimble_netif_close(nimble_netif_conn_get_by_addr(addr));


### PR DESCRIPTION
### Contribution description

`nimble_statconn_rm()` marks a static connection slot as unused and clears the stored peer address.

The stored address is `uint8_t addr[BLE_ADDR_LEN]`, but the current code uses `sizeof(BLE_ADDR_LEN)` as the `memset()` length. Since `BLE_ADDR_LEN` is a length macro (`6U`), this clears the size of that expression instead of the full address array.

Use `sizeof(s->addr)` so the whole stored peer address is cleared. This matters because `_get_addr()` matches slots by address only and does not filter by slot state.

### Testing procedure

- `git diff --check`
- `git show --stat --check --format=fuller HEAD`
- `git ls-files --eol -- pkg/nimble/statconn/nimble_statconn.c`
- `rg -n sizeof\s*\(\s*BLE_ADDR_LEN\s*\) pkg/nimble/statconn/nimble_statconn.c` returns no matches

I could not run the `tests/pkg/nimble_statconn_gnrc*` builds locally because this Windows environment does not have `make` installed.

### Issues/PRs references
None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- OpenAI Codex for code generation and local static review, with user-directed agent workflow.