### PR TITLE
dist/sliptools: device name may get truncated during open()

### DIFF
--- a/dist/tools/sliptty/sliptty.c
+++ b/dist/tools/sliptty/sliptty.c
@@ -64,11 +64,13 @@ static void _usage(char *cmd)
 #ifndef __linux__
 static int devopen(const char *dev, int flags)
 {
-    char devpath[1024];
-
-    strcpy(devpath, "/dev/");
-    strncat(devpath, dev, sizeof(devpath) - (sizeof("/dev/") - 1));
-    return open(devpath, flags);
+    char t[1024];
+    int written_len = snprintf(t, sizeof(t), "/dev/%s", dev);
+    if (written_len >= sizeof(t)) {
+        /* we got truncated */
+        return -1;
+    }
+    return open(t, flags);
 }
 #endif
 

--- a/dist/tools/tunslip/tunslip.c
+++ b/dist/tools/tunslip/tunslip.c
@@ -846,8 +846,11 @@ int
 devopen(const char *dev, int flags)
 {
     char t[1024];
-    strcpy(t, "/dev/");
-    strcat(t, dev);
+    int written_len = snprintf(t, sizeof(t), "/dev/%s", dev);
+    if (written_len >= sizeof(t)) {
+        /* we got truncated */
+        return -1;
+    }
     return open(t, flags);
 }
 

--- a/dist/tools/tunslip/tunslip6.c
+++ b/dist/tools/tunslip/tunslip6.c
@@ -647,10 +647,11 @@ int
 devopen(const char *dev, int flags)
 {
     char t[1024];
-    strcpy(t, "/dev/");
-    /* cppcheck-suppress bufferAccessOutOfBounds
-     * (reason: seems to be a bug in cppcheck 1.7x) */
-    strncat(t, dev, sizeof(t) - 5);
+    int written_len = snprintf(t, sizeof(t), "/dev/%s", dev);
+    if (written_len >= sizeof(t)) {
+        /* we got truncated */
+        return -1;
+    }
     return open(t, flags);
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hii :horse: 

this fixes minor issues in host-side tooling regarding slip. Found by @gulamovzavohir02-glitch Thanks!
If the device name exceeded the buffer it results in either memory corruption or unnoticed truncation.


### Testing procedure

Review.


### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
