### PR TITLE
sys/nanocoap: remove support for extended token length

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -629,12 +629,9 @@ static inline void coap_set_id(coap_pkt_t *pkt, uint16_t id)
 /**
  * @brief   Get a message's token length [in byte]
  *
- * If the `nanocoap_token_ext` module is enabled, this will include
- * the extended token length.
- *
  * @param[in]   pkt   CoAP packet
  *
- * @returns     length of token in the given message (0-8 byte)
+ * @returns     token length in bytes (0-COAP_TOKEN_LENGTH_MAX for valid packets)
  */
 static inline unsigned coap_get_token_len(const coap_pkt_t *pkt)
 {
@@ -695,52 +692,6 @@ static inline unsigned coap_get_ver(const coap_pkt_t *pkt)
 }
 
 /**
- * @brief   Get the size of the extended Token length field
- *          (RFC 8974)
- *
- * @deprecated  Use @ref coap_pkt_tkl_ext_len instead.
- *
- * @note    This requires the `nanocoap_token_ext` module to be enabled
- *
- * @param[in]   hdr   CoAP header
- *
- * @returns     number of bytes used for extended token length
- */
-static inline uint8_t coap_hdr_tkl_ext_len(const coap_udp_hdr_t *hdr)
-{
-    if (!IS_USED(MODULE_NANOCOAP_TOKEN_EXT)) {
-        return 0;
-    }
-
-    switch (hdr->ver_t_tkl & 0x0f) {
-    case 13:
-        return 1;
-    case 14:
-        return 2;
-    case 15:
-        assert(0);
-        /* fall-through */
-    default:
-        return 0;
-    }
-}
-
-/**
- * @brief   Get the size of the extended Token length field
- *          (RFC 8974)
- *
- * @note    This requires the `nanocoap_token_ext` module to be enabled
- *
-     * @param[in]   pkt     CoAP packet
- *
- * @returns     number of bytes used for extended token length
- */
-static inline uint8_t coap_pkt_tkl_ext_len(const coap_pkt_t *pkt)
-{
-    return coap_hdr_tkl_ext_len(coap_get_udp_hdr_const(pkt));
-}
-
-/**
  * @brief   Validate that the header of @p pkt is no longer than
  *          @p len bytes.
  *
@@ -773,7 +724,7 @@ bool coap_is_hdr_in_bounds(const coap_pkt_t *pkt, size_t len);
  */
 static inline uint8_t *coap_hdr_data_ptr(const coap_udp_hdr_t *hdr)
 {
-    return ((uint8_t *)hdr) + sizeof(coap_udp_hdr_t) + coap_hdr_tkl_ext_len(hdr);
+    return ((uint8_t *)hdr) + sizeof(coap_udp_hdr_t);
 }
 
 /**
@@ -785,8 +736,7 @@ static inline uint8_t *coap_hdr_data_ptr(const coap_udp_hdr_t *hdr)
  */
 static inline unsigned coap_get_total_hdr_len(const coap_pkt_t *pkt)
 {
-    return sizeof(coap_udp_hdr_t) + coap_hdr_tkl_ext_len(pkt->hdr) +
-           coap_get_token_len(pkt);
+    return sizeof(coap_udp_hdr_t) + coap_get_token_len(pkt);
 }
 
 /**
@@ -861,27 +811,7 @@ static inline void coap_hdr_set_type(coap_udp_hdr_t *hdr, unsigned type)
  */
 static inline size_t coap_hdr_get_token_len(const coap_udp_hdr_t *hdr)
 {
-    const uint8_t *buf = (const void *)hdr;
-    /* Regarding use unnamed magic numbers 13 and 269:
-     * - If token length is < 13 it fits into TKL field (4 bit)
-     * - If token length is < 269 it fits into 8-bit extended TKL field
-     * - Otherwise token length goes into 16-bit extended TKL field.
-     *
-     * (Not using named constants here, as RFC 8974 also has no names for those
-     * magic numbers.)
-     *
-     * See: https://www.rfc-editor.org/rfc/rfc8974#name-extended-token-length-tkl-f
-     */
-    switch (coap_hdr_tkl_ext_len(hdr)) {
-    case 0:
-        return hdr->ver_t_tkl & 0x0f;
-    case 1:
-        return buf[sizeof(coap_udp_hdr_t)] + 13;
-    case 2:
-        return byteorder_bebuftohs(buf + sizeof(coap_udp_hdr_t)) + 269;
-    }
-
-    return 0;
+    return hdr->ver_t_tkl & 0x0f;
 }
 
 /**
@@ -902,7 +832,8 @@ static inline size_t coap_hdr_get_token_len(const coap_udp_hdr_t *hdr)
 static inline const void * coap_hdr_get_token(const coap_udp_hdr_t *hdr)
 {
     uint8_t *token = (void *)hdr;
-    token += sizeof(*hdr) + coap_hdr_tkl_ext_len(hdr);
+    /* token comes directly after the fixed size header for UDP */
+    token += sizeof(*hdr);
     return token;
 }
 
@@ -922,7 +853,7 @@ static inline const void * coap_hdr_get_token(const coap_udp_hdr_t *hdr)
  */
 static inline size_t coap_hdr_len(const coap_udp_hdr_t *hdr)
 {
-    return sizeof(*hdr) + coap_hdr_tkl_ext_len(hdr) + coap_hdr_get_token_len(hdr);
+    return sizeof(*hdr) + coap_hdr_get_token_len(hdr);
 }
 
 /**
@@ -2577,12 +2508,6 @@ static inline ssize_t coap_build_hdr(coap_udp_hdr_t *hdr, unsigned type, const v
                                      size_t token_len, unsigned code, uint16_t id)
 {
     size_t fingers_crossed_size = sizeof(*hdr) + token_len;
-
-    if (IS_USED(MODULE_NANOCOAP_TOKEN_EXT)) {
-        /* With RFC 8974, we have an additional extended TKL
-         * field of 0-4 bytes in length */
-        fingers_crossed_size += 4;
-    }
 
     return coap_build_udp_hdr(hdr, fingers_crossed_size, type, token, token_len, code, id);
 }

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -74,38 +74,14 @@ bool coap_is_hdr_in_bounds(const coap_pkt_t *pkt, size_t len)
         return false;
     }
 
-    if (IS_USED(MODULE_NANOCOAP_TOKEN_EXT)) {
-        /* coap_pkt_tkl_ext_len() blows an assertion on invalid TKL value, so
-         * we have to rule that out here already. The magic number 15 is the
-         * only invalid value here, as per
-         * https://datatracker.ietf.org/doc/html/rfc8974#section-2.1.
-         * The magic number has no name in the RFC, so adding a named constant
-         * here would rather obfuscate then help when checking the code against
-         * the spec. */
-        if ((coap_get_udp_hdr_const(pkt)->ver_t_tkl & 0x0f) == 15) {
-            return false;
-        }
+    uint8_t tkl = coap_get_token_len(pkt);
 
-        min_len += coap_pkt_tkl_ext_len(pkt);
-
-        if (len < min_len) {
-            return false;
-        }
-
-        min_len += coap_get_token_len(pkt);
+    if (tkl > COAP_TOKEN_LENGTH_MAX) {
+        DEBUG("nanocoap: token length invalid\n");
+        return false;
     }
-    else {
-        uint8_t tkl = coap_get_token_len(pkt);
 
-        /* we have to either allow extendend token lengths fully
-         * (MODULE_NANOCOAP_TOKEN_EXT is used), or not at all */
-        if (tkl > COAP_TOKEN_LENGTH_MAX) {
-            DEBUG("nanocoap: token length invalid\n");
-            return false;
-        }
-
-        min_len += tkl;
-    }
+    min_len += tkl;
 
     return (len >= min_len);
 }
@@ -789,40 +765,21 @@ ssize_t coap_build_udp_hdr(void *buf, size_t buf_len, uint8_t type,
 {
     assert(!(type & ~0x3));
 
-    uint16_t tkl_ext = 0;
-    uint8_t tkl_ext_len, tkl;
-
-    if (token_len > 268 && IS_USED(MODULE_NANOCOAP_TOKEN_EXT)) {
-        tkl_ext_len = 2;
-        tkl_ext = htons(token_len - 269); /* 269 = 255 + 14 */
-        tkl = 14;
-    }
-    else if (token_len > 12 && IS_USED(MODULE_NANOCOAP_TOKEN_EXT)) {
-        tkl_ext_len = 1;
-        tkl_ext = token_len - 13;
-        tkl = 13;
-    }
-    else {
-        tkl = token_len;
-        tkl_ext_len = 0;
+    if (token_len > COAP_TOKEN_LENGTH_MAX) {
+        return -EINVAL;
     }
 
-    size_t hdr_len = sizeof(coap_udp_hdr_t) + token_len + tkl_ext_len;
-    if (buf_len < hdr_len) {
+    size_t hdr_len = sizeof(coap_udp_hdr_t) + token_len;
+    if (hdr_len > buf_len) {
         return -EOVERFLOW;
     }
 
     memset(buf, 0, sizeof(coap_udp_hdr_t));
     coap_udp_hdr_t *hdr = buf;
-    hdr->ver_t_tkl = (COAP_V1 << 6) | (type << 4) | tkl;
+    hdr->ver_t_tkl = (COAP_V1 << 6) | (type << 4) | (uint8_t)token_len;
     hdr->code = code;
     hdr->id = htons(id);
     buf += sizeof(coap_udp_hdr_t);
-
-    if (tkl_ext_len) {
-        memcpy(buf, &tkl_ext, tkl_ext_len);
-        buf += tkl_ext_len;
-    }
 
     /* Some users build a response packet in the same buffer that contained
      * the request. In this case, the argument token already points inside

--- a/tests/net/nanocoap_cli/nanocli_client.c
+++ b/tests/net/nanocoap_cli/nanocli_client.c
@@ -82,12 +82,7 @@ static ssize_t _send(coap_pkt_t *pkt, size_t len,
     return nanocoap_request(pkt, NULL, &remote, len);
 }
 
-#if MODULE_NANOCOAP_TOKEN_EXT
-#  define CLIENT_TOKEN_LENGTH_MAX   16
-#else
-#  define CLIENT_TOKEN_LENGTH_MAX   COAP_TOKEN_LENGTH_MAX
-#endif
-static uint8_t _client_token[CLIENT_TOKEN_LENGTH_MAX] = {0xDA, 0xEC};
+static uint8_t _client_token[COAP_TOKEN_LENGTH_MAX] = { 0xDA, 0xEC };
 static uint8_t _client_token_len = 2;
 
 static int _cmd_client(int argc, char **argv)

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -1220,108 +1220,39 @@ static void test_nanocoap__token_length_over_limit(void)
 }
 
 /*
- * Verifies that coap_parse_udp() recognizes 8 bit extended token length
+ * Verifies that coap_parse_udp() rejects 8 bit extended token length
  */
-static void test_nanocoap__token_length_ext_16(void)
+static void test_nanocoap__token_length_ext(void)
 {
     const char *token = "0123456789ABCDEF";
 
     uint8_t buf[32];
     coap_udp_hdr_t *hdr = (void *)buf;
 
-    /* build a request with an overlong token (that mandates the use of
-     * an 8 bit extended token length field) */
-    TEST_ASSERT_EQUAL_INT(21, coap_build_hdr(hdr, COAP_TYPE_CON,
-                                             (void *)token, strlen(token),
-                                             COAP_METHOD_DELETE, 23));
+    /* attempt to build a request with an overlong token (which would require
+     * an 8-bit extended token length field); this must be rejected */
+    TEST_ASSERT_EQUAL_INT(-EINVAL, coap_build_hdr(hdr, COAP_TYPE_CON,
+                                                  (void *)token, strlen(token),
+                                                  COAP_METHOD_DELETE, 23));
 
-    /* parse the packet build, and verify it parses back as expected */
+    uint8_t msg_long_token[] = {
+        /* Ver = 1, T = CON, TKL = 13 for 1 byte extended token length: */
+        (COAP_V1 << 6) | (COAP_TYPE_CON << 4) | 13,
+        /* Code DELETE: */
+        COAP_METHOD_DELETE,
+        /* Message ID = 0xABCD */
+        0xAB, 0xCD,
+        /* Extendedn Token Length */
+        strlen(token) - 13,
+        /* The Token */
+        '0', '1', '2', '3', '4', '5', '6', '7',
+        '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+    };
+    /* try to parse a packet with extended token */
     coap_pkt_t pkt;
-    ssize_t res = coap_parse_udp(&pkt, buf, 21);
+    ssize_t res = coap_parse_udp(&pkt, msg_long_token, sizeof(msg_long_token));
 
-    TEST_ASSERT_EQUAL_INT(21, res);
-    TEST_ASSERT_EQUAL_INT(21, coap_get_total_hdr_len(&pkt));
-    TEST_ASSERT_EQUAL_INT(COAP_METHOD_DELETE, coap_get_code_raw(&pkt));
-    TEST_ASSERT_EQUAL_INT(23, coap_get_id(&pkt));
-    TEST_ASSERT_EQUAL_INT(strlen(token), coap_get_token_len(&pkt));
-    TEST_ASSERT_EQUAL_INT(0, memcmp(coap_get_token(&pkt), token, strlen(token)));
-    TEST_ASSERT_EQUAL_INT(0, pkt.payload_len);
-    TEST_ASSERT_EQUAL_INT(13, hdr->ver_t_tkl & 0xf);
-
-    /* now build the corresponding reply and check that it parses back as
-     * expected */
-    uint8_t rbuf[sizeof(buf)];
-    /* build first using coap_build_reply() */
-    ssize_t len = coap_build_reply(&pkt, COAP_CODE_DELETED,
-                                   rbuf, sizeof(rbuf), 0);
-    TEST_ASSERT_EQUAL_INT(21, len);
-    /* build again using coap_build_reply_header() */
-    len = coap_build_reply_header(&pkt, COAP_CODE_DELETED, rbuf,
-                                  sizeof(rbuf), 0, NULL, NULL);
-    TEST_ASSERT_EQUAL_INT(21, len);
-    res = coap_parse_udp(&pkt, rbuf, 21);
-    TEST_ASSERT_EQUAL_INT(21, res);
-    TEST_ASSERT_EQUAL_INT(21, coap_get_total_hdr_len(&pkt));
-    TEST_ASSERT_EQUAL_INT(COAP_CODE_DELETED, coap_get_code_raw(&pkt));
-    TEST_ASSERT_EQUAL_INT(23, coap_get_id(&pkt));
-    TEST_ASSERT_EQUAL_INT(strlen(token), coap_get_token_len(&pkt));
-    TEST_ASSERT_EQUAL_INT(0, memcmp(coap_get_token(&pkt), token, strlen(token)));
-    TEST_ASSERT_EQUAL_INT(0, pkt.payload_len);
-    TEST_ASSERT_EQUAL_INT(13, hdr->ver_t_tkl & 0xf);
-}
-
-/*
- * Verifies that coap_parse_udp() recognizes 16 bit extended token length
- */
-static void test_nanocoap__token_length_ext_269(void)
-{
-    const char *token = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr,"
-                        "sed diam nonumy eirmod tempor invidunt ut labore et dolore"
-                        "magna aliquyam erat, sed diam voluptua. At vero eos et accusam"
-                        "et justo duo dolores et ea rebum. Stet clita kasd gubergren,"
-                        "no sea takimata sanctus est Lore.";
-    uint8_t buf[280];
-    coap_udp_hdr_t *hdr = (void *)buf;
-
-    /* build a request with an overlong token (that mandates the use of
-     * an 16 bit extended token length field) */
-    TEST_ASSERT_EQUAL_INT(275, coap_build_hdr(hdr, COAP_TYPE_CON,
-                                             (void *)token, strlen(token),
-                                             COAP_METHOD_DELETE, 23));
-
-    /* parse the packet build, and verify it parses back as expected */
-    coap_pkt_t pkt;
-    ssize_t res = coap_parse_udp(&pkt, buf, 275);
-
-    TEST_ASSERT_EQUAL_INT(275, res);
-    TEST_ASSERT_EQUAL_INT(275, coap_get_total_hdr_len(&pkt));
-    TEST_ASSERT_EQUAL_INT(COAP_METHOD_DELETE, coap_get_code_raw(&pkt));
-    TEST_ASSERT_EQUAL_INT(23, coap_get_id(&pkt));
-    TEST_ASSERT_EQUAL_INT(strlen(token), coap_get_token_len(&pkt));
-    TEST_ASSERT_EQUAL_INT(0, memcmp(coap_get_token(&pkt), token, strlen(token)));
-    TEST_ASSERT_EQUAL_INT(0, pkt.payload_len);
-    TEST_ASSERT_EQUAL_INT(14, hdr->ver_t_tkl & 0xf);
-
-    /* now build the corresponding reply and check that it parses back as
-     * expected */
-    uint8_t rbuf[sizeof(buf)];
-    /* build first using coap_build_reply() */
-    ssize_t len = coap_build_reply(&pkt, COAP_CODE_DELETED,
-                                   rbuf, sizeof(rbuf), 0);
-    /* build again using coap_build_reply_header() */
-    len = coap_build_reply_header(&pkt, COAP_CODE_DELETED, rbuf,
-                                  sizeof(rbuf), 0, NULL, NULL);
-
-    TEST_ASSERT_EQUAL_INT(275, len);
-    res = coap_parse_udp(&pkt, rbuf, 275);
-    TEST_ASSERT_EQUAL_INT(275, res);
-    TEST_ASSERT_EQUAL_INT(275, coap_get_total_hdr_len(&pkt));
-    TEST_ASSERT_EQUAL_INT(COAP_CODE_DELETED, coap_get_code_raw(&pkt));
-    TEST_ASSERT_EQUAL_INT(23, coap_get_id(&pkt));
-    TEST_ASSERT_EQUAL_INT(strlen(token), coap_get_token_len(&pkt));
-    TEST_ASSERT_EQUAL_INT(0, memcmp(coap_get_token(&pkt), token, strlen(token)));
-    TEST_ASSERT_EQUAL_INT(0, pkt.payload_len);
-    TEST_ASSERT_EQUAL_INT(14, hdr->ver_t_tkl & 0xf);
+    TEST_ASSERT_EQUAL_INT(-EBADMSG, res);
 }
 
 /*
@@ -1471,8 +1402,7 @@ Test *tests_nanocoap_tests(void)
         new_TestFixture(test_nanocoap__add_path_unterminated_string),
         new_TestFixture(test_nanocoap__add_get_proxy_uri),
         new_TestFixture(test_nanocoap__token_length_over_limit),
-        new_TestFixture(test_nanocoap__token_length_ext_16),
-        new_TestFixture(test_nanocoap__token_length_ext_269),
+        new_TestFixture(test_nanocoap__token_length_ext),
         new_TestFixture(test_nanocoap___rst_message),
         new_TestFixture(test_nanocoap__out_of_bounds_option),
         new_TestFixture(test_nanocoap__coap_build_reply_header),


### PR DESCRIPTION
### Contribution description

This feature has zero use cases in the embedded world but is a constant source of bugs and security vulnerabilities.

Let's prioritize maintainability of the code base and mental health of maintainers over features that nobody uses anyway.

### Testing procedure

nanocoap should work as before, only enabling support for extended tokens will no longer work.

### Issues/PRs references

Added in https://github.com/RIOT-OS/RIOT/pull/19487

This fixes the security issue reported in https://github.com/RIOT-OS/RIOT/security/advisories/GHSA-39j3-3v73-5mj2

Thanks, https://github.com/gulamovzavohir02-glitch, for reporting the issue :heart:

### Declaration of AI-Tools / LLMs usage:


AI-Tools / LLMs that were used are:
- Copilot reviewed
- Improvement for wording in comments from Copilot accepted