### PR TITLE
cpu/cc26xx: minor documentation fixes

### DIFF
--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_aux.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_aux.h
@@ -240,11 +240,11 @@ typedef struct {
 #define AUX_SYSIF            ((aux_sysif_regs_t *) (AUX_SYSIF_BASE))
 
 /**
- * @brief   AUX_SYSIF functions
+ * @name    AUX_SYSIF functions
  * @{
  */
 /**
- * @brief    Changes the AUX operational mode
+ * @brief   Changes the AUX operational mode
  *
  * @note Only this function should be used to change the operational mode,
  * because it needs to be done in order.

--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
@@ -134,7 +134,7 @@ typedef struct {
 /** @} */
 
 /**
- * @brief    DDI_0_OSC functions
+ * @name     DDI_0_OSC functions
  * @{
  */
 /**

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_ioc.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_ioc.h
@@ -29,8 +29,6 @@ extern "C" {
 
 /**
  * @brief obtain IOCFG-register for a DIO
- *
- * @param[in] dio_num DIO number (0-31)
  */
 typedef struct {
     reg32_t CFG[32]; /**< Config */


### PR DESCRIPTION
### Contribution description

A group should be started with `@name` and not `@brief`, also there was one `@param` that didn't have an actual parameter.

### Testing procedure

CI should be happy.

### Issues/PRs references

Possibly triggered by #22450?

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
