### PR TITLE
doc/guides/advanced_bs_tricks: update note on git-cache [backport 2026.07]

### DIFF
--- a/doc/guides/build-system/advanced_build_system_tricks.md
+++ b/doc/guides/build-system/advanced_build_system_tricks.md
@@ -109,11 +109,8 @@ slow down the initial build of a RIOT application, depending on your
 internet connection.
 
 To avoid downloading the full archive for each fresh build, a caching script
-was used called `git-cache`. This script has been deprecated in Release 2026.04
-and will be removed in favor of
-[`git-cache-rs`](https://github.com/kaspar030/git-cache-rs), which is
-implemented in Rust, offers more feature and is still under active development
-and maintenance.
+called [`git-cache-rs`](https://github.com/kaspar030/git-cache-rs) is used,
+which is implemented in Rust and under active development.
 
 Please note that many popular Linux distributions provide very old Rust
 versions in their repositories. Therefore, it is


### PR DESCRIPTION
# Backport of #22499

### Contribution description

When removing `git-cache` in #22197, I forgot to remove the deprecation note in the guides.

### Testing procedure

Look at the docs.

### Issues/PRs references

Follow up for #22197.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none