### PR TITLE
cpu/esp32/periph: restore caller's int state

### DIFF
--- a/cpu/esp32/periph/pm.c
+++ b/cpu/esp32/periph/pm.c
@@ -71,10 +71,11 @@ static inline void pm_set_lowest_normal(void)
     __asm__ volatile ("waiti 0");
 #else
     /* This function is entered with interrupts disabled, so we have to enable
-     * interrupts here to wait for an interrupt. */
-    irq_enable();
+     * interrupts here to wait for an interrupt.
+     * Save caller's interrupt state, enable interrupts for WFI, then restore. */
+    unsigned irq_state = irq_enable();
     __asm__ volatile ("wfi");
-    irq_disable();
+    irq_restore(irq_state);
 #endif
     /* reset system watchdog timer */
     system_wdt_feed();


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR fixes caller's interrupt state, enable interrupts for WFI, then restore. By using irq_restore() instead of irq_disable() ensures that threads which were running with interrupts enabled get them back after WFI,  preserving the original invariant.


### Testing procedure

I have used esp32c6, running an rtc test that sets alarm then pm_set(modem_sleep) which triggers pm_set_lowest() from a different thread than the idle thread. It resulted to the esp32c6 rebooting due to MWDT doing a system reset after 8s and not the rtc alarm. 

without the fix: 
```
2026-07-22 10:11:55,951 # WDT interrupt triggered
2026-07-22 10:11:55,952 # pm_set enter to power mode 2 @8087949
2026-07-22 10:11:55,953 # pm_set_lowest_normal
2026-07-22 10:11:59,952 # WDT interrupt triggered
2026-07-22 10:11:59,953 # pm_set enter to power mode 2 @12088245
2026-07-22 10:11:59,953 # pm_set_lowest_normal
rtc_test
2026-07-22 10:12:02,091 # rtc_test
2026-07-22 10:12:02,091 # enabling pm set
2026-07-22 10:12:02,091 # rtt_rtc: rtc_init
2026-07-22 10:12:02,092 # RTC TEST: sleep starting...
2026-07-22 10:12:02,092 # RTC TEST: alarm set for 2089-07-24 08:52:52
2026-07-22 10:12:02,093 # RTC TEST: entering pm_set(2)
2026-07-22 10:12:02,093 # pm_set enter to power mode 2 @14229142
2026-07-22 10:12:02,094 # pm_set_lowest_normal
ps
ps
ps
2026-07-22 10:12:10,093 # ESP-ROM:esp32c6-20220919
2026-07-22 10:12:10,094 # Build:Sep 19 2022
2026-07-22 10:12:10,095 # rst:0x7 (TG0_WDT_HPSYS),boot:0x2f (SPI_FAST_FLASH_BOOT)
2026-07-22 10:12:10,095 # Saved PC:0x42006706
2026-07-22 10:12:10,095 # SPIWP:0xee
2026-07-22 10:12:10,095 # mode:DIO, clock div:2
2026-07-22 10:12:10,098 # load:0x40875720,len:0x1c58
2026-07-22 10:12:10,100 # load:0x4086c110,len:0xcac
2026-07-22 10:12:10,103 # load:0x4086e610,len:0x3008
2026-07-22 10:12:10,105 # entry 0x4086c110
2026-07-22 10:12:10,117 # I (22) boot: ESP-IDF v5.4-300-gc8bb53292d 2nd stage bootloader
2026-07-22 10:12:10,118 # I (23) boot: chip revision: v0.1
2026-07-22 10:12:10,120 # I (24) boot: efuse block revision: v0.3
2026-07-22 10:12:10,125 # I (26) boot.esp32c6: SPI Speed      : 80MHz
2026-07-22 10:12:10,130 # I (31) boot.esp32c6: SPI Mode       : DIO
2026-07-22 10:12:10,134 # I (36) boot.esp32c6: SPI Flash Size : 4MB
2026-07-22 10:12:10,146 # W (40) boot.esp32c6: PRO CPU has been reset by WDT.
2026-07-22 10:12:10,147 # I (46) boot: Enabling RNG early entropy source...
2026-07-22 10:12:10,149 # I (51) boot: Partition Table:
2026-07-22 10:12:10,157 # I (55) boot: ## Label            Usage          Type ST Offset   Length
2026-07-22 10:12:10,164 # I (62) boot:  0 nvs              WiFi data        01 02 00009000 00006000
2026-07-22 10:12:10,171 # I (70) boot:  1 phy_init         RF data          01 01 0000f000 00001000
2026-07-22 10:12:10,179 # I (77) boot:  2 factory          factory app      00 00 00010000 000396e0
2026-07-22 10:12:10,183 # I (85) boot: End of partition table
2026-07-22 10:12:10,191 # I (89) esp_image: segment 0: paddr=00010020 vaddr=42020020 size=04d68h ( 19816) map
2026-07-22 10:12:10,200 # I (102) esp_image: segment 1: paddr=00014d90 vaddr=40800000 size=03288h ( 12936) load
2026-07-22 10:12:10,209 # I (109) esp_image: segment 2: paddr=00018020 vaddr=42000020 size=1c060h (114784) map
2026-07-22 10:12:10,233 # I (138) esp_image: segment 3: paddr=00034088 vaddr=40803288 size=045f4h ( 17908) load
2026-07-22 10:12:10,238 # I (143) esp_image: segment 4: paddr=00038684 vaddr=40810000 size=10fa8h ( 69544) load
2026-07-22 10:12:10,254 # I (159) esp_image: segment 5: paddr=00049634 vaddr=50000000 size=00080h (   128) load
2026-07-22 10:12:10,260 # I (165) boot: Loaded app from partition at offset 0x10000
2026-07-22 10:12:10,274 # I (166) boot: Disabling RNG early entropy source...
2026-07-22 10:12:10,274 # Unicore app
2026-07-22 10:12:10,282 # 
2026-07-22 10:12:10,283 # Starting ESP32x with ID: e4b063fffe43
2026-07-22 10:12:10,283 # ESP-IDF SDK Version v5.4-300-gc8bb53292d
2026-07-22 10:12:10,283 # 
2026-07-22 10:12:10,288 # Current clocks in Hz: CPU=80000000 APB=40000000 XTAL=40000000 SLOW=136000
2026-07-22 10:12:10,294 # PRO cpu is up (single core mode, only PRO cpu is used)
2026-07-22 10:12:10,296 # PRO cpu starts user code
2026-07-22 10:12:10,305 # Used clocks in Hz: CPU=80000000 APB=40000000 XTAL=40000000 FAST=8000000 SLOW=136000
2026-07-22 10:12:10,310 # RTC Slow Clock calibration value: 3871053
ps
2026-07-22 10:12:10,313 # Heap free: 296268 bytes

```

with the fix:
```
`# rtt_rtc: rtc_init
2026-07-22 09:56:16,943 # 	UART_DEV(0)pm_set enter to power mode 2 @265824
2026-07-22 09:56:16,943 # pm_set_lowest_normal
2026-07-22 09:56:20,940 # WDT interrupt triggered
2026-07-22 09:56:20,941 # pm_set enter to power mode 2 @4266117
2026-07-22 09:56:20,941 # pm_set_lowest_normal
2026-07-22 09:56:24,940 # WDT interrupt triggered
2026-07-22 09:56:24,941 # pm_set enter to power mode 2 @8266413
2026-07-22 09:56:24,941 # pm_set_lowest_normal
rtc_t2026-07-22 09:56:28,940 # WDT interrupt triggered
2026-07-22 09:56:28,941 # pm_set enter to power mode 2 @12266709
2026-07-22 09:56:28,941 # pm_set_lowest_normal
est
2026-07-22 09:56:29,472 # rtc_test
2026-07-22 09:56:29,473 # enabling pm set
2026-07-22 09:56:29,473 # rtt_rtc: rtc_init
2026-07-22 09:56:29,473 # RTC TEST: sleep starting...
2026-07-22 09:56:29,474 # RTC TEST: alarm set for 2091-08-27 23:06:06
2026-07-22 09:56:29,475 # RTC TEST: entering pm_set(2)
2026-07-22 09:56:29,476 # pm_set enter to power mode 2 @12799822
2026-07-22 09:56:29,476 # pm_set_lowest_normal
2026-07-22 09:56:29,476 # pm_set enter to power mode 2 @12800361
2026-07-22 09:56:29,477 # pm_set_lowest_normal
2026-07-22 09:56:34,473 # sys_isr
2026-07-22 09:56:34,474 # rtt_isr
2026-07-22 09:56:34,474 # RTC TEST: rtc callback called
2026-07-22 09:56:34,475 # _rtt_isr next rtt=RTC TEST: node woke up from sleep
2026-07-22 09:56:34,476 # RTC TEST: time after alarm 2091-08-27 23:06:06
2026-07-22 09:56:34,477 # RTC TEST: time set and get after alarm match
`
```


### Issues/PRs references
None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
Claude for double checking
