### PR TITLE
doc/boards: fix pinout path for Nucleo and other Stm32 boards

### DIFF
--- a/boards/common/blxxxpill/doc.md
+++ b/boards/common/blxxxpill/doc.md
@@ -16,7 +16,7 @@ which may or may not work with RIOT.
 
 ## Pinout
 
-![pinout](pinouts/pinout-bluepill.svg)
+![pinout](pinout-bluepill.svg)
 
 ## MCU
 

--- a/boards/nucleo-f030r8/doc.md
+++ b/boards/nucleo-f030r8/doc.md
@@ -16,7 +16,7 @@ boards_common_nucleo64 page.
 
 ## Pinout
 
-<img src="pinouts/nucleo-f030r8.svg" alt="Pinout for the Nucleo-F030R8 from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 28)" width=50% />
+<img src="nucleo-f030r8.svg" alt="Pinout for the Nucleo-F030R8 from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 28)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f031k6/doc.md
+++ b/boards/nucleo-f031k6/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo32 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f031k6-and-more.svg" alt="Pinout for the Nucleo-F031K6 (from ST User Manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 31)" width=25% />
+<img src="nucleo-f031k6-and-more.svg" alt="Pinout for the Nucleo-F031K6 (from ST User Manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 31)" width=25% />
 
 ### MCU
 

--- a/boards/nucleo-f042k6/doc.md
+++ b/boards/nucleo-f042k6/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo32 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f031k6-and-more.svg" alt="Pinout for the Nucleo-F042K6 (from ST User Manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 31)" width=25% />
+<img src="nucleo-f031k6-and-more.svg" alt="Pinout for the Nucleo-F042K6 (from ST User Manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 31)" width=25% />
 
 ### MCU
 

--- a/boards/nucleo-f070rb/doc.md
+++ b/boards/nucleo-f070rb/doc.md
@@ -16,7 +16,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f070rb.svg" alt="Pinout for the Nucleo-F070RB (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 28)" width=50% />
+<img src="nucleo-f070rb.svg" alt="Pinout for the Nucleo-F070RB (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 28)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f072rb/doc.md
+++ b/boards/nucleo-f072rb/doc.md
@@ -16,7 +16,7 @@ boards_common_nucleo64 page.
 
 ## Pinout
 
-<img src="pinouts/nucleo-f072rb.svg" alt="Pinout for the Nucleo-F072RB (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 29)" width=50% />
+<img src="nucleo-f072rb.svg" alt="Pinout for the Nucleo-F072RB (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 29)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f091rc/doc.md
+++ b/boards/nucleo-f091rc/doc.md
@@ -16,7 +16,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f091rc.svg" alt="Pinout for the Nucleo-F091RC (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 29)" width=50% />
+<img src="nucleo-f091rc.svg" alt="Pinout for the Nucleo-F091RC (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 29)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f103rb/doc.md
+++ b/boards/nucleo-f103rb/doc.md
@@ -16,7 +16,7 @@ boards_common_nucleo64 page.
 
 ## Pinout
 
-<img src="pinouts/nucleo-f103rb.svg" alt="Pinout for the Nucleo-F103RB (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 30)" width=50% />
+<img src="nucleo-f103rb.svg" alt="Pinout for the Nucleo-F103RB (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 30)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f207zg/doc.md
+++ b/boards/nucleo-f207zg/doc.md
@@ -16,7 +16,7 @@ You can find general information about the Nucleo144 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f207zg-and-more.svg" alt="Pinout for the Nucleo-F207ZG (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 32)" width=50% />
+<img src="nucleo-f207zg-and-more.svg" alt="Pinout for the Nucleo-F207ZG (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 32)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f302r8/doc.md
+++ b/boards/nucleo-f302r8/doc.md
@@ -18,7 +18,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f302r8.svg" alt="Pinout for the Nucleo-F302R8 (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 30)" width=50% />
+<img src="nucleo-f302r8.svg" alt="Pinout for the Nucleo-F302R8 (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 30)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f303k8/doc.md
+++ b/boards/nucleo-f303k8/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo32 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f031k6-and-more.svg" alt="Pinout for the Nucleo-F303K8 (from ST User Manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 31)" width=25% />
+<img src="nucleo-f031k6-and-more.svg" alt="Pinout for the Nucleo-F303K8 (from ST User Manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 31)" width=25% />
 
 ## Hardware
 

--- a/boards/nucleo-f303re/doc.md
+++ b/boards/nucleo-f303re/doc.md
@@ -17,7 +17,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f303re.svg" alt="Pinout for the Nucleo-F303RE (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 31)" width=50% />
+<img src="nucleo-f303re.svg" alt="Pinout for the Nucleo-F303RE (from user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 31)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f303ze/doc.md
+++ b/boards/nucleo-f303ze/doc.md
@@ -16,7 +16,7 @@ You can find general information about the Nucleo144 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f303ze.svg" alt="Pinout for the Nucleo-F303ZE (from STM user board manual, M1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 33)" width=55% />
+<img src="nucleo-f303ze.svg" alt="Pinout for the Nucleo-F303ZE (from STM user board manual, M1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 33)" width=55% />
 
 ### MCU
 

--- a/boards/nucleo-f334r8/doc.md
+++ b/boards/nucleo-f334r8/doc.md
@@ -17,7 +17,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f334r8.svg" alt="Pinout for the nucleo-F334R8 (from user manual UM1724, <http://www.st.com/resource/en/user_manual/dm00105823.pdf>, page 31)" width=50% />
+<img src="nucleo-f334r8.svg" alt="Pinout for the nucleo-F334R8 (from user manual UM1724, <http://www.st.com/resource/en/user_manual/dm00105823.pdf>, page 31)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f410rb/doc.md
+++ b/boards/nucleo-f410rb/doc.md
@@ -16,7 +16,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f410rb.svg" alt="Pinout for the Nucleo-F410RB (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 36)" width=50% />
+<img src="nucleo-f410rb.svg" alt="Pinout for the Nucleo-F410RB (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 36)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f411re/doc.md
+++ b/boards/nucleo-f411re/doc.md
@@ -16,7 +16,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f411re.svg" alt="Pinout for the Nucleo-F411RE (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 32)" width=50% />
+<img src="nucleo-f411re.svg" alt="Pinout for the Nucleo-F411RE (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 32)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f412zg/doc.md
+++ b/boards/nucleo-f412zg/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo144 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f412zg-and-f413zh.svg" alt="Pinout for the Nucleo-F412ZG (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 34)" width=50% />
+<img src="nucleo-f412zg-and-f413zh.svg" alt="Pinout for the Nucleo-F412ZG (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 34)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f413zh/doc.md
+++ b/boards/nucleo-f413zh/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo144 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f412zg-and-f413zh.svg" alt="Pinout for the nucleo-f413zh (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 34)" width=50% />
+<img src="nucleo-f412zg-and-f413zh.svg" alt="Pinout for the nucleo-f413zh (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 34)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f429zi/doc.md
+++ b/boards/nucleo-f429zi/doc.md
@@ -16,7 +16,7 @@ You can find general information about the Nucleo144 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f207zg-and-more.svg" alt="Pinout for the Nucleo-F429ZI (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 32)" width=50% />
+<img src="nucleo-f207zg-and-more.svg" alt="Pinout for the Nucleo-F429ZI (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 32)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f439zi/doc.md
+++ b/boards/nucleo-f439zi/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo144 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f207zg-and-more.svg"  alt="Pinout for the Nucleo-F439ZI (from STM user manual, UM1974, <http://www.st.com/resource/en/user_manual/dm00244518.pdf>, page 32)" width=50% />
+<img src="nucleo-f207zg-and-more.svg"  alt="Pinout for the Nucleo-F439ZI (from STM user manual, UM1974, <http://www.st.com/resource/en/user_manual/dm00244518.pdf>, page 32)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f446re/doc.md
+++ b/boards/nucleo-f446re/doc.md
@@ -16,7 +16,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f446re.svg" alt="Pinout for the Nucleo-F446RE (from STM user manual UM1724, <http://www.st.com/resource/en/user_manual/dm00105823.pdf>, page 35)" width=50% />
+<img src="nucleo-f446re.svg" alt="Pinout for the Nucleo-F446RE (from STM user manual UM1724, <http://www.st.com/resource/en/user_manual/dm00105823.pdf>, page 35)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f446ze/doc.md
+++ b/boards/nucleo-f446ze/doc.md
@@ -16,7 +16,7 @@ You can find general information about the Nucleo144 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f446ze-and-f722ze.svg" alt="Pinout for the Nucleo-F446ZE (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 35)" width=50% />
+<img src="nucleo-f446ze-and-f722ze.svg" alt="Pinout for the Nucleo-F446ZE (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 35)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f722ze/doc.md
+++ b/boards/nucleo-f722ze/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo144 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f446ze-and-f722ze.svg" alt="Pinout for the Nucleo-F722ZE (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 35)" width=50% />
+<img src="nucleo-f446ze-and-f722ze.svg" alt="Pinout for the Nucleo-F722ZE (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 35)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f746zg/doc.md
+++ b/boards/nucleo-f746zg/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo144 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f207zg-and-more.svg" alt="Pinout for the Nucleo-F746ZG (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 32)" width=50% />
+<img src="nucleo-f207zg-and-more.svg" alt="Pinout for the Nucleo-F746ZG (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 32)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f767zi/doc.md
+++ b/boards/nucleo-f767zi/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo144 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f207zg-and-more.svg" alt="Pinout for the Nucleo-F767ZI (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 32)" width=50% />
+<img src="nucleo-f207zg-and-more.svg" alt="Pinout for the Nucleo-F767ZI (from STM user manual, UM1974, http://www.st.com/resource/en/user_manual/dm00244518.pdf, page 32)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-g031k8/doc.md
+++ b/boards/nucleo-g031k8/doc.md
@@ -17,7 +17,7 @@ You can find general information about the Nucleo32 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-g031k8.svg" alt="Pinout for the Nucleo-G031K8 (from ST User Manual, UM2591, https://www.st.com/resource/en/user_manual/um2591-stm32g0-nucleo32-board-mb1455-stmicroelectronics.pdf, page 16)" width=25% />
+<img src="nucleo-g031k8.svg" alt="Pinout for the Nucleo-G031K8 (from ST User Manual, UM2591, https://www.st.com/resource/en/user_manual/um2591-stm32g0-nucleo32-board-mb1455-stmicroelectronics.pdf, page 16)" width=25% />
 
 ## MCU
 

--- a/boards/nucleo-g070rb/doc.md
+++ b/boards/nucleo-g070rb/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-g070rb-and-g071rb.svg" alt="Pinout for the Nucleo-G070RG (from STM user manual UM2324, https://www.st.com/resource/en/user_manual/um2324-stm32-nucleo64-boards-mb1360-stmicroelectronics.pdf, page 34)" width=50% />
+<img src="nucleo-g070rb-and-g071rb.svg" alt="Pinout for the Nucleo-G070RG (from STM user manual UM2324, https://www.st.com/resource/en/user_manual/um2324-stm32-nucleo64-boards-mb1360-stmicroelectronics.pdf, page 34)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-g071rb/doc.md
+++ b/boards/nucleo-g071rb/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-g070rb-and-g071rb.svg" alt="Pinout for the Nucleo-G071RG (from STM user manual UM2324, https://www.st.com/resource/en/user_manual/um2324-stm32-nucleo64-boards-mb1360-stmicroelectronics.pdf, page 34)" width=50% />
+<img src="nucleo-g070rb-and-g071rb.svg" alt="Pinout for the Nucleo-G071RG (from STM user manual UM2324, https://www.st.com/resource/en/user_manual/um2324-stm32-nucleo64-boards-mb1360-stmicroelectronics.pdf, page 34)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-g431rb/doc.md
+++ b/boards/nucleo-g431rb/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-g431rb-and-more.svg" alt="Pinout for the Nucleo-G431RB (from STM user manual UM2505, <https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf>, page 29)" width=50% />
+<img src="nucleo-g431rb-and-more.svg" alt="Pinout for the Nucleo-G431RB (from STM user manual UM2505, <https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf>, page 29)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-g474re/doc.md
+++ b/boards/nucleo-g474re/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-g431rb-and-more.svg" alt="Pinout for the Nucleo-G4741RE (from STM user manual UM2505, https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf, page 29)" width=50% />
+<img src="nucleo-g431rb-and-more.svg" alt="Pinout for the Nucleo-G4741RE (from STM user manual UM2505, https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf, page 29)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-g491re/doc.md
+++ b/boards/nucleo-g491re/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-g431rb-and-more.svg" alt="Pinout for the Nucleo-G491RE (from STM user manual UM2505 Rev 7, https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf, page 30)" width=50% />
+<img src="nucleo-g431rb-and-more.svg" alt="Pinout for the Nucleo-G491RE (from STM user manual UM2505 Rev 7, https://www.st.com/resource/en/user_manual/um2505-stm32g4-nucleo64-boards-mb1367-stmicroelectronics.pdf, page 30)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-h753zi/doc.md
+++ b/boards/nucleo-h753zi/doc.md
@@ -9,7 +9,7 @@ STM32H753ZI microcontroller with 1 MiB of RAM and 2 MiB of Flash.
 
 ## Pinout
 
-<img src="pinouts/nucleo-h753zi.svg" alt="Pinout for the Nucleo-H753ZI (from STM user manual UM2407, https://www.st.com/resource/en/user_manual/um2407-stm32h7-nucleo144-boards-mb1364-stmicroelectronics.pdf, page 38)" width=50% />
+<img src="nucleo-h753zi.svg" alt="Pinout for the Nucleo-H753ZI (from STM user manual UM2407, https://www.st.com/resource/en/user_manual/um2407-stm32h7-nucleo144-boards-mb1364-stmicroelectronics.pdf, page 38)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-l011k4/doc.md
+++ b/boards/nucleo-l011k4/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo32 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-l432kc-and-more.svg" alt="Pinout for the Nucleo-L011K4 (from STM user manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 32)" width=25% />
+<img src="nucleo-l432kc-and-more.svg" alt="Pinout for the Nucleo-L011K4 (from STM user manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 32)" width=25% />
 
 ### MCU
 

--- a/boards/nucleo-l031k6/doc.md
+++ b/boards/nucleo-l031k6/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo32 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-l432kc-and-more.svg" alt="Pinout for the Nucleo-L031K6 (from STM user manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 32)" width=25% />
+<img src="nucleo-l432kc-and-more.svg" alt="Pinout for the Nucleo-L031K6 (from STM user manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 32)" width=25% />
 
 ### MCU
 

--- a/boards/nucleo-l053r8/doc.md
+++ b/boards/nucleo-l053r8/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-l053r8.svg" alt="Pinout for the Nucleo-L053r8 (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 33)" width=50% />
+<img src="nucleo-l053r8.svg" alt="Pinout for the Nucleo-L053r8 (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 33)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-l073rz/doc.md
+++ b/boards/nucleo-l073rz/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-l073rz.svg" alt="Pinout for the Nucleo-L073RZ (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 33)" width=50% />
+<img src="nucleo-l073rz.svg" alt="Pinout for the Nucleo-L073RZ (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 33)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-l152re/doc.md
+++ b/boards/nucleo-l152re/doc.md
@@ -16,7 +16,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-l152re.svg" alt="Pinout for the Nucleo-L152RE (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 34)" width=50% />
+<img src="nucleo-l152re.svg" alt="Pinout for the Nucleo-L152RE (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 34)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-l412kb/doc.md
+++ b/boards/nucleo-l412kb/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo32 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-l432kc-and-more.svg" alt="Pinout for the Nucleo-L412KB (from STM user manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 32)" width=25% />
+<img src="nucleo-l432kc-and-more.svg" alt="Pinout for the Nucleo-L412KB (from STM user manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 32)" width=25% />
 
 ### MCU
 

--- a/boards/nucleo-l432kc/doc.md
+++ b/boards/nucleo-l432kc/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo32 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-l432kc-and-more.svg" alt="Pinout for the Nucleo-L432KC (from STM user manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 32)" width=25% />
+<img src="nucleo-l432kc-and-more.svg" alt="Pinout for the Nucleo-L432KC (from STM user manual, UM1956, https://www.st.com/resource/en/user_manual/um1956-stm32-nucleo32-boards-mb1180-stmicroelectronics.pdf, page 32)" width=25% />
 
 ### MCU
 

--- a/boards/nucleo-l433rc/doc.md
+++ b/boards/nucleo-l433rc/doc.md
@@ -16,7 +16,7 @@ You can find general information about the Nucleo64 boards on the
 
 ### Pinout
 
-<img src="pinouts/nucleo-l433rc.svg" alt="Pinout for the Nucleo-L433RC (from STM user manual, UM2206, http://www.st.com/resource/en/user_manual/um2206-stm32-nucleo64p-boards-mb1319-stmicroelectronics.pdf, page 37)" width=50% />
+<img src="nucleo-l433rc.svg" alt="Pinout for the Nucleo-L433RC (from STM user manual, UM2206, http://www.st.com/resource/en/user_manual/um2206-stm32-nucleo64p-boards-mb1319-stmicroelectronics.pdf, page 37)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-l452re/doc.md
+++ b/boards/nucleo-l452re/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-l452re.svg" alt="Pinout for the Nucleo-L452RE (from STM board manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 34)" width=50% />
+<img src="nucleo-l452re.svg" alt="Pinout for the Nucleo-L452RE (from STM board manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 34)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-l476rg/doc.md
+++ b/boards/nucleo-l476rg/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-l476rg.svg" alt="Pinout for the Nucleo-L476RG (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 35)" width=50% />
+<img src="nucleo-l476rg.svg" alt="Pinout for the Nucleo-L476RG (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 35)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-l496zg/doc.md
+++ b/boards/nucleo-l496zg/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo144 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-l496zg.svg" alt="Pinout for the Nucleo-L496ZG (from STM user manual, UM2179, https://www.st.com/resource/en/user_manual/um2179-stm32-nucleo144-boards-mb1312-stmicroelectronics.pdf, page 31)" width=55% />
+<img src="nucleo-l496zg.svg" alt="Pinout for the Nucleo-L496ZG (from STM user manual, UM2179, https://www.st.com/resource/en/user_manual/um2179-stm32-nucleo144-boards-mb1312-stmicroelectronics.pdf, page 31)" width=55% />
 
 ### MCU
 

--- a/boards/nucleo-l4r5zi/doc.md
+++ b/boards/nucleo-l4r5zi/doc.md
@@ -16,7 +16,7 @@ You can find general information about the Nucleo144 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-l4r5zi.svg"  alt="Pinout for the Nucleo-L4R5ZI (from STM user manual, UM2179, http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/um2179-stm32-nucleo144-boards-mb1312-stmicroelectronics.pdf, page 35)" width=55% />
+<img src="nucleo-l4r5zi.svg"  alt="Pinout for the Nucleo-L4R5ZI (from STM user manual, UM2179, http://www.st.com/st-web-ui/static/active/en/resource/technical/document/user_manual/um2179-stm32-nucleo144-boards-mb1312-stmicroelectronics.pdf, page 35)" width=55% />
 
 ### MCU
 

--- a/boards/p-nucleo-wb55/doc.md
+++ b/boards/p-nucleo-wb55/doc.md
@@ -19,7 +19,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/p-nucleo-wb55.svg" alt="Pinout for the p-nucleo-wb55" width=50% />
+<img src="p-nucleo-wb55.svg" alt="Pinout for the p-nucleo-wb55" width=50% />
 
 ### MCU
 

--- a/boards/stm32f429i-disc1/doc.md
+++ b/boards/stm32f429i-disc1/doc.md
@@ -11,7 +11,7 @@ This board is a replacement for the older @ref boards_stm32f429i-disco board.
 
 ## Pinout
 
-<img src="pinouts/stm32f429i-disc1.svg" alt="Pinout for the STM32F429I-DISC1, bottom layout (from STM user manual UM1607, https://www.st.com/resource/en/user_manual/um1670-discovery-kit-with-stm32f429zi-mcu-stmicroelectronics.pdf, page 12)" width=50% />
+<img src="stm32f429i-disc1.svg" alt="Pinout for the STM32F429I-DISC1, bottom layout (from STM user manual UM1607, https://www.st.com/resource/en/user_manual/um1670-discovery-kit-with-stm32f429zi-mcu-stmicroelectronics.pdf, page 12)" width=50% />
 
 ### MCU
 

--- a/boards/stm32l0538-disco/doc.md
+++ b/boards/stm32l0538-disco/doc.md
@@ -14,7 +14,7 @@ The board also provides an on-board 2.04\" E-paper display (not supported yet).
 
 ## Pinout
 
-<img src="pinouts/stm32l0538-disco.svg" alt="Pinout for the stm32l0538-disco (from STM board manual)" width=50% />
+<img src="stm32l0538-disco.svg" alt="Pinout for the stm32l0538-disco (from STM board manual)" width=50% />
 
 ### MCU
 

--- a/boards/stm32l476g-disco/doc.md
+++ b/boards/stm32l476g-disco/doc.md
@@ -14,7 +14,7 @@ ROM Flash.
 
 ## Pinout
 
-<img src="pinouts/stm32l476g-disco.svg" alt="Pinout for the stm32l476g-disco (from STM board manual)" width=50% />
+<img src="stm32l476g-disco.svg" alt="Pinout for the stm32l476g-disco (from STM board manual)" width=50% />
 
 ### MCU
 


### PR DESCRIPTION
### Contribution description

This PR is continuation of PR #22495, and fix path to pinouts for all Nucleo and Stm32 boards.

### Testing procedure

Check if in Murdock generated doc appear all pinouts for Nucleo and Stm32 boards.

### Issues/PRs references

PR #22499 
Issue #22353

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none