### PR TITLE
dist/tools/compile_commands: add -Wdocumentation for --clangd

### DIFF
--- a/dist/tools/compile_commands/compile_commands.py
+++ b/dist/tools/compile_commands/compile_commands.py
@@ -251,7 +251,15 @@ def generate_module_compile_commands(path, state, args):
             pass
 
     if args.clangd:
+        # Inject flags for better user experience if compile commands are
+        # intended to be consumed by clangd: We do not care if those are
+        # matching 100% what the compiler uses, but rather about best linting
+        # experience.
         cdetails.cflags.append('-Wno-unknown-warning-option')
+        cdetails.cflags.append('-Wdocumentation')
+        # This flag should be removed once all deprecations use the
+        # __attribute__((deprecated)) flag.
+        cdetails.cflags.append('-Wno-documentation-deprecated-sync')
 
     c_extra_includes = []
     cxx_extra_includes = []


### PR DESCRIPTION
### Contribution description

In case the user called with `--clangd`, we should try to give the best linting experience to users. Adding `-Wdocumentation` is particularly helpful for writing Doxygen markup, as it will directly in the editor point out when e.g. `@param <key>` is not matching any of the arguments.

### Testing procedure

Run `make compile-commands`, then open a header in a clangd enabled editor and rename a function parameter without changing the the corresponding `@param`. Now the editor should remind you to keep the parameter in sync.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
