### PR TITLE
cpu/cc2538: fix RSSI computation

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_radio_ops.c
+++ b/cpu/cc2538/radio/cc2538_rf_radio_ops.c
@@ -303,11 +303,14 @@ static int _read(ieee802154_dev_t *dev, void *buf, size_t size, ieee802154_rx_in
          * received packet */
         /* Make sure there is no overflow even if no signal with such
            low sensitivity should be detected */
-        const int hw_rssi_min = IEEE802154_RADIO_RSSI_OFFSET -
-                                CC2538_RSSI_OFFSET;
-        int8_t hw_rssi = rssi_val > hw_rssi_min ?
-            (CC2538_RSSI_OFFSET + rssi_val) : IEEE802154_RADIO_RSSI_OFFSET;
-        info->rssi = hw_rssi - IEEE802154_RADIO_RSSI_OFFSET;
+        const int hw_info_rssi_offset = CC2538_RSSI_OFFSET
+                                      - IEEE802154_RADIO_RSSI_OFFSET;
+        if (rssi_val + hw_info_rssi_offset >= 0) {
+            info->rssi = rssi_val + hw_info_rssi_offset;
+        }
+        else {
+            info->rssi = 0;
+        }
 
         corr_val = rfcore_read_byte() & CC2538_CORR_VAL_MASK;
         if (corr_val < CC2538_CORR_VAL_MIN) {


### PR DESCRIPTION
### Contribution description

- use `int` instead of `int8_t` to avoid loosing precision
- improved the readability of the code

### Testing procedure

One could send to an CC2538 board with another board next to it using different TX power settings and check if the RSSI is reasonable.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/22463

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
