### PR TITLE
sys/fmt: add scn_bool() helper function

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -521,6 +521,30 @@ int fmt_time_tm_iso8601(char out[20], const struct tm *tm, char separator)
     return pos - out;
 }
 
+int scn_bool(const char *str, size_t n)
+{
+    if (!strncmp(str, "1", n)) {
+        return 1;
+    }
+    if (!strncmp(str, "true", n)) {
+        return 1;
+    }
+    if (!strncmp(str, "on", n)) {
+        return 1;
+    }
+    if (!strncmp(str, "0", n)) {
+        return 0;
+    }
+    if (!strncmp(str, "false", n)) {
+        return 0;
+    }
+    if (!strncmp(str, "off", n)) {
+        return 0;
+    }
+
+    return -EINVAL;
+}
+
 uint32_t scn_u32_dec(const char *str, size_t n)
 {
     uint32_t res = 0;

--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -16,7 +16,6 @@
  */
 
 #include <assert.h>
-#include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -519,6 +518,40 @@ int fmt_time_tm_iso8601(char out[20], const struct tm *tm, char separator)
     *pos = '\0';
 
     return pos - out;
+}
+
+static int _check_array(const char *str, size_t str_len, const char **vals, size_t num_vals, bool ret)
+{
+    for (unsigned i = 0; i < num_vals; ++i) {
+        const char *val = vals[i];
+        size_t val_len = strlen(val);
+        if (str_len >= val_len && !memcmp(str, val, val_len)) {
+            /* check that there are no trailing characters, e.g. "yesterday" should not parse as 'true' */
+            unsigned char next_char = str[val_len];
+            return (str_len > val_len && next_char != '\0') ? -EINVAL : ret;
+        }
+    }
+
+    return -EINVAL;
+}
+
+int scn_bool(const char *str, size_t n)
+{
+    if (n < 1 || !str) {
+        return -EINVAL;
+    }
+
+    const char *trueish[] = {
+        "1", "on", "yes", "true"
+    };
+    const char *falsy[] = {
+        "0", "off", "no", "false"
+    };
+
+    int res = _check_array(str, n, trueish, ARRAY_SIZE(trueish), true);
+    return res == -EINVAL
+                ? _check_array(str, n, falsy, ARRAY_SIZE(falsy), false)
+                : res;
 }
 
 uint32_t scn_u32_dec(const char *str, size_t n)

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -39,6 +39,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -419,6 +420,38 @@ size_t fmt_to_lower(char *out, const char *str);
  *                          to an invalid date/time format
  */
 int fmt_time_tm_iso8601(char out[20], const struct tm *tm, char separator);
+
+/**
+ * @brief Convert a string to a boolean value
+ *
+ * Recognizes "1", "true" and "on" as true, and "0", "false" and "off"
+ * as false (case-sensitive).
+ *
+ * @param[in]   str  Pointer to string to read from
+ * @param[in]   n    Maximum nr of characters to consider
+ *
+ * @retval      1        if @p str is a truthy value
+ * @retval      0        if @p str is a falsy value
+ * @retval      -EINVAL  if @p str is neither a truthy nor a falsy value
+ */
+int scn_bool(const char *str, size_t n);
+
+/**
+ * @brief Convert a NUL-terminated string to a boolean value
+ *
+ * Convenience wrapper around scn_bool() that uses strlen(@p str) as
+ * length, so the whole string is considered.
+ *
+ * @param[in]   str  Pointer to NUL-terminated string to read from
+ *
+ * @retval      1        if @p str is a truthy value
+ * @retval      0        if @p str is a falsy value
+ * @retval      -EINVAL  if @p str is neither a truthy nor a falsy value
+ */
+static inline int scn_bool_str(const char *str)
+{
+    return scn_bool(str, strlen(str));
+}
 
 /**
  * @brief Convert string of decimal digits to uint32

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -37,8 +37,10 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  */
 
+#include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -419,6 +421,41 @@ size_t fmt_to_lower(char *out, const char *str);
  *                          to an invalid date/time format
  */
 int fmt_time_tm_iso8601(char out[20], const struct tm *tm, char separator);
+
+/**
+ * @brief Convert a string to a boolean value
+ *
+ * Recognizes "1", "true", "yes" and "on" as true, and "0", "false", "no" and "off"
+ * as false (case-sensitive).
+ *
+ * @param[in]   str  Pointer to string to read from
+ * @param[in]   n    Maximum nr of characters to consider
+ *
+ * @retval      1        if @p str is a truthy value
+ * @retval      0        if @p str is a falsy value
+ * @retval      -EINVAL  if @p str is neither a truthy nor a falsy value
+ */
+int scn_bool(const char *str, size_t n);
+
+/**
+ * @brief Convert a NUL-terminated string to a boolean value
+ *
+ * Convenience wrapper around scn_bool() that uses strlen(@p str) as
+ * length, so the whole string is considered.
+ *
+ * @param[in]   str  Pointer to NUL-terminated string to read from
+ *
+ * @retval      1        if @p str is a truthy value
+ * @retval      0        if @p str is a falsy value
+ * @retval      -EINVAL  if @p str is neither a truthy nor a falsy value
+ */
+static inline int scn_bool_str(const char *str)
+{
+    if (!str) {
+        return -EINVAL;
+    }
+    return scn_bool(str, strlen(str));
+}
 
 /**
  * @brief Convert string of decimal digits to uint32

--- a/tests/unittests/tests-fmt/tests-fmt.c
+++ b/tests/unittests/tests-fmt/tests-fmt.c
@@ -855,6 +855,21 @@ static void test_scn_u32_dec(void)
     TEST_ASSERT_EQUAL_INT(val2, scn_u32_dec(string1, 5));
 }
 
+static void test_scn_bool(void)
+{
+    TEST_ASSERT_EQUAL_INT(1, scn_bool_str("1"));
+    TEST_ASSERT_EQUAL_INT(1, scn_bool_str("true"));
+    TEST_ASSERT_EQUAL_INT(1, scn_bool_str("on"));
+
+    TEST_ASSERT_EQUAL_INT(0, scn_bool_str("0"));
+    TEST_ASSERT_EQUAL_INT(0, scn_bool_str("false"));
+    TEST_ASSERT_EQUAL_INT(0, scn_bool_str("off"));
+
+    TEST_ASSERT_EQUAL_INT(-EINVAL, scn_bool_str("yes"));
+    TEST_ASSERT_EQUAL_INT(-EINVAL, scn_bool_str("no"));
+    TEST_ASSERT_EQUAL_INT(-EINVAL, scn_bool_str("nobody"));
+}
+
 static void test_scn_u32_hex(void)
 {
     /* ´x´ is not a valid hexadecimal character */
@@ -1060,6 +1075,7 @@ Test *tests_fmt_tests(void)
         new_TestFixture(test_fmt_char),
         new_TestFixture(test_fmt_to_lower),
         new_TestFixture(test_scn_u32_dec),
+        new_TestFixture(test_scn_bool),
         new_TestFixture(test_scn_u32_hex),
         new_TestFixture(test_scn_buf_hex),
         new_TestFixture(test_fmt_lpad),

--- a/tests/unittests/tests-fmt/tests-fmt.c
+++ b/tests/unittests/tests-fmt/tests-fmt.c
@@ -855,6 +855,29 @@ static void test_scn_u32_dec(void)
     TEST_ASSERT_EQUAL_INT(val2, scn_u32_dec(string1, 5));
 }
 
+static void test_scn_bool(void)
+{
+    TEST_ASSERT_EQUAL_INT(1, scn_bool_str("1"));
+    TEST_ASSERT_EQUAL_INT(1, scn_bool_str("true"));
+    TEST_ASSERT_EQUAL_INT(1, scn_bool_str("on"));
+    TEST_ASSERT_EQUAL_INT(1, scn_bool_str("yes"));
+    TEST_ASSERT_EQUAL_INT(1, scn_bool("true, ", 4));
+
+    TEST_ASSERT_EQUAL_INT(0, scn_bool_str("0"));
+    TEST_ASSERT_EQUAL_INT(0, scn_bool_str("false"));
+    TEST_ASSERT_EQUAL_INT(0, scn_bool_str("off"));
+    TEST_ASSERT_EQUAL_INT(0, scn_bool_str("no"));
+    TEST_ASSERT_EQUAL_INT(0, scn_bool("off\non", 3));
+
+    TEST_ASSERT_EQUAL_INT(-EINVAL, scn_bool_str("10"));
+    TEST_ASSERT_EQUAL_INT(-EINVAL, scn_bool_str("01"));
+    TEST_ASSERT_EQUAL_INT(-EINVAL, scn_bool_str("nobody"));
+    TEST_ASSERT_EQUAL_INT(-EINVAL, scn_bool_str(""));
+    TEST_ASSERT_EQUAL_INT(-EINVAL, scn_bool_str(NULL));
+    TEST_ASSERT_EQUAL_INT(-EINVAL, scn_bool("true", 1));
+    TEST_ASSERT_EQUAL_INT(-EINVAL, scn_bool("false", 3));
+}
+
 static void test_scn_u32_hex(void)
 {
     /* ´x´ is not a valid hexadecimal character */
@@ -1060,6 +1083,7 @@ Test *tests_fmt_tests(void)
         new_TestFixture(test_fmt_char),
         new_TestFixture(test_fmt_to_lower),
         new_TestFixture(test_scn_u32_dec),
+        new_TestFixture(test_scn_bool),
         new_TestFixture(test_scn_u32_hex),
         new_TestFixture(test_scn_buf_hex),
         new_TestFixture(test_fmt_lpad),

--- a/tests/unittests/tests-fmt/tests-fmt.c
+++ b/tests/unittests/tests-fmt/tests-fmt.c
@@ -868,6 +868,9 @@ static void test_scn_bool(void)
     TEST_ASSERT_EQUAL_INT(-EINVAL, scn_bool_str("yes"));
     TEST_ASSERT_EQUAL_INT(-EINVAL, scn_bool_str("no"));
     TEST_ASSERT_EQUAL_INT(-EINVAL, scn_bool_str("nobody"));
+    TEST_ASSERT_EQUAL_INT(-EINVAL, scn_bool_str(""));
+    TEST_ASSERT_EQUAL_INT(-EINVAL, scn_bool("true", 1));
+    TEST_ASSERT_EQUAL_INT(-EINVAL, scn_bool("false", 3));
 }
 
 static void test_scn_u32_hex(void)


### PR DESCRIPTION
### Contribution description

Often you have a shell command to enable / disable something. Instead of manually parsing the argument (and likely discarding any invalid value) this adds a small helper function `scn_bool()` which concerts `1`, `true` and `on` to 1, `0`, `false` and `off` to 0 and everything else to `-EINVAL`.

### Testing procedure

A unit test was added to `tests-fmt`

### Issues/PRs references

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- Claude Code with Claude with Sonnet 5 wrote the documentation & unit tests 
