### PR TITLE
sys/bitfield: fix doxygen grouping

### DIFF
--- a/sys/include/bitfield.h
+++ b/sys/include/bitfield.h
@@ -12,14 +12,13 @@
  * @defgroup    sys_bitfield Bitfields
  * @ingroup     sys
  * @brief       Bitfields of arbitrary length
+ * @{
  *
  * The bitfields in this module have their most significant bytes first and
  * their most significant bits within each byte of the bitfield also first.
  *
  * @file
- * @{
- *
- * @brief       bitfields operations on bitfields of arbitrary length
+ * @brief       Bitfield operations on bitfields of arbitrary length
  *
  * @note        Code taken mostly from
  *              <a href="http://stackoverflow.com/questions/1590893/error-trying-to-define-a-1-024-bit-128-byte-bit-field">


### PR DESCRIPTION
### Contribution description

The opening bracket for the Doxygen group was in the wrong spot, leading to a mostly empty page.

Current master:
<img width="1872" height="952" alt="image" src="https://github.com/user-attachments/assets/82d18c0d-35eb-4d1a-88a3-ddce0f3b59f9" />

This PR:
<img width="1870" height="955" alt="image" src="https://github.com/user-attachments/assets/f5e6dd80-06f9-443d-9813-4e8b6670490b" />


### Testing procedure

Look at the docs 👀 

### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
