### PR TITLE
boards/nucleo-g031k8: add SPI peripheral support

### DIFF
--- a/boards/nucleo-g031k8/Makefile.features
+++ b/boards/nucleo-g031k8/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32g031k8
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/nucleo-g031k8/include/periph_conf.h
+++ b/boards/nucleo-g031k8/include/periph_conf.h
@@ -74,6 +74,29 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
+/**
+ * @name   SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev            = SPI1,
+        .mosi_pin       = GPIO_PIN(PORT_B, 5),  /* Arduino D11 */
+        .miso_pin       = GPIO_PIN(PORT_B, 4),  /* Arduino D12 */
+        .sclk_pin       = GPIO_PIN(PORT_B, 3),  /* Arduino D13 */
+        .cs_pin         = GPIO_UNDEF,
+        .mosi_af        = GPIO_AF0,
+        .miso_af        = GPIO_AF0,
+        .sclk_af        = GPIO_AF0,
+        .cs_af          = GPIO_AF0,
+        .rccmask        = RCC_APBENR2_SPI1EN,
+        .apbbus         = APB12,
+    },
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/drivers/atwinc15x0/Makefile.ci
+++ b/tests/drivers/atwinc15x0/Makefile.ci
@@ -15,6 +15,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f042k6 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/drivers/cc110x/Makefile.ci
+++ b/tests/drivers/cc110x/Makefile.ci
@@ -29,6 +29,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \

--- a/tests/drivers/nrf24l01p_ng/Makefile.ci
+++ b/tests/drivers/nrf24l01p_ng/Makefile.ci
@@ -16,6 +16,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     nucleo-l053r8 \


### PR DESCRIPTION
### Contribution description

Add SPI peripheral support for nucleo-g031k8 board, based the setup on the nucleo-g070rb and nucleo-g071rb.


### Testing procedure

Ran `tests/periph/spi` with a jumper connecting MOSI->MISO:

```
> BOARD=nucleo-g031k8 make flash term
Building application "tests_spi" for "nucleo-g031k8" with CPU "stm32".

... omitted ...

> init 0 0 2
2026-07-16 13:56:58,062 # init 0 0 2
2026-07-16 13:56:58,069 # Trying to initialize SPI_DEV(0): mode: 0, clk: 2, cs_port: 0, cs_pin: 0
2026-07-16 13:56:58,078 # (if below the program crashes with a failed assertion, then it means the configuration is not supported)
2026-07-16 13:56:58,079 # Success.
> send hello
2026-07-16 13:57:02,113 # send hello
2026-07-16 13:57:02,114 # Sent bytes
2026-07-16 13:57:02,117 #    0    1    2    3    4
2026-07-16 13:57:02,120 #   0x68 0x65 0x6c 0x6c 0x6f
2026-07-16 13:57:02,122 #     h    e    l    l    o
2026-07-16 13:57:02,123 #
2026-07-16 13:57:02,124 # Received bytes
2026-07-16 13:57:02,125 #    0    1    2    3    4
2026-07-16 13:57:02,128 #   0x68 0x65 0x6c 0x6c 0x6f
2026-07-16 13:57:02,130 #     h    e    l    l    o
2026-07-16 13:57:02,131 #
```

### Issues/PRs references

none

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
