### PR TITLE
pkg/decadriver: Port decadriver for dw3000 UWB chips

### DIFF
--- a/LICENSES/LicenseRef-QORVO-2.txt
+++ b/LICENSES/LicenseRef-QORVO-2.txt
@@ -1,0 +1,53 @@
+LicenseID:  LicenseRef-Qorvo-2
+
+ExtractedText: <text>
+Copyright (c) 2024, Qorvo US, Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions, and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+3. You may only use this software, with or without any modification, with an
+ integrated circuit developed by Qorvo US, Inc. or any of its affiliates
+ (collectively, "Qorvo"), or any module that contains such integrated circuit.
+
+4. You may not reverse engineer, disassemble, decompile, decode, adapt, or
+ otherwise attempt to derive or gain access to the source code to any software
+ distributed under this license in binary or object code form, in whole or in
+ part.
+
+5. You may not use any Qorvo name, trademarks, service marks, trade dress,
+ logos, trade names, or other symbols or insignia identifying the source of
+ Qorvo's products or services, or the names of any of Qorvo's developers to
+ endorse or promote products derived from this software without specific prior
+ written permission from Qorvo US, Inc. You must not call products derived from
+ this software "Qorvo", you must not have "Qorvo" appear in their name, without
+ the prior permission from Qorvo US, Inc.
+
+6. Qorvo may publish revised or new version of this license from time to time.
+ No one other than Qorvo US, Inc. has the right to modify the terms applicable
+ to the software provided under this license.
+
+THIS SOFTWARE IS PROVIDED BY QORVO US, INC. "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. NEITHER
+ QORVO, NOR ANY PERSON ASSOCIATED WITH QORVO MAKES ANY WARRANTY OR
+ REPRESENTATION WITH RESPECT TO THE COMPLETENESS, SECURITY, RELIABILITY, OR
+ ACCURACY OF THE SOFTWARE, THAT IT IS ERROR FREE OR THAT ANY DEFECTS WILL BE
+ CORRECTED, OR THAT THE SOFTWARE WILL OTHERWISE MEET YOUR NEEDS OR EXPECTATIONS.
+IN NO EVENT SHALL QORVO OR ANYBODY ASSOCIATED WITH QORVO BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</text>

--- a/pkg/decadriver/Makefile
+++ b/pkg/decadriver/Makefile
@@ -1,0 +1,13 @@
+PKG_NAME=decadriver
+PKG_URL=https://github.com/br101/dw3000-decadriver-source
+# Commit from July 22nd 2026
+PKG_VERSION=effcf6e601d20c323e8932575692bd7d565b8720
+# The code by br101 is licensed under ISC while the original Qorvo code has a
+# custom license from Qorvo. The license is attached to the sources.
+PKG_LICENSE=ISC AND LicenseRef-QORVO-2
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+all:
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(CURDIR)/Makefile.$(PKG_NAME)
+	$(QQ)"$(MAKE)" -C $(RIOTPKG)/decadriver/platform

--- a/pkg/decadriver/Makefile.decadriver
+++ b/pkg/decadriver/Makefile.decadriver
@@ -1,0 +1,37 @@
+MODULE=decadriver
+
+ifneq (,$(filter decadriver_dw3000,$(USEMODULE)))
+  SRC += dwt_uwb_driver/dw3000/dw3000_device.c
+  CFLAGS += -DCONFIG_DW3000_CHIP_DW3000=1
+endif
+
+ifneq (,$(filter decadriver_dw3720,$(USEMODULE)))
+  SRC += dwt_uwb_driver/dw3720/dw3720_device.c
+  CFLAGS += -DCONFIG_DW3000_CHIP_DW3720=1
+endif
+
+SRC += dwt_uwb_driver/deca_interface.c
+SRC += dwt_uwb_driver/deca_rsl.c
+SRC += dwt_uwb_driver/lib/qmath/src/qmath.c
+
+SRC += platform/deca_compat.c
+SRC += platform/dw3000_spi_trace.c
+
+INCLUDES += -I$(PKGDIRBASE)/decadriver/dwt_uwb_driver/lib/qmath/include
+
+CFLAGS += -Wno-overflow
+CFLAGS += -Wno-unused-parameter
+CFLAGS += -Wno-pointer-to-int-cast
+CFLAGS += -Wno-unused-but-set-variable
+CFLAGS += -Wno-unused-function
+CFLAGS += -Wno-return-type
+CFLAGS += -Wno-constant-conversion
+CFLAGS += -Wno-unknown-attributes
+
+# The ESP8266 compiler errorneously creates signed outputs from unsigned inputs
+# on shift operations.
+ifeq (esp8266,$(CPU))
+  CFLAGS += -Wno-sign-compare
+endif
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/decadriver/Makefile.dep
+++ b/pkg/decadriver/Makefile.dep
@@ -1,0 +1,13 @@
+USEMODULE += core_thread_flags
+USEMODULE += periph_gpio
+USEMODULE += periph_gpio_irq
+USEMODULE += periph_spi
+USEMODULE += ztimer
+USEMODULE += ztimer_msec
+
+USEMODULE += decadriver_riot
+
+# if no chip variant has been selected, use DW3000 as default
+ifeq (,$(filter decadriver_dw%,$(USEMODULE)))
+  USEMODULE += decadriver_dw3000
+endif

--- a/pkg/decadriver/Makefile.include
+++ b/pkg/decadriver/Makefile.include
@@ -1,0 +1,9 @@
+# Include headers provided by decadriver
+INCLUDES += -isystem$(PKGDIRBASE)/decadriver/dwt_uwb_driver
+INCLUDES += -isystem$(PKGDIRBASE)/decadriver/platform
+
+# Include headers for device config in platform code
+INCLUDES += -I$(RIOTPKG)/decadriver/platform/include
+
+PSEUDOMODULES += decadriver_dw3000
+PSEUDOMODULES += decadriver_dw3720

--- a/pkg/decadriver/doc.md
+++ b/pkg/decadriver/doc.md
@@ -1,0 +1,23 @@
+@defgroup pkg_decadriver Decadriver for Qorvo DW3000
+@ingroup  pkg
+@brief    RIOT adaptation of br101's adaptation of Qorvo's decadriver
+
+This package implements the adaptation layer of the
+[decadriver adaptation by br101](https://github.com/br101/dw3000-decadriver-source).
+This adaptation allows only *one DW3000* chip per system, with the benefit of
+using less resources.
+
+@see https://forum.qorvo.com/uploads/short-url/xD3TlXKvkujjdUaJWXv2b4E7GQN.pdf
+     for documentation of what the driver implements
+
+Similar to drivers, a `dw3000_params.h` includes the pin connection definition
+and can be overloaded just like any other driver, however only a single params
+definition can be added, as multiple DW3000 are not supported.
+
+@note The driver seems to also be compatible with DW3720, however no hardware
+      was available to verify this and specification and datasheets of the
+      DW3720 are also quite difficult to find.
+
+The DW3000 device is assumed by default using the package `decadriver`, but the
+DW3720 driver could be used instead by additionally specifying the
+`PSEUDOMODULE += decadriver_dw3720`.

--- a/pkg/decadriver/platform/Makefile
+++ b/pkg/decadriver/platform/Makefile
@@ -1,0 +1,3 @@
+MODULE=decadriver_riot
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/decadriver/platform/deca_port.c
+++ b/pkg/decadriver/platform/deca_port.c
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     pkg_decadriver
+ * @{
+ *
+ * @file
+ * @brief       Porting functions for decadriver like sleeping
+ *
+ * This file implements the functions required by decadriver
+ *
+ * @author      Simon Grund <mail@simongrund.de>
+ *
+ * @}
+ */
+#include "ztimer.h"
+
+#include "deca_interface.h"
+
+#include "dw3000_hw.h"
+#include "dw3000_spi.h"
+
+decaIrqStatus_t decamutexon(void)
+{
+    bool s = dw3000_hw_interrupt_is_enabled();
+    if (s) {
+        dw3000_hw_interrupt_disable();
+    }
+    return s;
+}
+
+void decamutexoff(decaIrqStatus_t s)
+{
+    if (s) {
+        dw3000_hw_interrupt_enable();
+    }
+}
+
+void deca_sleep(unsigned int time_ms)
+{
+    ztimer_sleep(ZTIMER_MSEC, time_ms);
+}
+
+/* The deca_usleep function seems to be unused or rarely used, so we do not
+ * want to activate `ZTIMER_USEC` for it. Instead, we sleep to the nearest
+ * time in milliseconds (rounded up). */
+void deca_usleep(unsigned long time_us)
+{
+    unsigned long time_ms = (time_us + 999) / 1000;
+    if (time_ms == 0) {
+        time_ms = 1;
+    }
+    ztimer_sleep(ZTIMER_MSEC, time_ms);
+}
+
+static const struct dwt_spi_s _dw3000_spi_fct = {
+    .readfromspi = dw3000_spi_read,
+    .writetospi = dw3000_spi_write,
+    .writetospiwithcrc = dw3000_spi_write_crc,
+    .setslowrate = dw3000_spi_speed_slow,
+    .setfastrate = dw3000_spi_speed_fast,
+};
+
+#if MODULE_DECADRIVER_DW3000
+extern const struct dwt_driver_s dw3000_driver;
+#elif MODULE_DECADRIVER_DW3720
+extern const struct dwt_driver_s dw3720_driver;
+#endif
+
+static const struct dwt_driver_s* _tmp_ptr[] = {
+#if MODULE_DECADRIVER_DW3000
+    &dw3000_driver,
+#elif MODULE_DECADRIVER_DW3720
+    &dw3720_driver
+#endif
+};
+
+const struct dwt_probe_s dw3000_probe_interf = {
+    .dw = NULL,
+    .spi = (void*)&_dw3000_spi_fct,
+    .wakeup_device_with_io = dw3000_hw_wakeup,
+    .driver_list = (struct dwt_driver_s**)_tmp_ptr,
+    .dw_driver_num = 1,
+};

--- a/pkg/decadriver/platform/dw3000_hw_spi.c
+++ b/pkg/decadriver/platform/dw3000_hw_spi.c
@@ -1,0 +1,270 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     pkg_decadriver
+ * @{
+ *
+ * @file
+ * @brief       Hardware (GPIO) and SPI abstraction for decadriver in RIOT
+ *
+ * @author      Simon Grund <mail@simongrund.de>
+ *
+ * @}
+ */
+#include "dw3000_hw.h"
+#include "dw3000_spi.h"
+#include "deca_device_api.h"
+#include "deca_interface.h"
+
+#include "dw3000_params.h"
+
+#include <stdint.h>
+
+#define ENABLE_DEBUG    0
+#include "debug.h"
+#include "periph/gpio.h"
+#include "periph/spi.h"
+#include "thread.h"
+#include "ztimer.h"
+
+/** Stack size of the user-space thread handling interrupts */
+#ifndef CONFIG_DECADRIVER_STACK_SIZE
+#  define CONFIG_DECADRIVER_STACK_SIZE          THREAD_STACKSIZE_MEDIUM
+#endif
+
+/**
+ * @brief Priority of the user-space thread handling interrupts
+ *
+ * Value inspired from GNRC_NETIF_PRIO */
+#ifndef CONFIG_DECADRIVER_ISR_THREAD_PRIO
+#  define CONFIG_DECADRIVER_ISR_THREAD_PRIO     (THREAD_PRIORITY_MAIN - 5)
+#endif
+
+
+static spi_clk_t _spi_speed = DW3000_PARAM_SPI_SPEED_SLOW;
+static bool _irq_active = false;
+static char _rx_stack[CONFIG_DECADRIVER_STACK_SIZE];
+static thread_t * _rx_thread_ptr = NULL;
+
+#define RX_THREAD_FLAG  1
+
+/* ------------------------------ dw3000_hw ------------------------------ */
+
+int dw3000_hw_init(void)
+{
+    _spi_speed = dw3000_params.spi_speed_slow;
+
+    if (gpio_is_valid(dw3000_params.reset)) {
+        gpio_init(dw3000_params.reset, GPIO_IN);
+    }
+
+    if (gpio_is_valid(dw3000_params.wakeup)) {
+        gpio_init(dw3000_params.wakeup, GPIO_OUT);
+    }
+
+    return dw3000_spi_init();
+}
+
+void dw3000_hw_reset(void)
+{
+    if (!gpio_is_valid(dw3000_params.reset)) {
+        /* If no reset pin is configured, try to reset via SPI.
+         * Note that this can lead to a NULL pointer access if this is called
+         * before dwt_probe() being successful. So to call reset initially, a
+         * reset pin is strongly recommended. */
+        DEBUG_PUTS("decadriver: dw3000_hw_reset() called without reset pin.\n"
+                   "            Attempting softreset...\n");
+        dw3000_spi_speed_slow();
+        dwt_softreset(0);
+        return;
+    }
+    else {
+        /* Interrupts need to be turned off before pulling reset low */
+        decaIrqStatus_t irq = decamutexon();
+
+        /* The timing values are taken from the Zephyr / nRF / ESP ports */
+        gpio_init(dw3000_params.reset, GPIO_OUT);
+        gpio_clear(dw3000_params.reset);
+        ztimer_sleep(ZTIMER_MSEC, 1);
+        gpio_init(dw3000_params.reset, GPIO_IN);
+        ztimer_sleep(ZTIMER_MSEC, 2);
+
+        decamutexoff(irq);
+    }
+}
+
+static void _interrupt_callback(void* arg)
+{
+    (void) arg;
+    thread_flags_set(_rx_thread_ptr, RX_THREAD_FLAG);
+}
+
+static void* _rx_thread(void* args)
+{
+    (void) args;
+
+    while (1) {
+        thread_flags_wait_any(RX_THREAD_FLAG);
+        while (gpio_read(dw3000_params.irq)) {
+            dwt_isr();
+        }
+    }
+    return NULL;
+}
+
+int dw3000_hw_init_interrupt(void)
+{
+    if (!gpio_is_valid(dw3000_params.irq)) {
+        DEBUG("decadriver: IRQ pin not configured");
+        return -ENOENT;
+    }
+
+    if (_rx_thread_ptr == NULL) {
+        kernel_pid_t pid = thread_create(_rx_stack, sizeof(_rx_stack),
+                                         CONFIG_DECADRIVER_ISR_THREAD_PRIO, 0,
+                                         _rx_thread, NULL, "deca rx");
+        if (pid < 0) {
+            return pid;
+        }
+        _rx_thread_ptr = thread_get(pid);
+    }
+
+    gpio_init_int(dw3000_params.irq, GPIO_IN, GPIO_RISING,
+                    _interrupt_callback, NULL);
+    _irq_active = true;
+    return 0;
+}
+
+void dw3000_hw_fini(void)
+{
+    dw3000_hw_interrupt_disable();
+    dw3000_spi_fini();
+}
+
+void dw3000_hw_wakeup(void)
+{
+    if (gpio_is_valid(dw3000_params.wakeup)) {
+        gpio_set(dw3000_params.wakeup);
+        ztimer_sleep(ZTIMER_MSEC, 1);
+        gpio_clear(dw3000_params.reset);
+    }
+    else {
+        dw3000_spi_wakeup();
+    }
+}
+
+void dw3000_hw_wakeup_pin_low(void)
+{
+    if (gpio_is_valid(dw3000_params.wakeup)) {
+        gpio_clear(dw3000_params.wakeup);
+    }
+}
+
+void dw3000_hw_interrupt_enable(void)
+{
+    if (gpio_is_valid(dw3000_params.irq)) {
+        gpio_irq_enable(dw3000_params.irq);
+        _irq_active = true;
+    }
+}
+
+void dw3000_hw_interrupt_disable(void)
+{
+    if (gpio_is_valid(dw3000_params.irq)) {
+        gpio_irq_disable(dw3000_params.irq);
+        _irq_active = false;
+    }
+}
+
+bool dw3000_hw_interrupt_is_enabled(void)
+{
+    return _irq_active;
+}
+
+/* ------------------------------ dw3000_spi ------------------------------ */
+
+int dw3000_spi_init(void)
+{
+    return spi_init_cs(dw3000_params.spi, dw3000_params.spi_cs);
+}
+
+void dw3000_spi_fini(void)
+{
+    return;
+}
+
+void dw3000_spi_wakeup(void)
+{
+    gpio_clear(dw3000_params.reset);
+    ztimer_sleep(ZTIMER_MSEC, 1);
+    gpio_set(dw3000_params.reset);
+}
+
+void dw3000_spi_speed_slow(void)
+{
+    _spi_speed = dw3000_params.spi_speed_slow;
+}
+
+void dw3000_spi_speed_fast(void)
+{
+    _spi_speed = dw3000_params.spi_speed_fast;
+}
+
+int32_t dw3000_spi_read(uint16_t headerLength, uint8_t* headerBuffer,
+                        uint16_t readLength, uint8_t* readBuffer)
+{
+    spi_acquire(dw3000_params.spi, dw3000_params.spi_cs,
+                dw3000_params.spi_mode, _spi_speed);
+    spi_transfer_bytes(dw3000_params.spi, dw3000_params.spi_cs, true,
+                       headerBuffer, NULL, headerLength);
+    spi_transfer_bytes(dw3000_params.spi, dw3000_params.spi_cs, false,
+                       NULL, readBuffer, readLength);
+    spi_release(dw3000_params.spi);
+    return DWT_SUCCESS;
+}
+
+int32_t dw3000_spi_write(uint16_t headerLength, const uint8_t* headerBuffer,
+                         uint16_t bodyLength, const uint8_t* bodyBuffer)
+{
+    /* This function is also used for commands only consisting of a header.
+     * So the body is full optional here. Only if it is given shall CS be held
+     * and the second spi_transfer_bytes() be called, otherwise leading to an
+     * assertion error in spi_transfer_bytes() */
+    bool has_body = bodyLength > 0;
+
+    spi_acquire(dw3000_params.spi, dw3000_params.spi_cs,
+                dw3000_params.spi_mode, _spi_speed);
+    spi_transfer_bytes(dw3000_params.spi, dw3000_params.spi_cs, has_body,
+                       headerBuffer, NULL, headerLength);
+    if (has_body) {
+        spi_transfer_bytes(dw3000_params.spi, dw3000_params.spi_cs, false,
+                           bodyBuffer, NULL, bodyLength);
+    }
+
+    spi_release(dw3000_params.spi);
+    return DWT_SUCCESS;
+}
+
+int32_t dw3000_spi_write_crc(uint16_t headerLength, const uint8_t* headerBuffer,
+                             uint16_t bodyLength, const uint8_t* bodyBuffer,
+                             uint8_t crc8)
+{
+    /* See dw3000_spi_write() */
+    bool has_body = bodyLength > 0;
+
+    spi_acquire(dw3000_params.spi, dw3000_params.spi_cs,
+                dw3000_params.spi_mode, _spi_speed);
+    spi_transfer_bytes(dw3000_params.spi, dw3000_params.spi_cs, true,
+                       headerBuffer, NULL, headerLength);
+    if (has_body) {
+        spi_transfer_bytes(dw3000_params.spi, dw3000_params.spi_cs, true,
+                           bodyBuffer, NULL, bodyLength);
+    }
+    spi_transfer_bytes(dw3000_params.spi, dw3000_params.spi_cs, false,
+                       &crc8, NULL, 1);
+    spi_release(dw3000_params.spi);
+    return DWT_SUCCESS;
+}

--- a/pkg/decadriver/platform/include/dw3000_conf.h
+++ b/pkg/decadriver/platform/include/dw3000_conf.h
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     pkg_decadriver
+ * @{
+ *
+ * @file
+ * @brief       Device configuration structs
+ *
+ * @author      Simon Grund <mail@simongrund.de>
+ */
+
+#include "periph/gpio.h"
+#include "periph/spi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Device initialization parameters
+ */
+typedef struct {
+    spi_t spi;                  /**< SPI */
+    gpio_t spi_cs;              /**< SPI CS pin */
+    /** @brief SPI operating mode
+     *
+     * If a something different than the default SPI mode (SPI_MODE_0) should be
+     * used, on the DW3000 two pins are used at startup to signal this. They are
+     * expected to be pulled to the correct setting manually, outside of this
+     * implementation. */
+    spi_mode_t spi_mode;
+    gpio_t irq;                 /**< pin to get interrupts from */
+    /** reset pin (optional, if not used set to GPIO_UNDEF) */
+    gpio_t reset;
+    /** wakeup pin (optional, if not used set to GPIO_UNDEF) */
+    gpio_t wakeup;
+    /** The fast mode speed (set with dw3000_spi_speed_fast()) */
+    spi_clk_t spi_speed_fast;
+    /** The slow mode speed (set with dw3000_spi_speed_slow()) */
+    spi_clk_t spi_speed_slow;
+} dw3000_params_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/pkg/decadriver/platform/include/dw3000_params.h
+++ b/pkg/decadriver/platform/include/dw3000_params.h
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     pkg_decadriver
+ * @{
+ *
+ * @file
+ * @brief       Default configuration for DW3000
+ *
+ * @author      Simon Grund <mail@simongrund.de>
+ */
+
+#include "board.h"
+/* Note: Since the dw3000.h is already used by decadriver, the name _conf.h is
+ * used here for the struct definitions */
+#include "dw3000_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters
+ *
+ * These default values correspond to the Qorvo DWM3000EVB Evaluation Shield
+ * on top of an nrf52840dk
+ * @{
+ */
+/** SPI device used */
+#ifndef DW3000_PARAM_SPI
+#  define DW3000_PARAM_SPI              SPI_DEV(0)
+#endif
+
+/** Chip Select pin for SPI */
+#ifndef DW3000_PARAM_SPI_CS
+#  define DW3000_PARAM_SPI_CS           GPIO_PIN(1, 12)
+#endif
+
+/** Mode that the SPI connection uses */
+#ifndef DW3000_PARAM_SPI_MODE
+#  define DW3000_PARAM_SPI_MODE         SPI_MODE_0
+#endif
+
+/** IRQ pin to receive interrupts from the DW3000 */
+#ifndef DW3000_PARAM_IRQ
+#  define DW3000_PARAM_IRQ              GPIO_PIN(1, 10)
+#endif
+
+/** Pin to reset the DW3000 */
+#ifndef DW3000_PARAM_RESET
+#  define DW3000_PARAM_RESET            GPIO_PIN(1, 8)
+#endif
+
+/**
+ * @brief Pin to wakeup the DW3000. Optional, set to GPIO_UNDEF if unused.
+ *
+ * If undefined, the DW3000 will be woken using SPI CS.
+ */
+#ifndef DW3000_PARAM_WAKEUP
+#  define DW3000_PARAM_WAKEUP           GPIO_PIN(1, 11)
+#endif
+
+/** The fast SPI speed. Can be activated after IDLE_RC */
+#ifndef DW3000_PARAM_SPI_SPEED_FAST
+#  define DW3000_PARAM_SPI_SPEED_FAST   SPI_CLK_10MHZ
+#endif
+
+/** The slow (and default) SPI speed */
+#ifndef DW3000_PARAM_SPI_SPEED_SLOW
+#  define DW3000_PARAM_SPI_SPEED_SLOW   SPI_CLK_1MHZ
+#endif
+
+/** Collection of all params. Only one device is allowed. */
+#ifndef DW3000_PARAMS
+#  define DW3000_PARAMS                 { .spi = DW3000_PARAM_SPI, \
+                                          .spi_cs = DW3000_PARAM_SPI_CS, \
+                                          .spi_mode = DW3000_PARAM_SPI_MODE, \
+                                          .irq = DW3000_PARAM_IRQ, \
+                                          .reset = DW3000_PARAM_RESET, \
+                                          .wakeup = DW3000_PARAM_WAKEUP, \
+                                          .spi_speed_fast = DW3000_PARAM_SPI_SPEED_FAST, \
+                                          .spi_speed_slow = DW3000_PARAM_SPI_SPEED_SLOW }
+#endif
+/**@}*/
+
+/**
+ * @brief   Configuration struct.
+ *
+ * The patched decadriver by br101 only allows a single device, with the benefit
+ * of reducing the code size and the reasoning that typical embedded devices
+ * will only ever use one DW3000 radio. Thus only a single params struct is
+ * allowed here.
+ */
+static const dw3000_params_t dw3000_params = DW3000_PARAMS;
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/tests/pkg/decadriver/Makefile
+++ b/tests/pkg/decadriver/Makefile
@@ -1,0 +1,12 @@
+include ../Makefile.pkg_common
+
+BOARD ?= nrf52840dk
+
+USEPKG += decadriver
+
+USEMODULE += fmt
+USEMODULE += ieee802154
+USEMODULE += shell
+USEMODULE += shell_cmds_default
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg/decadriver/Makefile.ci
+++ b/tests/pkg/decadriver/Makefile.ci
@@ -1,0 +1,13 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
+    atmega328p-xplained-mini \
+    atmega8 \
+    nucleo-f031k6 \
+    nucleo-l011k4 \
+    samd10-xmini \
+    stm32f030f4-demo \
+    #

--- a/tests/pkg/decadriver/README.md
+++ b/tests/pkg/decadriver/README.md
@@ -1,0 +1,113 @@
+## decadriver
+
+This test application can be used to verify the essential operations of a DW3000
+UWB module using the decadriver package. The DW3000 supports UWB channels 5 and
+9 and can be used for UWB ranging or data transmission.
+
+This test allows to verify the following capabilities:
+
+- Basic SPI communication with the module & module startup
+- Sending of frames
+- Reception of frames
+- Automatic generation (inside the DW3000) of ACKs
+- Frame filtering
+- Sleeping & Wakeup
+
+## Usage
+
+Compile the test for the board you are using and add the `_PARAMS` definitions
+for the pins used to connect to the DW3000.
+
+## Expected results
+
+### SPI communication & module startup
+
+The board should recognize the DW3000 chip and show successful initialization:
+```
+main(): This is RIOT! (Version: [...])
+[deca init] detected device id: deca0302
+[deca init] DW3xxx reached IDLE_RC
+[deca init] Device initialized and configured
+```
+
+### Reception of frames & Sending of frames & Auto ACK
+
+To send and receive frames you need a second DW3000 with the test flashed on the
+MCU of your choice.
+
+Use the `dw_addr` shell command to configure the MAC16 address of the module.
+In a real application both devices should have different addresses, but here it
+is not really necessary. By default the address is set to `0x0001`.
+
+#### Device 1
+```
+> dw_addr 1                                     # Set address to 0x0001
+dw_addr 1
+> dw_send 2 "Hello World!"                      # Send data to 0x0002
+dw_send 2 "Hello World!"
+[deca] TX sending (CRC bytes not included):
+618800CADE0200010048656C6C6F20576F726C6421
+[deca] TX complete
+[deca] RX ok with length 5:                     # Incoming ACK
+020000B8B5
+```
+
+#### Device 2
+```
+> dw_addr 2                                     # Set address to 0x0002
+dw_addr 2
+[deca] RX ok with length 23:
+618800CADE0200010048656C6C6F20576F726C6421349B
+[deca] TX complete                              # Outgoing ACK
+```
+
+The frames are 802.15.4 MAC frames. The frame generation is currently hard-coded
+and producing a data frame requesting an ACK. The DW3000 will handle the
+generation and verification of the CRC, i.e. it does not have to be calculated
+on the MCU.
+```
+6188 00 CADE 0200 0100 48656C6C6F20576F726C6421 349B
+|    |  |    |    |    |                        |
+Hdr. |  PAN  |    Src  |                        CRC
+     |       Dest      Payload "Hello World!"
+     Seq No.
+```
+
+### Frame filtering
+
+Frame filtering is enabled in this example. This means, frames with a
+destination other than the own address will not be processed further (But they
+will appear as an RX error).
+
+When sending a frame to another destination, the other device does not show the
+whole frame:
+#### Device 1
+```
+> dw_addr 1                                     # Set address to 0x0001
+dw_addr 1
+> dw_send 3 "Hi!"                               # Send to 0x0003
+dw_send 3 "Hi!"
+[deca] TX sending (CRC bytes not included):
+618801CADE03000100486921
+[deca] TX complete                              # Note: No ACK
+```
+
+#### Device 2
+```
+> dw_addr 2                                     # Set address to 0x0002
+dw_addr 2
+[deca] RX error: 0x23800f07                     # 0x20000000 shows frame filter
+```
+
+### Sleeping & Wakeup
+
+The DW3000 devices can sleep to reduce power consumption. Use the `dw_sleep`
+shell command to enter DEEPSLEEP state.
+
+Now, commands like `dw_addr` and `dw_send` on this device will likely not arrive
+(unless the SPI CS line is held down long enough during a normal SPI
+transaction to cause a wakeup).
+Frames sent from other devices will also not arrive.
+
+Use `dw_wakeup` to go back to the RX state, and frames can be sent and received
+again.

--- a/tests/pkg/decadriver/main.c
+++ b/tests/pkg/decadriver/main.c
@@ -1,0 +1,285 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Manual test application for DW3000 UWB devices
+ *
+ * This test can be used to verify the essential operations of a DW3000 (or
+ * DW3720) together with a MCU running RIOT. These include sending, receiving
+ * and sleeping.
+ *
+ * @author      Simon Grund <mail@simongrund.de>
+ *
+ * @}
+ */
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "fmt.h"
+#include "macros/utils.h"
+#include "net/ieee802154.h"
+#include "shell.h"
+
+#include "dw3000.h"
+#include "deca_device_api.h"
+
+/* PAN ID/short address */
+#define PAN_ID              0xDECA
+#define SHORT_ADDR_DEFAULT  0x0001
+
+static dwt_config_t _config = {
+    .chan = 9,
+    .txPreambLength = DWT_PLEN_64,
+    .rxPAC = DWT_PAC8,
+    .txCode = 11,
+    .rxCode = 11,
+    .sfdType = DWT_SFD_IEEE_4Z,
+    .dataRate = DWT_BR_6M8,
+    .phrMode = DWT_PHRMODE_STD,
+    .phrRate = DWT_PHRRATE_STD,
+    .sfdTO = (64 + 1 + 8 - 8),   /* (plen + 1 + SFD length - PAC size) */
+    .stsMode = DWT_STS_MODE_OFF, /* DWT_STS_MODE_1 | DWT_STS_MODE_SDC, */
+    .stsLength = DWT_STS_LEN_64,
+    .pdoaMode = DWT_PDOA_M0,     /* off */
+};
+
+#define FRAME_LEN_MAX   127
+static uint8_t _rx_buffer[FRAME_LEN_MAX];
+static uint8_t _tx_buffer[FRAME_LEN_MAX];
+
+static uint8_t _seq_no = 0;
+static uint16_t _self_address = SHORT_ADDR_DEFAULT;
+static bool _sleeping = false;
+
+static void _send_tx(uint16_t dest, uint8_t* buf, uint16_t len)
+{
+    network_uint16_t src = byteorder_htons(_self_address);
+    network_uint16_t dst = byteorder_htons(dest);
+    le_uint16_t pan      = byteorder_htols(PAN_ID);
+
+    size_t hdr_len = ieee802154_set_frame_hdr(_tx_buffer,
+                                              src.u8, 2,
+                                              dst.u8, 2,
+                                              pan, pan,
+                                              IEEE802154_FCF_TYPE_DATA |
+                                              IEEE802154_FCF_ACK_REQ |
+                                              IEEE802154_FCF_PAN_COMP,
+                                              _seq_no++);
+
+    /* Size of payload capped by the remaining size in the buffer*/
+    uint16_t payload_len = MIN(len, FRAME_LEN_MAX - hdr_len);
+    memcpy(_tx_buffer + hdr_len, buf, payload_len);
+
+    puts("[deca] TX sending (CRC bytes not included):");
+    print_bytes_hex(_tx_buffer, hdr_len + payload_len);
+    puts("");
+
+    dwt_forcetrxoff();
+    dwt_writetxdata(hdr_len + payload_len, _tx_buffer, 0);
+    /* This function needs to include the two CRC bytes */
+    dwt_writetxfctrl(hdr_len + payload_len + FCS_LEN, 0, 0);
+    dwt_starttx(DWT_START_TX_IMMEDIATE | DWT_RESPONSE_EXPECTED);
+}
+
+static void _irq_tx_done_cb(const dwt_cb_data_t* dat)
+{
+    (void) dat;
+    /* Either the ACK has been sent or a message was sent.
+     * Either way, listen for new data. */
+    dwt_rxenable(DWT_START_RX_IMMEDIATE);
+    puts("[deca] TX complete");
+}
+
+static void _irq_rx_ok_cb(const dwt_cb_data_t* dat)
+{
+    (void) dat;
+    uint16_t frame_len = dwt_getframelength(NULL);
+    printf("[deca] RX ok with length %"PRIu16":\n", frame_len);
+
+    if (frame_len <= FRAME_LEN_MAX) {
+        dwt_readrxdata(_rx_buffer, frame_len, 0);
+        print_bytes_hex(_rx_buffer, frame_len);
+        puts("");
+    }
+
+    if (!(_rx_buffer[0] & IEEE802154_FCF_ACK_REQ)) {
+        /* If no ACK is requested, continue RX immediately. Otherwise wait for
+         * the interrupt and the callback in _irq_tx_done_cb() */
+        dwt_rxenable(DWT_START_RX_IMMEDIATE);
+    }
+}
+
+static void _irq_err_cb(const dwt_cb_data_t* dat)
+{
+    (void) dat;
+    printf("[deca] RX error: 0x%"PRIx32"\n", dat->status);
+    dwt_rxenable(DWT_START_RX_IMMEDIATE);
+}
+
+/* Note 1: These callbacks happen on the driver "isr" thread, but outside of
+ *         ISR.
+ * Note 2: The dwt_isr() takes care of clearing the status register, so contrary
+ *         to the example using polling, no dwt_writesysstatuslo() is needed. */
+dwt_callbacks_s _dwt_callbacks = {
+    .cbTxDone = _irq_tx_done_cb,
+    .cbRxOk = _irq_rx_ok_cb,
+    .cbRxErr = _irq_err_cb,
+};
+
+static int _dw_send(int argc, char **argv)
+{
+    if (argc < 3) {
+        puts("Usage: dw_send <dest (hex without 0x)> <payload>");
+        return 0;
+    }
+
+    if (_sleeping) {
+        puts("Device is sleeping, commands will likely not arrive.");
+    }
+
+    uint32_t dest = scn_u32_hex(argv[1], 4);
+    _send_tx(dest, (uint8_t*) argv[2], strlen(argv[2]));
+
+    return 0;
+}
+
+static int _dw_addr(int argc, char **argv)
+{
+    if (argc < 2) {
+        puts("Usage: dw_addr <addr (hex without 0x)>");
+        return 0;
+    }
+
+    if (_sleeping) {
+        puts("Device is sleeping, commands will likely not arrive.");
+    }
+
+    _self_address = scn_u32_hex(argv[1], 4);
+    dwt_setaddress16(_self_address);
+
+    return 0;
+}
+
+static int _dw_sleep(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+
+    puts("[deca] Going to deepsleep. Use dw_wakeup to wake up.");
+    dwt_configuresleep(DWT_PGFCAL | DWT_GOTORX | DWT_RUNSAR | DWT_CONFIG,
+                       DWT_WAKE_CSN | DWT_WAKE_WUP | DWT_SLP_EN);
+
+    dw3000_hw_wakeup_pin_low();
+    _sleeping = true;
+    dwt_entersleep(DWT_DW_IDLE_RC);
+
+    return 0;
+}
+
+static int _dw_wakeup(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+
+    puts("[deca] Waking up...");
+
+    dw3000_hw_wakeup();
+    _sleeping = false;
+
+    return 0;
+}
+
+SHELL_COMMAND(dw_send, "Send UWB data frame", _dw_send);
+SHELL_COMMAND(dw_addr, "Set UWB 16 bit MAC address", _dw_addr);
+SHELL_COMMAND(dw_sleep, "Set DW3000 to deepsleep", _dw_sleep);
+SHELL_COMMAND(dw_wakeup, "Wake up the DW3000 again", _dw_wakeup);
+
+int main(void)
+{
+    dw3000_hw_init();
+    dw3000_hw_init_interrupt();
+    dw3000_hw_reset();
+
+    dwt_probe((struct dwt_probe_s *)&dw3000_probe_interf);
+    uint32_t dev_id = dwt_readdevid();
+    printf("[deca init] detected device id: %"PRIx32"\n", dev_id);
+
+    /* The API guide says it is recommended to check for idle rc before
+     * dwt_initialse(), while libdeca does the other order. */
+    while (!dwt_checkidlerc()) {};
+    puts("[deca init] DW3xxx reached IDLE_RC");
+
+    if (dwt_initialise(DWT_DW_IDLE) != DWT_SUCCESS) {
+        puts("[deca init] Error initializing device");
+        return 1;
+    }
+
+    /* After idle rc the SPI speed can be increased */
+    dw3000_spi_speed_fast();
+
+    if (dwt_configure(&_config) != DWT_SUCCESS) {
+        puts("[deca init] Error configuring device to given parameters");
+        return 1;
+    }
+    dwt_setrxtimeout(0);
+
+    dwt_setpanid(PAN_ID);
+    dwt_setaddress16(_self_address);
+
+    dwt_configureframefilter(DWT_FF_ENABLE_802_15_4, DWT_FF_DATA_EN |
+                                                     DWT_FF_ACK_EN);
+    /* The ACK delay here is arbitrarily high so that the sender is ready for
+     * receive again. It might be tuned to be lower. */
+    dwt_enableautoack(250, 1);
+
+    dwt_setcallbacks(&_dwt_callbacks);
+    /* Note: Making the wrong choice of interrupts here can lead to weird
+     *  problems, be aware.
+     *  For example, using SYS_STATUS_ALL_RX_GOOD (which one might expect to be
+     *  a mask for all good frame receptions) leads to RX errors. Why? (likely)
+     *  Because interrupts trigger already when *only the preamble* was detected
+     *  (looking at RXPRD), which seems to then cause some issues when
+     *  interacting with the DW3000 at that time, leading to no RX GOOD, but
+     *  instead an RX ERROR. In the end the values also used in libdeca seem
+     *  to work well here.
+     * Also, the ARFE interrupt (frame filter error) has to be set so to
+     *  generate an interrupt when a frame NOT matching the filter is received.
+     *  I would have expected that RX continues when a frame with the wrong
+     *  destination is received, but subsequent frames to the correct
+     *  destination do NOT arrive. This is especially weird since the DW3000
+     *  user manual says the benefit is to "only interrupt the host processor
+     *  when a frame arrives that passes the frame filtering criteria", but it
+     *  seems an interrupt is needed either way. This (unanswered) forum post
+     *  reported this too:
+     *  https://forum.qorvo.com/t/frame-filtering-rejection-stops-rx-why/17671*/
+    dwt_setinterrupt(DWT_INT_RXFCG_BIT_MASK | /* <-- RX success */
+                     /* RX errors: */
+                     DWT_INT_RXPHE_BIT_MASK |
+                     DWT_INT_RXFCE_BIT_MASK |
+                     DWT_INT_RXFSL_BIT_MASK |
+                     DWT_INT_RXSTO_BIT_MASK |
+                     DWT_INT_CIAERR_BIT_MASK |
+                     DWT_INT_ARFE_BIT_MASK |
+                     /* RX timeouts: */
+                     DWT_INT_RXFTO_BIT_MASK |
+                     DWT_INT_RXPTO_BIT_MASK |
+                     /* TX done: */
+                     DWT_INT_TXFRS_BIT_MASK,
+                     0, DWT_ENABLE_INT_ONLY);
+
+    puts("[deca init] Device initialized and configured");
+
+    dwt_rxenable(DWT_START_RX_IMMEDIATE);
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}


### PR DESCRIPTION
Add a new package "decadriver", which ports br101's adaptation of the Qorvo decadriver used for dw3000 (and dw3720) UWB chips.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

- Port of https://github.com/br101/dw3000-decadriver-source
- RIOT adaption layer for GPIO, SPI, ztimer
- `_params.h` in usual driver style for reconfiguration of pins / other options

I decided against the inclusion in `drivers/` since the struct requires that
"This device descriptor MUST contain all the state data of a device" (https://guide.riot-os.org/advanced_tutorials/device_drivers/), which cannot be done here. 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### TODO

- [x] There are some TODOs in the Code left
- [x] Some example / test to compile


### Testing procedure

`tests/pkg/decadriver` to test the sending & receiving of frames between two DW3000. Additionally this can test the sleeping state.

The expected (and observed output of a DWM3000 evaluation shield on an nrf52840dk) is given in the README of the test and in a comment further down below. MAC frames are received on the other device iff the address matches. Automatic ACK generation works. The devices can enter sleep mode where they are not responsive to SPI and can be woken up again.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

none

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none for anything code related
- Possibly asked ChatGPT for some conceptual things
