### PR TITLE
boards/waveshare-esp32s3-touch-lcd-128: don't use USB stdio [backport 2026.07]

### DIFF
--- a/boards/waveshare-esp32s3-touch-lcd-128/Makefile.dep
+++ b/boards/waveshare-esp32s3-touch-lcd-128/Makefile.dep
@@ -10,7 +10,6 @@ ifneq (,$(filter touch_dev,$(USEMODULE)))
   USEMODULE += cst816s
 endif
 
-include $(RIOTBOARD)/common/esp32s3/stdio_esp32s3_default.dep.mk
 include $(RIOTBOARD)/common/esp32s3/Makefile.dep
 
 USEMODULE += boards_common_esp32s3


### PR DESCRIPTION
# Backport of #22472

### Contribution description

The Waveshare ESP32S3 Touch board has an USB-C board, but the USB lines are not connected to the ESP32, but instead a USB to Serial converter is used.

<img width="993" height="901" alt="image" src="https://github.com/user-attachments/assets/575a972f-0408-4711-bb4a-7ce58daefb3d" />

Therefore, we can't use the USB CDC ACM or TinyUSB stdio, but the normal `stdio_uart`.


### Testing procedure

Current `master`:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ BOARD=waveshare-esp32s3-touch-lcd-128 make -C tests/sys/shell -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell'
Building application "tests_shell" for "waveshare-esp32s3-touch-lcd-128" with CPU "esp32".

"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/pkg/esp32_sdk/
...
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/shell/cmds
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/stdio
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/test_utils/interactive_sync
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/test_utils/print_stack_usage
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/tsrb
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/usb_board_reset
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/ztimer
...
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/cpu/esp32/periph
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/cpu/esp32/stdio_usb_serial_jtag
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/cpu/esp_common
...
Generating bootloader image /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell/bin/waveshare-esp32s3-touch-lcd-128/esp_bootloader/bootloader.bin
esptool v5.0.0
Creating ESP32S3 image...
Merged 1 ELF section.
Successfully created ESP32S3 image.
esptool v5.0.0
Creating ESP32S3 image...
Merged 3 ELF sections.
Successfully created ESP32S3 image.
# append size of /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell/bin/waveshare-esp32s3-touch-lcd-128/tests_shell.elf.bin
Parsing CSV input...
   text    data     bss     dec     hex filename
  68006   13812  267609  349427   554f3 /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell/bin/waveshare-esp32s3-touch-lcd-128/tests_shell.elf
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell'
```

With this PR:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ BOARD=waveshare-esp32s3-touch-lcd-128 make -C tests/sys/shell -j
make: Entering directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell'
Building application "tests_shell" for "waveshare-esp32s3-touch-lcd-128" with CPU "esp32".

"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/pkg/esp32_sdk/
...
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/stdio
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/sys/stdio_uart
...
"make" -C /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/cpu/esp_common/vendor/xtensa
Generating bootloader image /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell/bin/waveshare-esp32s3-touch-lcd-128/esp_bootloader/bootloader.bin
esptool v5.0.0
Creating ESP32S3 image...
Merged 1 ELF section.
Successfully created ESP32S3 image.
esptool v5.0.0
Creating ESP32S3 image...
Merged 3 ELF sections.
Successfully created ESP32S3 image.
# append size of /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell/bin/waveshare-esp32s3-touch-lcd-128/tests_shell.elf.bin
Parsing CSV input...
   text    data     bss     dec     hex filename
  68482   13864  267317  349663   555df /home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell/bin/waveshare-esp32s3-touch-lcd-128/tests_shell.elf
make: Leaving directory '/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/tests/sys/shell'
```


### Issues/PRs references

The bug was introduced in #22231 and I didn't test it thoroughly enough :/


### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
