### PR TITLE
Makefile.include: check for `which`

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -335,6 +335,12 @@ APPLICATION := $(strip $(APPLICATION))
 
 DOWNLOAD_TO_FILE ?= $(DLCACHE)
 
+# Check whether `which` is installed
+ifeq ($(shell command -v which 2>/dev/null),)
+  $(error 'which' is required but not found in PATH.)
+endif
+
+# Check whether unzip or 7z is installed, and set UNZIP_HERE to the command to use
 ifeq (,$(UNZIP_HERE))
   ifeq (0,$(shell which unzip > /dev/null 2>&1 ; echo $$?))
     UNZIP_HERE = $(call memoized,UNZIP_HERE,$(shell which unzip) -q)

--- a/doc/guides/getting-started/installing.mdx
+++ b/doc/guides/getting-started/installing.mdx
@@ -56,7 +56,7 @@ Depending on the operation distribution you are using, the installation of the r
 #### Arch Linux
 
 ```bash title="Arch Linux command to install required packages"
-    sudo pacman -S make gcc-multilib python-pyserial python-psutil wget unzip git openocd gdb esptool podman-docker clang
+    sudo pacman -S make base-devel gcc-multilib python-pyserial python-psutil wget unzip git openocd gdb esptool podman-docker clang
 ```
 
 This will show something like this depending on your distribution:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

A new user discovered that the compile-commands didn't work due to a missing 7zip installation while still being installed, turns out that we forgot to actually include base-devel in the arch installation command for RIOT thus never technically requiring which to be installed which means that the commands that are supposed to check for other stuff to be there were failing silently.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Change the `which` check to `foobar` so it warns you.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- My initial solution didn't work so I rubberduckied with claude

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
