### PR TITLE
drivers/ethos: port to stdio_provider infrastructure

### DIFF
--- a/drivers/ethos/Makefile.dep
+++ b/drivers/ethos/Makefile.dep
@@ -4,7 +4,3 @@ USEMODULE += netdev_eth
 USEMODULE += netdev_new_api
 USEMODULE += random
 USEMODULE += tsrb
-
-ifneq (,$(filter ethos_stdio,$(USEMODULE)))
-  USEMODULE += isrpipe
-endif

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -32,9 +32,7 @@
 #include "net/ethernet.h"
 
 #ifdef MODULE_ETHOS_STDIO
-#include "stdio_uart.h"
-#include "isrpipe.h"
-extern isrpipe_t ethos_stdio_isrpipe;
+#include "stdio_base.h"
 #endif
 
 #define ENABLE_DEBUG 0
@@ -86,12 +84,6 @@ static void _fail_frame(ethos_t *dev)
             tsrb_add_one(&dev->inbuf, ETHOS_FRAME_DELIMITER);
             break;
         case ETHOS_FRAME_TYPE_TEXT:
-#ifdef MODULE_ETHOS_STDIO
-            tsrb_clear(&ethos_stdio_isrpipe.tsrb);
-            /* signal to handler thread that frame is at an end (makes handler thread to
-             * truncate frame) */
-            isrpipe_write_one(&ethos_stdio_isrpipe, ETHOS_FRAME_DELIMITER);
-#endif
             break;
         case ETHOS_FRAME_TYPE_ERRORED:
             return;
@@ -113,7 +105,7 @@ static void _handle_char(ethos_t *dev, char c)
             break;
         case ETHOS_FRAME_TYPE_TEXT:
 #ifdef MODULE_ETHOS_STDIO
-            if (isrpipe_write_one(&ethos_stdio_isrpipe, c) < 0) {
+            if (isrpipe_write_one(&stdin_isrpipe, c) < 0) {
                 //puts("lost frame");
                 _fail_frame(dev);
             }
@@ -160,19 +152,42 @@ static void ethos_isr(void *arg, uint8_t c)
             }
             break;
         case IN_FRAME:
-            _handle_char(dev, c);
             if (c == ETHOS_ESC_CHAR) {
                 dev->state = IN_ESCAPE;
+                /* TEXT frames are unescaped in the ISR; for all other frame
+                 * types forward the raw byte so the thread layer can unescape
+                 * it via ethos_unstuff_readbyte() */
+                if (dev->frametype != ETHOS_FRAME_TYPE_TEXT) {
+                    _handle_char(dev, c);
+                }
             }
             else if (c == ETHOS_FRAME_DELIMITER) {
+                /* for TEXT frames unescaping is done in the ISR so we do not
+                 * use FRAME_DELIMITER as an in-band end-of-frame marker */
+                if (dev->frametype != ETHOS_FRAME_TYPE_TEXT) {
+                    _handle_char(dev, c);
+                }
                 _end_of_frame(dev);
+            }
+            else {
+                _handle_char(dev, c);
             }
             break;
         case IN_ESCAPE:
             switch (c) {
                 case (ETHOS_FRAME_DELIMITER ^ 0x20):
+                    if (dev->frametype == ETHOS_FRAME_TYPE_TEXT) {
+                        _handle_char(dev, ETHOS_FRAME_DELIMITER);
+                        dev->state = IN_FRAME;
+                        return;
+                    }
                     break;
                 case (ETHOS_ESC_CHAR ^ 0x20):
+                    if (dev->frametype == ETHOS_FRAME_TYPE_TEXT) {
+                        _handle_char(dev, ETHOS_ESC_CHAR);
+                        dev->state = IN_FRAME;
+                        return;
+                    }
                     break;
                 case (ETHOS_FRAME_TYPE_TEXT ^ 0x20):
                     dev->frametype = ETHOS_FRAME_TYPE_TEXT;

--- a/drivers/ethos/stdio.c
+++ b/drivers/ethos/stdio.c
@@ -19,66 +19,22 @@
  */
 
 #include "ethos.h"
-#include "isrpipe.h"
-#include "stdio_uart.h"
-
-#ifndef STDIO_UART_RX_BUFSIZE
-#define STDIO_UART_RX_BUFSIZE STDIO_RX_BUFSIZE
-#endif
+#include "stdio_base.h"
 
 extern ethos_t ethos;
 
-static uint8_t _rx_buf_mem[STDIO_UART_RX_BUFSIZE];
-isrpipe_t ethos_stdio_isrpipe = ISRPIPE_INIT(_rx_buf_mem);
-
-static void _isrpipe_write(void *arg, uint8_t data)
+static void _init(void)
 {
-    isrpipe_write_one(arg, (char)data);
+    /* will be overwritten by netdev init, provide early stdout */
+    uart_init(ETHOS_UART, ETHOS_BAUDRATE, NULL, NULL);
 }
 
-void stdio_init(void)
-{
-    uart_init(ETHOS_UART, ETHOS_BAUDRATE, _isrpipe_write, &ethos_stdio_isrpipe);
-}
-
-extern unsigned ethos_unstuff_readbyte(uint8_t *buf, uint8_t byte,
-                                       bool *escaped, uint8_t *frametype);
-
-ssize_t stdio_read(void* buffer, size_t len)
-{
-    uint8_t *ptr = buffer;
-    bool escaped = false;
-    uint8_t frametype = ETHOS_FRAME_TYPE_TEXT;
-    uint8_t byte;
-
-    do {
-        int read = isrpipe_read(&ethos_stdio_isrpipe, &byte, 1);
-        int tmp;
-
-        if (read == 0) {
-            continue;
-        }
-        else if (len == 0) {
-            return -ENOBUFS;
-        }
-        tmp = ethos_unstuff_readbyte(ptr, byte, &escaped, &frametype);
-        ptr += tmp;
-        if ((unsigned)(ptr - (uint8_t *)buffer) > len) {
-            while (byte != ETHOS_FRAME_DELIMITER) {
-                /* clear out unreceived frame */
-                isrpipe_read(&ethos_stdio_isrpipe, &byte, 1);
-            }
-            return -ENOBUFS;
-        }
-    } while (byte != ETHOS_FRAME_DELIMITER);
-
-    return ptr - (uint8_t *)buffer;
-}
-
-ssize_t stdio_write(const void* buffer, size_t len)
+static ssize_t _write(const void* buffer, size_t len)
 {
     ethos_send_frame(&ethos, (const uint8_t *)buffer, len, ETHOS_FRAME_TYPE_TEXT);
     return len;
 }
+
+STDIO_PROVIDER(STDIO_ETHOS, _init, NULL, _write)
 
 /** @} */

--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -18,15 +18,7 @@ STDIO_MODULES = \
   stdio_usb_serial_jtag \
   #
 
-# List of available legacy stdio backend modules.
-STDIO_LEGACY_MODULES = \
-  ethos_stdio \
-  stdio_ethos \
-  #
-
-ifeq (,$(filter $(STDIO_LEGACY_MODULES),$(USEMODULE)))
-  USEMODULE += stdio
-endif
+USEMODULE += stdio
 
 ifneq (,$(filter stdin,$(USEMODULE)))
   USEMODULE += isrpipe


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

It always bothered me a bit that `stdio_ethos` does not use the new `stdio_provider` infrastructure. For that it needs to unescape the text frames inside the ISR so it can write the data directly to the stdio isrpipe.

For all practical purposes, there is no reason to use `ethos` over `slipmux` since we don't need Ethernet emulation over UART, SLIP will offer less overhead.



### Testing procedure

I ran `examples/networking/gnrc/border_router` on `same54-xpro`, which defaults to `ethos`.

It did survive a `ping -f` while doing stdio (with some lost frames on both stdio and ethernet)

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- GitHub Copilot with Claude Sonnet 4.6 for porting the driver
