### PR TITLE
boards/nucleo-g491re: add support

### DIFF
--- a/boards/common/nucleo64/include/board.h
+++ b/boards/common/nucleo64/include/board.h
@@ -28,13 +28,13 @@ extern "C" {
  * @{
  */
 #if defined(CPU_MODEL_STM32F302R8) || defined(CPU_MODEL_STM32L433RC)
-#define LED0_PIN_NUM        13
-#define LED0_PORT           GPIO_PORT_B /**< GPIO port of LED 0 */
-#define LED0_PORT_NUM       PORT_B
+#  define LED0_PIN_NUM      13
+#  define LED0_PORT         GPIO_PORT_B /**< GPIO port of LED 0 */
+#  define LED0_PORT_NUM     PORT_B
 #else
-#define LED0_PIN_NUM        5
-#define LED0_PORT           GPIO_PORT_A /**< GPIO port of LED 0 */
-#define LED0_PORT_NUM       PORT_A
+#  define LED0_PIN_NUM      5
+#  define LED0_PORT         GPIO_PORT_A /**< GPIO port of LED 0 */
+#  define LED0_PORT_NUM     PORT_A
 #endif
 /** @} */
 
@@ -45,9 +45,9 @@ extern "C" {
 #define BTN0_PIN            GPIO_PIN(PORT_C, 13)
 #if defined(CPU_MODEL_STM32L433RC) || defined(CPU_MODEL_STM32G474RE) || \
     defined(CPU_MODEL_STM32G431RB)
-#define BTN0_MODE           GPIO_IN_PD
+#  define BTN0_MODE         GPIO_IN_PD
 #else
-#define BTN0_MODE           GPIO_IN_PU
+#  define BTN0_MODE         GPIO_IN_PU
 #endif
 /** @} */
 
@@ -56,25 +56,24 @@ extern "C" {
  * @{
  */
 #ifndef MRF24J40_PARAM_SPI
-#define MRF24J40_PARAM_SPI      SPI_DEV(0)
+#  define MRF24J40_PARAM_SPI        SPI_DEV(0)
 #endif
 
 #ifndef MRF24J40_PARAM_SPI_CLK
-#define MRF24J40_PARAM_SPI_CLK  SPI_CLK_5MHZ
+#  define MRF24J40_PARAM_SPI_CLK    SPI_CLK_5MHZ
 #endif
 
 #ifndef MRF24J40_PARAM_CS
-#define MRF24J40_PARAM_CS       ARDUINO_PIN_10
+#  define MRF24J40_PARAM_CS         ARDUINO_PIN_10
 #endif
 
 #ifndef MRF24J40_PARAM_INT
-#define MRF24J40_PARAM_INT      ARDUINO_PIN_7
+#  define MRF24J40_PARAM_INT        ARDUINO_PIN_7
 #endif
 
 #ifndef MRF24J40_PARAM_RESET
-#define MRF24J40_PARAM_RESET    ARDUINO_PIN_5
+#  define MRF24J40_PARAM_RESET      ARDUINO_PIN_5
 #endif
-
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/nucleo64/include/board.h
+++ b/boards/common/nucleo64/include/board.h
@@ -43,8 +43,8 @@ extern "C" {
  * @{
  */
 #define BTN0_PIN            GPIO_PIN(PORT_C, 13)
-#if defined(CPU_MODEL_STM32L433RC) || defined(CPU_MODEL_STM32G474RE) || \
-    defined(CPU_MODEL_STM32G431RB)
+#if defined(CPU_MODEL_STM32L433RC) || defined(CPU_MODEL_STM32G431RB) || \
+    defined(CPU_MODEL_STM32G474RE) || defined(CPU_MODEL_STM32G491RE)
 #  define BTN0_MODE         GPIO_IN_PD
 #else
 #  define BTN0_MODE         GPIO_IN_PU

--- a/boards/common/nucleo64/include/gpio_params.h
+++ b/boards/common/nucleo64/include/gpio_params.h
@@ -42,8 +42,8 @@ static const  saul_gpio_params_t saul_gpio_params[] =
         .name = "Button(B1 User)",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE,
-#if !defined(CPU_MODEL_STM32L433RC) && !defined(CPU_MODEL_STM32G474RE) && \
-    !defined(CPU_MODEL_STM32G431RB)
+#if !defined(CPU_MODEL_STM32L433RC) && !defined(CPU_MODEL_STM32G431RB) && \
+    !defined(CPU_MODEL_STM32G474RE) && !defined(CPU_MODEL_STM32G491RE)
         .flags = SAUL_GPIO_INVERTED
 #endif
     },

--- a/boards/nucleo-g491re/Kconfig
+++ b/boards/nucleo-g491re/Kconfig
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
+
+config BOARD
+    default "nucleo-g491re" if BOARD_NUCLEO_G491RE
+
+config BOARD_NUCLEO_G491RE
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32G491RE
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-g491re/Makefile
+++ b/boards/nucleo-g491re/Makefile
@@ -1,0 +1,4 @@
+MODULE = board
+DIRS = $(RIOTBOARD)/common/nucleo
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/nucleo-g491re/Makefile.dep
+++ b/boards/nucleo-g491re/Makefile.dep
@@ -1,0 +1,5 @@
+ifneq (,$(filter stdio_uart,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_lpuart
+endif
+
+include $(RIOTBOARD)/common/nucleo64/Makefile.dep

--- a/boards/nucleo-g491re/Makefile.features
+++ b/boards/nucleo-g491re/Makefile.features
@@ -1,0 +1,16 @@
+CPU = stm32
+CPU_MODEL = stm32g491re
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart periph_lpuart
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/common/nucleo64/Makefile.features

--- a/boards/nucleo-g491re/Makefile.include
+++ b/boards/nucleo-g491re/Makefile.include
@@ -1,0 +1,2 @@
+# load the common Makefile.include for Nucleo boards
+include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-g491re/doc.md
+++ b/boards/nucleo-g491re/doc.md
@@ -1,0 +1,42 @@
+@defgroup    boards_nucleo-g491re STM32 Nucleo-G491RE
+@ingroup     boards_common_nucleo64
+@brief       Support for the STM32 Nucleo-G491RE
+
+## Overview
+
+The Nucleo-G491RE is a board from ST's Nucleo family supporting a ARM
+Cortex-M4 STM32G491RE microcontroller with 112KiB of RAM and 512KiB of Flash.
+
+You can find general information about the Nucleo64 boards on the
+@ref boards_common_nucleo64 page.
+
+## Pinout
+
+<img src="pinouts/nucleo-g431rb-and-more.svg" alt="Pinout for the Nucleo-G491RE (from STM user manual UM2505 Rev 7, https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf, page 30)" width=50% />
+
+### MCU
+
+| MCU          | STM32G491RE
+|:-------------|:--------------------|
+| Family       | ARM Cortex-M4       |
+| Vendor       | ST Microelectronics |
+| RAM          | 112KiB              |
+| Flash        | 512KiB              |
+| Frequency    | up to 170MHz, clocked to 170MHz in RIOT |
+| Timers       | 15 (2x watchdog, 1 SysTick, 10x 16-bit, 1x 32-bit and 1x low power) |
+| ADCs         | 3x 16 bit (up to 36 channels) |
+| UARTs        | 6 (two UART, three USARTs and one Low-Power UART) |
+| I2Cs         | 3                   |
+| SPIs         | 3                   |
+| FDCANs       | 2                   |
+| RTC          | 1                   |
+| Datasheet    | [Datasheet](https://www.st.com/resource/en/datasheet/stm32g491cc.pdf)|
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0440-stm32g4-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)|
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0214-stm32-cortexm4-mcus-and-mpus-programming-manual-stmicroelectronics.pdf)|
+| Board Manual | [Board Manual](https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf)|
+
+## Flashing the Board
+
+A detailed description about the flashing process can be found on the
+[guides page](https://guide.riot-os.org/board_specific/stm32/).
+The board name for the Nucleo-G491RE is `nucleo-g491re`.

--- a/boards/nucleo-g491re/include/periph_conf.h
+++ b/boards/nucleo-g491re/include/periph_conf.h
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @ingroup     boards_nucleo-g491re
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the NUCLEO-G491RE board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+/* Add specific clock configuration (HSE, LSE) for this board here */
+#ifndef CONFIG_BOARD_HAS_LSE
+#  define CONFIG_BOARD_HAS_LSE          1
+#endif
+/* This board provides a 24MHz HSE oscillator */
+#ifndef CONFIG_BOARD_HAS_HSE
+#  define CONFIG_BOARD_HAS_HSE          1
+#endif
+/* By default, configure a 80MHz SYSCLK with PLL using HSE as input clock */
+#ifndef CONFIG_CLOCK_PLL_M
+#  define CONFIG_CLOCK_PLL_M            (6)
+#endif
+
+#include "periph_cpu.h"
+#include "clk_conf.h"
+#include "cfg_i2c1_pb8_pb9.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_tim2.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = LPUART1,
+        .rcc_mask   = RCC_APB1ENR2_LPUART1EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 3),
+        .tx_pin     = GPIO_PIN(PORT_A, 2),
+        .rx_af      = GPIO_AF12,
+        .tx_af      = GPIO_AF12,
+        .bus        = APB12,
+        .irqn       = LPUART1_IRQn,
+        .type       = STM32_LPUART,
+        .clk_src    = 0, /* Use APB clock */
+    },
+    { /* Connected to Arduino D0/D1 */
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_C, 5),
+        .tx_pin     = GPIO_PIN(PORT_C, 4),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
+    },
+};
+
+#define UART_0_ISR          (isr_lpuart1)
+#define UART_1_ISR          (isr_usart1)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name   SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev            = SPI1,
+        .mosi_pin       = GPIO_PIN(PORT_A, 7),  /* Arduino D11 */
+        .miso_pin       = GPIO_PIN(PORT_A, 6),  /* Arduino D12 */
+        .sclk_pin       = GPIO_PIN(PORT_A, 5),  /* Arduino D13 */
+        .cs_pin         = GPIO_UNDEF,
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB2ENR_SPI1EN,
+        .apbbus         = APB2,
+    },
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -29,9 +29,13 @@ ifneq (f1,$(CPU_FAM))
 endif
 
 ifneq (,$(filter $(CPU_FAM),c0 f0 f1 f3 g0 g4 l0 l1 l4 l5 u5 wb wl))
-  FEATURES_PROVIDED += periph_flashpage
-  FEATURES_PROVIDED += periph_flashpage_in_address_space
-  FEATURES_PROVIDED += periph_flashpage_pagewise
+  # The STM32G491 has "Category 4" flash which is currently not supported by
+  # the flashpage peripheral driver.
+  ifeq (,$(filter stm32g491%,$(CPU_MODEL)))
+    FEATURES_PROVIDED += periph_flashpage
+    FEATURES_PROVIDED += periph_flashpage_in_address_space
+    FEATURES_PROVIDED += periph_flashpage_pagewise
+  endif
 endif
 
 ifneq (,$(filter $(CPU_FAM),f0 f2 f3 f4 f7 l0 l1 l4 l5 u5 wb wl))

--- a/cpu/stm32/stm32_mem_lengths.mk
+++ b/cpu/stm32/stm32_mem_lengths.mk
@@ -204,6 +204,9 @@ else ifeq ($(STM32_TYPE), G)
     else ifeq ($(STM32_MODEL), 474)
       RAM_LEN = 96K
       CCMRAM_LEN = 32K
+    else ifeq ($(STM32_MODEL), 491)
+      RAM_LEN = 96K
+      CCRAM_LEN = 16K
     endif
   endif
 else ifeq ($(STM32_TYPE), H)


### PR DESCRIPTION
### Contribution description

This PR adds support for the Nucleo-G491RE. Not much to say, it was mostly copy&paste from the Nucleo-G474RE that's why I didn't change any copyright notices.


### Testing procedure

See below.

### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
