### PR TITLE
sys/net/unicoap: fix doc typos and leftovers

### DIFF
--- a/sys/include/net/unicoap/config.h
+++ b/sys/include/net/unicoap/config.h
@@ -202,19 +202,6 @@ static_assert(CONFIG_UNICOAP_GENERATED_TOKEN_LENGTH > 0,
 #  define CONFIG_UNICOAP_PDU_SIZE_MAX (128)
 #endif
 
-// todo: not true anymore it seems, only used for unicoap assist
-/**
- * @brief Maximum length of a resource path string. Only used for @ref CONFIG_UNICOAP_ASSIST.
- *
- * **Default**: 64 characters
- */
-#if !defined(CONFIG_UNICOAP_PATH_LENGTH_MAX) || defined(DOXYGEN)
-#  define CONFIG_UNICOAP_PATH_LENGTH_MAX (64)
-#endif
-
-static_assert(CONFIG_UNICOAP_PATH_LENGTH_MAX > 0,
-              "CONFIG_UNICOAP_PATH_LENGTH_MAX is zero: Path buffer too small");
-
 /**
  * @brief Maximum size of `/.well-known/core` payload.
  *

--- a/sys/include/net/unicoap/config.h
+++ b/sys/include/net/unicoap/config.h
@@ -202,17 +202,11 @@ static_assert(CONFIG_UNICOAP_GENERATED_TOKEN_LENGTH > 0,
 #  define CONFIG_UNICOAP_PDU_SIZE_MAX (128)
 #endif
 
+// todo: not true anymore it seems, only used for unicoap assist
 /**
- * @brief Maximum length of a resource path string. Used for request matching.
+ * @brief Maximum length of a resource path string. Only used for @ref CONFIG_UNICOAP_ASSIST.
  *
  * **Default**: 64 characters
- *
- * Normally, you could match a request's path against all resources' paths by comparing
- * the individual `Uri-Path` options present in the request. Re-parsing the options for each
- * resource the server hosts becomes expensive fast. Therefore, unicoap serializes the `Uri-Path`
- * and then does consecutive`strncmp` calls.
- *
- * @see @ref unicoap_resource_match_path_string and @ref unicoap_resource_match_path_options
  */
 #if !defined(CONFIG_UNICOAP_PATH_LENGTH_MAX) || defined(DOXYGEN)
 #  define CONFIG_UNICOAP_PATH_LENGTH_MAX (64)

--- a/sys/include/net/unicoap/constants.h
+++ b/sys/include/net/unicoap/constants.h
@@ -413,8 +413,6 @@ static_assert(sizeof(unicoap_status_t) == sizeof(uint8_t),
  */
 /**
  * @brief CoAP option number
- *
- * These option numbers are not valid in signaling messages.
  */
 typedef enum {
     /**

--- a/sys/include/net/unicoap/message.h
+++ b/sys/include/net/unicoap/message.h
@@ -323,8 +323,6 @@ typedef struct {
         /** @brief RFC 7252 message ID */
         uint16_t id;
     } rfc7252;
-
-    /** @brief CoAP message token */
 } unicoap_message_properties_t;
 
 /**
@@ -1146,7 +1144,7 @@ typedef struct {
  *
  * As `unicoap` cannot guarantee you won't add/insert/remove options later, @p cursor is not
  * qualified by `const`. That hypothetical `const` depends on your usage of the message and its
- * options. That hypothetical `const` depends on your usage of the message and its options.
+ * options.
  */
 ssize_t unicoap_pdu_parse_options_and_payload(uint8_t* cursor, const uint8_t* end,
                                               unicoap_message_t* message);

--- a/sys/include/net/unicoap/server.h
+++ b/sys/include/net/unicoap/server.h
@@ -190,7 +190,7 @@ ssize_t unicoap_path_stringify(const unicoap_pathspec_t* path, char* buffer, siz
  *
  * @note The path can be of arbitrary length.
  */
-void unicoap_path_print(const unicoap_pathspec_t* path);
+void unicoap_print_path(const unicoap_pathspec_t* path);
 /** @} */
 
 #ifndef DOXYGEN
@@ -424,6 +424,13 @@ struct unicoap_resource {
      */
     unicoap_proto_set_t protocols;
 };
+
+/**
+ * @brief Prints CoAP resource definition properties
+ *
+ * @param resource CoAP resource
+ */
+void unicoap_print_resource(const unicoap_resource_t* resource);
 /** @} */
 
 /* MARK: - Resource discovery */

--- a/sys/include/net/unicoap/server.h
+++ b/sys/include/net/unicoap/server.h
@@ -639,12 +639,6 @@ static inline bool unicoap_resource_match_path_string(const unicoap_resource_t* 
  * @param[in] resource Resource to check for matching path
  * @param[in] options Options to read URI path from
  *
- * @remark
- * If you want to call this function in a loop, consider reading the Uri-Path with
- * @ref unicoap_options_t::unicoap_options_copy_uri_path and then calling
- * @ref unicoap_resource_match_path_string repeatedly. This is useful when you want to match a
- * given request against a number of resources.
- *
  * This function obeys the @ref UNICOAP_RESOURCE_FLAG_MATCH_SUBTREE flag.
  *
  * @returns A boolean value indicating whether the given resource matches the path in @p options.

--- a/sys/net/application_layer/unicoap/iana/contenttype.js
+++ b/sys/net/application_layer/unicoap/iana/contenttype.js
@@ -3,7 +3,7 @@
 // https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats
 //
 // Copy and run this script in your web inspector, then copy into sys/include/net/unicoap/constants.h
-// into the unicoap_options_t enum.
+// into the unicoap_option_number_t enum.
 //
 // The script also adds cross-references to the documentation comment.
 [...document.querySelectorAll("#table-content-formats > tbody > tr")]

--- a/sys/net/application_layer/unicoap/server/server.c
+++ b/sys/net/application_layer/unicoap/server/server.c
@@ -38,7 +38,7 @@ int unicoap_resource_match_request_default(const unicoap_listener_t* listener,
         if (!unicoap_match_proto((*resource)->protocols, endpoint->proto)) {
             _SERVER_DEBUG("ignoring resource <");
             if (IS_ACTIVE(ENABLE_DEBUG)) {
-                unicoap_path_print(&(*resource)->path);
+                unicoap_print_path(&(*resource)->path);
             }
             DEBUG(">, proto %s not in allowed set\n", unicoap_string_from_proto(endpoint->proto));
             continue;

--- a/sys/net/application_layer/unicoap/state.c
+++ b/sys/net/application_layer/unicoap/state.c
@@ -224,15 +224,10 @@ void unicoap_listener_register(unicoap_listener_t* listener) {
     for (unsigned int i = 0; i < listener->resource_count; i += 1) {
         if (IS_ACTIVE(CONFIG_UNICOAP_ASSIST)) {
             if (!listener->resources[i].methods) {
-                char path[CONFIG_UNICOAP_PATH_LENGTH_MAX];
-                ssize_t length =
-                    unicoap_path_stringify(&listener->resources[i].path, path, sizeof(path));
-                if (length < 0) {
-                    continue;
-                }
-                unicoap_assist(API_WARNING("resource '%.*s' is inaccessible")
-                               FIXIT("Set .methods"),
-                               (int)length, path);
+                unicoap_print_resource(&listener->resources[i]);
+                printf(":\n");
+                unicoap_assist(API_WARNING("resource definition is inaccessible")
+                               FIXIT("Set .methods"));
             }
 
             /* TODO: Advanced features: emit warnings */
@@ -476,7 +471,7 @@ int unicoap_resource_find(const unicoap_packet_t* packet, const unicoap_resource
 
                     if (IS_ACTIVE(ENABLE_DEBUG)) {
                         _SERVER_DEBUG("<");
-                        unicoap_path_print(&resource->path);
+                        unicoap_print_path(&resource->path);
                         DEBUG("%s>: found\n",
                               (*resource_ptr)->flags & UNICOAP_RESOURCE_FLAG_MATCH_SUBTREE ? "/**" : "");
                     }
@@ -494,7 +489,7 @@ int unicoap_resource_find(const unicoap_packet_t* packet, const unicoap_resource
             switch (ret) {
                 case UNICOAP_STATUS_METHOD_NOT_ALLOWED:
                     _SERVER_DEBUG("<");
-                    unicoap_path_print(&(*resource_ptr)->path);
+                    unicoap_print_path(&(*resource_ptr)->path);
                     DEBUG("%s>: method %s not allowed\n",
                           (*resource_ptr)->flags & UNICOAP_RESOURCE_FLAG_MATCH_SUBTREE ? "/**" : "",
                           unicoap_string_from_method(unicoap_request_get_method(packet->message)));
@@ -540,7 +535,7 @@ void unicoap_print_listeners(void) {
                 const unicoap_resource_t* resource = &listener->resources[k];
 
                 printf("\t\t\t\t- resource #%" PRIuSIZE " ", k);
-                unicoap_path_print(&resource->path);
+                unicoap_print_path(&resource->path);
                 printf("\n");
 
                 printf("\t\t\t\t\t- flags=");

--- a/sys/net/application_layer/unicoap/utils.c
+++ b/sys/net/application_layer/unicoap/utils.c
@@ -41,7 +41,7 @@ size_t unicoap_path_component_count(const unicoap_pathspec_t* path) {
     return count;
 }
 
-void unicoap_path_print(const unicoap_pathspec_t* path) {
+void unicoap_print_path(const unicoap_pathspec_t* path) {
     assert(path);
     if (!path->_components) {
         printf("/");
@@ -701,6 +701,18 @@ void unicoap_print_resource_flags(unicoap_resource_flags_t flags) {
         printf("MATCH_SUBTREE ");
     }
     printf("]");
+}
+
+void unicoap_print_resource(const unicoap_resource_t* resource) {
+    printf("<");
+    unicoap_print_path(&resource->path);
+    printf(" methods=");
+    unicoap_print_methods(resource->methods);
+    printf(" protocols=");
+    unicoap_print_protocols(resource->protocols);
+    printf(" flags=");
+    unicoap_print_resource_flags(resource->flags);
+    printf(">");
 }
 
 void unicoap_assist_emit_diagnostic_missing_driver(unicoap_proto_t proto) {

--- a/sys/net/application_layer/unicoap/utils.c
+++ b/sys/net/application_layer/unicoap/utils.c
@@ -91,8 +91,7 @@ bool unicoap_path_is_equal(const unicoap_pathspec_t* lhs, const unicoap_pathspec
     assert(rhs);
 
     /* If one is a root path, the other must be, too. */
-    if ((!lhs->_components && !rhs->_components) ||
-        (!rhs->_components && !lhs->_components)) {
+    if ((!lhs->_components && !rhs->_components)) {
         return true;
     }
     /* If just one of them is a root path, they cannot be equal. */

--- a/tests/unittests/tests-unicoap/tests-unicoap-matching.c
+++ b/tests/unittests/tests-unicoap/tests-unicoap-matching.c
@@ -130,7 +130,7 @@ static void _test_long_with_string(bool match_subtree) {
     printf("'%.*s'\n", (int)res, test_buffer);
 
     printf("'");
-    unicoap_path_print(&r.path);
+    unicoap_print_path(&r.path);
     printf("'\n");
     */
 


### PR DESCRIPTION
### Contribution description

As the title says. Just a minor clean-up, mostly for documentation.


### Testing procedure

Look at the changes. Almost no actual code changes.


### Issues/PRs references

Follow-up of https://github.com/RIOT-OS/RIOT/pull/21582

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
