### PR TITLE
Makefile.include: don't check features for cleaning targets

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -961,7 +961,7 @@ include $(RIOTMAKE)/tools/targets.inc.mk
 include $(RIOTMAKE)/usb-codes.inc.mk
 
 # Warn if the selected board and drivers don't provide all needed features:
-ifeq (, $(filter help generate-Makefile.ci, $(MAKECMDGOALS)))
+ifeq (, $(filter clean distclean generate-Makefile.ci help, $(MAKECMDGOALS)))
   EXPECT_ERRORS :=
 
   # Test if there where dependencies against a module in DISABLE_MODULE.
@@ -986,13 +986,15 @@ ifeq (, $(filter help generate-Makefile.ci, $(MAKECMDGOALS)))
     EXPECT_ERRORS := 1
   endif
 
-BOARDS_SUPPORTED += $(BOARD_WHITELIST)
-BOARDS_UNSUPPORTED += $(BOARD_BLACKLIST)
+  BOARDS_SUPPORTED += $(BOARD_WHITELIST)
+  BOARDS_UNSUPPORTED += $(BOARD_BLACKLIST)
 
-ifneq (, $(BOARD_WHITELIST)$(BOARD_BLACKLIST))
-  $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)BOARD_WHITELIST has been renamed to BOARDS_SUPPORTED and BOARD_BLACKLIST to BOARDS_UNSUPPORTED.$(COLOR_RESET)" 1>&2)
-  $(shell $(COLOR_ECHO) "The contents of BOARD_WHITELIST have been appended to BOARDS_SUPPORTED and the contents of BOARD_BLACKLIST to BOARDS_UNSUPPORTED for compatibility." 1>&2)
-endif
+  ifneq (, $(BOARD_WHITELIST)$(BOARD_BLACKLIST))
+    $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)BOARD_WHITELIST has been renamed to"\
+      "BOARDS_SUPPORTED and BOARD_BLACKLIST to BOARDS_UNSUPPORTED.$(COLOR_RESET)" 1>&2)
+    $(shell $(COLOR_ECHO) "The contents of BOARD_WHITELIST have been appended to"\
+      "BOARDS_SUPPORTED and the contents of BOARD_BLACKLIST to BOARDS_UNSUPPORTED for compatibility." 1>&2)
+  endif
 
   # Test if any used feature conflict with another one.
   ifneq (,$(FEATURES_CONFLICTING))


### PR DESCRIPTION
### Contribution description

Currently, the feature checks are also executed for `clean` and `distclean` targets, which means that applications incompatible with `native64` won't be cleaned. One example for this is `stdio_semihosting`.

We therefore add `clean` and `distclean` to the exlusion list.

Also, while we're at it, fix some whitespace errors introduced in #22114.

### Testing procedure

This can be tested without hardware, but for `stdio_semihosting` you'll have to use a Cortex-M board to generate some content for the `bin/` subdirectory.

Behavior on `master`:
```
buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ BUILD_IN_DOCKER=1 BOARD=nrf52dk make -C tests/sys/stdio_semihosting/ -j
make: Entering directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/tests/sys/stdio_semihosting'
Launching build container using image ...
...
Building application "tests_stdio_semihosting" for "nrf52dk" with CPU "nrf52".
...
"make" -C /data/riotbuild/riotbase/sys/ztimer
   text    data     bss     dec     hex filename
  12680     108    2428   15216    3b70 /data/riotbuild/riotbase/tests/sys/stdio_semihosting/bin/nrf52dk/tests_stdio_semihosting.elf
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/tests/sys/stdio_semihosting'

buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ ls tests/sys/stdio_semihosting/
bin  main.c  Makefile  README.md

buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ make -C tests/sys/stdio_semihosting/ distclean
make: Entering directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/tests/sys/stdio_semihosting'
using BOARD="native64" as "native" on a 64-bit system
There are unsatisfied feature requirements: cpu_core_cortexm
/home/buechse/RIOTstuff/riot-vanilla/RIOT/tests/sys/stdio_semihosting/../../../Makefile.include:1041: *** You can let the build continue on expected errors by setting CONTINUE_ON_EXPECTED_ERRORS=1 to the command line.  Stop.
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/tests/sys/stdio_semihosting'

buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ ls tests/sys/stdio_semihosting/
bin  main.c  Makefile  README.md
```

Behavior with this PR:
```
buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ BUILD_IN_DOCKER=1 BOARD=nrf52dk make -C tests/sys/stdio_semihosting/ -j
make: Entering directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/tests/sys/stdio_semihosting'
Launching build container using image ...
Building application "tests_stdio_semihosting" for "nrf52dk" with CPU "nrf52".
...
"make" -C /data/riotbuild/riotbase/sys/ztimer
   text    data     bss     dec     hex filename
  12680     108    2428   15216    3b70 /data/riotbuild/riotbase/tests/sys/stdio_semihosting/bin/nrf52dk/tests_stdio_semihosting.elf
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/tests/sys/stdio_semihosting'

buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ ls tests/sys/stdio_semihosting/bin/
nrf52dk

buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ make -C tests/sys/stdio_semihosting/ distclean
make: Entering directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/tests/sys/stdio_semihosting'
using BOARD="native64" as "native" on a 64-bit system
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/tests/sys/stdio_semihosting'

buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ ls tests/sys/stdio_semihosting/bin/
ls: cannot access 'tests/sys/stdio_semihosting/bin/': No such file or directory
```

Proof that the line breaks did not break the output:
```
buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ BOARD_BLACKLIST=native32 make -C tests/sys/shell
make: Entering directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/tests/sys/shell'
using BOARD="native64" as "native" on a 64-bit system
BOARD_WHITELIST has been renamed to BOARDS_SUPPORTED and BOARD_BLACKLIST to BOARDS_UNSUPPORTED.
The contents of BOARD_WHITELIST have been appended to BOARDS_SUPPORTED and the contents of BOARD_BLACKLIST to BOARDS_UNSUPPORTED for compatibility.
Building application "tests_shell" for "native64" with CPU "native".
```

### Issues/PRs references

Fixes whitespace errors introduced in #22114.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
