### PR TITLE
Makefile.include: add exception for ESP to clean-intermediates

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -814,9 +814,13 @@ ifndef MAKE_RESTARTS
 endif
 
 # Remove intermediates, but keep the .elf, .hex and .map etc.
+# Special care has to be taken for ESP32 targets, the bootloader directory has
+# to be kept!
 clean-intermediates:
 	-@$(foreach dir,$(PKG_PATHS),"$(MAKE)" -C $(dir) distclean $(NEWLINE))
-	-@rm -rf $(BINDIR)/*.a $(BINDIR)/*/
+	-@rm -rf $(BINDIR)/*.a
+	-@find $(BINDIR)/ -mindepth 1 \
+	    -not -path "*/esp\_bootloader" -type d -exec rm -rf {} +;
 
 clean-pkg:
 	-@$(foreach dir,$(PKG_PATHS),"$(MAKE)" -C $(dir) distclean $(NEWLINE))


### PR DESCRIPTION
### Contribution description

The ESP32 targets build the ESP bootloader in the `$application/$(BOARD)/bin/esp_bootloader` subdirectory, which is deleted when running `clean-intermediates`. It has to be kept for `flash-only` to work, as `flash-only` does no rebuilds.

I would prefer not to add special cases to a general taget, but I also don't want to introduce a new variable either like `CLEANUP_INTERMEDIATES_RETAIN` or something like that.

### Testing procedure

See #22468. Can be tested without hardware too.

### Issues/PRs references

Fixes #22468.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
