### PR TITLE
cpu/esp32/periph:add irq_isr_enter/exit to ISRs

### DIFF
--- a/cpu/esp32/periph/rtt_hw_rtc.c
+++ b/cpu/esp32/periph/rtt_hw_rtc.c
@@ -167,6 +167,8 @@ static void _rtc_clear_alarm(void)
 
 static void IRAM _rtc_isr(void *arg)
 {
+    irq_isr_enter();
+
     /* disable alarms first */
     LP_TIMER.target[0].hi.enable = 0;
 
@@ -192,6 +194,7 @@ static void IRAM _rtc_isr(void *arg)
         /* call the alarm handler afterwards if callback was defined */
         alarm_cb(alarm_arg);
     }
+    irq_isr_exit();
 }
 
 #else

--- a/cpu/esp32/periph/rtt_hw_sys.c
+++ b/cpu/esp32/periph/rtt_hw_sys.c
@@ -187,6 +187,7 @@ static void IRAM _sys_isr(void *arg)
         return;
     }
 
+    irq_isr_enter();
     /* disable alarms first */
     timer_ll_enable_intr(sys_timer.dev, TIMER_LL_EVENT_ALARM(sys_timer.timer_id), false);
     timer_ll_enable_alarm(sys_timer.dev, sys_timer.timer_id, false);
@@ -214,6 +215,7 @@ static void IRAM _sys_isr(void *arg)
         /* call the alarm handler afterwards if callback was defined */
         alarm_cb(alarm_arg);
     }
+    irq_isr_exit();
 }
 
 const rtt_hw_driver_t _rtt_hw_sys_driver = {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This fixes a bug in the ESP32 RTT hardware drivers (cpu/esp32/periph/rtt_hw_sys.c and cpu/esp32/periph/rtt_hw_rtc.c).

_sys_isr and _rtc_isr were missing irq_isr_enter() / irq_isr_exit() calls around their bodies.


### Testing procedure

I am using esp32c6 and I run a custom rtc test, that sets then gets time, then it sets the alarm and sets pm to 1 (light sleep)
without the fix: 
```
2026-07-17 17:10:47,582 # self-test rtc
2026-07-17 17:10:47,582 # *****Start self_test*****
2026-07-17 17:10:47,583 # SELFTEST: Running test 1/1 (MLPA_SELF_TEST_RTC)
2026-07-17 17:10:47,584 # RTC TEST: time 2020-02-28 23:59:00 setting succeeded
2026-07-17 17:10:47,585 # RTC TEST: time 2020-02-28 23:59:00 getting succeeded
2026-07-17 17:10:47,585 # RTC TEST: time set and get match
2026-07-17 17:10:47,585 # rtc_set_alarm in rtt_rtc.c
2026-07-17 17:10:47,585 # RTC TEST: alarm set for 2020-02-28 23:59:10

ps
ps


```
with the fix:
```
2026-07-17 17:04:12,014 # *****Start self_test*****
2026-07-17 17:04:12,015 # SELFTEST: Running test 1/1 (MLPA_SELF_TEST_RTC)
2026-07-17 17:04:12,015 # RTC TEST: time 2020-02-28 23:59:00 setting succeeded
2026-07-17 17:04:12,016 # RTC TEST: time 2020-02-28 23:59:00 getting succeeded
2026-07-17 17:04:12,017 # RTC TEST: time set and get match
2026-07-17 17:04:12,017 # rtc_set_alarm in rtt_rtc.c
2026-07-17 17:04:12,017 # RTC TEST: alarm set for 2020-02-28 23:59:10
2026-07-17 17:04:21,972 # RTC TEST: node woke up from sleepRTC TEST: time after alarm 2020-02-28 23:59:10
2026-07-17 17:04:21,973 # RTC TEST: time set and get after alarm match
2026-07-17 17:04:21,973 # SELFTEST: Test successful
```



### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

Claude Sonnet 4.6 for double checking
