### PR TITLE
doc/guides: Update path for package tests in documentation

### DIFF
--- a/doc/guides/getting-started/finding_modules.mdx
+++ b/doc/guides/getting-started/finding_modules.mdx
@@ -128,5 +128,5 @@ USEPKG += mcufont
 Using packages is often more challenging than using modules. Some packages
 require additional `CFLAGS` or other configuration flags to function as
 intended. So the best strategy for using a package is to look at examples or
-tests that use it. The package tests can be found in the `examples/pkg`
+tests that use it. The package tests can be found in the `tests/pkg`
 subdirectory.


### PR DESCRIPTION
### Contribution description
I noticed that probably another folder was meant.

### Testing procedure
building the docs, i guess?

### Issues/PRs references
### Declaration of AI-Tools / LLMs usage:
AI-Tools / LLMs that were used are:
- none