### PR TITLE
cpu/esp32: add python3-venv to toolchain deps

### DIFF
--- a/cpu/esp32/doc.md
+++ b/cpu/esp32/doc.md
@@ -529,6 +529,7 @@ toolchain (Debian/Ubuntu package names):
 - `curl`
 - `python3`
 - `python3-serial`
+- `python3-venv`
 - `telnet`
 
 ### Script-based installation


### PR DESCRIPTION
### Contribution description

In #21619, the `esptool` was updated and is now installed in a virtual environment. This also means that `python3-venv` is required as a package.

### Testing procedure

Look at the docs 👀 

### Issues/PRs references

Adds the dependency for the changes from #21619.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
