### PR TITLE
dist/tools/commit-msg: check the first commit too

### DIFF
--- a/dist/tools/commit-msg/check.sh
+++ b/dist/tools/commit-msg/check.sh
@@ -57,7 +57,7 @@ fi
 
 ERROR="$(git log \
     --no-merges --pretty=format:'%s' "$(git merge-base "${BRANCH}" HEAD)"..HEAD | \
-    while read -r msg; do
+    while read -r msg || [ -n "$msg" ]; do
         ERROR=0
         MSG=""
 


### PR DESCRIPTION
### Contribution description

As it turns out, the combination of `git log`, `read` and `while` has weird implications. `git log` does not print an additional newline at the end of the commit list. That means, that `read` will find an `EOF` at the last entry (the first commit) and return `1`, which makes `while` abort. If the list is only one entry long, the code inside of the `while` loop is never executed, if it is longer, the last entry (which is the first commit) is omitted.

However, `read` will set the `msg` variable before returning, so a check can be added to see if the line is empty or not. If it is not, we execute one last round in the loop (or the first round for single commit PRs).

It would appear that this bug has been present since the skript was added 9 years ago.


### Testing procedure

The `commit-msg` check should fail in this PR. Other than that, you can test the code line isolated in your shell:

Situation in `master`: first commit is omitted:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ git log --pretty=format:'%s' -n2
dist/tools/commit-msg: check the last commit too
README: totally unrelated change that I made to have the commit-msg check fail for a long line
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ BRANCH=master; git log     --no-merges --pretty=format:'%s' "$(git merge-base "${BRANCH}" HEAD)"..HEAD |     while read -r msg; do echo "${msg}"; done
dist/tools/commit-msg: check the last commit too
```

Situation in this PR: first commit is also printed.
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ git log --pretty=format:'%s' -n2
dist/tools/commit-msg: check the last commit too
README: totally unrelated change that I made to have the commit-msg check fail for a long line
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ BRANCH=master; git log     --no-merges --pretty=format:'%s' "$(git merge-base "${BRANCH}" HEAD)"..HEAD |     while read -r msg || [ -n "$msg" ]; do echo "${msg}"; done
dist/tools/commit-msg: check the last commit too
README: totally unrelated change that I made to have the commit-msg check fail for a long line
```

### Issues/PRs references

Discoverd in #22421 that only has one commit and a long commit message.

### Declaration of AI-Tools / LLMs usage:

Asked ChatGPT about the weird shell syntax and stuff like that, ya know.