### PR TITLE
sys/net/gnrc_sixlowpan: fix potential out of bounds read

### DIFF
--- a/sys/include/net/gnrc/sixlowpan.h
+++ b/sys/include/net/gnrc/sixlowpan.h
@@ -150,6 +150,29 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Same as @ref sixlowpan_frag_is but operates on a @ref gnrc_pktsnip_t
+ *
+ * @param[in]   snip    Packet snip to check for a valid 6LoWPAN fragment
+ *                      header
+ *
+ * @retval  true    @p snip starts with a valid 6LoWPAN fragment header
+ * @retval  false   @p snip does **NOT** start with a valid 6LoWPAN fragment
+ *                  header
+ */
+static inline bool sixlowpan_frag_is_snip(const gnrc_pktsnip_t *snip)
+{
+    if (snip->size < sizeof(sixlowpan_frag_t)) {
+        return false;
+    }
+
+    if (sixlowpan_frag_n_is(snip->data)) {
+        return snip->size >= sizeof(sixlowpan_frag_n_t);
+    }
+
+    return sixlowpan_frag_1_is(snip->data);
+}
+
+/**
  * @brief   Initialization of the 6LoWPAN thread.
  *
  * @details If 6LoWPAN was already initialized, it will just return the PID of

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -229,7 +229,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
 #endif
     }
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG
-    else if (sixlowpan_frag_is((sixlowpan_frag_t *)dispatch)) {
+    else if (sixlowpan_frag_is_snip(payload)) {
         DEBUG("6lo: received 6LoWPAN fragment\n");
         gnrc_sixlowpan_frag_recv(pkt, NULL, 0);
         return;


### PR DESCRIPTION
### Contribution description

This adds and uses a helper, `sixlowpan_frag_is_snip()`, that is a wrapper around `sixlowpan_frag_is()`. It takes an `gnrc_pktsnip_t *` instead of an `sixlowpan_frag_t *` and checks if the snipped is large enough to contain at least an 6LoWPAN fragment header.

### Testing procedure

1. No change in behavior as long as all parties send valid 6LoWPAN frames.
2. No more out of bounds read if not.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/security/advisories/GHSA-m8mc-q4p7-p8j3

Thanks @gulamovzavohir02-glitch for the report

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none yet, but I'll ask copilot for a review