### PR TITLE
sys/include: use SPDX license tags [a-m]

### DIFF
--- a/sys/include/analog_util.h
+++ b/sys/include/analog_util.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/app_metadata.h
+++ b/sys/include/app_metadata.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/architecture.h
+++ b/sys/include/architecture.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/atomic_utils.h
+++ b/sys/include/atomic_utils.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/auto_init.h
+++ b/sys/include/auto_init.h
@@ -1,11 +1,9 @@
 /*
- * Copyright (C) 2010,2015 Freie Universität Berlin
- * Copyright (C) 2010 Kaspar Schleiser <kaspar@schleiser.de>
- * Copyright (C) 2013-2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2010 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2010 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2013-2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/auto_init_utils.h
+++ b/sys/include/auto_init_utils.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Otto-von-Guericke-Universität Magdebug
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Otto-von-Guericke-Universität Magdebug
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/bcd.h
+++ b/sys/include/bcd.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/benchmark.h
+++ b/sys/include/benchmark.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017,2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017-2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/bhp.h
+++ b/sys/include/bhp.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/bhp/event.h
+++ b/sys/include/bhp/event.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/bhp/msg.h
+++ b/sys/include/bhp/msg.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/bit.h
+++ b/sys/include/bit.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/bitfield.h
+++ b/sys/include/bitfield.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 INRIA
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 INRIA
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/bloom.h
+++ b/sys/include/bloom.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/busy_wait.h
+++ b/sys/include/busy_wait.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/byteorder.h
+++ b/sys/include/byteorder.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 René Kijewski
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 René Kijewski
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/can/can.h
+++ b/sys/include/can/can.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/can/common.h
+++ b/sys/include/can/common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/can/conn/isotp.h
+++ b/sys/include/can/conn/isotp.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/can/conn/raw.h
+++ b/sys/include/can/conn/raw.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/can/device.h
+++ b/sys/include/can/device.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/can/dll.h
+++ b/sys/include/can/dll.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/can/isotp.h
+++ b/sys/include/can/isotp.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/can/pkt.h
+++ b/sys/include/can/pkt.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2018 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016-2018 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/can/raw.h
+++ b/sys/include/can/raw.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/can/router.h
+++ b/sys/include/can/router.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016-2018 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2016-2018 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/cb_mux.h
+++ b/sys/include/cb_mux.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Acutam Automation, LLC
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Acutam Automation, LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/chunked_ringbuffer.h
+++ b/sys/include/chunked_ringbuffer.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/clif.h
+++ b/sys/include/clif.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/clk.h
+++ b/sys/include/clk.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/coding/xor.h
+++ b/sys/include/coding/xor.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Benjamin Valentin <benjamin.valentin@ml-pa.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/color.h
+++ b/sys/include/color.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2014-2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/congure.h
+++ b/sys/include/congure.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/congure/abe.h
+++ b/sys/include/congure/abe.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/congure/config.h
+++ b/sys/include/congure/config.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/congure/mock.h
+++ b/sys/include/congure/mock.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/congure/quic.h
+++ b/sys/include/congure/quic.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/congure/reno.h
+++ b/sys/include/congure/reno.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/congure/test.h
+++ b/sys/include/congure/test.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/crypto/ciphers.h
+++ b/sys/include/crypto/ciphers.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin, Computer Systems & Telematics
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Freie Universität Berlin, Computer Systems & Telematics
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/crypto/helper.h
+++ b/sys/include/crypto/helper.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/crypto/modes/cbc.h
+++ b/sys/include/crypto/modes/cbc.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/crypto/modes/ccm.h
+++ b/sys/include/crypto/modes/ccm.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/crypto/modes/ctr.h
+++ b/sys/include/crypto/modes/ctr.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/crypto/modes/ecb.h
+++ b/sys/include/crypto/modes/ecb.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/crypto/modes/ocb.h
+++ b/sys/include/crypto/modes/ocb.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Mathias Tausig
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Mathias Tausig
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/crypto/psa/riot_ciphers.h
+++ b/sys/include/crypto/psa/riot_ciphers.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/dbgpin.h
+++ b/sys/include/dbgpin.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/debug_irq_disable.h
+++ b/sys/include/debug_irq_disable.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/div.h
+++ b/sys/include/div.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/ecc/hamming256.h
+++ b/sys/include/ecc/hamming256.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Lucas Jenß
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Lucas Jenß
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/ecc/repetition.h
+++ b/sys/include/ecc/repetition.h
@@ -1,24 +1,7 @@
 /*
- * Copyright (c) 2007 - 2015 Joseph Gaeddert
- * Copyright (c) 2018        HAW Hamburg
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * SPDX-FileCopyrightText: 2007-2015 Joseph Gaeddert
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/sys/include/eepreg.h
+++ b/sys/include/eepreg.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Acutam Automation, LLC
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Acutam Automation, LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/embUnit.h
+++ b/sys/include/embUnit.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Martine Lenders <mlenders@inf.fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Martine Lenders <mlenders@inf.fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/include/embUnit/AssertImpl.h
+++ b/sys/include/embUnit/AssertImpl.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: AssertImpl.h,v 1.6 2003/09/16 11:09:53 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_ASSERTIMPL_H
 #define EMBUNIT_ASSERTIMPL_H

--- a/sys/include/embUnit/ColorOutputter.h
+++ b/sys/include/embUnit/ColorOutputter.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Janos Kutscherauer <noshky@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Janos Kutscherauer <noshky@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/embUnit/ColorTextOutputter.h
+++ b/sys/include/embUnit/ColorTextOutputter.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Janos Kutscherauer <noshky@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Janos Kutscherauer <noshky@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/embUnit/CompilerOutputter.h
+++ b/sys/include/embUnit/CompilerOutputter.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: CompilerOutputter.h,v 1.2 2003/09/06 13:28:27 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_COMPILEROUTPUTTER_H
 #define EMBUNIT_COMPILEROUTPUTTER_H

--- a/sys/include/embUnit/HelperMacro.h
+++ b/sys/include/embUnit/HelperMacro.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: HelperMacro.h,v 1.3 2004/02/10 16:19:29 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_HELPERMACRO_H
 #define EMBUNIT_HELPERMACRO_H

--- a/sys/include/embUnit/Outputter.h
+++ b/sys/include/embUnit/Outputter.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: Outputter.h,v 1.2 2003/09/06 13:28:27 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_OUTPUTTER_H
 #define EMBUNIT_OUTPUTTER_H

--- a/sys/include/embUnit/RepeatedTest.h
+++ b/sys/include/embUnit/RepeatedTest.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: RepeatedTest.h,v 1.7 2004/02/10 16:19:29 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_REPEATEDTEST_H
 #define EMBUNIT_REPEATEDTEST_H

--- a/sys/include/embUnit/Test.h
+++ b/sys/include/embUnit/Test.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: Test.h,v 1.4 2004/02/10 16:19:29 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_TEST_H
 #define EMBUNIT_TEST_H

--- a/sys/include/embUnit/TestCaller.h
+++ b/sys/include/embUnit/TestCaller.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: TestCaller.h,v 1.7 2004/02/10 16:19:29 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_TESTCALLER_H
 #define EMBUNIT_TESTCALLER_H

--- a/sys/include/embUnit/TestCase.h
+++ b/sys/include/embUnit/TestCase.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: TestCase.h,v 1.7 2004/02/10 16:19:29 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_TESTCASE_H
 #define EMBUNIT_TESTCASE_H

--- a/sys/include/embUnit/TestListener.h
+++ b/sys/include/embUnit/TestListener.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: TestListener.h,v 1.4 2004/02/10 16:19:29 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_TESTLISTENER_H
 #define EMBUNIT_TESTLISTENER_H

--- a/sys/include/embUnit/TestResult.h
+++ b/sys/include/embUnit/TestResult.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: TestResult.h,v 1.7 2004/02/10 16:19:29 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_TESTRESULT_H
 #define EMBUNIT_TESTRESULT_H

--- a/sys/include/embUnit/TestRunner.h
+++ b/sys/include/embUnit/TestRunner.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: TestRunner.h,v 1.6 2004/02/10 16:19:29 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_TESTRUNNER_H
 #define EMBUNIT_TESTRUNNER_H

--- a/sys/include/embUnit/TestSuite.h
+++ b/sys/include/embUnit/TestSuite.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: TestSuite.h,v 1.7 2004/02/10 16:19:29 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_TESTSUITE_H
 #define EMBUNIT_TESTSUITE_H

--- a/sys/include/embUnit/TextOutputter.h
+++ b/sys/include/embUnit/TextOutputter.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: TextOutputter.h,v 1.2 2003/09/06 13:28:27 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_TEXTOUTPUTTER_H
 #define EMBUNIT_TEXTOUTPUTTER_H

--- a/sys/include/embUnit/TextUIRunner.h
+++ b/sys/include/embUnit/TextUIRunner.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: TextUIRunner.h,v 1.3 2003/09/06 13:28:27 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_TEXTUIRUNNER_H
 #define EMBUNIT_TEXTUIRUNNER_H

--- a/sys/include/embUnit/XMLOutputter.h
+++ b/sys/include/embUnit/XMLOutputter.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: XMLOutputter.h,v 1.3 2003/09/06 13:28:27 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_XMLOUTPUTTER_H
 #define EMBUNIT_XMLOUTPUTTER_H

--- a/sys/include/embUnit/embUnit.h
+++ b/sys/include/embUnit/embUnit.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: embUnit.h,v 1.4 2004/02/10 16:16:19 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_EMBUNIT_H
 #define EMBUNIT_EMBUNIT_H

--- a/sys/include/embUnit/embUnit_config.h
+++ b/sys/include/embUnit/embUnit_config.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: config.h,v 1.7 2004/02/10 16:17:07 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_EMBUNIT_CONFIG_H
 #define EMBUNIT_EMBUNIT_CONFIG_H

--- a/sys/include/embUnit/stdImpl.h
+++ b/sys/include/embUnit/stdImpl.h
@@ -1,36 +1,6 @@
 /*
- * COPYRIGHT AND PERMISSION NOTICE
- *
- * Copyright (c) 2003 Embedded Unit Project
- *
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons
- * to whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies
- * of the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
- * OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
- * HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
- * SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
- * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
- * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Except as contained in this notice, the name of a copyright holder
- * shall not be used in advertising or otherwise to promote the sale,
- * use or other dealings in this Software without prior written
- * authorization of the copyright holder.
- *
- * $Id: stdImpl.h,v 1.4 2004/02/10 16:15:25 arms22 Exp $
+ * SPDX-FileCopyrightText: 2003 Embedded Unit Project
+ * SPDX-License-Identifier: ICU
  */
 #ifndef EMBUNIT_STDIMPL_H
 #define EMBUNIT_STDIMPL_H

--- a/sys/include/endian.h
+++ b/sys/include/endian.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2024 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/entropy_source.h
+++ b/sys/include/entropy_source.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/entropy_source/adc_noise.h
+++ b/sys/include/entropy_source/adc_noise.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/entropy_source/zero_entropy.h
+++ b/sys/include/entropy_source/zero_entropy.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2017 Inria
- *               2017 Kaspar Schleiser <kaspar@schleiser.de>
- *               2018-2019 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2018-2019 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/event/callback.h
+++ b/sys/include/event/callback.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2017 Inria
- *               2017 Freie Universität Berlin
- *               2017 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/event/deferred_callback.h
+++ b/sys/include/event/deferred_callback.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/event/periodic.h
+++ b/sys/include/event/periodic.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/event/periodic_callback.h
+++ b/sys/include/event/periodic_callback.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/event/source.h
+++ b/sys/include/event/source.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/event/thread.h
+++ b/sys/include/event/thread.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
- *               2020 Freie Universität Berlin
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/event/timeout.h
+++ b/sys/include/event/timeout.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2017 Inria
- *               2017 Freie Universität Berlin
- *               2017 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/evtimer.h
+++ b/sys/include/evtimer.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016-17 Kaspar Schleiser <kaspar@schleiser.de>
- *               2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/evtimer_mbox.h
+++ b/sys/include/evtimer_mbox.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Simon Brummer <simon.brummer@posteo.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Simon Brummer <simon.brummer@posteo.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/evtimer_msg.h
+++ b/sys/include/evtimer_msg.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016-17 Kaspar Schleiser <kaspar@schleiser.de>
- *               2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016-2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fido2/ctap.h
+++ b/sys/include/fido2/ctap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fido2/ctap/ctap.h
+++ b/sys/include/fido2/ctap/ctap.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fido2/ctap/ctap_cbor.h
+++ b/sys/include/fido2/ctap/ctap_cbor.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fido2/ctap/ctap_crypto.h
+++ b/sys/include/fido2/ctap/ctap_crypto.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fido2/ctap/ctap_mem.h
+++ b/sys/include/fido2/ctap/ctap_mem.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fido2/ctap/ctap_utils.h
+++ b/sys/include/fido2/ctap/ctap_utils.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fido2/ctap/transport/ctap_transport.h
+++ b/sys/include/fido2/ctap/transport/ctap_transport.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fido2/ctap/transport/hid/ctap_hid.h
+++ b/sys/include/fido2/ctap/transport/hid/ctap_hid.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/flash_utils.h
+++ b/sys/include/flash_utils.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2022 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fmt_table.h
+++ b/sys/include/fmt_table.h
@@ -1,9 +1,6 @@
 /*
- * Copyright 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/frac.h
+++ b/sys/include/frac.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fs/constfs.h
+++ b/sys/include/fs/constfs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fs/devfs.h
+++ b/sys/include/fs/devfs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fs/fatfs.h
+++ b/sys/include/fs/fatfs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 HAW-Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fs/littlefs2_fs.h
+++ b/sys/include/fs/littlefs2_fs.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fs/littlefs_fs.h
+++ b/sys/include/fs/littlefs_fs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fs/lwext4_fs.h
+++ b/sys/include/fs/lwext4_fs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fs/native_fs.h
+++ b/sys/include/fs/native_fs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fs/spiffs_fs.h
+++ b/sys/include/fs/spiffs_fs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/fuzzing.h
+++ b/sys/include/fuzzing.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2019 Sören Tempel <tempel@uni-bremen.de>
- * Copyright (C) 2022 Bennet Blischke <bennet.blischke@haw-hamburg.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Sören Tempel <tempel@uni-bremen.de>
+ * SPDX-FileCopyrightText: 2022 Bennet Blischke <bennet.blischke@haw-hamburg.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/hashes.h
+++ b/sys/include/hashes.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/hashes/aes128_cmac.h
+++ b/sys/include/hashes/aes128_cmac.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Fundación Inria Chile
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Fundación Inria Chile
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/hashes/md5.h
+++ b/sys/include/hashes/md5.h
@@ -1,20 +1,7 @@
 /*
- * Copyright (C) 2003-2005 by Christopher R. Hertel
- *               2015 Freie Universität Berlin
- *
- *  This library is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public
- *  License as published by the Free Software Foundation; either
- *  version 2.1 of the License, or (at your option) any later version.
- *
- *  This library is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- *  Lesser General Public License for more details.
- *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * SPDX-FileCopyrightText: 2003-2005 by Christopher R. Hertel
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/sys/include/hashes/pbkdf2.h
+++ b/sys/include/hashes/pbkdf2.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/hashes/psa/riot_hashes.h
+++ b/sys/include/hashes/psa/riot_hashes.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/hashes/sha1.h
+++ b/sys/include/hashes/sha1.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Oliver Hahm <oliver.hahm@inria.fr>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Oliver Hahm <oliver.hahm@inria.fr>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/hashes/sha224.h
+++ b/sys/include/hashes/sha224.h
@@ -1,33 +1,10 @@
-/*-
- * Copyright 2005 Colin Percival
- * Copyright 2013 Christian Mehlis & René Kijewski
- * Copyright 2016 Martin Landsmann <martin.landsmann@haw-hamburg.de>
- * Copyright 2016 OTA keys S.A.
- * Copyright 2020 HAW Hamburg
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- *
- * $FreeBSD: src/lib/libmd/sha256.h,v 1.1.2.1 2005/06/24 13:32:25 cperciva Exp $
+/*
+ * SPDX-FileCopyrightText: 2005 Colin Percival
+ * SPDX-FileCopyrightText: 2013 Christian Mehlis & René Kijewski
+ * SPDX-FileCopyrightText: 2016 Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once

--- a/sys/include/hashes/sha256.h
+++ b/sys/include/hashes/sha256.h
@@ -1,32 +1,9 @@
 /*-
- * Copyright 2005 Colin Percival
- * Copyright 2013 Christian Mehlis & René Kijewski
- * Copyright 2016 Martin Landsmann <martin.landsmann@haw-hamburg.de>
- * Copyright 2016 OTA keys S.A.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- *
- * $FreeBSD: src/lib/libmd/sha256.h,v 1.1.2.1 2005/06/24 13:32:25 cperciva Exp $
+ * SPDX-FileCopyrightText: 2005 Colin Percival
+ * SPDX-FileCopyrightText: 2013 Christian Mehlis & René Kijewski
+ * SPDX-FileCopyrightText: 2016 Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once

--- a/sys/include/hashes/sha2xx_common.h
+++ b/sys/include/hashes/sha2xx_common.h
@@ -1,33 +1,10 @@
 /*-
- * Copyright 2005 Colin Percival
- * Copyright 2013 Christian Mehlis & René Kijewski
- * Copyright 2016 Martin Landsmann <martin.landsmann@haw-hamburg.de>
- * Copyright 2016 OTA keys S.A.
- * Copyright 2020 HAW Hamburg
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- *
- * $FreeBSD: src/lib/libmd/sha256.h,v 1.1.2.1 2005/06/24 13:32:25 cperciva Exp $
+ * SPDX-FileCopyrightText: 2005 Colin Percival
+ * SPDX-FileCopyrightText: 2013 Christian Mehlis & René Kijewski
+ * SPDX-FileCopyrightText: 2016 Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ * SPDX-FileCopyrightText: 2016 OTA keys S.A.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once

--- a/sys/include/hashes/sha3.h
+++ b/sys/include/hashes/sha3.h
@@ -1,14 +1,12 @@
-/*-
- * Implementation by the Keccak, Keyak and Ketje Teams, namely, Guido Bertoni,
- * Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer, hereby
- * denoted as "the implementer".
- *
- * RIOT-OS adaptation by Mathias Tausig
- *
- * This software is released under the Creative Commons CC0 1.0 license.
- * To the extent possible under law, the implementer has waived all copyright
- * and related or neighboring rights to the source code in this file.
- * For more information see: http://creativecommons.org/publicdomain/zero/1.0/
+/*
+ * SPDX-FileCopyrightText: Keccak, Keyak and Ketje Teams
+ * SPDX-FileCopyrightText: Guido Bertoni
+ * SPDX-FileCopyrightText: Joan Daemen
+ * SPDX-FileCopyrightText: Michaël Peeters
+ * SPDX-FileCopyrightText: Gilles Van Assche
+ * SPDX-FileCopyrightText: Ronny Van Keer
+ * SPDX-FileCopyrightText: 2017-2018 Mathias Tausig
+ * SPDX-License-Identifier: CC0-1.0
  */
 
 /**

--- a/sys/include/hashes/sha384.h
+++ b/sys/include/hashes/sha384.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/hashes/sha512.h
+++ b/sys/include/hashes/sha512.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/hashes/sha512_224.h
+++ b/sys/include/hashes/sha512_224.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/hashes/sha512_256.h
+++ b/sys/include/hashes/sha512_256.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/hashes/sha512_common.h
+++ b/sys/include/hashes/sha512_common.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/imath.h
+++ b/sys/include/imath.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/iolist.h
+++ b/sys/include/iolist.h
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2018 Kaspar Schleiser <kaspar@schleiser.de>
- *               2018 Inria
- *               2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/isrpipe.h
+++ b/sys/include/isrpipe.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/isrpipe/read_timeout.h
+++ b/sys/include/isrpipe/read_timeout.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/luid.h
+++ b/sys/include/luid.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/malloc_monitor.h
+++ b/sys/include/malloc_monitor.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/malloc_monitor_internal.h
+++ b/sys/include/malloc_monitor_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2024 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2024 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/matstat.h
+++ b/sys/include/matstat.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/memarray.h
+++ b/sys/include/memarray.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Tobias Heider <heidert@nm.ifi.lmu.de>
- *               2020 Koen Zandberg <koen@bergzand.net>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Tobias Heider <heidert@nm.ifi.lmu.de>
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg <koen@bergzand.net>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/include/mineplex.h
+++ b/sys/include/mineplex.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once


### PR DESCRIPTION
<!--The RIOT community cares a lot about code quality.-->

### Contribution description

This took #21908 and has just [a-m] (mostly 'net') to avoid too many files Github issues  (part 1/3)

#22475 got Licenses and may be (or not) merged first

### Testing procedure

check diff for correctness 
@maribu did when creating the original @kfessel does while creating this before switching it from draft

### Issues/PRs references

#21515 tracking issue
#22476 [a-m]
#22477 [n]
#22478 [o-z]
#21908 original 
#22475 Licenses
#22324 another one has given up 

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- some M365copilot chat was used to identify the ICU license (it actually suggested it might be X11, ICU was found by @kfessel) 
- AI/LLM did no edits and nothing was copied from an LLM interaction 
- none otherwise
