### PR TITLE
treewide: use the correct name for Makefiles in doc code blocks

### DIFF
--- a/boards/seeedstudio-xiao-esp32c6/doc.md
+++ b/boards/seeedstudio-xiao-esp32c6/doc.md
@@ -99,7 +99,7 @@ switch accordingly at startup.
 To use the external U.FL antenna instead, enable the
 `CONFIG_XIAO_ESP32C6_EXT_ANTENNA` option, for example by adding
 the following line to the application's Makefile:
-```Makefile
+```makefile
 CFLAGS += -DCONFIG_XIAO_ESP32C6_EXT_ANTENNA=1
 ```
 

--- a/cpu/esp32/esp-eth/doc.md
+++ b/cpu/esp32/esp-eth/doc.md
@@ -12,17 +12,23 @@ module.
 
 @author      Gunar Schorcht <gunar@schorcht.net>
 
-ESP32 provides an <b>Ethernet MAC layer module (EMAC)</b> according to the IEEE 802.3 standard which can be used together with an external physical layer chip (PHY) to realize a 100/10 Mbps Ethernet interface. Supported PHY chips are the Microchip LAN8710/LAN8720, the IC Plus 101G, and the Texas Instruments TLK110.
+The ESP32 provides an <b>Ethernet MAC layer module (EMAC)</b> according to the
+IEEE 802.3 standard which can be used together with an external physical layer
+chip (PHY) to realize a 100/10 Mbps Ethernet interface. Supported PHY chips are
+the Microchip LAN8710/LAN8720, the IC Plus 101G, and the Texas Instruments TLK110.
 
-The RIOT port for ESP32 realizes with module ```esp_eth``` a ```netdev``` driver for the EMAC which uses RIOT's standard Ethernet interface.
+The RIOT port for ESP32 realizes the Ethernet support with the `esp_eth` module,
+which is a `netdev` driver for the EMAC which uses RIOT's standard Ethernet interface.
 
-If the board has one of the supported PHY layer chips connected to the ESP32, the ```esp_eth``` module should be enabled by default in board's ```Makefile.dep``` when module ```netdev_default``` is used.
-```
+If the board has one of the supported PHY layer chips connected to the ESP32,
+the `esp_eth` module should be enabled by default in board's `Makefile.dep`
+when the `netdev_default` module is used.
+```makefile
 ifneq (,$(filter netdev_default,$(USEMODULE)))
     USEMODULE += esp_eth
 endif
 ```
-Otherwise, the application has to add the ```esp_eth``` module in its makefile when needed.
+Otherwise, the application has to add the `esp_eth` module in its Makefile when needed.
 
-@note
-The board has to have one of the supported PHY modules to be able to use the Ethernet MAC module.
+@note The board has to have one of the supported PHY modules to be able to
+      use the Ethernet MAC module.

--- a/examples/basic/subfolders/README.md
+++ b/examples/basic/subfolders/README.md
@@ -31,7 +31,7 @@ while the source files in `folder` are considered part of the application itself
 
 At a minimum, each module in RIOT requires a `Makefile` with the following content:
 
-```Makefile
+```makefile
 include $(RIOTBASE)/Makefile.base
 ```
 
@@ -45,7 +45,7 @@ RIOT modules are also described in greater detail [in the documentation](https:/
 
 Two lines need to be added to the application's Makefile in order to compile and use the module:
 
-```Makefile
+```makefile
 EXTERNAL_MODULE_DIRS += $(CURDIR)/external_modules/
 USEMODULE += module
 ```
@@ -61,7 +61,7 @@ Compared to the module approach, no additional Makefile is needed in the subfold
 The application's Makefile needs to add _all_ source files explicitly,
 including the ones residing directly in the application directory:
 
-```Makefile
+```makefile
 SRC += main.c
 SRC += folder/a.c folder/subfolder/b.c
 ```
@@ -69,7 +69,7 @@ SRC += folder/a.c folder/subfolder/b.c
 To avoid listing all source files individually, it is of course possible
 to use normal GNU make functions such as `wildcard`:
 
-```Makefile
+```makefile
 SRC += $(wildcard *.c folder/*.c folder/**/*.c)
 ```
 

--- a/pkg/cryptoauthlib/doc.md
+++ b/pkg/cryptoauthlib/doc.md
@@ -116,7 +116,7 @@ In your custom file you can now add a second device to `ATCA_PARAMS`:
 
 Now you just need to add the following to your Makefile:
 
-```Makefile
+```makefile
 CFLAGS += -DCUSTOM_ATCA_PARAMS
 INCLUDES += -I$(APPDIR)
 ```

--- a/pkg/u8g2/doc.md
+++ b/pkg/u8g2/doc.md
@@ -42,7 +42,7 @@ want to use it with the generic display interface.
 
 Add the following to your application's Makefile:
 
-```Makefile
+```makefile
 USEPKG += u8g2
 USEMODULE += disp_dev
 ```
@@ -50,7 +50,7 @@ U8G2 supports both I2C and SPI to communicate with displays, so it will not
 automatically pull any peripheral dependency. Therefore, you need to
 additionally add the corresponding feature to the application's Makefile:
 
-```Makefile
+```makefile
 FEATURES_REQUIRED += periph_i2c
 ```
 
@@ -62,7 +62,7 @@ the initialization function, refer to the setup documentation of the package:
 https://github.com/olikraus/u8g2/wiki/u8g2setupc#setup-function-reference. You
 can set these values in your Makefile, for example:
 
-```Makefile
+```makefile
 # I2C device 1, this will depend on which bus you connect the display on your
 # board
 CFLAGS += -DU8G2_DISPLAY_PARAM_DEV=I2C_DEV\(1\)
@@ -84,7 +84,7 @@ want to use it with the generic display interface.
 
 Add the following to your application's Makefile:
 
-```Makefile
+```makefile
 USEPKG += u8g2
 USEMODULE += disp_dev
 ```
@@ -93,7 +93,7 @@ U8G2 supports both I2C and SPI to communicate with displays, so it will not
 automatically pull any peripheral dependency. Therefore, you need to
 additionally add the corresponding feature to the application's Makefile:
 
-```Makefile
+```makefile
 FEATURES_REQUIRED += periph_spi
 ```
 
@@ -106,7 +106,7 @@ function, refer to the setup documentation of the package:
 https://github.com/olikraus/u8g2/wiki/u8g2setupc#setup-function-reference. You
 can set these values in your Makefile, for example:
 
-```Makefile
+```makefile
 # SPI device 1, this will depend on which bus you connect the display on your
 # board
 CFLAGS += -DU8G2_DISPLAY_PARAM_DEV=SPI_DEV\(1\)
@@ -122,7 +122,7 @@ CFLAGS += -DU8G2_DISPLAY_PARAM_INIT_FUNCTION=u8g2_Setup_ssd1306_128x64_noname_f
 ## Usage via Package API {#direct-usage}
 If you prefer to use the package directly, you first need to add it to your
 application's Makefile:
-```Makefile
+```makefile
 USEPKG += u8g2
 ```
 Then, add the header in your code: `#include "u8g2.h"`.
@@ -189,7 +189,7 @@ only available on native targets that have SDL installed. It uses `sdl2-config`
 to find the headers and libraries. Note that RIOT-OS builds 32-bit binaries and
 requires 32-bit SDL libraries. Using SDL requires more stack so in case you are
 using it add the following to your Makefile:
-```Makefile
+```makefile
 CFLAGS += '-DTHREAD_STACKSIZE_MAIN= 48*1024'
 ```
 48kB is enough for the test application in RIOT, other uses may need more or may

--- a/sys/net/application_layer/unicoap/docs/doc.md
+++ b/sys/net/application_layer/unicoap/docs/doc.md
@@ -27,7 +27,7 @@ discovery, message fragmentation, and end-to-end message protection.
 ## Quick start
 
 In your application Makefile, add
-```Makefile
+```makefile
 USEMODULE += unicoap
 USEMODULE += unicoap_driver_udp
 ```

--- a/sys/stdio/doc.md
+++ b/sys/stdio/doc.md
@@ -23,7 +23,7 @@ consumption. This includes the following features:
 | `stdin`              | Support for input (default is output only)    |
 
 The additional features can be enabled in the application Makefile:
-```Makefile
+```makefile
 USEMODULE += printf_float
 ```
 
@@ -58,7 +58,7 @@ list below:
 As with the additional features, you can specify the STDIO backend to be used
 in your application Makefile:
 
-```Makefile
+```makefile
 USEMODULE += stdio_cdc_acm
 ```
 


### PR DESCRIPTION
### Contribution description

I noticed that Starlight was complaining about not knowing `Makefile` for syntax highlighting, so I went on a hunt...

`````
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ grep -RnwI \`\`\`Makefile . | grep ".md"
./cpu/esp32/esp-eth/doc.md:19:If the board has one of the supported PHY layer chips connected to the ESP32, the ```esp_eth``` module should be enabled by default in board's ```Makefile.dep``` when module ```netdev_default``` is used.
./examples/basic/subfolders/README.md:34:```Makefile
./examples/basic/subfolders/README.md:48:```Makefile
./examples/basic/subfolders/README.md:64:```Makefile
./examples/basic/subfolders/README.md:72:```Makefile
./pkg/cryptoauthlib/doc.md:119:```Makefile
./pkg/u8g2/doc.md:45:```Makefile
./pkg/u8g2/doc.md:53:```Makefile
./pkg/u8g2/doc.md:65:```Makefile
./pkg/u8g2/doc.md:87:```Makefile
./pkg/u8g2/doc.md:96:```Makefile
./pkg/u8g2/doc.md:109:```Makefile
./pkg/u8g2/doc.md:125:```Makefile
./pkg/u8g2/doc.md:192:```Makefile
./boards/seeedstudio-xiao-esp32c6/doc.md:102:```Makefile
./sys/net/application_layer/unicoap/docs/doc.md:30:```Makefile
./sys/stdio/doc.md:26:```Makefile
./sys/stdio/doc.md:61:```Makefile
`````

### Testing procedure

Look at the docs 👀 


### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
