### PR TITLE
cpu/cc26x2_cc13x2: fix doxygen errors

### DIFF
--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_aux.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_aux.h
@@ -240,10 +240,6 @@ typedef struct {
 #define AUX_SYSIF            ((aux_sysif_regs_t *) (AUX_SYSIF_BASE))
 
 /**
- * @brief   AUX_SYSIF functions
- * @{
- */
-/**
  * @brief    Changes the AUX operational mode
  *
  * @note Only this function should be used to change the operational mode,
@@ -252,7 +248,6 @@ typedef struct {
  * @param[in] target_opmode The opmode we want to change to.
  */
 void aux_sysif_opmode_change(uint32_t target_opmode);
-/** @} */
 
 /**
  * @brief   AUX_TIMER01 registers

--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
@@ -134,10 +134,6 @@ typedef struct {
 /** @} */
 
 /**
- * @brief    DDI_0_OSC functions
- * @{
- */
-/**
  * @brief   Switch the high frequency clock.
  *
  * @note This function will not return until the clock source has been switched.
@@ -145,7 +141,6 @@ typedef struct {
  * @param[in] osc The oscillator to use.
  */
 void osc_hf_source_switch(uint32_t osc);
-/** @} */
 
 /**
  * @brief    AON_PMCTL registers

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_ioc.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_ioc.h
@@ -29,8 +29,6 @@ extern "C" {
 
 /**
  * @brief obtain IOCFG-register for a DIO
- *
- * @param[in] dio_num DIO number (0-31)
  */
 typedef struct {
     reg32_t CFG[32]; /**< Config */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

These errors started popping up and make the build of `examples/lang_support/official/rust-hello-world` fail on CI.

Let's see if this is enough to get CI passing again.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none
