### PR TITLE
cpu/esp32/periph: fix esp32c6 timer clk

### DIFF
--- a/cpu/esp32/periph/timer.c
+++ b/cpu/esp32/periph/timer.c
@@ -27,6 +27,7 @@
 #include "esp_cpu.h"
 #include "esp_private/periph_ctrl.h"
 #include "esp_rom_sys.h"
+#include "hal/clk_tree_ll.h"
 #include "hal/timer_hal.h"
 #include "hal/timer_ll.h"
 #include "rom/ets_sys.h"
@@ -59,6 +60,19 @@
 #define TIMER_1         1
 
 /* hardware timer modules used */
+
+#if CPU_FAM_ESP32 || CPU_FAM_ESP32S2 || CPU_FAM_ESP32S3 || CPU_FAM_ESP32C3
+/* For ESP32, ESP32-S2, ESP32-S3, ESP32-C2 and ESP32-C3, the TIMER_CLOCK_FREQ
+ * is based on APB_CLK_FREQ. This is fixed at 80MHz for CPU clock frequencies
+ * >=80MHz and equal to the CPU clock frequency for CPU clock frequencies <80Mhz. */
+#  define TIMER_CLOCK_FREQ rtc_clk_apb_freq_get() /* APB_CLK is used */
+#elif CPU_FAM_ESP32C6
+#  define TIMER_CLOCK_FREQ ((uint32_t)CLK_LL_PLL_80M_FREQ_MHZ * MHZ)  /* PLL_F80M_CLK is used */
+#elif CPU_FAM_ESP32H2
+#  define TIMER_CLOCK_FREQ ((uint32_t)CLK_LL_PLL_48M_FREQ_MHZ * MHZ)  /* PLL_F48M_CLK is used */
+#else
+#  error "Platform implementation is missing"
+#endif
 
 /**
  * ESP32 and ESP32-S2 have four 64 bit hardware timers while ESP32-S3 has four
@@ -196,7 +210,7 @@ int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
     DEBUG("%s dev=%u freq=%" PRIu32 " cb=%p arg=%p\n",
           __func__, dev, freq, cb, arg);
 
-    uint32_t clk_div = rtc_clk_apb_freq_get() / freq;
+    uint32_t clk_div = TIMER_CLOCK_FREQ / freq;
 
     assert(dev <  HW_TIMER_NUMOF);
     assert(clk_div >= 2 && clk_div <= 65536);

--- a/cpu/esp_common/periph/uart.c
+++ b/cpu/esp_common/periph/uart.c
@@ -72,19 +72,15 @@
 #include "soc/uart_pins.h"
 
 #undef  UART_CLK_FREQ
-
 #if CPU_FAM_ESP32 || CPU_FAM_ESP32S2 || CPU_FAM_ESP32S3 || CPU_FAM_ESP32C3
-/* UART_CLK_FREQ corresponds to APB_CLK_FREQ for ESP32, ESP32-S2, ESP32-S3,
- * ESP32-C2 and ESP32-C3, which is a fixed frequency of 80 MHz. However,
- * this only applies to CPU clock frequencies of 80 MHz and above.
- * For lower CPU clock frequencies, the APB clock corresponds to the CPU clock
- * frequency. Therefore, we need to determine the actual UART clock frequency
- * from the actual APB clock frequency. */
+/* For ESP32, ESP32-S2, ESP32-S3, ESP32-C2 and ESP32-C3, the UART_CLK_FREQ
+ * is based on APB_CLK_FREQ. This is fixed at 80MHz for CPU clock frequencies
+ * >=80MHz and equal to the CPU clock frequency for CPU clock frequencies <80Mhz. */
 #  define UART_CLK_FREQ rtc_clk_apb_freq_get() /* APB_CLK is used */
 #elif CPU_FAM_ESP32C6
-#  define UART_CLK_FREQ (CLK_LL_PLL_80M_FREQ_MHZ * MHZ)  /* PLL_F80M_CLK is used */
+#  define UART_CLK_FREQ ((uint32_t)CLK_LL_PLL_80M_FREQ_MHZ * MHZ)  /* PLL_F80M_CLK is used */
 #elif CPU_FAM_ESP32H2
-#  define UART_CLK_FREQ (CLK_LL_PLL_48M_FREQ_MHZ * MHZ)  /* PLL_F48M_CLK is used */
+#  define UART_CLK_FREQ ((uint32_t)CLK_LL_PLL_48M_FREQ_MHZ * MHZ)  /* PLL_F48M_CLK is used */
 #else
 #  error "Platform implementation is missing"
 #endif


### PR DESCRIPTION

### Contribution description

This PR fixes the timer clock source used on the ESP32-C6 in the GPTimer peripheral.

The existing implementation always used rtc_clk_apb_freq_get() to calculate the timer clock divider. While this is correct for ESP32, ESP32-S2, ESP32-S3 and ESP32-C3, the ESP32-C6 GPTimer is clocked from the fixed 80 MHz PLL (PLL_F80M_CLK) instead of the APB clock.


### Testing procedure

hello world application on esp32c6 board: 
Test application: examples/hello-world on an ESP32-C6 board

I used the hello-world example because it is a minimal application that helps me isolate issues and eliminates the influence of other modules or application logic. 
I used it  the app to check the timer. 

**Makefile:**
```
BOARD ?= add_your_board
FEATURES_REQUIRED = periph_timer
USEMODULE += ztimer_msec
TIMER_SPEED ?= 1000000

CFLAGS += -DTIMER_SPEED=$(TIMER_SPEED)
```

**main.c**

```
/*
 * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
 * SPDX-License-Identifier: LGPL-2.1-only
 */

/**
 * @ingroup     examples
 * @{
 *
 * @file
 * @brief       Hello World application
 *
 * @author      Kaspar Schleiser <kaspar@schleiser.de>
 * @author      Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
 *
 * @}
 */

#include <stdio.h>
#include "ztimer.h"
#include "periph/timer.h"

static void cb(void *arg, int chan)
{
    (void)arg;
    (void)chan;
    puts("timer fired");
}

int main(void)
{
   
    puts("Hello World!");

    printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
    printf("This board features a(n) %s CPU.\n", RIOT_CPU);

    printf("Available timers: %i\n", TIMER_NUMOF);
    timer_init(TIMER_DEV(0), 1000000, cb, NULL);
    timer_stop(TIMER_DEV(0));
    
    timer_set(TIMER_DEV(0), 0, 1000000);
    timer_start(TIMER_DEV(0));
    puts("timer set for 1 second, waiting for callback...");
    while (1) {
        ztimer_sleep(ZTIMER_MSEC, 100);
    }
    return 0;
}

```
**without the fix:**

2026-07-10 10:21:10,997 # Hello World!
2026-07-10 10:21:10,998 # You are running RIOT on a(n) index_wr_tracker board.
2026-07-10 10:21:10,999 # This board features a(n) esp32 CPU.
2026-07-10 10:21:10,999 # Available timers: 1
2026-07-10 10:21:10,999 # timer set for 1 second, waiting for callback...
2026-07-10 10:21:11,499 # timer fired

**with the fix:**

2026-07-10 10:22:42,063 # Hello World!
2026-07-10 10:22:42,064 # You are running RIOT on a(n) index_wr_tracker board.
2026-07-10 10:22:42,064 # This board features a(n) esp32 CPU.
2026-07-10 10:22:42,064 # Available timers: 1
2026-07-10 10:22:42,065 # timer set for 1 second, waiting for callback...
2026-07-10 10:22:43,064 # timer fired

**Issues/PRs references**

None.

**Declaration of AI-Tools / LLMs usage:**

AI-Tools / LLMs that were used are:

    none


