### PR TITLE
drivers/ds18: fix 1-Wire signaling to use open-drain output

### DIFF
--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -151,6 +151,11 @@ typedef enum {
 } gpio_mode_t;
 /** @} */
 
+/**
+ * @brief Compile-time flag: platform supports combined input + open-drain mode
+ */
+#define HAVE_GPIO_IN_OD_PU
+
 /* BEGIN: GPIO LL overwrites */
 
 #if SOC_GPIO_PIN_COUNT > 32

--- a/drivers/ds18/ds18.c
+++ b/drivers/ds18/ds18.c
@@ -29,15 +29,22 @@
 
 static void ds18_low(const ds18_t *dev)
 {
-    /* Set gpio as output and clear pin */
-    gpio_init(dev->params.pin, GPIO_OUT);
+    /* Clear pin */
+    if (dev->params.out_mode != dev->params.in_mode) {
+        gpio_init(dev->params.pin, dev->params.out_mode);
+    }
     gpio_clear(dev->params.pin);
 }
 
 static void ds18_release(const ds18_t *dev)
 {
-    /* Init pin as input */
-    gpio_init(dev->params.pin, dev->params.in_mode);
+    /* Set pin */
+    if (dev->params.out_mode != dev->params.in_mode) {
+        gpio_init(dev->params.pin, dev->params.in_mode);
+    }
+    else {
+        gpio_set(dev->params.pin);
+    }
 }
 
 static void ds18_write_bit(const ds18_t *dev, uint8_t bit)
@@ -203,16 +210,23 @@ int ds18_get_temperature(const ds18_t *dev, int16_t *temperature)
 
 int ds18_init(ds18_t *dev, const ds18_params_t *params)
 {
-    int res;
-
     dev->params = *params;
 
     /* Deduct the input mode from the output mode. If pull-up resistors are
      * used for output then will be used for input as well. */
     dev->params.in_mode = (dev->params.out_mode == GPIO_OD_PU) ? GPIO_IN_PU : GPIO_IN;
 
-    /* Initialize the device and the pin */
-    res = gpio_init(dev->params.pin, dev->params.in_mode) == 0 ? DS18_OK : DS18_ERROR;
-
-    return res;
+#if defined(HAVE_GPIO_IN_OD_PU)
+    if (gpio_init(dev->params.pin, GPIO_IN_OD_PU) == 0) {
+        dev->params.out_mode = GPIO_IN_OD_PU;
+        dev->params.in_mode  = GPIO_IN_OD_PU;
+    }
+    else
+#endif
+    {
+        dev->params.in_mode = (dev->params.out_mode == GPIO_OD_PU) ? GPIO_IN_PU : GPIO_IN;
+        gpio_init(dev->params.pin, dev->params.in_mode);
+    }
+    gpio_set(dev->params.pin);
+    return DS18_OK;
 }


### PR DESCRIPTION

### Contribution description

This fixes  the ds18 driver for DS18B20/DS1822 temperature sensors on platforms where gpio_init() introduces significant reconfiguration overhead.

**Bug:** The previous implementation called gpio_init() on every single bit operation, switching the pin between GPIO_OUT and GPIO_IN/GPIO_IN_PU inside ds18_low() and ds18_release(). On some MCUs, this reconfiguration takes long enough to extend the low pulse beyond the 1-Wire specification limit for writing a 1 bit (<15 µs). As a result, the sensor misinterprets 1 bits as 0 bits, the scratchpad read returns 0xFF 0xFF, and the reported temperature is garbage.

**Fix:** Initialize the pin once as GPIO_IN_OD_PU (open-drain with internal pull-up) in ds18_init(). Use gpio_clear() to pull the line low and gpio_set() to release it (letting the pull-up restore the high level). This removes all gpio_init() calls from the hot path and keeps the low pulses within the timing constraints required by the 1-Wire protocol.


### Testing procedure
I have used esp32c6.
Connect a DS18B20 sensor to an esp32c6  and compile the example of ds18.

**without the fix:**
```
2026-07-10 11:25:34,334 # +-------------------------------------+
2026-07-10 11:25:36,335 # [DS18] Convert T
2026-07-10 11:25:36,339 # [DS18] Wait for convert T
2026-07-10 11:25:37,089 # [DS18] Reset and read scratchpad
2026-07-10 11:25:37,094 # [DS18] Received byte: 0xff
2026-07-10 11:25:37,096 # [DS18] Received byte: 0xff
2026-07-10 11:25:37,096 # Temperature [ºC]: -0.07
2026-07-10 11:25:37,096 # +-------------------------------------+
2026-07-10 11:25:39,097 # [DS18] Convert T
2026-07-10 11:25:39,101 # [DS18] Wait for convert T
2026-07-10 11:25:39,851 # [DS18] Reset and read scratchpad
2026-07-10 11:25:39,856 # [DS18] Received byte: 0xff
2026-07-10 11:25:39,858 # [DS18] Received byte: 0xff
2026-07-10 11:25:39,858 # Temperature [ºC]: -0.07
```

**Oscillopscope shows:**
<img width="2573" height="1448" alt="image" src="https://github.com/user-attachments/assets/55b3fd7d-aade-41f5-8627-b07661e93e82" />

**With the fix:**
```
2026-07-10 11:27:45,638 # Temperature [ºC]:  25.93
2026-07-10 11:27:45,638 # +-------------------------------------+
2026-07-10 11:27:48,396 # Temperature [ºC]:  25.93
2026-07-10 11:27:48,396 # +-------------------------------------+
2026-07-10 11:27:51,154 # Temperature [ºC]:  25.93
2026-07-10 11:27:51,154 # +-------------------------------------+
```

### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
None.


