### PR TITLE
doc/starlight: fix typo in Caution message

### DIFF
--- a/doc/starlight/src/pages/[moduleType]/[...modulePath].astro
+++ b/doc/starlight/src/pages/[moduleType]/[...modulePath].astro
@@ -79,8 +79,8 @@ const { Content, headings } = await render(module);
 >
   <Aside type="caution">
     This page is automatically generated from RIOT doxygen documentation. If you
-    find any issues or have suggestions for improvement, please report them on
-    <a href="https://github.com/RIOT-OS/RIOT/issues/22203">Github</a>
+    find any issues or have suggestions for improvement, please report them
+    on <a href="https://github.com/RIOT-OS/RIOT/issues/22203">GitHub</a>.
   </Aside>
 
   <CardGrid>


### PR DESCRIPTION
### Contribution description

This PR fix small typo in RIOT Guide pages - lack of space between word "on" and link to Github.

<img width="913" height="162" alt="obraz" src="https://github.com/user-attachments/assets/c9c3b206-7097-4680-9aab-e336c0bce294" />

For example, see [https://guide.riot-os.org/boards/nucleo-f429zi/](https://guide.riot-os.org/boards/nucleo-f429zi/).
I checked this behaviour using Firefox and Edge browsers.

### Testing procedure

Generate Guide pages and check if space between word "on" and link to Github appear.

```
make doc-starlight
```
And in other terminal connect to starlight documentation  `xdg-open http://localhost:4321/`,  and check automatically generated pages for boards, for example for nucleo-f429zi.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none

