### PR TITLE
sys/isrpipe: fix isrpipe_write() return value documentation

### DIFF
--- a/sys/include/isrpipe.h
+++ b/sys/include/isrpipe.h
@@ -77,8 +77,8 @@ int isrpipe_write_one(isrpipe_t *isrpipe, uint8_t c);
  * @param[in]   buf         bytes to add to isrpipe buffer
  * @param[in]   n           number of bytes to add from buf to isrpipe's buffer
  *
- * @returns     number of bytes that could be added
- * @returns     -1 if buffer was full
+ * @returns     Number of bytes that have been added. Can be less than @p n
+ *              if the buffer had insufficient space.
  */
 int isrpipe_write(isrpipe_t *isrpipe, const uint8_t *buf, size_t n);
 


### PR DESCRIPTION
### Contribution description

The value -1 is not returned by [isrpipe_write](https://github.com/RIOT-OS/RIOT/blob/master/sys/isrpipe/isrpipe.c#L40) (or from [tsrb_add](https://github.com/RIOT-OS/RIOT/blob/master/sys/include/tsrb.h#L199) or [turb_add](https://github.com/RIOT-OS/RIOT/blob/master/sys/include/turb.h#L218)). Only the bytes number of bytes added is returned, which can be less than the number of bytes to add, or even 0 when the buffer was already full.

### Testing procedure

Documentation only.

### Issues/PRs references

#22429

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
