### PR TITLE
drivers/slipdev: Replace nanocoap with unicoap

### DIFF
--- a/drivers/include/slipdev.h
+++ b/drivers/include/slipdev.h
@@ -61,6 +61,7 @@
 #include <stdint.h>
 
 #include "cib.h"
+#include "event.h"
 #include "net/netdev.h"
 #include "periph/uart.h"
 #include "chunked_ringbuffer.h"
@@ -173,7 +174,7 @@ typedef struct {
 #if IS_USED(MODULE_SLIPDEV_CONFIG)
     chunk_ringbuf_t rb_config;                      /**< Ringbuffer stores received configuration frames */
     uint8_t rxmem_config[CONFIG_SLIPDEV_BUFSIZE];   /**< memory used by RX buffer */
-    kernel_pid_t coap_server_pid;                   /**< The PID of the CoAP server */
+    event_t rxevent;                                /**< The event that is send to the CoAP server */
 #endif
 
     slipdev_params_t config;                /**< configuration parameters */
@@ -193,6 +194,53 @@ typedef struct {
  *                      If initialized manually, pass a unique identifier instead.
  */
 void slipdev_setup(slipdev_t *dev, const slipdev_params_t *params, uint8_t index);
+
+/**
+ * @brief   Setup the event queue that will be notified when a config frame arrives
+ *
+ * @param[in] q         event queue
+ */
+void slipdev_coap_set_event_queue(event_queue_t *q);
+
+/**
+ * @brief   Teardown the event queue
+ */
+void slipdev_coap_unset_event_queue(void);
+
+/**
+ * @brief   Callback to inform unicoap that a new configuration frame is available
+ *
+ * @param[in] event     event of the received frame
+ */
+void unicoap_slipdev_recv_handler(event_t * event);
+
+
+/**
+ * @brief   Receive a CoAP packet into the given buffer
+ *
+ * This function handles the unescaping and checks the FCS for correctness.
+ *
+ * @param[in] buf       buffer into which the received frame is copied.
+ * @param[in] buf_size  length of @p buf.
+ * @param[in] dev       device descriptor to identify the slipdev instance.
+ *
+ * @retval >0   length of the stored frame in bytes
+ * @retval  0   No frame available, the buffer was not modified
+ * @retval -1   Frame length exceeds buffer size or the frame was too short to be valid
+ * @retval -2   The checksum was invalid, the buffer was modified
+ */
+int slipdev_coap_recv(uint8_t *buf, size_t buf_size, slipdev_t *dev);
+
+/**
+ * @brief   Send a CoAP message as a configuration frame
+ *
+ * This functions handles the calculation of the needed checksum, the escaping
+ * of data, the framing and finally sends the result onto the wire.
+ *
+ * @param[in] iolist    IO vector list to send.
+ * @param[in] dev       device descriptor to identify the slipdev instance.
+ */
+void slipdev_coap_send(const iolist_t *iolist,  const slipdev_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/slipdev.h
+++ b/drivers/include/slipdev.h
@@ -208,7 +208,7 @@ void slipdev_coap_set_event_queue(event_queue_t *q);
 void slipdev_coap_unset_event_queue(void);
 
 /**
- * @brief   Unicoap callback to handle a received config frame
+ * @brief   Callback to inform unicoap that a new configuration frame is available
  *
  * @param[in] event     event of the received frame
  */
@@ -216,7 +216,9 @@ void unicoap_slipdev_recv_handler(event_t * event);
 
 
 /**
- * @brief   Called by unicoap to receive a config frame
+ * @brief   Receive a CoAP packet into the given buffer
+ *
+ * This function handles the unescaping and checks the FCS for correctness.
  *
  * @param[in] buf       buffer into which the received frame is copied.
  * @param[in] buf_size  length of @p buf.
@@ -230,7 +232,7 @@ void unicoap_slipdev_recv_handler(event_t * event);
 int slipdev_coap_recv(uint8_t *buf, size_t buf_size, slipdev_t *dev);
 
 /**
- * @brief   Called by unicoap to send a coap message as a config frame
+ * @brief   Send a CoAP message as a configuration frame
  *
  * This functions handles the calculation of the needed checksum, the escaping
  * of data, the framing and finally sends the result onto the wire.

--- a/drivers/include/slipdev.h
+++ b/drivers/include/slipdev.h
@@ -240,7 +240,7 @@ int slipdev_coap_recv(uint8_t *buf, size_t buf_size, slipdev_t *dev);
  * @param[in] iolist    IO vector list to send.
  * @param[in] dev       device descriptor to identify the slipdev instance.
  */
-void slipdev_coap_send(iolist_t *iolist,  const slipdev_t *dev);
+void slipdev_coap_send(const iolist_t *iolist,  const slipdev_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/slipdev.h
+++ b/drivers/include/slipdev.h
@@ -237,11 +237,10 @@ int slipdev_coap_recv(uint8_t *buf, size_t buf_size, slipdev_t *dev);
  * This functions handles the calculation of the needed checksum, the escaping
  * of data, the framing and finally sends the result onto the wire.
  *
- * @param[in] buf       buffer into which the received frame is copied.
- * @param[in] buf_size  length of @p buf.
+ * @param[in] iolist    IO vector list to send.
  * @param[in] dev       device descriptor to identify the slipdev instance.
  */
-void slipdev_coap_send(uint8_t *buf, size_t buf_size, const slipdev_t *dev);
+void slipdev_coap_send(iolist_t *iolist,  const slipdev_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/slipdev.h
+++ b/drivers/include/slipdev.h
@@ -61,6 +61,7 @@
 #include <stdint.h>
 
 #include "cib.h"
+#include "event.h"
 #include "net/netdev.h"
 #include "periph/uart.h"
 #include "chunked_ringbuffer.h"
@@ -173,7 +174,7 @@ typedef struct {
 #if IS_USED(MODULE_SLIPDEV_CONFIG)
     chunk_ringbuf_t rb_config;                      /**< Ringbuffer stores received configuration frames */
     uint8_t rxmem_config[CONFIG_SLIPDEV_BUFSIZE];   /**< memory used by RX buffer */
-    kernel_pid_t coap_server_pid;                   /**< The PID of the CoAP server */
+    event_t rxevent;                                /**< The event that is send to the CoAP server */
 #endif
 
     slipdev_params_t config;                /**< configuration parameters */
@@ -193,6 +194,52 @@ typedef struct {
  *                      If initialized manually, pass a unique identifier instead.
  */
 void slipdev_setup(slipdev_t *dev, const slipdev_params_t *params, uint8_t index);
+
+/**
+ * @brief   Setup the event queue that will be notified when a config frame arrives
+ *
+ * @param[in] q         event queue
+ */
+void slipdev_coap_set_event_queue(event_queue_t *q);
+
+/**
+ * @brief   Teardown the event queue
+ */
+void slipdev_coap_unset_event_queue(void);
+
+/**
+ * @brief   Unicoap callback to handle a received config frame
+ *
+ * @param[in] event     event of the received frame
+ */
+void unicoap_slipdev_recv_handler(event_t * event);
+
+
+/**
+ * @brief   Called by unicoap to receive a config frame
+ *
+ * @param[in] buf       buffer into which the received frame is copied.
+ * @param[in] buf_size  length of @p buf.
+ * @param[in] dev       device descriptor to identify the slipdev instance.
+ *
+ * @retval >0   length of the stored frame in bytes
+ * @retval  0   No frame available, the buffer was not modified
+ * @retval -1   Frame length exceeds buffer size or the frame was too short to be valid
+ * @retval -2   The checksum was invalid, the buffer was modified
+ */
+int slipdev_coap_recv(uint8_t *buf, size_t buf_size, slipdev_t *dev);
+
+/**
+ * @brief   Called by unicoap to send a coap message as a config frame
+ *
+ * This functions handles the calculation of the needed checksum, the escaping
+ * of data, the framing and finally sends the result onto the wire.
+ *
+ * @param[in] buf       buffer into which the received frame is copied.
+ * @param[in] buf_size  length of @p buf.
+ * @param[in] dev       device descriptor to identify the slipdev instance.
+ */
+void slipdev_coap_send(uint8_t *buf, size_t buf_size, const slipdev_t *dev);
 
 #ifdef __cplusplus
 }

--- a/drivers/slipmux/Makefile.dep
+++ b/drivers/slipmux/Makefile.dep
@@ -14,10 +14,9 @@ endif
 
 ifneq (,$(filter slipdev_config,$(USEMODULE)))
   USEMODULE += checksum
-  USEMODULE += sock_udp
-  USEMODULE += gnrc_ipv6
-  USEMODULE += nanocoap_sock
-  USEMODULE += nanocoap_resources
+  USEMODULE += unicoap
+  USEMODULE += unicoap_server
+  USEMODULE += unicoap_driver_slipmux
 endif
 
 ifneq (,$(filter slipdev_stdio,$(USEMODULE)))

--- a/drivers/slipmux/coap.c
+++ b/drivers/slipmux/coap.c
@@ -10,15 +10,15 @@
  * @author  Bennet Hattesen <bennet.hattesen@haw-hamburg.de>
  */
 #include "checksum/crc16_ccitt.h"
-#include "net/nanocoap.h"
+#include "event.h"
+#include "net/unicoap/transport.h"
 #include "slipdev.h"
 #include "slipdev_internal.h"
 
 /* The special init is the result of normal fcs init combined with slipmux config start (0xa9) */
 #define SPECIAL_INIT_FCS (0x374cU)
-#define COAP_STACKSIZE (1024)
 
-static char coap_stack[COAP_STACKSIZE];
+static event_queue_t *queue = NULL;
 
 static inline void _slipdev_lock(void)
 {
@@ -34,62 +34,63 @@ static inline void _slipdev_unlock(void)
     }
 }
 
-void *_coap_server_thread(void *arg)
+/* called in ISR context */
+void slipdev_coap_dispatch_recv(event_t *event)
 {
-    static uint8_t buf[512];
-    slipdev_t *dev = arg;
-
-    while (1) {
-        thread_flags_wait_any(1);
-        size_t len;
-        while (crb_get_chunk_size(&dev->rb_config, &len)) {
-            if (len > sizeof(buf)) {
-                crb_consume_chunk(&dev->rb_config, NULL, len);
-                continue;
-            }
-            crb_consume_chunk(&dev->rb_config, buf, len);
-
-            /* Is the crc correct via residue(=0xF0B8) test */
-            if (crc16_ccitt_fcs_update(SPECIAL_INIT_FCS, buf, len) != 0xF0B8) {
-                break;
-            }
-
-            /* cut off the FCS checksum at the end */
-            size_t pktlen = len - 2;
-
-            coap_pkt_t pkt;
-            sock_udp_ep_t remote;
-            coap_request_ctx_t ctx = {
-                .remote = &remote,
-            };
-            if (coap_parse(&pkt, buf, pktlen) < 0) {
-                break;
-            }
-            unsigned int res = 0;
-            if ((res = coap_handle_req(&pkt, buf, sizeof(buf), &ctx)) <= 0) {
-                break;
-            }
-
-            uint16_t fcs_sum = crc16_ccitt_fcs_finish(SPECIAL_INIT_FCS, buf, res);
-
-            _slipdev_lock();
-            slipdev_write_byte(dev->config.uart, SLIPDEV_START_COAP);
-            slipdev_write_bytes(dev->config.uart, buf, res);
-            slipdev_write_bytes(dev->config.uart, (uint8_t *)&fcs_sum, 2);
-            slipdev_write_byte(dev->config.uart, SLIPDEV_END);
-            _slipdev_unlock();
-        }
+    if (queue) {
+        event_post(queue, event);
     }
-
-    return NULL;
 }
 
-void slipdev_setup_coap(slipdev_t *dev) {
-    crb_init(&dev->rb_config, dev->rxmem_config, sizeof(dev->rxmem_config));
+void slipdev_coap_set_event_queue(event_queue_t *q)
+{
+    queue = q;
+}
 
-    dev->coap_server_pid = thread_create(coap_stack, sizeof(coap_stack), THREAD_PRIORITY_MAIN - 1,
-                                         THREAD_CREATE_STACKTEST, _coap_server_thread,
-                                         (void *)dev, "Slipmux CoAP server");
+void slipdev_coap_unset_event_queue(void)
+{
+    queue = NULL;
+}
+
+int slipdev_coap_recv(uint8_t *buf, size_t buf_size, slipdev_t *dev)
+{
+    size_t len;
+
+    if (crb_get_chunk_size(&dev->rb_config, &len)) {
+        if ((len > buf_size) || (len <= 2)) {
+            crb_consume_chunk(&dev->rb_config, NULL, len);
+            return -1;
+        }
+        crb_consume_chunk(&dev->rb_config, buf, len);
+
+        /* Is the crc correct via residue(=0xF0B8) test */
+        if (crc16_ccitt_fcs_update(SPECIAL_INIT_FCS, buf, len) != 0xF0B8) {
+            return -2;
+        }
+        /* cut off the FCS checksum at the end */
+        size_t pktlen = len - 2;
+
+        return pktlen;
+    }
+    return 0;
+}
+
+void slipdev_coap_send(uint8_t *buf, size_t buf_size, const slipdev_t *dev)
+{
+    uint16_t fcs_sum = crc16_ccitt_fcs_finish(SPECIAL_INIT_FCS, buf, buf_size);
+
+    _slipdev_lock();
+    slipdev_write_byte(dev->config.uart, SLIPDEV_START_COAP);
+    slipdev_write_bytes(dev->config.uart, buf, buf_size);
+    slipdev_write_bytes(dev->config.uart, (uint8_t *)&fcs_sum, 2);
+    slipdev_write_byte(dev->config.uart, SLIPDEV_END);
+    _slipdev_unlock();
+}
+
+void slipdev_setup_coap(slipdev_t *dev)
+{
+    crb_init(&dev->rb_config, dev->rxmem_config, sizeof(dev->rxmem_config));
+    dev->rxevent.handler = unicoap_slipdev_recv_handler;
 }
 
 /** @} */

--- a/drivers/slipmux/coap.c
+++ b/drivers/slipmux/coap.c
@@ -10,15 +10,15 @@
  * @author  Bennet Hattesen <bennet.hattesen@haw-hamburg.de>
  */
 #include "checksum/crc16_ccitt.h"
-#include "net/nanocoap.h"
+#include "event.h"
+#include "net/unicoap/transport.h"
 #include "slipdev.h"
 #include "slipdev_internal.h"
 
 /* The special init is the result of normal fcs init combined with slipmux config start (0xa9) */
 #define SPECIAL_INIT_FCS (0x374cU)
-#define COAP_STACKSIZE (1024)
 
-static char coap_stack[COAP_STACKSIZE];
+static event_queue_t *queue = NULL;
 
 static inline void _slipdev_lock(void)
 {
@@ -34,62 +34,70 @@ static inline void _slipdev_unlock(void)
     }
 }
 
-void *_coap_server_thread(void *arg)
+/* called in ISR context */
+void slipdev_coap_dispatch_recv(event_t *event)
 {
-    static uint8_t buf[512];
-    slipdev_t *dev = arg;
+    if (queue) {
+        event_post(queue, event);
+    }
+}
 
-    while (1) {
-        thread_flags_wait_any(1);
-        size_t len;
-        while (crb_get_chunk_size(&dev->rb_config, &len)) {
-            if (len > sizeof(buf)) {
-                crb_consume_chunk(&dev->rb_config, NULL, len);
-                continue;
-            }
-            crb_consume_chunk(&dev->rb_config, buf, len);
+void slipdev_coap_set_event_queue(event_queue_t *q)
+{
+    queue = q;
+}
 
-            /* Is the crc correct via residue(=0xF0B8) test */
-            if (crc16_ccitt_fcs_update(SPECIAL_INIT_FCS, buf, len) != 0xF0B8) {
-                break;
-            }
+void slipdev_coap_unset_event_queue(void)
+{
+    queue = NULL;
+}
 
-            /* cut off the FCS checksum at the end */
-            size_t pktlen = len - 2;
+int slipdev_coap_recv(uint8_t *buf, size_t buf_size, slipdev_t *dev)
+{
+    size_t len;
 
-            coap_pkt_t pkt;
-            sock_udp_ep_t remote;
-            coap_request_ctx_t ctx = {
-                .remote = &remote,
-            };
-            if (coap_parse(&pkt, buf, pktlen) < 0) {
-                break;
-            }
-            unsigned int res = 0;
-            if ((res = coap_handle_req(&pkt, buf, sizeof(buf), &ctx)) <= 0) {
-                break;
-            }
+    if (crb_get_chunk_size(&dev->rb_config, &len)) {
+        if ((len > buf_size) || (len <= 2)) {
+            crb_consume_chunk(&dev->rb_config, NULL, len);
+            return -1;
+        }
+        crb_consume_chunk(&dev->rb_config, buf, len);
 
-            uint16_t fcs_sum = crc16_ccitt_fcs_finish(SPECIAL_INIT_FCS, buf, res);
+        /* Is the crc correct via residue(=0xF0B8) test */
+        if (crc16_ccitt_fcs_update(SPECIAL_INIT_FCS, buf, len) != 0xF0B8) {
+            return -2;
+        }
+        /* cut off the FCS checksum at the end */
+        size_t pktlen = len - 2;
 
-            _slipdev_lock();
-            slipdev_write_byte(dev->config.uart, SLIPDEV_START_COAP);
-            slipdev_write_bytes(dev->config.uart, buf, res);
-            slipdev_write_bytes(dev->config.uart, (uint8_t *)&fcs_sum, 2);
-            slipdev_write_byte(dev->config.uart, SLIPDEV_END);
-            _slipdev_unlock();
+        return pktlen;
+    }
+    return 0;
+}
+
+void slipdev_coap_send(const iolist_t *iolist, const slipdev_t *dev)
+{
+    uint16_t fcs_sum = SPECIAL_INIT_FCS;
+    _slipdev_lock();
+    slipdev_write_byte(dev->config.uart, SLIPDEV_START_COAP);
+
+    for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
+        if (iol->iol_len) {
+            fcs_sum = crc16_ccitt_fcs_update(fcs_sum, iol->iol_base, iol->iol_len);
+            slipdev_write_bytes(dev->config.uart, iol->iol_base, iol->iol_len);
         }
     }
 
-    return NULL;
+    fcs_sum = crc16_ccitt_fcs_finish(fcs_sum, NULL, 0);
+    slipdev_write_bytes(dev->config.uart, (uint8_t *)&fcs_sum, 2);
+    slipdev_write_byte(dev->config.uart, SLIPDEV_END);
+    _slipdev_unlock();
 }
 
-void slipdev_setup_coap(slipdev_t *dev) {
+void slipdev_setup_coap(slipdev_t *dev)
+{
     crb_init(&dev->rb_config, dev->rxmem_config, sizeof(dev->rxmem_config));
-
-    dev->coap_server_pid = thread_create(coap_stack, sizeof(coap_stack), THREAD_PRIORITY_MAIN - 1,
-                                         THREAD_CREATE_STACKTEST, _coap_server_thread,
-                                         (void *)dev, "Slipmux CoAP server");
+    dev->rxevent.handler = unicoap_slipdev_recv_handler;
 }
 
 /** @} */

--- a/drivers/slipmux/coap.c
+++ b/drivers/slipmux/coap.c
@@ -75,7 +75,7 @@ int slipdev_coap_recv(uint8_t *buf, size_t buf_size, slipdev_t *dev)
     return 0;
 }
 
-void slipdev_coap_send(iolist_t *iolist, const slipdev_t *dev)
+void slipdev_coap_send(const iolist_t *iolist, const slipdev_t *dev)
 {
     uint16_t fcs_sum = SPECIAL_INIT_FCS;
     _slipdev_lock();

--- a/drivers/slipmux/coap.c
+++ b/drivers/slipmux/coap.c
@@ -75,13 +75,20 @@ int slipdev_coap_recv(uint8_t *buf, size_t buf_size, slipdev_t *dev)
     return 0;
 }
 
-void slipdev_coap_send(uint8_t *buf, size_t buf_size, const slipdev_t *dev)
+void slipdev_coap_send(iolist_t *iolist, const slipdev_t *dev)
 {
-    uint16_t fcs_sum = crc16_ccitt_fcs_finish(SPECIAL_INIT_FCS, buf, buf_size);
-
+    uint16_t fcs_sum = SPECIAL_INIT_FCS;
     _slipdev_lock();
     slipdev_write_byte(dev->config.uart, SLIPDEV_START_COAP);
-    slipdev_write_bytes(dev->config.uart, buf, buf_size);
+
+    for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
+        if (iol->iol_len) {
+            fcs_sum = crc16_ccitt_fcs_update(fcs_sum, iol->iol_base, iol->iol_len);
+            slipdev_write_bytes(dev->config.uart, iol->iol_base, iol->iol_len);
+        }
+    }
+
+    fcs_sum = crc16_ccitt_fcs_finish(fcs_sum, NULL, 0);
     slipdev_write_bytes(dev->config.uart, (uint8_t *)&fcs_sum, 2);
     slipdev_write_byte(dev->config.uart, SLIPDEV_END);
     _slipdev_unlock();

--- a/drivers/slipmux/slipdev.c
+++ b/drivers/slipmux/slipdev.c
@@ -36,6 +36,7 @@
 /* forward declarations, implementation is in net/coap */
 void slipdev_setup_net(slipdev_t *dev, uint8_t index);
 void slipdev_setup_coap(slipdev_t *dev);
+void slipdev_coap_dispatch_recv(event_t *event);
 
 /* For synchronization between stdio/config/net threads */
 mutex_t slipdev_mutex = MUTEX_INIT;
@@ -65,7 +66,7 @@ static inline void _slipdev_config_end_frame(slipdev_t *dev)
 {
 #ifdef MODULE_SLIPDEV_CONFIG
     crb_end_chunk(&dev->rb_config, true);
-    thread_flags_set(thread_get(dev->coap_server_pid), 1);
+    slipdev_coap_dispatch_recv(&dev->rxevent);
 #else
     (void)dev;
 #endif
@@ -301,7 +302,7 @@ void slipdev_setup(slipdev_t *dev, const slipdev_params_t *params, uint8_t index
 {
     /* set device descriptor fields */
     dev->config = *params;
-    dev->state = SLIPDEV_STATE_NONE;
+    dev->state = SLIPDEV_STATE_UNKNOWN;
 
     /* we only support one coap server at the moment */
     if ((index == 0) && IS_USED(MODULE_SLIPDEV_CONFIG)) {

--- a/sys/include/net/unicoap/transport.h
+++ b/sys/include/net/unicoap/transport.h
@@ -193,7 +193,7 @@ static inline bool unicoap_transport_uses_sock_tl_ep(unicoap_proto_t proto)
      * such as CoAP over GATT, return false here. */
     /* MARK: unicoap_driver_extension_point */
     default:
-        return true;
+        return false;
     }
 }
 

--- a/sys/include/net/unicoap/transport.h
+++ b/sys/include/net/unicoap/transport.h
@@ -26,6 +26,10 @@
 #  include "net/sock/dtls.h"
 #endif
 
+#if IS_USED(MODULE_UNICOAP_DRIVER_SLIPMUX) || defined(DOXYGEN)
+#  include "slipdev.h"
+#endif
+
 /* MARK: unicoap_driver_extension_point */
 
 #include "net/unicoap/message.h"
@@ -97,6 +101,11 @@ extern "C" {
 #define UNICOAP_SCHEME_BLE_GATT               "coap"
 
 /**
+ * @brief URI scheme for CoAP over Slipmux
+ */
+#define UNICOAP_SCHEME_SLIPMUX                "coap+uart"
+
+/**
  * @brief Domain for for CoAP over GATT over Bluetooth Low Energy (BLE)
  *
  * Example URI: `coap://001122334455.ble.arpa/.well-known/core`,
@@ -126,6 +135,8 @@ extern "C" {
 
 /**
  * @brief Transport protocol CoAP is used over.
+ *
+ * The LSB is used to check if the transport is inherently reliable.
  */
 typedef enum {
     /** @brief CoAP over UDP endpoint */
@@ -133,6 +144,9 @@ typedef enum {
 
     /** @brief CoAP over DTLS over UDP endpoint */
     UNICOAP_PROTO_DTLS = 2 << 1,
+
+    /** @brief CoAP over Slipmux endpoint */
+    UNICOAP_PROTO_SLIPMUX = 3 << 1,
 
     /* MARK: unicoap_driver_extension_point */
 } __attribute__((__packed__)) unicoap_proto_t;
@@ -169,11 +183,18 @@ static inline bool unicoap_transport_is_reliable(unicoap_proto_t proto)
  */
 static inline bool unicoap_transport_uses_sock_tl_ep(unicoap_proto_t proto)
 {
-    (void)proto;
+    switch (proto) {
+    case UNICOAP_PROTO_UDP:
+    case UNICOAP_PROTO_DTLS:
+        return true;
+    case UNICOAP_PROTO_SLIPMUX:
+        return false;
     /* If a new transport driver does not use RIOT's socket API,
      * such as CoAP over GATT, return false here. */
     /* MARK: unicoap_driver_extension_point */
-    return true;
+    default:
+        return false;
+    }
 }
 
 /**
@@ -198,7 +219,9 @@ typedef struct {
         /** @brief RIOT sock DTLS endpoint */
         sock_udp_ep_t dtls_ep;
 #endif /* IS_USED(MODULE_UNICOAP_SOCK_SUPPORT) || defined(DOXYGEN) */
-
+#if IS_USED(MODULE_UNICOAP_DRIVER_SLIPMUX) || defined(DOXYGEN)
+        slipdev_t *slipmux_ep;
+#endif /* IS_USED(MODULE_UNICOAP_DRIVER_SLIPMUX) || defined(DOXYGEN) */
         /* MARK: unicoap_driver_extension_point */
     };
 } unicoap_endpoint_t;

--- a/sys/include/net/unicoap/transport.h
+++ b/sys/include/net/unicoap/transport.h
@@ -26,6 +26,10 @@
 #  include "net/sock/dtls.h"
 #endif
 
+#if IS_USED(MODULE_UNICOAP_DRIVER_SLIPMUX) || defined(DOXYGEN)
+#  include "slipdev.h"
+#endif
+
 /* MARK: unicoap_driver_extension_point */
 
 #include "net/unicoap/message.h"
@@ -97,6 +101,11 @@ extern "C" {
 #define UNICOAP_SCHEME_BLE_GATT               "coap"
 
 /**
+ * @brief URI scheme for CoAP over Slipmux
+ */
+#define UNICOAP_SCHEME_SLIPMUX                "coap+uart"
+
+/**
  * @brief Domain for for CoAP over GATT over Bluetooth Low Energy (BLE)
  *
  * Example URI: `coap://001122334455.ble.arpa/.well-known/core`,
@@ -126,6 +135,8 @@ extern "C" {
 
 /**
  * @brief Transport protocol CoAP is used over.
+ *
+ * The LSB is used to check if the transport is inherently reliable.
  */
 typedef enum {
     /** @brief CoAP over UDP endpoint */
@@ -133,6 +144,9 @@ typedef enum {
 
     /** @brief CoAP over DTLS over UDP endpoint */
     UNICOAP_PROTO_DTLS = 2 << 1,
+
+    /** @brief CoAP over Slipmux endpoint */
+    UNICOAP_PROTO_SLIPMUX = 3 << 1,
 
     /* MARK: unicoap_driver_extension_point */
 } __attribute__((__packed__)) unicoap_proto_t;
@@ -169,11 +183,18 @@ static inline bool unicoap_transport_is_reliable(unicoap_proto_t proto)
  */
 static inline bool unicoap_transport_uses_sock_tl_ep(unicoap_proto_t proto)
 {
-    (void)proto;
+    switch (proto) {
+    case UNICOAP_PROTO_UDP:
+    case UNICOAP_PROTO_DTLS:
+        return true;
+    case UNICOAP_PROTO_SLIPMUX:
+        return false;
     /* If a new transport driver does not use RIOT's socket API,
      * such as CoAP over GATT, return false here. */
     /* MARK: unicoap_driver_extension_point */
-    return true;
+    default:
+        return true;
+    }
 }
 
 /**
@@ -198,7 +219,9 @@ typedef struct {
         /** @brief RIOT sock DTLS endpoint */
         sock_udp_ep_t dtls_ep;
 #endif /* IS_USED(MODULE_UNICOAP_SOCK_SUPPORT) || defined(DOXYGEN) */
-
+#if IS_USED(MODULE_UNICOAP_DRIVER_SLIPMUX) || defined(DOXYGEN)
+        slipdev_t *slipmux_ep;
+#endif /* IS_USED(MODULE_UNICOAP_DRIVER_SLIPMUX) || defined(DOXYGEN) */
         /* MARK: unicoap_driver_extension_point */
     };
 } unicoap_endpoint_t;

--- a/sys/net/application_layer/unicoap/Makefile
+++ b/sys/net/application_layer/unicoap/Makefile
@@ -10,6 +10,9 @@ endif
 ifneq (,$(filter unicoap_driver_dtls,$(USEMODULE)))
   DIRS += drivers/rfc7252/dtls
 endif
+ifneq (,$(filter unicoap_driver_slipmux,$(USEMODULE)))
+  DIRS += drivers/rfc7252/slipmux
+endif
 
 # MARK: unicoap_driver_extension_point
 

--- a/sys/net/application_layer/unicoap/Makefile.dep
+++ b/sys/net/application_layer/unicoap/Makefile.dep
@@ -45,12 +45,13 @@ endif
 # This variable ensures the "No drivers" warning gets printed only once
 _UNICOAP_MISSING_DRIVER ?= 0
 
-ifeq (,$(filter %_udp %_dtls %_tcp %_tls %_websocket %_websocket_tls %_rfc7252_common_pdu %_rfc7252_pdu,$(filter unicoap_driver_%,$(USEMODULE))))
+ifeq (,$(filter %_udp %_dtls %_tcp %_tls %_websocket %_websocket_tls %_slipmux %_rfc7252_common_pdu %_rfc7252_pdu,$(filter unicoap_driver_%,$(USEMODULE))))
   ifeq (0, $(_UNICOAP_MISSING_DRIVER))
     $(warning No drivers imported, did you forget to import a driver?)
-    $(info +++ FIXIT: Makefile: Add USEMODULE += unicoap_driver_dtls for CoAP over DTLS driver)
-    $(info +++ FIXIT: Makefile: Add USEMODULE += unicoap_driver_udp for CoAP over UDP driver)
-    $(info +++ FIXIT: Makefile: Add USEMODULE += unicoap_driver_rfc7252_pdu for CoAP over UDP/DTLS PDU parser only)
+    $(shell echo '+++ FIXIT: Makefile: Add USEMODULE += unicoap_driver_dtls for CoAP over DTLS driver' 1>&2)
+    $(shell echo '+++ FIXIT: Makefile: Add USEMODULE += unicoap_driver_udp for CoAP over UDP driver' 1>&2)
+    $(shell echo '+++ FIXIT: Makefile: Add USEMODULE += unicoap_driver_rfc7252_pdu for CoAP over UDP/DTLS PDU parser only' 1>&2)
+    $(shell echo '+++ FIXIT: Makefile: Add USEMODULE += unicoap_driver_slipmux for CoAP over Slipmux driver' 1>&2)
     # MARK: unicoap_driver_extension_point
   endif
   _UNICOAP_MISSING_DRIVER = 1
@@ -91,6 +92,11 @@ ifneq (,$(filter unicoap_driver_dtls,$(USEMODULE)))
   USEMODULE += prng_sha1prng
   USEMODULE += dsm
   USEMODULE += ztimer_usecf
+endif
+
+ifneq (,$(filter unicoap_driver_slipmux,$(USEMODULE)))
+  # CoAP over Slipmux uses RFC 7252 messaging layer
+  USEMODULE += unicoap_driver_rfc7252_common
 endif
 
 # MARK: unicoap_driver_extension_point

--- a/sys/net/application_layer/unicoap/drivers/rfc7252/common/messaging/messaging.c
+++ b/sys/net/application_layer/unicoap/drivers/rfc7252/common/messaging/messaging.c
@@ -324,6 +324,16 @@ static int _sendv(iolist_t* list, const unicoap_endpoint_t* remote, const unicoa
     }
 #endif
 
+#if IS_USED(MODULE_UNICOAP_DRIVER_SLIPMUX)
+    case UNICOAP_PROTO_SLIPMUX: {
+        extern int unicoap_transport_sendv_slipmux(iolist_t * iolist,
+                                                   const unicoap_endpoint_t* remote);
+        return unicoap_transport_sendv_slipmux(list, remote);
+    }
+#endif
+
+/* MARK: unicoap_driver_extension_point */
+
     default:
         MESSAGING_7252_DEBUG("unsupported protocol number\n");
         unicoap_assist_emit_diagnostic_missing_driver(remote->proto);

--- a/sys/net/application_layer/unicoap/drivers/rfc7252/slipmux/Makefile
+++ b/sys/net/application_layer/unicoap/drivers/rfc7252/slipmux/Makefile
@@ -1,0 +1,3 @@
+MODULE = unicoap_driver_slipmux
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/application_layer/unicoap/drivers/rfc7252/slipmux/doc.md
+++ b/sys/net/application_layer/unicoap/drivers/rfc7252/slipmux/doc.md
@@ -1,0 +1,20 @@
+@defgroup net_unicoap_drivers_slipmux CoAP over Slipmux Driver
+@ingroup net_unicoap_drivers
+@brief Use CoAP over the Slipmux protocol
+
+Module. Specify `USEMODULE += unicoap_driver_slipmux` in your application's Makefile.
+
+This module is typically selected by `slipdev_config` as a dependency.
+You don't need to select this module directly.
+
+@see @ref UNICOAP_PROTO_SLIPMUX
+
+This is the dependency graph of this driver:
+
+```
+unicoap_driver_udp
+├── unicoap_driver_rfc7252_common
+│   ├── unicoap_driver_rfc7252_common_messaging
+│   └── unicoap_driver_rfc7252_common_pdu
+└── ... (operating system networking module)
+```

--- a/sys/net/application_layer/unicoap/drivers/rfc7252/slipmux/doc.md
+++ b/sys/net/application_layer/unicoap/drivers/rfc7252/slipmux/doc.md
@@ -1,0 +1,20 @@
+@defgroup net_unicoap_drivers_slipmux CoAP over Slipmux Driver
+@ingroup net_unicoap_drivers
+@brief Use CoAP over the Slipmux protocol
+
+Module. Specify `USEMODULE += unicoap_driver_slipmux` in your application's Makefile.
+
+This module is typically selected by `slipdev_config` as a dependency.
+You don't need to select this module directly.
+
+@see @ref UNICOAP_PROTO_SLIPMUX
+
+This is the dependency graph of this driver:
+
+```
+unicoap_driver_slipmux
+├── unicoap_driver_rfc7252_common
+│   ├── unicoap_driver_rfc7252_common_messaging
+│   └── unicoap_driver_rfc7252_common_pdu
+└── ... (operating system networking module)
+```

--- a/sys/net/application_layer/unicoap/drivers/rfc7252/slipmux/doc.md
+++ b/sys/net/application_layer/unicoap/drivers/rfc7252/slipmux/doc.md
@@ -12,7 +12,7 @@ You don't need to select this module directly.
 This is the dependency graph of this driver:
 
 ```
-unicoap_driver_udp
+unicoap_driver_slipmux
 ├── unicoap_driver_rfc7252_common
 │   ├── unicoap_driver_rfc7252_common_messaging
 │   └── unicoap_driver_rfc7252_common_pdu

--- a/sys/net/application_layer/unicoap/drivers/rfc7252/slipmux/transport.c
+++ b/sys/net/application_layer/unicoap/drivers/rfc7252/slipmux/transport.c
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2026 Carl Seifert
+ * SPDX-FileCopyrightText: 2024-2026 TU Dresden
+ * SPDX-FileCopyrightText: 2026 Bennet Hattesen
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @file
+ * @ingroup net_unicoap_drivers_slipmux
+ * @brief   Transport implementation of CoAP over Slipmux driver
+ * @author  Bennet Hattesen
+ */
+
+#include <stdint.h>
+#include <errno.h>
+#include "architecture.h"
+#include "net/unicoap/transport.h"
+
+#define ENABLE_DEBUG CONFIG_UNICOAP_DEBUG_LOGGING
+#include "debug.h"
+#include "private.h"
+
+#define _SLIPMUX_DEBUG(...) _UNICOAP_PREFIX_DEBUG(".transport.slipmux", __VA_ARGS__)
+
+/* Provides unicoap_receiver_buffer */
+UNICOAP_DECL_RECEIVER_STORAGE_EXTERN;
+
+extern int unicoap_messaging_process_rfc7252(const uint8_t *pdu, size_t size, bool truncated,
+                                             unicoap_packet_t *packet);
+
+void unicoap_slipdev_recv_handler(event_t *event)
+{
+    slipdev_t *dev = container_of(event, slipdev_t, rxevent);
+
+    unicoap_endpoint_t remote = {
+        .proto = UNICOAP_PROTO_SLIPMUX,
+        .slipmux_ep = dev,
+    };
+
+    unicoap_packet_t packet = { .remote = &remote };
+
+    while (1) {
+        ssize_t len = slipdev_coap_recv(unicoap_receiver_buffer, sizeof(unicoap_receiver_buffer),
+                                        dev);
+        if (len <= 0) {
+            if (len == -2) {
+                _SLIPMUX_DEBUG(
+                    "received configuration frame with bad checksum on UART(%d)\n",
+                    dev->config.uart);
+            }
+            if (len == -1) {
+                _SLIPMUX_DEBUG(
+                    "received configuration frame is too long or too short on UART(%d)\n",
+                    dev->config.uart);
+            }
+            return;
+        }
+        unicoap_messaging_process_rfc7252(unicoap_receiver_buffer, len, false, &packet);
+    }
+}
+
+int unicoap_transport_sendv_slipmux(iolist_t *iolist, const unicoap_endpoint_t *remote)
+{
+    _SLIPMUX_DEBUG("sendv: %" PRIuSIZE " bytes via UART(%d)\n", iolist_size(iolist),
+                   remote->slipmux_ep->config.uart);
+
+    slipdev_coap_send(iolist, remote->slipmux_ep);
+
+    return 0;
+}
+
+int unicoap_init_slipmux(event_queue_t *queue)
+{
+    slipdev_coap_set_event_queue(queue);
+    return 0;
+}
+
+int unicoap_deinit_slipmux(event_queue_t *queue)
+{
+    (void)queue;
+    slipdev_coap_unset_event_queue();
+    return 0;
+}

--- a/sys/net/application_layer/unicoap/drivers/rfc7252/slipmux/transport.c
+++ b/sys/net/application_layer/unicoap/drivers/rfc7252/slipmux/transport.c
@@ -65,9 +65,8 @@ int unicoap_transport_sendv_slipmux(iolist_t *iolist, const unicoap_endpoint_t *
 {
     _SLIPMUX_DEBUG("sendv: %" PRIuSIZE " bytes via UART(%d)\n", iolist_size(iolist),
                    remote->slipmux_ep->config.uart);
-    size_t len = iolist_to_buffer(iolist, unicoap_receiver_buffer,
-                                  sizeof(unicoap_receiver_buffer));
-    slipdev_coap_send(unicoap_receiver_buffer, len, remote->slipmux_ep);
+
+    slipdev_coap_send(iolist, remote->slipmux_ep);
 
     return 0;
 }

--- a/sys/net/application_layer/unicoap/drivers/rfc7252/slipmux/transport.c
+++ b/sys/net/application_layer/unicoap/drivers/rfc7252/slipmux/transport.c
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2026 Carl Seifert
+ * SPDX-FileCopyrightText: 2024-2026 TU Dresden
+ * SPDX-FileCopyrightText: 2024-2026 Bennet Hattesen
+ * SPDX-FileCopyrightText: 2024-2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @file
+ * @ingroup net_unicoap_drivers_slipmux
+ * @brief   Transport implementation of CoAP over Slipmux driver
+ * @author  Bennet Hattesen
+ */
+
+#include <stdint.h>
+#include <errno.h>
+#include "architecture.h"
+#include "net/unicoap/transport.h"
+
+#define ENABLE_DEBUG CONFIG_UNICOAP_DEBUG_LOGGING
+#include "debug.h"
+#include "private.h"
+
+#define _SLIPMUX_DEBUG(...) _UNICOAP_PREFIX_DEBUG(".transport.slipmux", __VA_ARGS__)
+
+/* Provides unicoap_receiver_buffer */
+UNICOAP_DECL_RECEIVER_STORAGE_EXTERN;
+
+extern int unicoap_messaging_process_rfc7252(const uint8_t *pdu, size_t size, bool truncated,
+                                             unicoap_packet_t *packet);
+
+void unicoap_slipdev_recv_handler(event_t *event)
+{
+    slipdev_t *dev = container_of(event, slipdev_t, rxevent);
+
+    unicoap_endpoint_t remote = {
+        .proto = UNICOAP_PROTO_SLIPMUX,
+        .slipmux_ep = dev,
+    };
+
+    unicoap_packet_t packet = { .remote = &remote };
+
+    while (1) {
+        ssize_t len = slipdev_coap_recv(unicoap_receiver_buffer, sizeof(unicoap_receiver_buffer),
+                                        dev);
+        if (len <= 0) {
+            if (len == -2) {
+                _SLIPMUX_DEBUG(
+                    "received configuration frame with bad checksum on UART(%d)\n",
+                    dev->config.uart);
+            }
+            if (len == -1) {
+                _SLIPMUX_DEBUG(
+                    "received configuration frame is too long or too short on UART(%d)\n",
+                    dev->config.uart);
+            }
+            return;
+        }
+        unicoap_messaging_process_rfc7252(unicoap_receiver_buffer, len, false, &packet);
+    }
+}
+
+int unicoap_transport_sendv_slipmux(iolist_t *iolist, const unicoap_endpoint_t *remote)
+{
+    _SLIPMUX_DEBUG("sendv: %" PRIuSIZE " bytes via UART(%d)\n", iolist_size(iolist),
+                   remote->slipmux_ep->config.uart);
+    size_t len = iolist_to_buffer(iolist, unicoap_receiver_buffer,
+                                  sizeof(unicoap_receiver_buffer));
+    slipdev_coap_send(unicoap_receiver_buffer, len, remote->slipmux_ep);
+
+    return 0;
+}
+
+int unicoap_init_slipmux(event_queue_t *queue)
+{
+    slipdev_coap_set_event_queue(queue);
+    return 0;
+}
+
+int unicoap_deinit_slipmux(event_queue_t *queue)
+{
+    (void)queue;
+    slipdev_coap_unset_event_queue();
+    return 0;
+}

--- a/sys/net/application_layer/unicoap/drivers/rfc7252/slipmux/transport.c
+++ b/sys/net/application_layer/unicoap/drivers/rfc7252/slipmux/transport.c
@@ -1,8 +1,8 @@
 /*
  * SPDX-FileCopyrightText: 2024-2026 Carl Seifert
  * SPDX-FileCopyrightText: 2024-2026 TU Dresden
- * SPDX-FileCopyrightText: 2024-2026 Bennet Hattesen
- * SPDX-FileCopyrightText: 2024-2026 HAW Hamburg
+ * SPDX-FileCopyrightText: 2026 Bennet Hattesen
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
  * SPDX-License-Identifier: LGPL-2.1-only
  */
 

--- a/sys/net/application_layer/unicoap/endpoint.c
+++ b/sys/net/application_layer/unicoap/endpoint.c
@@ -74,7 +74,12 @@ void unicoap_print_endpoint(const unicoap_endpoint_t* endpoint) {
         return;
     }
 #endif /* IS_USED(MODULE_UNICOAP_SOCK_SUPPORT) */
-
+#if IS_USED(MODULE_UNICOAP_DRIVER_SLIPMUX)
+    if (endpoint->proto == UNICOAP_PROTO_SLIPMUX) {
+        printf("<uart(%d)>", endpoint->slipmux_ep->config.uart);
+        return;
+    }
+#endif
     printf("<endpoint (unprintable) proto=%u>", endpoint->proto);
 }
 
@@ -84,6 +89,8 @@ const char* unicoap_string_from_proto(unicoap_proto_t proto) {
         return "UDP";
     case UNICOAP_PROTO_DTLS:
         return "DTLS";
+    case UNICOAP_PROTO_SLIPMUX:
+        return "SLIPMUX";
         /* MARK: unicoap_driver_extension_point */
     default:
         return "?";
@@ -103,6 +110,10 @@ bool unicoap_endpoint_is_equal(const unicoap_endpoint_t* lhs,
     case UNICOAP_PROTO_DTLS:
         return sock_tl_ep_equal(&lhs->_tl_ep, &rhs->_tl_ep);
 #endif /* IS_USED(MODULE_UNICOAP_SOCK_SUPPORT) */
+#if IS_USED(MODULE_UNICOAP_DRIVER_SLIPMUX)
+    case UNICOAP_PROTO_SLIPMUX:
+        return lhs->slipmux_ep->config.uart == rhs->slipmux_ep->config.uart;
+#endif /* IS_USED(MODULE_UNICOAP_DRIVER_SLIPMUX) */
     /* MARK: unicoap_driver_extension_point */
     default:
         assert(false);
@@ -120,6 +131,8 @@ bool unicoap_endpoint_is_multicast(const unicoap_endpoint_t* endpoint) {
         UNICOAP_DEBUG("sock support is missing, cannot check if multicast addr, driver missing?\n");
         return false;
 #endif
+    case UNICOAP_PROTO_SLIPMUX:
+        return false;
     /* MARK: unicoap_driver_extension_point */
     default:
         assert(false);

--- a/sys/net/application_layer/unicoap/include/private.h
+++ b/sys/net/application_layer/unicoap/include/private.h
@@ -182,6 +182,12 @@ int unicoap_init_dtls(event_queue_t* queue);
 /** @brief Deinitializes the CoAP over DTLS over UDP driver on the given @p queue */
 int unicoap_deinit_dtls(event_queue_t* queue);
 
+/** @brief Initializes the CoAP over Slipmux driver on the given @p queue */
+int unicoap_init_slipmux(event_queue_t* queue);
+
+/** @brief Deinitializes the CoAP over Slipmux driver on the given @p queue */
+int unicoap_deinit_slipmux(event_queue_t* queue);
+
 /** @brief Initializes the common RFC 7252 driver on the given @p queue */
 int unicoap_init_rfc7252_common(event_queue_t* queue);
 

--- a/sys/net/application_layer/unicoap/state.c
+++ b/sys/net/application_layer/unicoap/state.c
@@ -118,6 +118,11 @@ static inline int _init_drivers(event_queue_t* queue) {
         return -1;
     }
 #endif
+#if IS_USED(MODULE_UNICOAP_DRIVER_SLIPMUX)
+    if (unicoap_init_slipmux(queue) < 0) {
+        return -1;
+    }
+#endif
     /* MARK: unicoap_driver_extension_point */
     return 0;
 }
@@ -133,6 +138,9 @@ static inline int _deinit_drivers(event_queue_t* queue) {
 #endif
 #if IS_USED(MODULE_UNICOAP_DRIVER_DTLS)
     res += unicoap_deinit_dtls(queue);
+#endif
+#if IS_USED(MODULE_UNICOAP_DRIVER_SLIPMUX)
+    res += unicoap_deinit_slipmux(queue);
 #endif
     /* MARK: unicoap_driver_extension_point */
     return res;
@@ -300,6 +308,7 @@ int unicoap_messaging_send(unicoap_packet_t* packet, unicoap_messaging_flags_t f
 #if IS_USED(MODULE_UNICOAP_DRIVER_RFC7252_COMMON)
     case UNICOAP_PROTO_UDP:
     case UNICOAP_PROTO_DTLS:
+    case UNICOAP_PROTO_SLIPMUX:
         return unicoap_messaging_send_rfc7252(packet, flags);
 #endif
     /* MARK: unicoap_driver_extension_point */

--- a/sys/net/application_layer/unicoap/utils.c
+++ b/sys/net/application_layer/unicoap/utils.c
@@ -717,6 +717,11 @@ void unicoap_assist_emit_diagnostic_missing_driver(unicoap_proto_t proto) {
                            FIXIT("USEMODULE += unicoap_driver_dtls"));
             break;
 
+        case UNICOAP_PROTO_SLIPMUX:
+            unicoap_assist(API_ERROR("CoAP over Slipmux driver missing")
+                           FIXIT("USEMODULE += unicoap_driver_slipmux"));
+            break;
+
         default:
             break;
         }


### PR DESCRIPTION
### Contribution description

Hey hey :leopard: 

this reworks the slipdev driver to utilize the new unicoap server instead of nanocoap.

Reason: Unicoap has fewer dependencies which means small binaries in a lot of use cases (in particular: Using `slipdev_config` without any IP networking is now **significantly cheaper**!). We also gain all the other benefits unicoap offers :p 

### Testing procedure

Review, compile and manual testing

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
