### PR TITLE
sys/shell,tests/drivers/mtd_raw: validate parameter before `mtd_dev_get()` call

### DIFF
--- a/sys/shell/cmds/mtd.c
+++ b/sys/shell/cmds/mtd.c
@@ -448,7 +448,7 @@ static int _cmd_mtd(int argc, char **argv)
     }
 
     unsigned idx = atoi(argv[1]);
-    if (idx > MTD_NUMOF) {
+    if (idx >= MTD_NUMOF) {
         printf("%s: invalid device: %s\n", argv[0], argv[1]);
         return -1;
     }

--- a/tests/drivers/mtd_raw/main.c
+++ b/tests/drivers/mtd_raw/main.c
@@ -35,7 +35,7 @@ static mtd_dev_t *_get_dev(int argc, char **argv)
 
     unsigned idx = atoi(argv[1]);
 
-    if (idx > MTD_NUMOF) {
+    if (idx >= MTD_NUMOF) {
         printf("%s: invalid device: %s\n", argv[0], argv[1]);
         return NULL;
     }


### PR DESCRIPTION
### Contribution description
`mtd_dev_get()` asserts that the device index is strictly below `MTD_NUMOF` before indexing the MTD device table.

The MTD shell command and the raw MTD test currently reject only `idx > MTD_NUMOF`, which still lets `idx == MTD_NUMOF` reach `mtd_dev_get()`. Reject that upper-bound value at the input parsing layer.

### Testing procedure
- `git diff --check HEAD~1 HEAD`
- `git show --stat --check --format=fuller HEAD`
- Confirmed the call chain with `mtd_dev_get(idx)` and `assert(idx < MTD_NUMOF)` in `drivers/include/mtd.h`

Not run locally:
- build/tests: local `make`, `gcc`, `arm-none-eabi-gcc`, and `clang` are not installed

### Issues/PRs references
None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- OpenAI Codex for code generation and local static review, with user-directed agent workflow.