### PR TITLE
doccheck: less exclude_simple

### DIFF
--- a/dist/tools/doccheck/exclude_simple
+++ b/dist/tools/doccheck/exclude_simple
@@ -1,28 +1,8 @@
-warning: explicit link request to 'esp32_application_specific_board_configuration' could not be resolved
 warning: explicit link request to 'esp32_application_specific_configurations' could not be resolved
-warning: explicit link request to 'esp32_heltec_lora32_v2_optional_hardware' could not be resolved
 warning: explicit link request to 'esp32_local_toolchain_installation' could not be resolved
-warning: explicit link request to 'esp32_mh_et_live_minikit_optional_hardware' could not be resolved
-warning: explicit link request to 'esp32_wemos_lolin_d32_pro_optional_hardware' could not be resolved
 warning: explicit link request to 'l3gxxxx_data_interrupt' could not be resolved
 warning: explicit link request to 'l3gxxxx_event_interrupt' could not be resolved
 warning: explicit link request to 'l3gxxxx_odr_filters' could not be resolved
-warning: found documented return type for at86rf2xx_get_addr_long that does not return anything
-warning: found documented return type for at86rf2xx_get_addr_short that does not return anything
-warning: found documented return type for bloom_add that does not return anything
-warning: found documented return type for bloom_del that does not return anything
-warning: found documented return type for cc2420_get_addr_long that does not return anything
-warning: found documented return type for cc2420_setup that does not return anything
-warning: found documented return type for core_panic that does not return anything
-warning: found documented return type for mcp47xx_dac_get that does not return anything
-warning: found documented return type for mcp47xx_dac_poweroff that does not return anything
-warning: found documented return type for mcp47xx_dac_poweron that does not return anything
-warning: found documented return type for mcp47xx_dac_set that does not return anything
-warning: found documented return type for pthread_exit that does not return anything
-warning: found documented return type for senml_set_duration_ms that does not return anything
-warning: found documented return type for senml_set_duration_us that does not return anything
-warning: found documented return type for sx127x_set_state that does not return anything
-warning: found documented return type for xbee_setup that does not return anything
 warning: Member a0_OFFSET (macro definition) of file context_frame.h is not documented.
 warning: Member a1_OFFSET (macro definition) of file context_frame.h is not documented.
 warning: Member a2_OFFSET (macro definition) of file context_frame.h is not documented.
@@ -62,19 +42,11 @@ warning: Member AD7746_VT_SETUP_VTSHORT_BIT (macro definition) of file ad7746_in
 warning: Member adc_channel_config[] (variable) of file periph_conf.h is not documented.
 warning: Member adc_channels[] (variable) of file periph_conf_common.h is not documented.
 warning: Member adc_channels[] (variable) of file periph_conf.h is not documented.
-warning: Member adc_config[] (variable) of file cfg_adc_default.h is not documented.
-warning: Member adc_config[] (variable) of file periph_conf_common.h is not documented.
-warning: Member adc_config[] (variable) of file periph_conf.h is not documented.
-warning: Member ADC_DEV (macro definition) of file periph_conf.h is not documented.
 warning: Member ADC_DEV_NUMOF (macro definition) of file periph_conf.h is not documented.
 warning: Member ADC_GAIN_FACTOR_DEFAULT (macro definition) of file periph_conf_common.h is not documented.
 warning: Member ADC_GAIN_FACTOR_DEFAULT (macro definition) of file periph_conf.h is not documented.
 warning: Member ADC_NEG_INPUT (macro definition) of file periph_conf_common.h is not documented.
 warning: Member ADC_NEG_INPUT (macro definition) of file periph_conf.h is not documented.
-warning: Member ADC_NUMOF (macro definition) of file cfg_adc_default.h is not documented.
-warning: Member ADC_NUMOF (macro definition) of file periph_conf_common.h is not documented.
-warning: Member ADC_NUMOF (macro definition) of file periph_conf.h is not documented.
-warning: Member ADC_NUMOF (macro definition) of file periph_cpu.h is not documented.
 warning: Member ADC_PRESCALER (macro definition) of file periph_conf_common.h is not documented.
 warning: Member ADC_PRESCALER (macro definition) of file periph_conf.h is not documented.
 warning: Member ADC_REF_DEFAULT (macro definition) of file periph_conf_common.h is not documented.
@@ -104,46 +76,6 @@ warning: Member ADI_SET (macro definition) of file cc26xx_cc13xx.h is not docume
 warning: Member ADPS9960_PARAM_ADDR (macro definition) of file board.h is not documented.
 warning: Member ADPS9960_PARAM_I2C (macro definition) of file board.h is not documented.
 warning: Member ADPS9960_PARAM_PIN_INT (macro definition) of file board.h is not documented.
-warning: Member ADS1X1X_AIN0_DIFFM_AIN1 (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_AIN0_DIFFM_AIN3 (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_AIN0_SINGM (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_AIN1_DIFFM_AIN3 (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_AIN1_SINGM (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_AIN2_DIFFM_AIN3 (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_AIN2_SINGM (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_AIN3_SINGM (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_ALERT_PARAMS (macro definition) of file ads1x1x_params.h is not documented.
-warning: Member ADS1X1X_CONF_ADDR (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_CONF_COMP_DIS (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_CONF_COMP_MODE_WIND (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_CONF_OS_CONV (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_CONV_RES_ADDR (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_DATAR_128 (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_DATAR_1600 (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_DATAR_2400 (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_DATAR_250 (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_DATAR_3300 (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_DATAR_490 (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_DATAR_920 (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_DATAR_MASK (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_HIGH_LIMIT_ADDR (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_LOW_LIMIT_ADDR (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_MUX_MASK (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_PARAM_ADDR (macro definition) of file ads1x1x_params.h is not documented.
-warning: Member ADS1X1X_PARAM_ALERT_PIN (macro definition) of file ads1x1x_params.h is not documented.
-warning: Member ADS1X1X_PARAM_HIGH_LIMIT (macro definition) of file ads1x1x_params.h is not documented.
-warning: Member ADS1X1X_PARAM_I2C (macro definition) of file ads1x1x_params.h is not documented.
-warning: Member ADS1X1X_PARAM_LOW_LIMIT (macro definition) of file ads1x1x_params.h is not documented.
-warning: Member ADS1X1X_PARAM_MUX_GAIN (macro definition) of file ads1x1x_params.h is not documented.
-warning: Member ADS1X1X_PARAMS (macro definition) of file ads1x1x_params.h is not documented.
-warning: Member ADS1X1X_PGA_FSR_0V256 (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_PGA_FSR_0V512 (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_PGA_FSR_1V024 (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_PGA_FSR_2V048 (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_PGA_FSR_4V096 (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_PGA_FSR_6V144 (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_PGA_MASK (macro definition) of file ads1x1x_internal.h is not documented.
-warning: Member ADS1X1X_SAUL_INFO (macro definition) of file ads1x1x_params.h is not documented.
 warning: Member ADT7310_CONF_CT_POL_MASK (macro definition) of group drivers_adt7310 is not documented.
 warning: Member ADT7310_CONF_CT_POL_SHIFT (macro definition) of group drivers_adt7310 is not documented.
 warning: Member ADT7310_CONF_CT_POL(x) (macro definition) of group drivers_adt7310 is not documented.
@@ -583,12 +515,7 @@ warning: Member ATCA_DEVTYPE (macro definition) of group drivers_atca_config is 
 warning: Member ATCA_PARAM_ADDR (macro definition) of group drivers_atca_config is not documented.
 warning: Member ATCA_PARAM_I2C (macro definition) of file board.h is not documented.
 warning: Member ATCA_PARAM_I2C (macro definition) of group drivers_atca_config is not documented.
-warning: Member ATCA_PARAMS (macro definition) of group drivers_atca_config is not documented.
 warning: Member ATCA_RX_RETRIES (macro definition) of group drivers_atca_config is not documented.
-warning: Member ATMEGA_GPIO_BASE_PORT_A (macro definition) of file atmega_gpio.h is not documented.
-warning: Member ATMEGA_GPIO_OFFSET_PIN_PIN (macro definition) of file atmega_gpio.h is not documented.
-warning: Member ATMEGA_GPIO_OFFSET_PIN_PORT (macro definition) of file atmega_gpio.h is not documented.
-warning: Member ATMEGA_GPIO_OFFSET_PORT_H (macro definition) of file atmega_gpio.h is not documented.
 warning: Member ATWINC15X0_PARAM_CHIP_EN_PIN (macro definition) of file atwinc15x0_params.h is not documented.
 warning: Member ATWINC15X0_PARAM_CHIP_EN_PIN (macro definition) of file board.h is not documented.
 warning: Member ATWINC15X0_PARAM_IRQ_PIN (macro definition) of file atwinc15x0_params.h is not documented.
@@ -636,38 +563,6 @@ warning: Member BH1900NUX_PARAM_ADDR (macro definition) of file bh1900nux_params
 warning: Member BH1900NUX_PARAM_I2C (macro definition) of file bh1900nux_params.h is not documented.
 warning: Member BH1900NUX_PARAMS (macro definition) of file bh1900nux_params.h is not documented.
 warning: Member BH1900NUX_REG_ADDR (macro definition) of group drivers_bh1900nux is not documented.
-warning: Member BIT0 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT10 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT11 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT12 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT13 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT14 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT15 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT16 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT17 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT18 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT19 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT1 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT20 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT21 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT22 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT23 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT24 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT25 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT26 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT27 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT28 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT29 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT2 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT30 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT31 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT3 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT4 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT5 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT6 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT7 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT8 (macro definition) of file bitarithm.h is not documented.
-warning: Member BIT9 (macro definition) of file bitarithm.h is not documented.
 warning: Member BIT_ACC_RANGE_16G (macro definition) of file bmx055_internal.h is not documented.
 warning: Member BIT_ACC_RANGE_2G (macro definition) of file bmx055_internal.h is not documented.
 warning: Member BIT_ACC_RANGE_4G (macro definition) of file bmx055_internal.h is not documented.
@@ -901,7 +796,6 @@ warning: Member BME680_PARAM_SPI_NSS_PIN (macro definition) of file bme680_param
 warning: Member BMEX80_RST_REG (macro definition) of file bmx280_internals.h is not documented.
 warning: Member BMP180_ADDR (macro definition) of file bmp180_internals.h is not documented.
 warning: Member BMP180_CALIBRATION_AC1 (macro definition) of file bmp180_internals.h is not documented.
-warning: Member BMP180_HIGHRES_DELAY (macro definition) of file bmp180_internals.h is not documented.
 warning: Member BMP180_PARAM_I2C_ADDR (macro definition) of file bmp180_params.h is not documented.
 warning: Member BMP180_PARAM_I2C_DEV (macro definition) of file bmp180_params.h is not documented.
 warning: Member BMP180_PARAM_OVERSAMPLING (macro definition) of file bmp180_params.h is not documented.
@@ -911,10 +805,7 @@ warning: Member BMP180_REGISTER_CONTROL (macro definition) of file bmp180_intern
 warning: Member BMP180_REGISTER_DATA (macro definition) of file bmp180_internals.h is not documented.
 warning: Member BMP180_REGISTER_ID (macro definition) of file bmp180_internals.h is not documented.
 warning: Member BMP180_SAUL_INFO (macro definition) of file bmp180_params.h is not documented.
-warning: Member BMP180_STANDARD_DELAY (macro definition) of file bmp180_internals.h is not documented.
 warning: Member BMP180_TEMPERATURE_COMMAND (macro definition) of file bmp180_internals.h is not documented.
-warning: Member BMP180_ULTRAHIGHRES_DELAY (macro definition) of file bmp180_internals.h is not documented.
-warning: Member BMP180_ULTRALOWPOWER_DELAY (macro definition) of file bmp180_internals.h is not documented.
 warning: Member BMP280_I2C (macro definition) of file board.h is not documented.
 warning: Member BMX055_PARAM_ACC_ADDR (macro definition) of file bmx055_params.h is not documented.
 warning: Member BMX055_PARAM_ACC_RANGE (macro definition) of file bmx055_params.h is not documented.
@@ -1043,7 +934,6 @@ warning: Member CAN_ISOTP_DEFAULT_PAD_CONTENT (macro definition) of group sys_ca
 warning: Member CAN_ISOTP_DEFAULT_RECV_BS (macro definition) of group sys_can_isotp is not documented.
 warning: Member CAN_ISOTP_DEFAULT_RECV_STMIN (macro definition) of group sys_can_isotp is not documented.
 warning: Member CAN_ISOTP_DEFAULT_RECV_WFTMAX (macro definition) of group sys_can_isotp is not documented.
-warning: Member CAN_STM32_NB_FILTER (macro definition) of file candev_stm32.h is not documented.
 warning: Member _CASTASGN(a, b) (macro definition) of group sys_ut is not documented.
 warning: Member CC1200_CSN_GPIO (macro definition) of file board.h is not documented.
 warning: Member CC1200_GPD0_GPIO (macro definition) of file board.h is not documented.
@@ -1276,7 +1166,6 @@ warning: Member CIPHER_ERR_DEC_FAILED (macro definition) of file ciphers.h is no
 warning: Member CIPHER_ERR_ENC_FAILED (macro definition) of file ciphers.h is not documented.
 warning: Member CIPHER_ERR_INVALID_KEY_SIZE (macro definition) of file ciphers.h is not documented.
 warning: Member CIPHER_ERR_INVALID_LENGTH (macro definition) of file ciphers.h is not documented.
-warning: Member cipher_id_t (variable) of file ciphers.h is not documented.
 warning: Member CIPHER_MAX_BLOCK_SIZE (macro definition) of file ciphers.h is not documented.
 warning: Member CLIC_BASE_ADDR (macro definition) of file cpu_conf.h is not documented.
 warning: Member clic_clicint_t (variable) of file clic.h is not documented.
@@ -1292,7 +1181,6 @@ warning: Member CLKLOADCTL_LOADDONE (macro definition) of file cc26x0_cc13x0_prc
 warning: Member CLKLOADCTL_LOADDONE (macro definition) of file cc26x2_cc13x2_prcm.h is not documented.
 warning: Member clk_mux_config[] (variable) of file periph_conf.h is not documented.
 warning: Member CLK_MUX_NUMOF (macro definition) of file periph_conf.h is not documented.
-warning: Member CLOCK_8MHZ (macro definition) of file periph_conf.h is not documented.
 warning: Member CLOCK_AHB (macro definition) of file cfg_clock_default.h is not documented.
 warning: Member CLOCK_APB1 (macro definition) of file cfg_clock_default.h is not documented.
 warning: Member CLOCK_APB2 (macro definition) of file cfg_clock_default.h is not documented.
@@ -1300,14 +1188,11 @@ warning: Member CLOCK_BUSCLOCK (macro definition) of file periph_conf_common.h i
 warning: Member CLOCK_BUSCLOCK (macro definition) of file periph_conf.h is not documented.
 warning: Member clock_config (variable) of file periph_conf_common.h is not documented.
 warning: Member clock_config (variable) of file periph_conf.h is not documented.
-warning: Member CLOCK_CORECLOCK (macro definition) of file board.h is not documented.
 warning: Member CLOCK_CORECLOCK (macro definition) of file cfg_clk_default.h is not documented.
 warning: Member CLOCK_CORECLOCK (macro definition) of file cfg_clock_default.h is not documented.
-warning: Member CLOCK_CORECLOCK (macro definition) of file clk_conf.h is not documented.
 warning: Member CLOCK_CORECLOCK (macro definition) of file periph_conf_atmega_common.h is not documented.
 warning: Member CLOCK_CORECLOCK (macro definition) of file periph_conf_common.h is not documented.
 warning: Member CLOCK_CORECLOCK (macro definition) of file periph_conf.h is not documented.
-warning: Member CLOCK_CORECLOCK (macro definition) of group cpu_esp8266_conf is not documented.
 warning: Member CLOCK_CORE_DIV (macro definition) of file periph_conf.h is not documented.
 warning: Member CLOCK_EXTAHB_DIV (macro definition) of file periph_conf.h is not documented.
 warning: Member CLOCK_EXTAHB (macro definition) of file periph_conf.h is not documented.
@@ -1322,11 +1207,6 @@ warning: Member CLOCK_HF (macro definition) of file periph_conf.h is not documen
 warning: Member CLOCK_IO (macro definition) of file cfg_clk_default.h is not documented.
 warning: Member CLOCK_LFA (macro definition) of file periph_conf.h is not documented.
 warning: Member CLOCK_LFB (macro definition) of file periph_conf.h is not documented.
-warning: Member CLOCK_LFCLK (macro definition) of file cfg_clock_16_0.h is not documented.
-warning: Member CLOCK_LFCLK (macro definition) of file cfg_clock_16_1.h is not documented.
-warning: Member CLOCK_LFCLK (macro definition) of file cfg_clock_32_0.h is not documented.
-warning: Member CLOCK_LFCLK (macro definition) of file cfg_clock_32_1.h is not documented.
-warning: Member CLOCK_LFCLK (macro definition) of file periph_conf.h is not documented.
 warning: Member CLOCK_LFE (macro definition) of file periph_conf.h is not documented.
 warning: Member CLOCK_MCGFLLCLK (macro definition) of file periph_conf.h is not documented.
 warning: Member CLOCK_MCGIRCLK (macro definition) of file periph_conf_common.h is not documented.
@@ -1335,18 +1215,10 @@ warning: Member CLOCK_OSC32K (macro definition) of file cfg_clk_default.h is not
 warning: Member CLOCK_OSCERCLK (macro definition) of file periph_conf.h is not documented.
 warning: Member CLOCK_OSC (macro definition) of file cfg_clk_default.h is not documented.
 warning: Member CLOCK_PCLK (macro definition) of file periph_conf.h is not documented.
-warning: Member CLOCK_PLL_DIV (macro definition) of file cfg_clock_default.h is not documented.
-warning: Member CLOCK_PLL_DIV (macro definition) of file periph_conf_common.h is not documented.
 warning: Member CLOCK_PLL_DIV (macro definition) of file periph_conf.h is not documented.
-warning: Member CLOCK_PLL_INPUT_CLOCK (macro definition) of file clk_conf.h is not documented.
-warning: Member CLOCK_PLL_MUL (macro definition) of file cfg_clock_default.h is not documented.
-warning: Member CLOCK_PLL_MUL (macro definition) of file periph_conf_common.h is not documented.
 warning: Member CLOCK_PLL_MUL (macro definition) of file periph_conf.h is not documented.
-warning: Member CLOCK_PLL_OUT (macro definition) of file clk_conf.h is not documented.
 warning: Member CLOCK_PLLQ (macro definition) of file cfg_clock_default.h is not documented.
-warning: Member CLOCK_PLL_REFR (macro definition) of file clk_conf.h is not documented.
 warning: Member CLOCK_PLL_SRC (macro definition) of file cfg_clock_default.h is not documented.
-warning: Member CLOCK_PLL_VCO (macro definition) of file clk_conf.h is not documented.
 warning: Member CLOCK_RADIOXTAL (macro definition) of file periph_conf_common.h is not documented.
 warning: Member CLOCK_RADIOXTAL (macro definition) of file periph_conf.h is not documented.
 warning: Member CLOCK_SCLK_XTAL (macro definition) of file periph_conf.h is not documented.
@@ -1355,7 +1227,6 @@ warning: Member CLOCK_USE_PLL (macro definition) of file cfg_clock_default.h is 
 warning: Member CLOCK_USE_PLL (macro definition) of file periph_conf_common.h is not documented.
 warning: Member CLOCK_USE_PLL (macro definition) of file periph_conf.h is not documented.
 warning: Member CLOCK_USE_XOSC32_DFLL (macro definition) of file periph_conf.h is not documented.
-warning: Member CLOCK_XOSC32K (macro definition) of file periph_conf.h is not documented.
 warning: Member CMD_BFC (macro definition) of file enc28j60_regs.h is not documented.
 warning: Member CMD_BFS (macro definition) of file enc28j60_regs.h is not documented.
 warning: Member CMD_FLUSH_RX (macro definition) of file nrf24l01p_settings.h is not documented.
@@ -1407,7 +1278,6 @@ warning: Member COAP_FORMAT_SENSML_CBOR (macro definition) of group net_coap is 
 warning: Member COAP_FORMAT_SENSML_EXI (macro definition) of group net_coap is not documented.
 warning: Member COAP_FORMAT_SENSML_JSON (macro definition) of group net_coap is not documented.
 warning: Member COAP_FORMAT_SENSML_XML (macro definition) of group net_coap is not documented.
-warning: Member COAP_FORMAT_TEXT (macro definition) of group net_coap is not documented.
 warning: Member COAP_FORMAT_XML (macro definition) of group net_coap is not documented.
 warning: Member COAP_GET (macro definition) of group net_nanocoap is not documented.
 warning: Member COAP_IPATCH (macro definition) of group net_nanocoap is not documented.
@@ -1463,7 +1333,6 @@ warning: Member CONFIG_AT86RF215_DEFAULT_SUBGHZ_CHANNEL (macro definition) of gr
 warning: Member CONFIG_AT86RF215_RPC_EN (macro definition) of group drivers_at86rf215_config is not documented.
 warning: Member CONFIG_BOARD_HAS_HSE (macro definition) of file periph_conf_common.h is not documented.
 warning: Member CONFIG_BOARD_HAS_HSE (macro definition) of file periph_conf.h is not documented.
-warning: Member CONFIG_BOARD_HAS_HXTAL (macro definition) of file periph_conf.h is not documented.
 warning: Member CONFIG_BOARD_HAS_LSE (macro definition) of file periph_conf_common.h is not documented.
 warning: Member CONFIG_BOARD_HAS_LSE (macro definition) of file periph_conf.h is not documented.
 warning: Member CONFIG_CC2538_RF_OBS_0 (macro definition) of file cc2538_rf.h is not documented.
@@ -1493,15 +1362,12 @@ warning: Member CONFIG_CLOCK_HFROSC_DIV (macro definition) of file clk_conf.h is
 warning: Member CONFIG_CLOCK_HFROSC_TRIM (macro definition) of file clk_conf.h is not documented.
 warning: Member CONFIG_CLOCK_HSE (macro definition) of file cfg_clock_common_fx_gx_mp1_c0.h is not documented.
 warning: Member CONFIG_CLOCK_HSE (macro definition) of file cfg_clock_common_lx_u5_wx.h is not documented.
-warning: Member CONFIG_CLOCK_HSE (macro definition) of file cfg_clock_common_lx_wx.h is not documented.
 warning: Member CONFIG_CLOCK_HSE (macro definition) of file periph_conf_common.h is not documented.
 warning: Member CONFIG_CLOCK_HSE (macro definition) of file periph_conf.h is not documented.
 warning: Member CONFIG_CLOCK_HSI (macro definition) of file cfg_clock_common_fx_gx_mp1_c0.h is not documented.
 warning: Member CONFIG_CLOCK_HSI (macro definition) of file cfg_clock_common_lx_u5_wx.h is not documented.
-warning: Member CONFIG_CLOCK_HSI (macro definition) of file cfg_clock_common_lx_wx.h is not documented.
 warning: Member CONFIG_CLOCK_MCU_DIV (macro definition) of file cfg_clock_default.h is not documented.
 warning: Member CONFIG_CLOCK_MSI (macro definition) of file cfg_clock_common_lx_u5_wx.h is not documented.
-warning: Member CONFIG_CLOCK_MSI (macro definition) of file cfg_clock_common_lx_wx.h is not documented.
 warning: Member CONFIG_CLOCK_PLL_DIV (macro definition) of file cfg_clock_default.h is not documented.
 warning: Member CONFIG_CLOCK_PLL_F (macro definition) of file clk_conf.h is not documented.
 warning: Member CONFIG_CLOCK_PLL_M (macro definition) of file cfg_clock_default_100.h is not documented.
@@ -1556,7 +1422,6 @@ warning: Member CONFIG_USE_CLOCK_HFXOSC (macro definition) of file clk_conf.h is
 warning: Member CONFIG_USE_CLOCK_HFXOSC_PLL (macro definition) of file clk_conf.h is not documented.
 warning: Member CONFIG_USE_CLOCK_PLL (macro definition) of file cfg_clock_common_fx_gx_mp1_c0.h is not documented.
 warning: Member CONFIG_USE_CLOCK_PLL (macro definition) of file cfg_clock_common_lx_u5_wx.h is not documented.
-warning: Member CONFIG_USE_CLOCK_PLL (macro definition) of file cfg_clock_common_lx_wx.h is not documented.
 warning: Member CONFIG_ZTIMER_LPTIMER_BLOCK_PM_MODE (macro definition) of file board.h is not documented.
 warning: Member CONFIG_ZTIMER_LPTIMER_DEV (macro definition) of file board.h is not documented.
 warning: Member CONFIG_ZTIMER_LPTIMER_FREQ (macro definition) of file board.h is not documented.
@@ -1584,28 +1449,17 @@ warning: Member CPU_ATMEGA_CLK_SCALE_INIT (macro definition) of group boards_com
 warning: Member cpu_clock_init(int) (function) of file cpu_conf.h is not documented.
 warning: Member CPU_DEFAULT_IRQ_PRIO (macro definition) of file cpu_conf.h is not documented.
 warning: Member CPU_DEFAULT_IRQ_PRIO (macro definition) of file cpu_conf_kinetis.h is not documented.
-warning: Member CPU_DEFAULT_IRQ_PRIO (macro definition) of group cpu_nrf52 is not documented.
-warning: Member CPU_EBI_H (macro definition) of file cpu_ebi.h is not documented.
 warning: Member CPU_FLASH_BASE (macro definition) of file cpu_conf.h is not documented.
 warning: Member CPU_FLASH_BASE (macro definition) of file cpu_conf_kinetis.h is not documented.
 warning: Member CPU_FLASH_BASE (macro definition) of group cpu_cc26xx_cc13xx is not documented.
-warning: Member CPU_FLASH_BASE (macro definition) of group cpu_lm4f120 is not documented.
-warning: Member CPU_FLASH_BASE (macro definition) of group cpu_lpc1768 is not documented.
-warning: Member CPU_FLASH_BASE (macro definition) of group cpu_nrf51 is not documented.
-warning: Member CPU_FLASH_BASE (macro definition) of group cpu_nrf52 is not documented.
 warning: Member CPU_FLASH_RWWEE_BASE (macro definition) of file cpu_conf.h is not documented.
 warning: Member CPU_HAS_BITBAND (macro definition) of file cpu_conf.h is not documented.
-warning: Member CPU_HAS_BITBAND (macro definition) of group cpu_lm4f120 is not documented.
-warning: Member CPU_HAS_BITBAND (macro definition) of group cpu_lpc1768 is not documented.
 warning: Member CPUID_LEN (macro definition) of file periph_cpu_common.h is not documented.
 warning: Member CPUID_LEN (macro definition) of file periph_cpu.h is not documented.
 warning: Member cpu_int_lvl_t (enumeration) of file periph_cpu.h is not documented.
 warning: Member CPU_IRQ_NUMOF (macro definition) of file cpu_conf.h is not documented.
 warning: Member CPU_IRQ_NUMOF (macro definition) of file cpu_conf_kinetis.h is not documented.
 warning: Member CPU_IRQ_NUMOF (macro definition) of group cpu_cc26xx_cc13xx is not documented.
-warning: Member CPU_IRQ_NUMOF (macro definition) of group cpu_lm4f120 is not documented.
-warning: Member CPU_IRQ_NUMOF (macro definition) of group cpu_lpc1768 is not documented.
-warning: Member CPU_IRQ_NUMOF (macro definition) of group cpu_nrf51 is not documented.
 warning: Member CPU_STM32WL_SUBGHZSPI_DEBUG_MISOOUT_AF (macro definition) of group cpu_stm32_wl_debug_subghz_spi is not documented.
 warning: Member CPU_STM32WL_SUBGHZSPI_DEBUG_MISOOUT (macro definition) of group cpu_stm32_wl_debug_subghz_spi is not documented.
 warning: Member CPU_STM32WL_SUBGHZSPI_DEBUG_MOSIOUT_AF (macro definition) of group cpu_stm32_wl_debug_subghz_spi is not documented.
@@ -1632,21 +1486,17 @@ warning: Member CST816S_PARAM_IRQ (macro definition) of file cst816s_params.h is
 warning: Member CST816S_PARAM_RESET (macro definition) of file board.h is not documented.
 warning: Member CST816S_PARAM_RESET (macro definition) of file cst816s_params.h is not documented.
 warning: Member CST816S_PARAMS (macro definition) of file cst816s_params.h is not documented.
-warning: Member CST816S_RESET_DURATION_HIGH (macro definition) of file cst816s_internal.h is not documented.
-warning: Member CST816S_RESET_DURATION_LOW (macro definition) of file cst816s_internal.h is not documented.
 warning: Member CT_COEF_IF (macro definition) of file tcs37727-internal.h is not documented.
 warning: Member CT_OFFSET_IF (macro definition) of file tcs37727-internal.h is not documented.
 warning: Member CTRL_REG0_DEFAULT (macro definition) of file lis2dh12_internal.h is not documented.
 warning: Member dac_channel_config[] (variable) of file periph_conf.h is not documented.
 warning: Member DAC_CLOCK (macro definition) of file periph_conf.h is not documented.
-warning: Member dac_config[] (variable) of file periph_conf.h is not documented.
 warning: Member DAC_DDS_PARAM_DAC (macro definition) of file dac_dds_params.h is not documented.
 warning: Member DAC_DDS_PARAMS (macro definition) of file dac_dds_params.h is not documented.
 warning: Member DAC_DDS_PARAM_TIMER_HZ (macro definition) of file dac_dds_params.h is not documented.
 warning: Member DAC_DDS_PARAM_TIMER (macro definition) of file dac_dds_params.h is not documented.
 warning: Member DAC_DEV_NUMOF (macro definition) of file periph_conf.h is not documented.
 warning: Member DAC_GPIOS (macro definition) of file periph_conf.h is not documented.
-warning: Member DAC_NUMOF (macro definition) of file periph_conf.h is not documented.
 warning: Member DAC_VREF (macro definition) of file periph_conf.h is not documented.
 warning: Member DATA_BASE (macro definition) of file bmx280_internals.h is not documented.
 warning: Member DATA_RESPONSE_ACCEPTED(X) (macro definition) of file sdcard_spi_internal.h is not documented.
@@ -1716,11 +1566,6 @@ warning: Member DHT_PARAMS (macro definition) of file dht_params.h is not docume
 warning: Member DHT_PARAM_TYPE (macro definition) of file dht_params.h is not documented.
 warning: Member DHT_SAULINFO (macro definition) of file dht_params.h is not documented.
 warning: Member DISABLE_INTERRUPTS() (macro definition) of file board_info.h is not documented.
-warning: Member DISK_GET_BLOCK_SIZE (macro definition) of group sys_shell_commands is not documented.
-warning: Member DISK_GET_SECTOR_COUNT (macro definition) of group sys_shell_commands is not documented.
-warning: Member DISK_GET_SECTOR_SIZE (macro definition) of group sys_shell_commands is not documented.
-warning: Member DISK_READ_BYTES_CMD (macro definition) of group sys_shell_commands is not documented.
-warning: Member DISK_READ_SECTOR_CMD (macro definition) of group sys_shell_commands is not documented.
 warning: Member DISP_COM_PIN (macro definition) of file board.h is not documented.
 warning: Member DISP_CS_PIN (macro definition) of file board.h is not documented.
 warning: Member DISP_ENABLE_PIN (macro definition) of file board.h is not documented.
@@ -1746,14 +1591,6 @@ warning: Member DMA_6_ISR (macro definition) of file periph_conf.h is not docume
 warning: Member DMA_7_ISR (macro definition) of file periph_conf.h is not documented.
 warning: Member dma_config[] (variable) of file periph_conf_common.h is not documented.
 warning: Member dma_config[] (variable) of file periph_conf.h is not documented.
-warning: Member DMA_DATA_WIDTH_BYTE (macro definition) of file periph_cpu.h is not documented.
-warning: Member DMA_DATA_WIDTH_HALF_WORD (macro definition) of file periph_cpu.h is not documented.
-warning: Member DMA_DATA_WIDTH_MASK (macro definition) of file periph_cpu.h is not documented.
-warning: Member DMA_DATA_WIDTH_SHIFT (macro definition) of file periph_cpu.h is not documented.
-warning: Member DMA_DATA_WIDTH_WORD (macro definition) of file periph_cpu.h is not documented.
-warning: Member DMA_INC_BOTH_ADDR (macro definition) of file periph_cpu.h is not documented.
-warning: Member DMA_INC_DST_ADDR (macro definition) of file periph_cpu.h is not documented.
-warning: Member DMA_INC_SRC_ADDR (macro definition) of file periph_cpu.h is not documented.
 warning: Member DMA_NUMOF (macro definition) of file periph_conf_common.h is not documented.
 warning: Member DMA_NUMOF (macro definition) of file periph_conf.h is not documented.
 warning: Member DMA_SHARED_ISR_0 (macro definition) of file periph_conf.h is not documented.
@@ -2021,7 +1858,6 @@ warning: Member ENC_MAADR2 (macro definition) of file encx24j600_defines.h is no
 warning: Member ENC_MAADR3 (macro definition) of file encx24j600_defines.h is not documented.
 warning: Member ENC_MACON2 (macro definition) of file encx24j600_defines.h is not documented.
 warning: Member ENC_MAMXFL (macro definition) of file encx24j600_defines.h is not documented.
-warning: Member ENC_MCEN (macro definition) of file encx24j600_defines.h is not documented.
 warning: Member ENC_MIREGADR (macro definition) of file encx24j600_defines.h is not documented.
 warning: Member ENC_MIWR (macro definition) of file encx24j600_defines.h is not documented.
 warning: Member ENC_MODEXIE (macro definition) of file encx24j600_defines.h is not documented.
@@ -2079,7 +1915,6 @@ warning: Member ERXFCON_MCEN (macro definition) of file enc28j60_regs.h is not d
 warning: Member ERXFCON_MPEN (macro definition) of file enc28j60_regs.h is not documented.
 warning: Member ERXFCON_PMEN (macro definition) of file enc28j60_regs.h is not documented.
 warning: Member ERXFCON_UCEN (macro definition) of file enc28j60_regs.h is not documented.
-warning: Member ESP32_XTAL_FREQ (macro definition) of file board_common.h is not documented.
 warning: Member ESP_NOW_STACKSIZE (macro definition) of group cpu_esp8266_conf is not documented.
 warning: Member ESP_PM_DEEP_SLEEP (macro definition) of file periph_cpu.h is not documented.
 warning: Member ESP_PM_LIGHT_SLEEP (macro definition) of file periph_cpu.h is not documented.
@@ -2160,7 +1995,6 @@ warning: Member FLASHPAGE_BLOCK_PHRASE (macro definition) of file cpu_conf_kinet
 warning: Member FLASHPAGE_BLOCK_SECTION_ALIGNMENT (macro definition) of file cpu_conf_kinetis_k.h is not documented.
 warning: Member FLASHPAGE_BLOCK_SECTION_ALIGNMENT (macro definition) of file cpu_conf_kinetis_w.h is not documented.
 warning: Member FLASHPAGE_CC2538_USE_CCA_PAGE (macro definition) of file cpu_conf.h is not documented.
-warning: Member FLASHPAGE_ERASE_STATE (macro definition) of file cpu_conf.h is not documented.
 warning: Member FLASHPAGE_NUMOF (macro definition) of file cpu_conf.h is not documented.
 warning: Member FLASHPAGE_NUMOF (macro definition) of file cpu_conf_kinetis_k.h is not documented.
 warning: Member FLASHPAGE_NUMOF (macro definition) of file cpu_conf_kinetis_w.h is not documented.
@@ -2170,12 +2004,9 @@ warning: Member FLASHPAGE_SIZE (macro definition) of file cpu_conf_kinetis_w.h i
 warning: Member FLASHPAGE_WRITE_BLOCK_ALIGNMENT (macro definition) of file cpu_conf.h is not documented.
 warning: Member FLASHPAGE_WRITE_BLOCK_ALIGNMENT (macro definition) of file cpu_conf_kinetis_k.h is not documented.
 warning: Member FLASHPAGE_WRITE_BLOCK_ALIGNMENT (macro definition) of file cpu_conf_kinetis_w.h is not documented.
-warning: Member FLASHPAGE_WRITE_BLOCK_ALIGNMENT (macro definition) of group cpu_nrf51 is not documented.
-warning: Member FLASHPAGE_WRITE_BLOCK_ALIGNMENT (macro definition) of group cpu_nrf52 is not documented.
 warning: Member FLASHPAGE_WRITE_BLOCK_SIZE (macro definition) of file cpu_conf.h is not documented.
 warning: Member FLASHPAGE_WRITE_BLOCK_SIZE (macro definition) of file cpu_conf_kinetis_k.h is not documented.
 warning: Member FLASHPAGE_WRITE_BLOCK_SIZE (macro definition) of file cpu_conf_kinetis_w.h is not documented.
-warning: Member FLASHPAGE_WRITE_BLOCK_SIZE (macro definition) of group cpu_nrf51 is not documented.
 warning: Member FLASH_SPI (macro definition) of file board.h is not documented.
 warning: Member fnv_hash(const uint8_t *buf, size_t len) (function) of file hashes.h is not documented.
 warning: Member __FOPEN_MAX__ (macro definition) of file cpu_conf.h is not documented.
@@ -2213,7 +2044,6 @@ warning: Member FSK_SRATE_150K (macro definition) of file at86rf215_registers.h 
 warning: Member FSK_SRATE_200K (macro definition) of file at86rf215_registers.h is not documented.
 warning: Member FSK_SRATE_300K (macro definition) of file at86rf215_registers.h is not documented.
 warning: Member FSK_SRATE_400K (macro definition) of file at86rf215_registers.h is not documented.
-warning: Member FT5X06_AUTO_CALIB_NEEDED (macro definition) of file ft5x06_constants.h is not documented.
 warning: Member FT5X06_DEVIDE_MODE_REG (macro definition) of file ft5x06_constants.h is not documented.
 warning: Member FT5X06_G_AUTO_CLB_MODE_REG (macro definition) of file ft5x06_constants.h is not documented.
 warning: Member FT5X06_G_CIPHER_REG (macro definition) of file ft5x06_constants.h is not documented.
@@ -2267,10 +2097,8 @@ warning: Member FT5X06_TOUCH5_XH_REG (macro definition) of file ft5x06_constants
 warning: Member FT5X06_TOUCH5_XL_REG (macro definition) of file ft5x06_constants.h is not documented.
 warning: Member FT5X06_TOUCH5_YH_REG (macro definition) of file ft5x06_constants.h is not documented.
 warning: Member FT5X06_TOUCH5_YL_REG (macro definition) of file ft5x06_constants.h is not documented.
-warning: Member FT5X06_TOUCHES_COUNT_MAX (macro definition) of file ft5x06_constants.h is not documented.
 warning: Member FT5X06_TOUCH_POS_LSB_MASK (macro definition) of file ft5x06_constants.h is not documented.
 warning: Member FT5X06_TOUCH_POS_MSB_MASK (macro definition) of file ft5x06_constants.h is not documented.
-warning: Member FT5X06_VENDOR_ID (macro definition) of file ft5x06_constants.h is not documented.
 warning: Member FTFA_Collision_IRQn (macro definition) of file cpu_conf.h is not documented.
 warning: Member FTFA_IRQn (macro definition) of file cpu_conf.h is not documented.
 warning: Member FTFE_Collision_IRQn (macro definition) of file cpu_conf.h is not documented.
@@ -2324,20 +2152,10 @@ warning: Member GNRC_RPL_MOP_STORING_MODE_NO_MC (macro definition) of group net_
 warning: Member GNRC_RPL_NETSTATS_MULTICAST (macro definition) of file netstats.h is not documented.
 warning: Member GNRC_RPL_NETSTATS_UNICAST (macro definition) of file netstats.h is not documented.
 warning: Member GNRC_RPL_NORMAL_NODE (macro definition) of group net_gnrc_rpl is not documented.
-warning: Member GNRC_RPL_OPT_DAG_METRIC_CONTAINER (macro definition) of group net_gnrc_rpl is not documented.
 warning: Member GNRC_RPL_OPT_DODAG_CONF_LEN (macro definition) of file structs.h is not documented.
-warning: Member GNRC_RPL_OPT_DODAG_CONF (macro definition) of group net_gnrc_rpl is not documented.
-warning: Member GNRC_RPL_OPT_PAD1 (macro definition) of group net_gnrc_rpl is not documented.
-warning: Member GNRC_RPL_OPT_PADN (macro definition) of group net_gnrc_rpl is not documented.
 warning: Member GNRC_RPL_OPT_PREFIX_INFO_LEN (macro definition) of file structs.h is not documented.
-warning: Member GNRC_RPL_OPT_PREFIX_INFO (macro definition) of group net_gnrc_rpl is not documented.
-warning: Member GNRC_RPL_OPT_ROUTE_INFO (macro definition) of group net_gnrc_rpl is not documented.
-warning: Member GNRC_RPL_OPT_SOLICITED_INFO (macro definition) of group net_gnrc_rpl is not documented.
-warning: Member GNRC_RPL_OPT_TARGET_DESC (macro definition) of group net_gnrc_rpl is not documented.
 warning: Member GNRC_RPL_OPT_TARGET_LEN (macro definition) of file structs.h is not documented.
-warning: Member GNRC_RPL_OPT_TARGET (macro definition) of group net_gnrc_rpl is not documented.
 warning: Member GNRC_RPL_OPT_TRANSIT_INFO_LEN (macro definition) of file structs.h is not documented.
-warning: Member GNRC_RPL_OPT_TRANSIT (macro definition) of group net_gnrc_rpl is not documented.
 warning: Member GNRC_RPL_P2P_DEFAULT_DIO_INTERVAL_MIN (macro definition) of group net_gnrc_rpl_p2p is not documented.
 warning: Member GNRC_RPL_P2P_DEFAULT_DIO_REDUNDANCY_CONSTANT (macro definition) of group net_gnrc_rpl_p2p is not documented.
 warning: Member GNRC_RPL_P2P_DEFAULT_LIFETIME (macro definition) of group net_gnrc_rpl_p2p is not documented.
@@ -2356,25 +2174,8 @@ warning: Member GPIO13 (macro definition) of file periph_cpu.h is not documented
 warning: Member GPIO14 (macro definition) of file periph_cpu.h is not documented.
 warning: Member GPIO15 (macro definition) of file periph_cpu.h is not documented.
 warning: Member GPIO16 (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIO17 (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIO18 (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIO19 (macro definition) of file periph_cpu.h is not documented.
 warning: Member GPIO1 (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIO21 (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIO22 (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIO23 (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIO25 (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIO26 (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIO27 (macro definition) of file periph_cpu.h is not documented.
 warning: Member GPIO2 (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIO32 (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIO33 (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIO34 (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIO35 (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIO36 (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIO37 (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIO38 (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIO39 (macro definition) of file periph_cpu.h is not documented.
 warning: Member GPIO3 (macro definition) of file periph_cpu.h is not documented.
 warning: Member GPIO4 (macro definition) of file periph_cpu.h is not documented.
 warning: Member GPIO5 (macro definition) of file periph_cpu.h is not documented.
@@ -2390,20 +2191,16 @@ warning: Member GPIOCLKGS_CLK_EN (macro definition) of file cc26x0_cc13x0_prcm.h
 warning: Member GPIOCLKGS_CLK_EN (macro definition) of file cc26x2_cc13x2_prcm.h is not documented.
 warning: Member gpio_dir_t (enumeration) of file periph_cpu.h is not documented.
 warning: Member gpio_flank_t (enumeration) of file periph_cpu.h is not documented.
-warning: Member GPIOHANDLE_REQUEST_PULL_DOWN (macro definition) of file periph_cpu.h is not documented.
-warning: Member GPIOHANDLE_REQUEST_PULL_UP (macro definition) of file periph_cpu.h is not documented.
 warning: Member GPIO_MODE (enumeration) of file periph_cpu.h is not documented.
 warning: Member gpio_mode_t (typedef) of file periph_cpu.h is not documented.
 warning: Member GPIO_PIN(x, y) (macro definition) of file periph_cpu_common.h is not documented.
 warning: Member GPIO_PIN(x, y) (macro definition) of file periph_cpu.h is not documented.
-warning: Member gpio_t (typedef) of file periph_cpu_common.h is not documented.
 warning: Member gpio_t (typedef) of file periph_cpu.h is not documented.
 warning: Member GPS_ENABLE_MASK (macro definition) of file board.h is not documented.
 warning: Member GPS_ENABLE_OFF (macro definition) of file board.h is not documented.
 warning: Member GPS_ENABLE_ON (macro definition) of file board.h is not documented.
 warning: Member GPS_ENABLE_PIN (macro definition) of file board.h is not documented.
 warning: Member GPS_ENABLE_PORT (macro definition) of file board.h is not documented.
-warning: Member GPS_RST_PIN (macro definition) of group boards_ublox-c030-u201 is not documented.
 warning: Member GPS_TIMEPULSE_MODE (macro definition) of file board.h is not documented.
 warning: Member GPS_TIMEPULSE_PIN (macro definition) of file board.h is not documented.
 warning: Member GPT1 (macro definition) of file cc26xx_cc13xx_gpt.h is not documented.
@@ -2518,8 +2315,6 @@ warning: Member __HAL_DISABLE_INTERRUPTS(x) (macro definition) of file mcu.h is 
 warning: Member __HAL_ENABLE_INTERRUPTS(x) (macro definition) of file mcu.h is not documented.
 warning: Member _handle_6co(const icmpv6_hdr_t *icmpv6, const sixlowpan_nd_opt_6ctx_t *sixco, _nib_abr_entry_t *abr) (function) of file _nib-6ln.h is not documented.
 warning: Member _handle_abro(const sixlowpan_nd_opt_abr_t *abro) (function) of file _nib-6ln.h is not documented.
-warning: Member HAVE_GPIO_FLANK_T (macro definition) of file periph_cpu.h is not documented.
-warning: Member HAVE_GPIO_MODE_T (macro definition) of file periph_cpu.h is not documented.
 warning: Member HAVE_GPIO_T (macro definition) of file periph_cpu.h is not documented.
 warning: Member HAVE_I2C_SPEED_T (macro definition) of file periph_cpu.h is not documented.
 warning: Member HAVE_PWM_MODE_T (macro definition) of file periph_conf.h is not documented.
@@ -2668,11 +2463,6 @@ warning: Member I2CCLKGR_CLK_EN (macro definition) of file cc26x0_cc13x0_prcm.h 
 warning: Member I2CCLKGR_CLK_EN (macro definition) of file cc26x2_cc13x2_prcm.h is not documented.
 warning: Member I2CCLKGS_CLK_EN (macro definition) of file cc26x0_cc13x0_prcm.h is not documented.
 warning: Member I2CCLKGS_CLK_EN (macro definition) of file cc26x2_cc13x2_prcm.h is not documented.
-warning: Member i2c_config[] (variable) of file cfg_i2c1_pb6_pb7.h is not documented.
-warning: Member i2c_config[] (variable) of file cfg_i2c1_pb8_pb9.h is not documented.
-warning: Member i2c_config[] (variable) of file cfg_i2c_default.h is not documented.
-warning: Member i2c_config[] (variable) of file periph_conf_common.h is not documented.
-warning: Member i2c_config[] (variable) of file periph_conf.h is not documented.
 warning: Member I2C_DISABLE (macro definition) of file board.h is not documented.
 warning: Member I2C_ENABLE (macro definition) of file board.h is not documented.
 warning: Member I2C_EN_MASK (macro definition) of file board.h is not documented.
@@ -2681,11 +2471,6 @@ warning: Member I2C_EN_PIN (macro definition) of file board.h is not documented.
 warning: Member I2C_EN_PORT (macro definition) of file board.h is not documented.
 warning: Member I2C_IRQ_PRIO (macro definition) of file cfg_i2c_default.h is not documented.
 warning: Member I2C_IRQ_PRIO (macro definition) of file periph_conf.h is not documented.
-warning: Member I2C_NUMOF (macro definition) of file cfg_i2c1_pb6_pb7.h is not documented.
-warning: Member I2C_NUMOF (macro definition) of file cfg_i2c1_pb8_pb9.h is not documented.
-warning: Member I2C_NUMOF (macro definition) of file cfg_i2c_default.h is not documented.
-warning: Member I2C_NUMOF (macro definition) of file periph_conf_common.h is not documented.
-warning: Member I2C_NUMOF (macro definition) of file periph_conf.h is not documented.
 warning: Member I2C_PIN_MASK (macro definition) of file periph_cpu.h is not documented.
 warning: Member i2c_pin_scl(dev) (macro definition) of file periph_cpu.h is not documented.
 warning: Member i2c_pin_sda(dev) (macro definition) of file periph_cpu.h is not documented.
@@ -2737,7 +2522,6 @@ warning: Member ILI9341_PARAM_DCX (macro definition) of file ili9341_params.h is
 warning: Member ILI9341_PARAM_INVERTED (macro definition) of file board.h is not documented.
 warning: Member ILI9341_PARAM_INVERTED (macro definition) of file ili9341_params.h is not documented.
 warning: Member ILI9341_PARAM_NUM_LINES (macro definition) of file board.h is not documented.
-warning: Member ILI9341_PARAM_NUM_LINES (macro definition) of file ili9341_params.h is not documented.
 warning: Member ILi9341_PARAM_RGB (macro definition) of file board.h is not documented.
 warning: Member ILI9341_PARAM_RGB (macro definition) of file board.h is not documented.
 warning: Member ILI9341_PARAM_RGB (macro definition) of file ili9341_params.h is not documented.
@@ -2745,7 +2529,6 @@ warning: Member ILI9341_PARAM_ROTATION (macro definition) of file board.h is not
 warning: Member ILI9341_PARAM_ROTATION (macro definition) of file ili9341_params.h is not documented.
 warning: Member ILI9341_PARAM_RST (macro definition) of file board.h is not documented.
 warning: Member ILI9341_PARAM_RST (macro definition) of file ili9341_params.h is not documented.
-warning: Member ILI9341_PARAMS (macro definition) of file ili9341_params.h is not documented.
 warning: Member ILI9341_PARAM_SPI_CLK (macro definition) of file board.h is not documented.
 warning: Member ILI9341_PARAM_SPI_CLK (macro definition) of file ili9341_params.h is not documented.
 warning: Member ILI9341_PARAM_SPI (macro definition) of file board.h is not documented.
@@ -2754,7 +2537,6 @@ warning: Member ILI9341_PARAM_SPI_MODE (macro definition) of file board.h is not
 warning: Member ILI9341_PARAM_SPI_MODE (macro definition) of file ili9341_params.h is not documented.
 warning: Member INA2XX_PARAMS (macro definition) of file ina2xx_params.h is not documented.
 warning: Member INA2XX_SAULINFO (macro definition) of file ina2xx_params.h is not documented.
-warning: Member INFOMEM (macro definition) of file board-conf.h is not documented.
 warning: Member INITIAL_ADDRESS_WIDTH (macro definition) of file nrf24l01p_settings.h is not documented.
 warning: Member INITIAL_RF_CHANNEL (macro definition) of file nrf24l01p_settings.h is not documented.
 warning: Member INITIAL_RX_POWER_0dB (macro definition) of file nrf24l01p_settings.h is not documented.
@@ -3072,11 +2854,8 @@ warning: Member LED_PANIC (macro definition) of file board.h is not documented.
 warning: Member LED_PANIC (macro definition) of group boards_common_arduino-atmega is not documented.
 warning: Member LED_PORT_DDR (macro definition) of file board.h is not documented.
 warning: Member LED_PORT (macro definition) of file board.h is not documented.
-warning: Member LED_PORT (macro definition) of group boards_bastwan is not documented.
 warning: Member LED_PORT (macro definition) of group boards_common_arduino_zero is not documented.
 warning: Member LED_PORT (macro definition) of group boards_common_saml1x is not documented.
-warning: Member LED_PORT (macro definition) of group boards_samr30-xpro is not documented.
-warning: Member LED_PORT (macro definition) of group boards_samr34-xpro is not documented.
 warning: Member LED_PORT_MASK (macro definition) of file board.h is not documented.
 warning: Member LED_RAINBOW() (macro definition) of file fancy_leds.h is not documented.
 warning: Member LED_RED_OFF (macro definition) of file board.h is not documented.
@@ -3238,18 +3017,13 @@ warning: Member LL_DELETE2_VS2008(head, del, next) (macro definition) of group s
 warning: Member LL_DELETE_VS2008(head, del) (macro definition) of group sys_ut is not documented.
 warning: Member LL_SORT2(list, cmp, next) (macro definition) of group sys_ut is not documented.
 warning: Member LL_SORT(list, cmp) (macro definition) of group sys_ut is not documented.
-warning: Member LOCK_TCPIP_CORE() (macro definition) of file sys_arch.h is not documented.
 warning: Member LOCK_TCPIP_CORE() (macro definition) of group pkg_lwip_sys is not documented.
 warning: Member LOG_CRITICAL(...) (macro definition) of file log.h is not documented.
-warning: Member LOG_DEBUG(...) (macro definition) of file log.h is not documented.
-warning: Member LOG_ERROR(...) (macro definition) of file log.h is not documented.
-warning: Member LOG_INFO(...) (macro definition) of file log.h is not documented.
 warning: Member log_register(__X, __Y, __Z, __A, __B) (macro definition) of file log.h is not documented.
 warning: Member LOG_RIOT_DEBUG(...) (macro definition) of file openwsn_log.h is not documented.
 warning: Member LOG_RIOT_ERROR(...) (macro definition) of file openwsn_log.h is not documented.
 warning: Member LOG_RIOT_INFO(...) (macro definition) of file openwsn_log.h is not documented.
 warning: Member LOG_RIOT_WARNING(...) (macro definition) of file openwsn_log.h is not documented.
-warning: Member LOG_WARNING(...) (macro definition) of file log.h is not documented.
 warning: Member LOG_WARN(...) (macro definition) of file log.h is not documented.
 warning: Member log_write(level,...) (macro definition) of file log_module.h is not documented.
 warning: Member LORA_RESET_MASK (macro definition) of file board.h is not documented.
@@ -3285,7 +3059,6 @@ warning: Member LPTMR_ISR_0 (macro definition) of file periph_conf_common.h is n
 warning: Member LPTMR_ISR_0 (macro definition) of file periph_conf.h is not documented.
 warning: Member LPTMR_NUMOF (macro definition) of file periph_conf_common.h is not documented.
 warning: Member LPTMR_NUMOF (macro definition) of file periph_conf.h is not documented.
-warning: Member LPUART_0_CLOCK (macro definition) of file periph_conf.h is not documented.
 warning: Member LPUART_0_ISR (macro definition) of file periph_conf_common.h is not documented.
 warning: Member LPUART_0_ISR (macro definition) of file periph_conf.h is not documented.
 warning: Member LPUART_0_SRC (macro definition) of file periph_conf_common.h is not documented.
@@ -3402,355 +3175,34 @@ warning: Member LTC4150_PARAMS (macro definition) of file ltc4150_params.h is no
 warning: Member LTC4150_SAULINFO (macro definition) of file ltc4150_params.h is not documented.
 warning: Member LUAR_LOAD_ALL (macro definition) of file lua_run.h is not documented.
 warning: Member LUAR_LOAD_NONE (macro definition) of file lua_run.h is not documented.
-warning: Member lv_anim_user_data_t (typedef) of group pkg_lvgl7 is not documented.
-warning: Member lv_anim_user_data_t (typedef) of group pkg_lvgl is not documented.
-warning: Member LV_ANTIALIAS (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_ANTIALIAS (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_ATTRIBUTE_DMA (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_ATTRIBUTE_DMA (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_ATTRIBUTE_FAST_MEM (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_ATTRIBUTE_FAST_MEM (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_ATTRIBUTE_FLUSH_READY (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_ATTRIBUTE_FLUSH_READY (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_ATTRIBUTE_LARGE_CONST (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_ATTRIBUTE_LARGE_CONST (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_ATTRIBUTE_MEM_ALIGN (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_ATTRIBUTE_MEM_ALIGN (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_ATTRIBUTE_MEM_ALIGN_SIZE (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_ATTRIBUTE_MEM_ALIGN_SIZE (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_ATTRIBUTE_TASK_HANDLER (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_ATTRIBUTE_TASK_HANDLER (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_ATTRIBUTE_TICK_INC (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_ATTRIBUTE_TICK_INC (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_BIG_ENDIAN_SYSTEM (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_BIG_ENDIAN_SYSTEM (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_CALENDAR_WEEK_STARTS_MONDAY (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_CALENDAR_WEEK_STARTS_MONDAY (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_CHART_AXIS_TICK_LABEL_MAX_LEN (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_CHART_AXIS_TICK_LABEL_MAX_LEN (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_COLOR_16_SWAP (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_COLOR_16_SWAP (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_COLOR_DEPTH (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_COLOR_DEPTH (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_COLOR_SCREEN_TRANSP (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_COLOR_SCREEN_TRANSP (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_COLOR_TRANSP (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_COLOR_TRANSP (macro definition) of group pkg_lvgl is not documented.
 warning: Member lv_coord_t (typedef) of file lvgl_riot_conf.h is not documented.
-warning: Member LV_DISP_DEF_REFR_PERIOD (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_DISP_DEF_REFR_PERIOD (macro definition) of group pkg_lvgl is not documented.
-warning: Member lv_disp_drv_user_data_t (typedef) of group pkg_lvgl7 is not documented.
-warning: Member lv_disp_drv_user_data_t (typedef) of group pkg_lvgl is not documented.
-warning: Member LV_DISP_LARGE_LIMIT (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_DISP_LARGE_LIMIT (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_DISP_MEDIUM_LIMIT (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_DISP_MEDIUM_LIMIT (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_DISP_SMALL_LIMIT (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_DISP_SMALL_LIMIT (macro definition) of group pkg_lvgl is not documented.
 warning: Member LVD_LVW_DCDC_IRQn (macro definition) of file cpu_conf.h is not documented.
-warning: Member LV_DPI (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_DPI (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_DROPDOWN_DEF_ANIM_TIME (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_DROPDOWN_DEF_ANIM_TIME (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_ENABLE_GC (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_ENABLE_GC (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_EXPORT_CONST_INT(int_value) (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_EXPORT_CONST_INT(int_value) (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_CUSTOM_DECLARE (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_CUSTOM_DECLARE (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_DEJAVU_16_PERSIAN_HEBREW (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_DEJAVU_16_PERSIAN_HEBREW (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_FMT_TXT_LARGE (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_FMT_TXT_LARGE (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_12 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_12 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_12_SUBPX (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_12_SUBPX (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_14 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_14 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_16 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_16 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_18 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_18 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_20 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_20 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_22 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_22 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_24 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_24 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_26 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_26 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_28_COMPRESSED (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_28_COMPRESSED (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_28 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_28 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_30 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_30 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_32 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_32 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_34 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_34 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_36 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_36 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_38 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_38 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_40 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_40 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_42 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_42 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_44 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_44 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_46 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_46 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_MONTSERRAT_48 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_MONTSERRAT_48 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_SIMSUN_16_CJK (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_SIMSUN_16_CJK (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_SUBPX_BGR (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_SUBPX_BGR (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_FONT_UNSCII_8 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_FONT_UNSCII_8 (macro definition) of group pkg_lvgl is not documented.
-warning: Member lv_font_user_data_t (typedef) of group pkg_lvgl7 is not documented.
-warning: Member lv_font_user_data_t (typedef) of group pkg_lvgl is not documented.
-warning: Member lv_group_user_data_t (typedef) of group pkg_lvgl7 is not documented.
-warning: Member lv_group_user_data_t (typedef) of group pkg_lvgl is not documented.
-warning: Member LV_IMGBTN_TILED (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_IMGBTN_TILED (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_IMG_CACHE_DEF_SIZE (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_IMG_CACHE_DEF_SIZE (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_IMG_CF_ALPHA (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_IMG_CF_ALPHA (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_IMG_CF_INDEXED (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_IMG_CF_INDEXED (macro definition) of group pkg_lvgl is not documented.
-warning: Member lv_img_decoder_user_data_t (typedef) of group pkg_lvgl7 is not documented.
-warning: Member lv_img_decoder_user_data_t (typedef) of group pkg_lvgl is not documented.
-warning: Member LV_INDEV_DEF_DRAG_LIMIT (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_INDEV_DEF_DRAG_LIMIT (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_INDEV_DEF_DRAG_THROW (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_INDEV_DEF_DRAG_THROW (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_INDEV_DEF_GESTURE_LIMIT (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_INDEV_DEF_GESTURE_LIMIT (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_INDEV_DEF_GESTURE_MIN_VELOCITY (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_INDEV_DEF_GESTURE_MIN_VELOCITY (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_INDEV_DEF_LONG_PRESS_REP_TIME (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_INDEV_DEF_LONG_PRESS_REP_TIME (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_INDEV_DEF_LONG_PRESS_TIME (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_INDEV_DEF_LONG_PRESS_TIME (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_INDEV_DEF_READ_PERIOD (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_INDEV_DEF_READ_PERIOD (macro definition) of group pkg_lvgl is not documented.
-warning: Member lv_indev_drv_user_data_t (typedef) of group pkg_lvgl7 is not documented.
-warning: Member lv_indev_drv_user_data_t (typedef) of group pkg_lvgl is not documented.
-warning: Member LV_LABEL_DEF_SCROLL_SPEED (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_LABEL_DEF_SCROLL_SPEED (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_LABEL_LONG_TXT_HINT (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_LABEL_LONG_TXT_HINT (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_LABEL_TEXT_SEL (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_LABEL_TEXT_SEL (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_LABEL_WAIT_CHAR_COUNT (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_LABEL_WAIT_CHAR_COUNT (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_LED_BRIGHT_MAX (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_LED_BRIGHT_MAX (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_LED_BRIGHT_MIN (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_LED_BRIGHT_MIN (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_LINEMETER_PRECISE (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_LINEMETER_PRECISE (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_LIST_DEF_ANIM_TIME (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_LIST_DEF_ANIM_TIME (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_MEM_ADR (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_MEM_ADR (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_MEM_ATTR (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_MEM_ATTR (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_MEM_AUTO_DEFRAG (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_MEM_AUTO_DEFRAG (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_MEMCPY_MEMSET_STD (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_MEMCPY_MEMSET_STD (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_MEM_CUSTOM (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_MEM_CUSTOM (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_MEM_SIZE (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_MEM_SIZE (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_PAGE_DEF_ANIM_TIME (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_PAGE_DEF_ANIM_TIME (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_ROLLER_DEF_ANIM_TIME (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_ROLLER_DEF_ANIM_TIME (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_ROLLER_INF_PAGES (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_ROLLER_INF_PAGES (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_SPINNER_DEF_ANIM (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_SPINNER_DEF_ANIM (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_SPINNER_DEF_ARC_LENGTH (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_SPINNER_DEF_ARC_LENGTH (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_SPINNER_DEF_SPIN_TIME (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_SPINNER_DEF_SPIN_TIME (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_SPRINTF_CUSTOM (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_SPRINTF_CUSTOM (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_TABLE_CELL_STYLE_CNT (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_TABLE_CELL_STYLE_CNT (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_TABLE_COL_MAX (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_TABLE_COL_MAX (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_TABVIEW_DEF_ANIM_TIME (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_TABVIEW_DEF_ANIM_TIME (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_TEXTAREA_DEF_CURSOR_BLINK_TIME (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_TEXTAREA_DEF_CURSOR_BLINK_TIME (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_TEXTAREA_DEF_PWD_SHOW_TIME (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_TEXTAREA_DEF_PWD_SHOW_TIME (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_THEME_DEFAULT_COLOR_PRIMARY (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_THEME_DEFAULT_COLOR_PRIMARY (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_THEME_DEFAULT_COLOR_SECONDARY (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_THEME_DEFAULT_COLOR_SECONDARY (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_THEME_DEFAULT_FLAG (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_THEME_DEFAULT_FLAG (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_THEME_DEFAULT_FONT_NORMAL (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_THEME_DEFAULT_FONT_NORMAL (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_THEME_DEFAULT_FONT_SMALL (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_THEME_DEFAULT_FONT_SMALL (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_THEME_DEFAULT_FONT_SUBTITLE (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_THEME_DEFAULT_FONT_SUBTITLE (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_THEME_DEFAULT_FONT_TITLE (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_THEME_DEFAULT_FONT_TITLE (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_THEME_DEFAULT_INCLUDE (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_THEME_DEFAULT_INCLUDE (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_THEME_DEFAULT_INIT (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_THEME_DEFAULT_INIT (macro definition) of group pkg_lvgl is not documented.
 warning: Member LV_TICK_CUSTOM_INCLUDE (macro definition) of file lvgl_riot_conf.h is not documented.
 warning: Member LV_TICK_CUSTOM (macro definition) of file lvgl_riot_conf.h is not documented.
 warning: Member LV_TICK_CUSTOM_SYS_TIME_EXPR (macro definition) of file lvgl_riot_conf.h is not documented.
-warning: Member LV_TILEVIEW_DEF_ANIM_TIME (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_TILEVIEW_DEF_ANIM_TIME (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_TXT_BREAK_CHARS (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_TXT_BREAK_CHARS (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_TXT_COLOR_CMD (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_TXT_COLOR_CMD (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_TXT_ENC (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_TXT_ENC (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_TXT_LINE_BREAK_LONG_LEN (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_TXT_LINE_BREAK_LONG_LEN (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_ANIMATION (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_ANIMATION (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_API_EXTENSION_V6 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_API_EXTENSION_V6 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_API_EXTENSION_V7 (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_API_EXTENSION_V7 (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_ARABIC_PERSIAN_CHARS (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_ARABIC_PERSIAN_CHARS (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_ARC (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_ARC (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_BAR (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_BAR (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_BIDI (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_BIDI (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_BLEND_MODES (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_BLEND_MODES (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_BTN (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_BTN (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_BTNMATRIX (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_BTNMATRIX (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_CALENDAR (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_CALENDAR (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_CANVAS (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_CANVAS (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_CHART (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_CHART (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_CHECKBOX (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_CHECKBOX (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_CONT (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_CONT (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_CPICKER (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_CPICKER (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_DEBUG (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_DEBUG (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_DROPDOWN (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_DROPDOWN (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_EXT_CLICK_AREA (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_EXT_CLICK_AREA (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_FILESYSTEM (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_FILESYSTEM (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_FONT_COMPRESSED (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_FONT_COMPRESSED (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_FONT_SUBPX (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_FONT_SUBPX (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_GAUGE (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_GAUGE (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_GPU (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_GPU (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_GPU_STM32_DMA2D (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_USE_GPU_STM32_DMA2D (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_GROUP (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_GROUP (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_IMGBTN (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_IMGBTN (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_IMG (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_IMG (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_IMG_TRANSFORM (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_IMG_TRANSFORM (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_KEYBOARD (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_KEYBOARD (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_LABEL (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_LABEL (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_LED (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_LED (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_LINE (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_LINE (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_LINEMETER (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_LINEMETER (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_LIST (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_LIST (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_LOG (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_USE_LOG (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_MSGBOX (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_MSGBOX (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_OBJMASK (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_OBJMASK (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_OBJ_REALIGN (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_OBJ_REALIGN (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_OPA_SCALE (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_OPA_SCALE (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_OUTLINE (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_OUTLINE (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_PAGE (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_PAGE (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_PATTERN (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_PATTERN (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_PERF_MONITOR (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_USE_PERF_MONITOR (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_ROLLER (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_ROLLER (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_SHADOW (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_SHADOW (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_SLIDER (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_SLIDER (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_SPINBOX (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_SPINBOX (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_SPINNER (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_SPINNER (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_SWITCH (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_SWITCH (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_TABLE (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_TABLE (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_TABVIEW (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_TABVIEW (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_TEXTAREA (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_TEXTAREA (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_THEME_EMPTY (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_THEME_EMPTY (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_THEME_MATERIAL (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_THEME_MATERIAL (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_THEME_MONO (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_THEME_MONO (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_THEME_TEMPLATE (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_THEME_TEMPLATE (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_TILEVIEW (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_TILEVIEW (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_USER_DATA (macro definition) of group pkg_lvgl7 is not documented.
 warning: Member LV_USE_USER_DATA (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_VALUE_STR (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_VALUE_STR (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_USE_WIN (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_USE_WIN (macro definition) of group pkg_lvgl is not documented.
-warning: Member LV_VER_RES_MAX (macro definition) of group pkg_lvgl7 is not documented.
-warning: Member LV_VER_RES_MAX (macro definition) of group pkg_lvgl is not documented.
 warning: Member LWIP_6LOWPAN (macro definition) of group pkg_lwip_opts is not documented.
 warning: Member LWIP_ASSERT_CORE_LOCKED() (macro definition) of group pkg_lwip_opts is not documented.
 warning: Member LWIP_AUTOIP (macro definition) of group pkg_lwip_opts is not documented.
@@ -3811,10 +3263,8 @@ warning: Member MAG3110_DR_STATUS_ZYXDR (macro definition) of file mag3110_reg.h
 warning: Member MAG3110_DR_STATUS_ZYXOW (macro definition) of file mag3110_reg.h is not documented.
 warning: Member MAG3110_PARAM_ADDR (macro definition) of file board.h is not documented.
 warning: Member MAG3110_PARAM_ADDR (macro definition) of file mag3110_params.h is not documented.
-warning: Member MAG3110_PARAM_ADDR (macro definition) of group boards_frdm-kl43z is not documented.
 warning: Member MAG3110_PARAM_I2C (macro definition) of file board.h is not documented.
 warning: Member MAG3110_PARAM_I2C (macro definition) of file mag3110_params.h is not documented.
-warning: Member MAG3110_PARAM_I2C (macro definition) of group boards_frdm-kl43z is not documented.
 warning: Member MAG3110_PARAM_OFFSET (macro definition) of file mag3110_params.h is not documented.
 warning: Member MAG3110_PARAMS (macro definition) of file mag3110_params.h is not documented.
 warning: Member MAG3110_SAUL_INFO (macro definition) of file mag3110_params.h is not documented.
@@ -3825,7 +3275,6 @@ warning: Member MAIPGL_FD (macro definition) of file enc28j60_regs.h is not docu
 warning: Member MASK_MAX_RT (macro definition) of file nrf24l01p_settings.h is not documented.
 warning: Member MASK_RX_DR (macro definition) of file nrf24l01p_settings.h is not documented.
 warning: Member MASK_TX_DS (macro definition) of file nrf24l01p_settings.h is not documented.
-warning: Member MAX4(a, b, c, d) (macro definition) of group sys_vfs is not documented.
 warning: Member max(a, b) (macro definition) of file os.h is not documented.
 warning: Member MAX_RT (macro definition) of file nrf24l01p_settings.h is not documented.
 warning: Member MCP2515_BFPCTRL_B0BFE (macro definition) of file mcp2515_defines.h is not documented.
@@ -3954,10 +3403,7 @@ warning: Member MCP2515_RXB0CTRL_BUKT (macro definition) of file mcp2515_defines
 warning: Member MCP2515_RXB0CTRL_FILHIT0 (macro definition) of file mcp2515_defines.h is not documented.
 warning: Member MCP2515_RXB0CTRL (macro definition) of file mcp2515_defines.h is not documented.
 warning: Member MCP2515_RXB0CTRL_MODE_RECV_ALL (macro definition) of file mcp2515_defines.h is not documented.
-warning: Member MCP2515_RXB0CTRL_MODE_RECV_EXT (macro definition) of file mcp2515_defines.h is not documented.
 warning: Member MCP2515_RXB0CTRL_MODE_RECV_FILTER (macro definition) of file mcp2515_defines.h is not documented.
-warning: Member MCP2515_RXB0CTRL_MODE_RECV_STD (macro definition) of file mcp2515_defines.h is not documented.
-warning: Member MCP2515_RXB0CTRL_MODE_RECV_STD_OR_EXT (macro definition) of file mcp2515_defines.h is not documented.
 warning: Member MCP2515_RXB0CTRL_RXM0 (macro definition) of file mcp2515_defines.h is not documented.
 warning: Member MCP2515_RXB0CTRL_RXM1 (macro definition) of file mcp2515_defines.h is not documented.
 warning: Member MCP2515_RXB0CTRL_RXRTR (macro definition) of file mcp2515_defines.h is not documented.
@@ -3979,10 +3425,7 @@ warning: Member MCP2515_RXB1CTRL_FILHIT1 (macro definition) of file mcp2515_defi
 warning: Member MCP2515_RXB1CTRL_FILHIT2 (macro definition) of file mcp2515_defines.h is not documented.
 warning: Member MCP2515_RXB1CTRL (macro definition) of file mcp2515_defines.h is not documented.
 warning: Member MCP2515_RXB1CTRL_MODE_RECV_ALL (macro definition) of file mcp2515_defines.h is not documented.
-warning: Member MCP2515_RXB1CTRL_MODE_RECV_EXT (macro definition) of file mcp2515_defines.h is not documented.
 warning: Member MCP2515_RXB1CTRL_MODE_RECV_FILTER (macro definition) of file mcp2515_defines.h is not documented.
-warning: Member MCP2515_RXB1CTRL_MODE_RECV_STD (macro definition) of file mcp2515_defines.h is not documented.
-warning: Member MCP2515_RXB1CTRL_MODE_RECV_STD_OR_EXT (macro definition) of file mcp2515_defines.h is not documented.
 warning: Member MCP2515_RXB1CTRL_RXM0 (macro definition) of file mcp2515_defines.h is not documented.
 warning: Member MCP2515_RXB1CTRL_RXM1 (macro definition) of file mcp2515_defines.h is not documented.
 warning: Member MCP2515_RXB1CTRL_RXRTR (macro definition) of file mcp2515_defines.h is not documented.
@@ -4122,8 +3565,6 @@ warning: Member MEAS_OSRS_T_POS (macro definition) of file bmx280_internals.h is
 warning: Member MEM_ALIGNMENT (macro definition) of group pkg_lwip_opts is not documented.
 warning: Member MEMP_MEM_MALLOC (macro definition) of group pkg_lwip_opts is not documented.
 warning: Member MEM_SIZE (macro definition) of group pkg_lwip_opts is not documented.
-warning: Member M_GPIO2_PIN (macro definition) of group boards_ublox-c030-u201 is not documented.
-warning: Member M_GPIO3_PIN (macro definition) of group boards_ublox-c030-u201 is not documented.
 warning: Member MHZ19_BUF_SIZE (macro definition) of file mhz19_internals.h is not documented.
 warning: Member MHZ19_SAUL_INFO (macro definition) of file mhz19_params.h is not documented.
 warning: Member MHZ19_TIMEOUT_CMD (macro definition) of file mhz19_internals.h is not documented.
@@ -4147,18 +3588,6 @@ warning: Member MICROBIT_LED_ROW3 (macro definition) of file board.h is not docu
 warning: Member MICROBIT_LED_ROW4 (macro definition) of file board.h is not documented.
 warning: Member MICROBIT_LED_ROW5 (macro definition) of file board.h is not documented.
 warning: Member min(a, b) (macro definition) of file os.h is not documented.
-warning: Member MINI_LED_COL1 (macro definition) of file board.h is not documented.
-warning: Member MINI_LED_COL2 (macro definition) of file board.h is not documented.
-warning: Member MINI_LED_COL3 (macro definition) of file board.h is not documented.
-warning: Member MINI_LED_COL4 (macro definition) of file board.h is not documented.
-warning: Member MINI_LED_COL5 (macro definition) of file board.h is not documented.
-warning: Member MINI_LED_COL6 (macro definition) of file board.h is not documented.
-warning: Member MINI_LED_COL7 (macro definition) of file board.h is not documented.
-warning: Member MINI_LED_COL8 (macro definition) of file board.h is not documented.
-warning: Member MINI_LED_COL9 (macro definition) of file board.h is not documented.
-warning: Member MINI_LED_ROW1 (macro definition) of file board.h is not documented.
-warning: Member MINI_LED_ROW2 (macro definition) of file board.h is not documented.
-warning: Member MINI_LED_ROW3 (macro definition) of file board.h is not documented.
 warning: Member MISTAT_BUSY (macro definition) of file enc28j60_regs.h is not documented.
 warning: Member MISTAT_NVALID (macro definition) of file enc28j60_regs.h is not documented.
 warning: Member MISTAT_SCAN (macro definition) of file enc28j60_regs.h is not documented.
@@ -4493,10 +3922,8 @@ warning: Member MMA8X5X_INT_SOURCE_PULSE (macro definition) of file mma8x5x_regs
 warning: Member MMA8X5X_INT_SOURCE_TRANS (macro definition) of file mma8x5x_regs.h is not documented.
 warning: Member MMA8X5X_PARAM_ADDR (macro definition) of file board.h is not documented.
 warning: Member MMA8X5X_PARAM_ADDR (macro definition) of file mma8x5x_params.h is not documented.
-warning: Member MMA8X5X_PARAM_ADDR (macro definition) of group boards_frdm-kl43z is not documented.
 warning: Member MMA8X5X_PARAM_I2C (macro definition) of file board.h is not documented.
 warning: Member MMA8X5X_PARAM_I2C (macro definition) of file mma8x5x_params.h is not documented.
-warning: Member MMA8X5X_PARAM_I2C (macro definition) of group boards_frdm-kl43z is not documented.
 warning: Member MMA8X5X_PARAM_OFFSET (macro definition) of file mma8x5x_params.h is not documented.
 warning: Member MMA8X5X_PARAM_PIN_INT1 (macro definition) of file board.h is not documented.
 warning: Member MMA8X5X_PARAM_PIN_INT2 (macro definition) of file board.h is not documented.
@@ -4504,7 +3931,6 @@ warning: Member MMA8X5X_PARAM_RANGE (macro definition) of file mma8x5x_params.h 
 warning: Member MMA8X5X_PARAM_RATE (macro definition) of file mma8x5x_params.h is not documented.
 warning: Member MMA8X5X_PARAMS (macro definition) of file mma8x5x_params.h is not documented.
 warning: Member MMA8X5X_PARAM_TYPE (macro definition) of file board.h is not documented.
-warning: Member MMA8X5X_PARAM_TYPE (macro definition) of group boards_frdm-kl43z is not documented.
 warning: Member MMA8X5X_PL_BF_ZCOMP_BKFR_MASK (macro definition) of file mma8x5x_regs.h is not documented.
 warning: Member MMA8X5X_PL_BF_ZCOMP_ZLOCK_MASK (macro definition) of file mma8x5x_regs.h is not documented.
 warning: Member MMA8X5X_PL_CFG_DBCNTM (macro definition) of file mma8x5x_regs.h is not documented.
@@ -4584,7 +4010,6 @@ warning: Member MODE_AUTOSLEEP_SHIFT (macro definition) of group drivers_mma7660
 warning: Member MODE_AUTOWAKE_SHIFT (macro definition) of group drivers_mma7660 is not documented.
 warning: Member MODE_INTERRUPT_DEFAULT (macro definition) of group drivers_mma7660 is not documented.
 warning: Member MODE_PRESCALE_SHIFT (macro definition) of group drivers_mma7660 is not documented.
-warning: Member MODULE_ATMEGA_PCINT0 (macro definition) of file board.h is not documented.
 warning: Member MODULE_PIN_F0 (macro definition) of file board_module.h is not documented.
 warning: Member MODULE_PIN_F10 (macro definition) of file board_module.h is not documented.
 warning: Member MODULE_PIN_F11 (macro definition) of file board_module.h is not documented.
@@ -4704,10 +4129,8 @@ warning: Member MP_RIOT_HEAPSIZE (macro definition) of file micropython.h is not
 warning: Member MP_STACK_SAFEAREA (macro definition) of file micropython.h is not documented.
 warning: Member MPU9X50_ACCEL_CFG_REG (macro definition) of file mpu9x50_regs.h is not documented.
 warning: Member MPU9X50_ACCEL_START_REG (macro definition) of file mpu9x50_regs.h is not documented.
-warning: Member MPU9X50_BYPASS_SLEEP_US (macro definition) of file mpu9x50_internal.h is not documented.
 warning: Member MPU9X50_COMPASS_DATA_START_REG (macro definition) of file mpu9x50_regs.h is not documented.
 warning: Member MPU9X50_COMP_FUSE_ROM (macro definition) of file mpu9x50_internal.h is not documented.
-warning: Member MPU9X50_COMP_MODE_SLEEP_US (macro definition) of file mpu9x50_internal.h is not documented.
 warning: Member MPU9X50_COMP_POWER_DOWN (macro definition) of file mpu9x50_internal.h is not documented.
 warning: Member MPU9X50_COMP_SELF_TEST (macro definition) of file mpu9x50_internal.h is not documented.
 warning: Member MPU9X50_COMP_SINGLE_MEASURE (macro definition) of file mpu9x50_internal.h is not documented.
@@ -4735,7 +4158,6 @@ warning: Member MPU9X50_PARAM_I2C (macro definition) of file mpu9x50_params.h is
 warning: Member MPU9X50_PARAM_SAMPLE_RATE (macro definition) of file mpu9x50_params.h is not documented.
 warning: Member MPU9X50_PARAMS (macro definition) of file mpu9x50_params.h is not documented.
 warning: Member MPU9X50_PWR_ACCEL (macro definition) of file mpu9x50_internal.h is not documented.
-warning: Member MPU9X50_PWR_CHANGE_SLEEP_US (macro definition) of file mpu9x50_internal.h is not documented.
 warning: Member MPU9X50_PWR_GYRO (macro definition) of file mpu9x50_internal.h is not documented.
 warning: Member MPU9X50_PWR_MGMT_1_REG (macro definition) of file mpu9x50_regs.h is not documented.
 warning: Member MPU9X50_PWR_MGMT_2_REG (macro definition) of file mpu9x50_regs.h is not documented.
@@ -4743,7 +4165,6 @@ warning: Member MPU9X50_PWR_PLL (macro definition) of file mpu9x50_internal.h is
 warning: Member MPU9X50_PWR_RESET (macro definition) of file mpu9x50_internal.h is not documented.
 warning: Member MPU9X50_PWR_WAKEUP (macro definition) of file mpu9x50_internal.h is not documented.
 warning: Member MPU9X50_RATE_DIV_REG (macro definition) of file mpu9x50_regs.h is not documented.
-warning: Member MPU9X50_RESET_SLEEP_US (macro definition) of file mpu9x50_internal.h is not documented.
 warning: Member MPU9X50_SAUL_INFO (macro definition) of file mpu9x50_params.h is not documented.
 warning: Member MPU9X50_SLAVE0_ADDR_REG (macro definition) of file mpu9x50_regs.h is not documented.
 warning: Member MPU9X50_SLAVE0_CTRL_REG (macro definition) of file mpu9x50_regs.h is not documented.
@@ -4829,7 +4250,6 @@ warning: Member MRF24J40_PARAM_INT (macro definition) of file board.h is not doc
 warning: Member MRF24J40_PARAM_RESET (macro definition) of file mrf24j40_params.h is not documented.
 warning: Member MRF24J40_PARAM_RESET (macro definition) of file board.h is not documented.
 warning: Member MRF24J40_PARAMS (macro definition) of file mrf24j40_params.h is not documented.
-warning: Member MRF24J40_PARAMS (macro definition) of file board.h is not documented.
 warning: Member MRF24J40_PARAM_SPI_CLK (macro definition) of file mrf24j40_params.h is not documented.
 warning: Member MRF24J40_PARAM_SPI_CLK (macro definition) of file board.h is not documented.
 warning: Member MRF24J40_PARAM_SPI (macro definition) of file mrf24j40_params.h is not documented.
@@ -5049,16 +4469,8 @@ warning: Member MRF24J40_WAKECON_REGWAKE (macro definition) of file mrf24j40_reg
 warning: Member MRF24J40_WAKEUP_DELAY (macro definition) of file mrf24j40_registers.h is not documented.
 warning: Member MRF25J40_BBREG2_CCAMODE1 (macro definition) of file mrf24j40_registers.h is not documented.
 warning: Member MTD_0 (macro definition) of file board.h is not documented.
-warning: Member mtd0 (variable) of file board.h is not documented.
-warning: Member MTD_1 (macro definition) of file board.h is not documented.
-warning: Member mtd1 (variable) of file board.h is not documented.
-warning: Member MTD_2 (macro definition) of file board.h is not documented.
-warning: Member mtd2 (variable) of file board.h is not documented.
 warning: Member MTD_NATIVE_FILENAME (macro definition) of file board.h is not documented.
-warning: Member MTD_NUMOF (macro definition) of file board.h is not documented.
 warning: Member MTD_PAGE_SIZE (macro definition) of file board.h is not documented.
-warning: Member MTD_SD_CARD_PAGES_PER_SECTOR (macro definition) of file board.h is not documented.
-warning: Member MTD_SD_CARD_SECTOR_COUNT (macro definition) of file board.h is not documented.
 warning: Member MTD_SECTOR_NUM (macro definition) of file board.h is not documented.
 warning: Member MTD_SECTOR_SIZE (macro definition) of file board.h is not documented.
 warning: Member MULLE_NOR_SPI_CLK (macro definition) of file board.h is not documented.
@@ -5072,38 +4484,14 @@ warning: Member mulle_nvram (variable) of file mulle-nvram.h is not documented.
 warning: Member MULLE_VBAT_ADC_LINE (macro definition) of file board.h is not documented.
 warning: Member MULLE_VCHR_ADC_LINE (macro definition) of file board.h is not documented.
 warning: Member MULTIPLY_DATA(data_raw, integration_time) (macro definition) of file tsl4531x_internals.h is not documented.
-warning: Member MUX0_ENABLE_PORT (macro definition) of file board.h is not documented.
-warning: Member MUX0_OFF (macro definition) of file board.h is not documented.
-warning: Member MUX0_ON (macro definition) of file board.h is not documented.
-warning: Member MUX0_PIN (macro definition) of file board.h is not documented.
-warning: Member MUX0_PORT (macro definition) of file board.h is not documented.
-warning: Member MUX1_ENABLE_PORT (macro definition) of file board.h is not documented.
-warning: Member MUX1_OFF (macro definition) of file board.h is not documented.
-warning: Member MUX1_ON (macro definition) of file board.h is not documented.
-warning: Member MUX1_PIN (macro definition) of file board.h is not documented.
-warning: Member MUX1_PORT (macro definition) of file board.h is not documented.
-warning: Member MUX_PW_ENABLE_PORT (macro definition) of file board.h is not documented.
-warning: Member MUX_PW_OFF (macro definition) of file board.h is not documented.
-warning: Member MUX_PW_ON (macro definition) of file board.h is not documented.
-warning: Member MUX_PW_PIN (macro definition) of file board.h is not documented.
-warning: Member MUX_PW_PORT (macro definition) of file board.h is not documented.
-warning: Member MUX_USB_XBEE_ENABLE_PORT (macro definition) of file board.h is not documented.
-warning: Member MUX_USB_XBEE_OFF (macro definition) of file board.h is not documented.
-warning: Member MUX_USB_XBEE_ON (macro definition) of file board.h is not documented.
-warning: Member MUX_USB_XBEE_PIN (macro definition) of file board.h is not documented.
-warning: Member MUX_USB_XBEE_PORT (macro definition) of file board.h is not documented.
 warning: Member MYNEWT_VAL_CHOICE(_name, _val) (macro definition) of file syscfg.h is not documented.
 warning: Member MYNEWT_VAL(_name) (macro definition) of file syscfg.h is not documented.
-warning: Member native_cli_add_eui64(const char *s) (function) of file native_cli_eui_provider.h is not documented.
-warning: Member native_cli_get_eui64(uint8_t index, eui64_t *addr) (function) of file native_cli_eui_provider.h is not documented.
-warning: Member _native_flash[FLASHPAGE_SIZE *FLASHPAGE_NUMOF] (variable) of file cpu_conf.h is not documented.
 warning: Member _native_LED_GREEN_OFF(void) (function) of file board.h is not documented.
 warning: Member _native_LED_GREEN_ON(void) (function) of file board.h is not documented.
 warning: Member _native_LED_GREEN_TOGGLE(void) (function) of file board.h is not documented.
 warning: Member _native_LED_RED_OFF(void) (function) of file board.h is not documented.
 warning: Member _native_LED_RED_ON(void) (function) of file board.h is not documented.
 warning: Member _native_LED_RED_TOGGLE(void) (function) of file board.h is not documented.
-warning: Member NATIVE_TIMER_MIN_RES (macro definition) of file periph_conf.h is not documented.
 warning: Member NB_IOT_DISABLE (macro definition) of file board.h is not documented.
 warning: Member NB_IOT_ENABLE (macro definition) of file board.h is not documented.
 warning: Member NB_IOT_ENABLE_MASK (macro definition) of file board.h is not documented.
@@ -5318,9 +4706,7 @@ warning: Member PDSTAT1_VIMS_ON (macro definition) of file cc26x0_cc13x0_prcm.h 
 warning: Member PDSTAT1_VIMS_ON (macro definition) of file cc26x2_cc13x2_prcm.h is not documented.
 warning: Member PERIPH_CLOCK (macro definition) of file periph_cpu.h is not documented.
 warning: Member PERIPH_FLASHPAGE_NEEDS_FLASHPAGE_PAGE (macro definition) of file cpu_conf.h is not documented.
-warning: Member PERIPH_I2C_NEED_READ_REGS (macro definition) of file periph_cpu.h is not documented.
 warning: Member PERIPH_I2C_NEED_WRITE_REG (macro definition) of file periph_cpu.h is not documented.
-warning: Member PERIPH_INIT_LED0 (macro definition) of group boards_common_nucleo144 is not documented.
 warning: Member PERIPH_SPI_NEEDS_INIT_CS (macro definition) of file periph_cpu.h is not documented.
 warning: Member PERIPH_SPI_NEEDS_TRANSFER_BYTE (macro definition) of file periph_cpu_common.h is not documented.
 warning: Member PERIPH_SPI_NEEDS_TRANSFER_BYTE (macro definition) of file periph_cpu.h is not documented.
@@ -5405,23 +4791,16 @@ warning: Member PN532_FW_FEATURES(fwver) (macro definition) of group drivers_pn5
 warning: Member PN532_FW_REVISION(fwver) (macro definition) of group drivers_pn532 is not documented.
 warning: Member PN532_FW_VERSION(fwver) (macro definition) of group drivers_pn532 is not documented.
 warning: Member PN532_IC_VERSION(fwver) (macro definition) of group drivers_pn532 is not documented.
-warning: Member PORT_delayRx (macro definition) of file board_info.h is not documented.
-warning: Member PORT_delayTx (macro definition) of file board_info.h is not documented.
 warning: Member PORT_delayTx (macro definition) of file openwsn_defs.h is not documented.
 warning: Member _PORT (macro definition) of group boards_common_saml1x is not documented.
-warning: Member PORT_maxRxAckPrepare (macro definition) of file board_info.h is not documented.
 warning: Member PORT_maxRxAckPrepare (macro definition) of file openwsn_defs.h is not documented.
-warning: Member PORT_maxRxDataPrepare (macro definition) of file board_info.h is not documented.
 warning: Member PORT_maxRxDataPrepare (macro definition) of file openwsn_defs.h is not documented.
-warning: Member PORT_maxTxAckPrepare (macro definition) of file board_info.h is not documented.
 warning: Member PORT_maxTxAckPrepare (macro definition) of file openwsn_defs.h is not documented.
-warning: Member PORT_maxTxDataPrepare (macro definition) of file board_info.h is not documented.
 warning: Member PORT_maxTxDataPrepare (macro definition) of file openwsn_defs.h is not documented.
 warning: Member PORT_RADIOTIMER_WIDTH (macro definition) of file board_info.h is not documented.
 warning: Member PORT_SIGNED_INT_WIDTH (macro definition) of file board_info.h is not documented.
 warning: Member PORT_TICS_PER_MS (macro definition) of file board_info.h is not documented.
 warning: Member PORT_TIMER_WIDTH (macro definition) of file board_info.h is not documented.
-warning: Member PORT_TsSlotDuration (macro definition) of file board_info.h is not documented.
 warning: Member PORT_US_PER_TICK (macro definition) of file board_info.h is not documented.
 warning: Member POWER_PRESENCE (macro definition) of file board.h is not documented.
 warning: Member PPP_SUPPORT (macro definition) of group pkg_lwip_opts is not documented.
@@ -5454,12 +4833,9 @@ warning: Member PWM_CH1_PIN (macro definition) of file periph_conf.h is not docu
 warning: Member PWM_CH2 (macro definition) of file periph_conf.h is not documented.
 warning: Member PWM_CH2_MR (macro definition) of file periph_conf.h is not documented.
 warning: Member PWM_CH2_PIN (macro definition) of file periph_conf.h is not documented.
-warning: Member pwm_chan0_config[] (variable) of file periph_conf_common.h is not documented.
 warning: Member pwm_chan0_config[] (variable) of file periph_conf.h is not documented.
-warning: Member pwm_chan1_config[] (variable) of file periph_conf.h is not documented.
 warning: Member pwm_channel_config[] (variable) of file periph_conf.h is not documented.
 warning: Member PWM_CHANNELS (macro definition) of file periph_conf.h is not documented.
-warning: Member PWM_CHANNELS (macro definition) of file periph_cpu.h is not documented.
 warning: Member PWM_CHAN_NUMOF (macro definition) of file periph_conf.h is not documented.
 warning: Member pwm_chan[] (variable) of file periph_conf.h is not documented.
 warning: Member PWMCLKEN_CPE (macro definition) of file cc26xx_cc13xx_rfc.h is not documented.
@@ -5471,17 +4847,9 @@ warning: Member PWMCLKEN_PHA (macro definition) of file cc26xx_cc13xx_rfc.h is n
 warning: Member PWMCLKEN_RAT (macro definition) of file cc26xx_cc13xx_rfc.h is not documented.
 warning: Member PWMCLKEN_RFC (macro definition) of file cc26xx_cc13xx_rfc.h is not documented.
 warning: Member PWMCLKEN_RFERAM (macro definition) of file cc26xx_cc13xx_rfc.h is not documented.
-warning: Member pwm_config[] (variable) of file periph_conf_common.h is not documented.
-warning: Member pwm_config[] (variable) of file periph_conf.h is not documented.
-warning: Member pwm_config[] (variable) of group boards_common_nrf52xxxdk is not documented.
 warning: Member PWM_DEV_NUMOF (macro definition) of file periph_conf.h is not documented.
 warning: Member PWM_FUNC (macro definition) of file periph_conf.h is not documented.
 warning: Member pwm_mode_t (enumeration) of file periph_conf.h is not documented.
-warning: Member pwm_mode_t (enumeration) of file periph_cpu.h is not documented.
-warning: Member PWM_MODE(ud, pol) (macro definition) of file periph_cpu.h is not documented.
-warning: Member PWM_NUMOF (macro definition) of file periph_conf_common.h is not documented.
-warning: Member PWM_NUMOF (macro definition) of file periph_conf.h is not documented.
-warning: Member PWM_NUMOF (macro definition) of group boards_common_nrf52xxxdk is not documented.
 warning: Member PWM_PIN (macro definition) of file periph_conf.h is not documented.
 warning: Member PWM_PORT (macro definition) of file periph_conf.h is not documented.
 warning: Member PWM_PPI_A (macro definition) of file cpu_conf.h is not documented.
@@ -5737,11 +5105,8 @@ warning: Member RFCORE_ASSERT_failure(const char *expr, const char *func, int li
 warning: Member RFCORE_FLUSH_RECEIVE_FIFO() (macro definition) of file cc2538_rf.h is not documented.
 warning: Member RFCORE_WAIT_UNTIL(expr) (macro definition) of file cc2538_rf.h is not documented.
 warning: Member RFCTL1_PIN (macro definition) of file board.h is not documented.
-warning: Member RFCTL1_PIN (macro definition) of group boards_samr30-xpro is not documented.
 warning: Member RFCTL2_PIN (macro definition) of file board.h is not documented.
-warning: Member RFCTL2_PIN (macro definition) of group boards_samr30-xpro is not documented.
 warning: Member RFCTL_ANTENNA_DEFAULT (macro definition) of file board.h is not documented.
-warning: Member RFCTL_ANTENNA_DEFAULT (macro definition) of group boards_samr30-xpro is not documented.
 warning: Member RF_DTB_128_US (macro definition) of file at86rf215_registers.h is not documented.
 warning: Member RF_DTB_32_US (macro definition) of file at86rf215_registers.h is not documented.
 warning: Member RF_DTB_8_US (macro definition) of file at86rf215_registers.h is not documented.
@@ -5837,17 +5202,10 @@ warning: Member RTT_CLOCK_FREQUENCY (macro definition) of file cfg_rtt_default.h
 warning: Member RTT_CLOCK_FREQUENCY (macro definition) of file periph_cpu.h is not documented.
 warning: Member RTT_DEV (macro definition) of file cfg_rtt_default.h is not documented.
 warning: Member RTT_DEV (macro definition) of file periph_cpu.h is not documented.
-warning: Member RTT_FREQUENCY (macro definition) of file cfg_rtt_default.h is not documented.
-warning: Member RTT_FREQUENCY (macro definition) of file periph_conf_common.h is not documented.
-warning: Member RTT_FREQUENCY (macro definition) of file periph_conf.h is not documented.
-warning: Member RTT_FREQUENCY (macro definition) of file periph_cpu_common.h is not documented.
-warning: Member RTT_FREQUENCY (macro definition) of file periph_cpu.h is not documented.
 warning: Member RTT_INTR_PRIORITY (macro definition) of file periph_cpu.h is not documented.
 warning: Member RTT_IRQ (macro definition) of file periph_cpu.h is not documented.
 warning: Member RTT_IRQ_PRIO (macro definition) of file periph_cpu.h is not documented.
 warning: Member RTT_ISR (macro definition) of file periph_cpu.h is not documented.
-warning: Member RTT_MAX_FREQUENCY (macro definition) of file cfg_rtt_default.h is not documented.
-warning: Member RTT_MAX_FREQUENCY (macro definition) of file periph_cpu.h is not documented.
 warning: Member RTT_MAX_VALUE (macro definition) of file cfg_rtt_default.h is not documented.
 warning: Member RTT_MAX_VALUE (macro definition) of file periph_cpu_common.h is not documented.
 warning: Member RTT_MAX_VALUE (macro definition) of file periph_cpu.h is not documented.
@@ -5923,25 +5281,7 @@ warning: Member SD_ACMD_41_ARG_HC (macro definition) of file sdcard_spi_internal
 warning: Member SD_BLOCKS_FOR_REG_READ (macro definition) of file sdcard_spi_internal.h is not documented.
 warning: Member sdbm_hash(const uint8_t *buf, size_t len) (function) of file hashes.h is not documented.
 warning: Member SD_CARD_PREINIT_CLOCK_PERIOD_US (macro definition) of file sdcard_spi_internal.h is not documented.
-warning: Member SDCARD_SPI_PARAM_CLK (macro definition) of file board.h is not documented.
-warning: Member SDCARD_SPI_PARAM_CLK (macro definition) of file sdcard_spi_params.h is not documented.
-warning: Member SDCARD_SPI_PARAM_CLK (macro definition) of group boards_ublox-c030-u201 is not documented.
-warning: Member SDCARD_SPI_PARAM_CS (macro definition) of file board.h is not documented.
-warning: Member SDCARD_SPI_PARAM_CS (macro definition) of file sdcard_spi_params.h is not documented.
-warning: Member SDCARD_SPI_PARAM_CS (macro definition) of group boards_ublox-c030-u201 is not documented.
-warning: Member SDCARD_SPI_PARAM_MISO (macro definition) of file board.h is not documented.
-warning: Member SDCARD_SPI_PARAM_MISO (macro definition) of file sdcard_spi_params.h is not documented.
-warning: Member SDCARD_SPI_PARAM_MISO (macro definition) of group boards_ublox-c030-u201 is not documented.
-warning: Member SDCARD_SPI_PARAM_MOSI (macro definition) of file board.h is not documented.
-warning: Member SDCARD_SPI_PARAM_MOSI (macro definition) of file sdcard_spi_params.h is not documented.
-warning: Member SDCARD_SPI_PARAM_MOSI (macro definition) of group boards_ublox-c030-u201 is not documented.
-warning: Member SDCARD_SPI_PARAM_POWER_AH (macro definition) of file board.h is not documented.
-warning: Member SDCARD_SPI_PARAM_POWER (macro definition) of file board.h is not documented.
-warning: Member SDCARD_SPI_PARAM_POWER (macro definition) of file sdcard_spi_params.h is not documented.
 warning: Member SDCARD_SPI_PARAMS (macro definition) of file sdcard_spi_params.h is not documented.
-warning: Member SDCARD_SPI_PARAM_SPI (macro definition) of file board.h is not documented.
-warning: Member SDCARD_SPI_PARAM_SPI (macro definition) of file sdcard_spi_params.h is not documented.
-warning: Member SDCARD_SPI_PARAM_SPI (macro definition) of group boards_ublox-c030-u201 is not documented.
 warning: Member SD_CARD_WAIT_AFTER_POWER_UP_US (macro definition) of file sdcard_spi_internal.h is not documented.
 warning: Member SD_CMD_0 (macro definition) of file sdcard_spi_internal.h is not documented.
 warning: Member SD_CMD_10 (macro definition) of file sdcard_spi_internal.h is not documented.
@@ -6055,25 +5395,11 @@ warning: Member SERPENTE_NOR_SPI_CS (macro definition) of file board.h is not do
 warning: Member SERPENTE_NOR_SPI_DEV (macro definition) of file board.h is not documented.
 warning: Member SERPENTE_NOR_SPI_MODE (macro definition) of file board.h is not documented.
 warning: Member __set_cpsr(unsigned val) (function) of file irq_arch.h is not documented.
-warning: Member SET_MUX_AUX1_MODULE (macro definition) of file board.h is not documented.
-warning: Member SET_MUX_AUX2_MODULE (macro definition) of file board.h is not documented.
-warning: Member SET_MUX_GPS (macro definition) of file board.h is not documented.
-warning: Member SET_MUX_SOCKET0 (macro definition) of file board.h is not documented.
-warning: Member SET_MUX_SOCKET1 (macro definition) of file board.h is not documented.
-warning: Member SET_MUX_USB_MODULE (macro definition) of file board.h is not documented.
 warning: Member setsockopt(int socket, int level, int option_name, const void *option_value, socklen_t option_len) (function) of group posix_sockets is not documented.
 warning: Member setup_fpu(void) (function) of file cpu_conf.h is not documented.
 warning: Member SGP30_PARAM_I2C_DEV (macro definition) of file sgp30_params.h is not documented.
 warning: Member SGP30_PARAMS (macro definition) of file sgp30_params.h is not documented.
 warning: Member SGP30_SAUL_INFO (macro definition) of file sgp30_params.h is not documented.
-warning: Member SHT1X_PARAM_CLK (macro definition) of file board.h is not documented.
-warning: Member SHT1X_PARAM_DATA (macro definition) of file board.h is not documented.
-warning: Member SHT2X_PARAM_CRC_MODE (macro definition) of file sht2x_params.h is not documented.
-warning: Member SHT2X_PARAM_I2C_ADDR (macro definition) of file sht2x_params.h is not documented.
-warning: Member SHT2X_PARAM_MEASURE_MODE (macro definition) of file sht2x_params.h is not documented.
-warning: Member SHT2X_PARAM_RESOLUTION (macro definition) of file sht2x_params.h is not documented.
-warning: Member SHT2X_PARAMS_DEFAULT (macro definition) of file sht2x_params.h is not documented.
-warning: Member SHT2X_SAUL_INFO (macro definition) of file sht2x_params.h is not documented.
 warning: Member SHT2X_USER_EOB_MASK (macro definition) of group drivers_sht2x is not documented.
 warning: Member SHT2X_USER_HEATER_MASK (macro definition) of group drivers_sht2x is not documented.
 warning: Member SHT2X_USER_OTP_MASK (macro definition) of group drivers_sht2x is not documented.
@@ -6084,8 +5410,6 @@ warning: Member SHT3X_PARAM_MODE (macro definition) of file sht3x_params.h is no
 warning: Member SHT3X_PARAM_REPEAT (macro definition) of file sht3x_params.h is not documented.
 warning: Member SHT3X_PARAMS (macro definition) of file sht3x_params.h is not documented.
 warning: Member SHT3X_SAUL_INFO (macro definition) of file sht3x_params.h is not documented.
-warning: Member SHTCX_PARAM_I2C_ADDR (macro definition) of file shtcx_params.h is not documented.
-warning: Member SHTCX_PARAM_I2C_DEV (macro definition) of file shtcx_params.h is not documented.
 warning: Member SHTCX_PARAMS (macro definition) of file shtcx_params.h is not documented.
 warning: Member SHTCX_SAUL_INFO (macro definition) of file shtcx_params.h is not documented.
 warning: Member SHUTDOWN_DONE_GPIO (macro definition) of file board.h is not documented.
@@ -6312,7 +5636,6 @@ warning: Member SI114X_REG_UV_INDEX0 (macro definition) of file si114x_internals
 warning: Member SI114X_REG_UV_INDEX1 (macro definition) of file si114x_internals.h is not documented.
 warning: Member SI114X_RESET (macro definition) of file si114x_internals.h is not documented.
 warning: Member SI114X_SAUL_INFO (macro definition) of file si114x_params.h is not documented.
-warning: Member SI114X_STARTUP_TIME (macro definition) of file si114x_internals.h is not documented.
 warning: Member SI114X_UCOEF0_DEFAULT (macro definition) of file si114x_internals.h is not documented.
 warning: Member SI114X_UCOEF1_DEFAULT (macro definition) of file si114x_internals.h is not documented.
 warning: Member SI114X_UCOEF2_DEFAULT (macro definition) of file si114x_internals.h is not documented.
@@ -6328,10 +5651,8 @@ warning: Member SI70XX_MEASURE_TEMP_HOLD (macro definition) of file si70xx_inter
 warning: Member SI70XX_MEASURE_TEMP (macro definition) of file si70xx_internals.h is not documented.
 warning: Member SI70XX_MEASURE_TEMP_PREV (macro definition) of file si70xx_internals.h is not documented.
 warning: Member SI70XX_PARAM_ADDR (macro definition) of file si70xx_params.h is not documented.
-warning: Member SI70XX_PARAM_ADDR (macro definition) of group boards_ublox-c030-u201 is not documented.
 warning: Member SI70XX_PARAM_I2C_DEV (macro definition) of file board.h is not documented.
 warning: Member SI70XX_PARAM_I2C_DEV (macro definition) of file si70xx_params.h is not documented.
-warning: Member SI70XX_PARAM_I2C_DEV (macro definition) of group boards_ublox-c030-u201 is not documented.
 warning: Member SI70XX_PARAMS (macro definition) of file si70xx_params.h is not documented.
 warning: Member SI70XX_READ_HEATER_REG (macro definition) of file si70xx_internals.h is not documented.
 warning: Member SI70XX_READ_ID_FIRST_A (macro definition) of file si70xx_internals.h is not documented.
@@ -6345,7 +5666,6 @@ warning: Member SI70XX_RESET (macro definition) of file si70xx_internals.h is no
 warning: Member SI70XX_REVISION_1 (macro definition) of file si70xx_internals.h is not documented.
 warning: Member SI70XX_REVISION_2 (macro definition) of file si70xx_internals.h is not documented.
 warning: Member SI70XX_SAUL_INFO (macro definition) of file si70xx_params.h is not documented.
-warning: Member SI70XX_SAUL_INFO (macro definition) of group boards_ublox-c030-u201 is not documented.
 warning: Member SI70XX_WRITE_HEATER_REG (macro definition) of file si70xx_internals.h is not documented.
 warning: Member SI70XX_WRITE_USER_REG (macro definition) of file si70xx_internals.h is not documented.
 warning: Member SI7210_ENABLED (macro definition) of file board.h is not documented.
@@ -6385,17 +5705,11 @@ warning: Member SOFT_UART_PARAM_TIMER_RX (macro definition) of file soft_uart_pa
 warning: Member SOFT_UART_PARAM_TIMER_TX (macro definition) of file soft_uart_params.h is not documented.
 warning: Member SOFT_UART_PARAM_TX (macro definition) of file soft_uart_params.h is not documented.
 warning: Member SPEAKER_PIN (macro definition) of file board.h is not documented.
-warning: Member SPI_BASE (macro definition) of file periph_conf.h is not documented.
-warning: Member SPI_SFR (macro definition) of file periph_conf.h is not documented.
 warning: Member spi_clk_config[] (variable) of file periph_conf_common.h is not documented.
 warning: Member spi_clk_config[] (variable) of file periph_conf.h is not documented.
 warning: Member spi_clk_t (enumeration) of file periph_cpu.h is not documented.
-warning: Member spi_config[] (variable) of file cfg_spi_default.h is not documented.
-warning: Member spi_config[] (variable) of file periph_conf_common.h is not documented.
-warning: Member spi_config[] (variable) of file periph_conf.h is not documented.
 warning: Member spi_confs[] (variable) of file periph_conf.h is not documented.
 warning: Member SPIFFS_ALIGNED_OBJECT_INDEX_TABLES (macro definition) of file board_common.h is not documented.
-warning: Member SPIFFS_[_A-Z]+ (macro definition) of file board_common.h is not documented.
 warning: Member SPIFFS_CACHE (macro definition) of file board_common.h is not documented.
 warning: Member SPIFFS_CACHE (macro definition) of file board.h is not documented.
 warning: Member SPIFFS_HAL_CALLBACK_EXTRA (macro definition) of file board_common.h is not documented.
@@ -6405,23 +5719,9 @@ warning: Member SPIFFS_READ_ONLY (macro definition) of file board.h is not docum
 warning: Member SPIFFS_SINGLETON (macro definition) of file board_common.h is not documented.
 warning: Member SPIFFS_SINGLETON (macro definition) of file board.h is not documented.
 warning: Member SPIFFS_VFS_FILE_BUFFER_SIZE (macro definition) of group sys_vfs is not documented.
-warning: Member SPI_IE (macro definition) of file periph_conf.h is not documented.
-warning: Member SPI_IE_RX_BIT (macro definition) of file periph_conf.h is not documented.
-warning: Member SPI_IE_TX_BIT (macro definition) of file periph_conf.h is not documented.
-warning: Member SPI_IF (macro definition) of file periph_conf.h is not documented.
-warning: Member SPI_ME_BIT (macro definition) of file periph_conf.h is not documented.
-warning: Member SPI_ME (macro definition) of file periph_conf.h is not documented.
 warning: Member SPI_MISOSEL (macro definition) of file periph_cpu.h is not documented.
 warning: Member SPI_MOSISEL (macro definition) of file periph_cpu.h is not documented.
-warning: Member SPI_NUMOF (macro definition) of file cfg_spi_default.h is not documented.
-warning: Member SPI_NUMOF (macro definition) of file periph_conf_common.h is not documented.
-warning: Member SPI_NUMOF (macro definition) of file periph_conf.h is not documented.
-warning: Member SPI_PIN_CLK (macro definition) of file periph_conf.h is not documented.
-warning: Member SPI_PIN_MISO (macro definition) of file periph_conf.h is not documented.
-warning: Member SPI_PIN_MOSI (macro definition) of file periph_conf.h is not documented.
-warning: Member SPI_SCKSEL (macro definition) of file periph_cpu.h is not documented.
 warning: Member spi_t (typedef) of file periph_cpu.h is not documented.
-warning: Member SPI_USE_USCI (macro definition) of file periph_conf.h is not documented.
 warning: Member SPS30_PARAM_I2C_DEV (macro definition) of file sps30_params.h is not documented.
 warning: Member SPS30_PARAMS (macro definition) of file sps30_params.h is not documented.
 warning: Member SPS30_SAUL_INFO (macro definition) of file sps30_params.h is not documented.
@@ -6443,10 +5743,6 @@ warning: Member STDIO_UART_BAUDRATE (macro definition) of file board.h is not do
 warning: Member STDIO_UART_BAUDRATE (macro definition) of group boards_common_arduino-atmega is not documented.
 warning: Member STDIO_UART_BAUDRATE (macro definition) of group boards_common_iotlab is not documented.
 warning: Member stm32_flashpage_block_t (typedef) of file cpu_conf.h is not documented.
-warning: Member STM32_PM_STANDBY (macro definition) of file periph_cpu.h is not documented.
-warning: Member STM32_PM_STOP (macro definition) of file periph_cpu.h is not documented.
-warning: Member stm32_usb_otg_fshs_config[] (variable) of file cfg_usb_otg_fs.h is not documented.
-warning: Member stm32_usb_otg_fshs_config[] (variable) of file cfg_usb_otg_hs_fs.h is not documented.
 warning: Member STMPE811_PARAM_ADDR (macro definition) of file stmpe811_params.h is not documented.
 warning: Member STMPE811_PARAM_I2C_DEV (macro definition) of file stmpe811_params.h is not documented.
 warning: Member STMPE811_PARAM_INT_PIN (macro definition) of file stmpe811_params.h is not documented.
@@ -6458,7 +5754,6 @@ warning: Member suit_parameter_t (enumeration) of group sys_suit is not document
 warning: Member _SV(elt, list) (macro definition) of group sys_ut is not documented.
 warning: Member SX126X_PARAM_BUSY (macro definition) of file sx126x_params.h is not documented.
 warning: Member SX126X_PARAM_DIO1 (macro definition) of file sx126x_params.h is not documented.
-warning: Member SX126X_PARAM_REGULATOR (macro definition) of file sx126x_params.h is not documented.
 warning: Member SX126X_PARAM_RESET (macro definition) of file sx126x_params.h is not documented.
 warning: Member SX126X_PARAM_SET_RF_MODE_CB (macro definition) of file sx126x_params.h is not documented.
 warning: Member SX126X_PARAMS (macro definition) of file sx126x_params.h is not documented.
@@ -6511,42 +5806,26 @@ warning: Member SX127X_IQ_INVERTED_FLAG (macro definition) of group drivers_sx12
 warning: Member SX127X_LOW_DATARATE_OPTIMIZE_FLAG (macro definition) of group drivers_sx127x is not documented.
 warning: Member SX127X_PARAM_DIO0 (macro definition) of file board.h is not documented.
 warning: Member SX127X_PARAM_DIO0 (macro definition) of file sx127x_params.h is not documented.
-warning: Member SX127X_PARAM_DIO0 (macro definition) of group boards_bastwan is not documented.
-warning: Member SX127X_PARAM_DIO0 (macro definition) of group boards_samr34-xpro is not documented.
 warning: Member SX127X_PARAM_DIO1 (macro definition) of file board.h is not documented.
 warning: Member SX127X_PARAM_DIO1 (macro definition) of file sx127x_params.h is not documented.
-warning: Member SX127X_PARAM_DIO1 (macro definition) of group boards_bastwan is not documented.
-warning: Member SX127X_PARAM_DIO1 (macro definition) of group boards_samr34-xpro is not documented.
 warning: Member SX127X_PARAM_DIO2 (macro definition) of file board.h is not documented.
 warning: Member SX127X_PARAM_DIO2 (macro definition) of file sx127x_params.h is not documented.
-warning: Member SX127X_PARAM_DIO2 (macro definition) of group boards_bastwan is not documented.
-warning: Member SX127X_PARAM_DIO2 (macro definition) of group boards_samr34-xpro is not documented.
 warning: Member SX127X_PARAM_DIO3 (macro definition) of file board.h is not documented.
 warning: Member SX127X_PARAM_DIO3 (macro definition) of file sx127x_params.h is not documented.
-warning: Member SX127X_PARAM_DIO3 (macro definition) of group boards_bastwan is not documented.
-warning: Member SX127X_PARAM_DIO3 (macro definition) of group boards_samr34-xpro is not documented.
 warning: Member SX127X_PARAM_DIO4 (macro definition) of file board.h is not documented.
 warning: Member SX127X_PARAM_DIO5 (macro definition) of file board.h is not documented.
 warning: Member SX127X_PARAM_DIO_MULTI (macro definition) of file board.h is not documented.
 warning: Member SX127X_PARAM_PASELECT (macro definition) of file board.h is not documented.
 warning: Member SX127X_PARAM_PASELECT (macro definition) of file sx127x_params.h is not documented.
-warning: Member SX127X_PARAM_PASELECT (macro definition) of group boards_bastwan is not documented.
-warning: Member SX127X_PARAM_PASELECT (macro definition) of group boards_samr34-xpro is not documented.
 warning: Member SX127X_PARAM_RESET (macro definition) of file board.h is not documented.
 warning: Member SX127X_PARAM_RESET (macro definition) of file sx127x_params.h is not documented.
-warning: Member SX127X_PARAM_RESET (macro definition) of group boards_bastwan is not documented.
-warning: Member SX127X_PARAM_RESET (macro definition) of group boards_samr34-xpro is not documented.
 warning: Member SX127X_PARAM_RX_SWITCH (macro definition) of file board.h is not documented.
 warning: Member SX127X_PARAM_RX_SWITCH (macro definition) of file sx127x_params.h is not documented.
 warning: Member SX127X_PARAMS (macro definition) of file sx127x_params.h is not documented.
 warning: Member SX127X_PARAM_SPI (macro definition) of file board.h is not documented.
 warning: Member SX127X_PARAM_SPI (macro definition) of file sx127x_params.h is not documented.
-warning: Member SX127X_PARAM_SPI (macro definition) of group boards_bastwan is not documented.
-warning: Member SX127X_PARAM_SPI (macro definition) of group boards_samr34-xpro is not documented.
 warning: Member SX127X_PARAM_SPI_NSS (macro definition) of file board.h is not documented.
 warning: Member SX127X_PARAM_SPI_NSS (macro definition) of file sx127x_params.h is not documented.
-warning: Member SX127X_PARAM_SPI_NSS (macro definition) of group boards_bastwan is not documented.
-warning: Member SX127X_PARAM_SPI_NSS (macro definition) of group boards_samr34-xpro is not documented.
 warning: Member SX127X_PARAM_TX_SWITCH (macro definition) of file board.h is not documented.
 warning: Member SX127X_PARAM_TX_SWITCH (macro definition) of file sx127x_params.h is not documented.
 warning: Member SX127X_POR_ACTIVE_LOGIC_LEVEL (macro definition) of file sx127x_internal.h is not documented.
@@ -7587,44 +6866,28 @@ warning: Member SX127X_RSSI_OFFSET_LF (macro definition) of file sx127x_internal
 warning: Member SX127X_RX_CONTINUOUS_FLAG (macro definition) of group drivers_sx127x is not documented.
 warning: Member SYNC_ACCURACY (macro definition) of file board_info.h is not documented.
 warning: Member SYS32Mode (macro definition) of group cpu_arm7_common is not documented.
-warning: Member SYS_ARCH_DECL_PROTECT(x) (macro definition) of file sys_arch.h is not documented.
 warning: Member SYS_ARCH_DECL_PROTECT(x) (macro definition) of group pkg_lwip_sys is not documented.
-warning: Member SYS_ARCH_PROTECT(x) (macro definition) of file sys_arch.h is not documented.
 warning: Member SYS_ARCH_PROTECT(x) (macro definition) of group pkg_lwip_sys is not documented.
-warning: Member SYS_ARCH_UNPROTECT(x) (macro definition) of file sys_arch.h is not documented.
 warning: Member SYS_ARCH_UNPROTECT(x) (macro definition) of group pkg_lwip_sys is not documented.
 warning: Member sys_check_core_locked(void) (function) of group pkg_lwip_opts is not documented.
 warning: Member SYS_CTRL_OSC32K_USE_XTAL (macro definition) of file cfg_clk_default.h is not documented.
 warning: Member SYS_CTRL_OSC_USE_XTAL (macro definition) of file cfg_clk_default.h is not documented.
 warning: Member SYS_EINVAL (macro definition) of file os_types.h is not documented.
 warning: Member SYS_ENOMEM (macro definition) of file os_types.h is not documented.
-warning: Member sys_lock_tcpip_core(void) (function) of file sys_arch.h is not documented.
 warning: Member sys_lock_tcpip_core(void) (function) of group pkg_lwip_sys is not documented.
 warning: Member sys_mark_tcpip_thread(void) (function) of group pkg_lwip_opts is not documented.
-warning: Member sys_mbox_set_invalid(mbox) (macro definition) of file sys_arch.h is not documented.
 warning: Member sys_mbox_set_invalid(mbox) (macro definition) of group pkg_lwip_sys is not documented.
-warning: Member sys_mbox_set_invalid(sys_mbox_t *mbox) (function) of file sys_arch.h is not documented.
 warning: Member sys_mbox_set_invalid(sys_mbox_t *mbox) (function) of group pkg_lwip_sys is not documented.
-warning: Member SYS_MBOX_SIZE (macro definition) of file sys_arch.h is not documented.
 warning: Member SYS_MBOX_SIZE (macro definition) of group pkg_lwip_sys is not documented.
-warning: Member sys_mbox_valid(mbox) (macro definition) of file sys_arch.h is not documented.
 warning: Member sys_mbox_valid(mbox) (macro definition) of group pkg_lwip_sys is not documented.
-warning: Member sys_mbox_valid(sys_mbox_t *mbox) (function) of file sys_arch.h is not documented.
 warning: Member sys_mbox_valid(sys_mbox_t *mbox) (function) of group pkg_lwip_sys is not documented.
-warning: Member sys_mutex_set_invalid(mutex) (macro definition) of file sys_arch.h is not documented.
 warning: Member sys_mutex_set_invalid(mutex) (macro definition) of group pkg_lwip_sys is not documented.
-warning: Member sys_mutex_valid(mutex) (macro definition) of file sys_arch.h is not documented.
 warning: Member sys_mutex_valid(mutex) (macro definition) of group pkg_lwip_sys is not documented.
-warning: Member sys_mutex_valid(sys_mutex_t *mutex) (function) of file sys_arch.h is not documented.
 warning: Member sys_mutex_valid(sys_mutex_t *mutex) (function) of group pkg_lwip_sys is not documented.
-warning: Member sys_sem_set_invalid(sem) (macro definition) of file sys_arch.h is not documented.
 warning: Member sys_sem_set_invalid(sem) (macro definition) of group pkg_lwip_sys is not documented.
-warning: Member sys_sem_valid(sem) (macro definition) of file sys_arch.h is not documented.
 warning: Member sys_sem_valid(sem) (macro definition) of group pkg_lwip_sys is not documented.
-warning: Member sys_sem_valid(sys_sem_t *sem) (function) of file sys_arch.h is not documented.
 warning: Member sys_sem_valid(sys_sem_t *sem) (function) of group pkg_lwip_sys is not documented.
 warning: Member SYSTEM_VOLTAGE (macro definition) of file sdcard_spi_internal.h is not documented.
-warning: Member sys_unlock_tcpip_core(void) (function) of file sys_arch.h is not documented.
 warning: Member sys_unlock_tcpip_core(void) (function) of group pkg_lwip_sys is not documented.
 warning: Member SZT_F (macro definition) of group pkg_lwip_sys is not documented.
 warning: Member t0_OFFSET (macro definition) of file context_frame.h is not documented.
@@ -7651,23 +6914,16 @@ warning: Member TCS37727_PARAM_I2C (macro definition) of file board.h is not doc
 warning: Member TCS37727_PARAM_I2C (macro definition) of file tcs37727_params.h is not documented.
 warning: Member TCS37727_PARAMS (macro definition) of file tcs37727_params.h is not documented.
 warning: Member TCS37727_SAUL_INFO (macro definition) of file tcs37727_params.h is not documented.
-warning: Member TCXO_PWR_PIN (macro definition) of group boards_bastwan is not documented.
-warning: Member TCXO_PWR_PIN (macro definition) of group boards_samr34-xpro is not documented.
-warning: Member THREAD_EXTRA_STACKSIZE_PRINTF_FLOAT (macro definition) of file cpu_conf.h is not documented.
 warning: Member THREAD_EXTRA_STACKSIZE_PRINTF (macro definition) of file cpu_conf_common.h is not documented.
 warning: Member THREAD_EXTRA_STACKSIZE_PRINTF (macro definition) of file cpu_conf.h is not documented.
-warning: Member THREAD_EXTRA_STACKSIZE_PRINTF (macro definition) of group cpu_esp32_conf is not documented.
 warning: Member THREAD_EXTRA_STACKSIZE_PRINTF (macro definition) of group cpu_esp8266_conf is not documented.
 warning: Member THREAD_STACKSIZE_DEFAULT (macro definition) of file cpu_conf_common.h is not documented.
 warning: Member THREAD_STACKSIZE_DEFAULT (macro definition) of file cpu_conf.h is not documented.
-warning: Member THREAD_STACKSIZE_DEFAULT (macro definition) of group cpu_esp32_conf is not documented.
 warning: Member THREAD_STACKSIZE_DEFAULT (macro definition) of group cpu_esp8266_conf is not documented.
 warning: Member THREAD_STACKSIZE_IDLE (macro definition) of file cpu_conf_common.h is not documented.
 warning: Member THREAD_STACKSIZE_IDLE (macro definition) of file cpu_conf.h is not documented.
-warning: Member THREAD_STACKSIZE_IDLE (macro definition) of group cpu_esp32_conf is not documented.
 warning: Member THREAD_STACKSIZE_IDLE (macro definition) of group cpu_esp8266_conf is not documented.
 warning: Member THREAD_STACKSIZE_MAIN (macro definition) of group cpu_esp8266_conf is not documented.
-warning: Member THREAD_STACKSIZE_MINIMUM (macro definition) of file cpu_conf.h is not documented.
 warning: Member THREAD_STACKSIZE_SMALL (macro definition) of group cpu_esp8266_conf is not documented.
 warning: Member THREAD_STACKSIZE_TINY (macro definition) of group cpu_esp8266_conf is not documented.
 warning: Member thread_status_t (enumeration) of group core_sched is not documented.
@@ -7679,7 +6935,6 @@ warning: Member TIMER_0_DEV (macro definition) of file periph_conf.h is not docu
 warning: Member TIMER_0_FLAG (macro definition) of file default_timer_config.h is not documented.
 warning: Member TIMER_0_FREQ (macro definition) of file periph_conf.h is not documented.
 warning: Member TIMER_0_IRQ (macro definition) of file periph_conf.h is not documented.
-warning: Member TIMER_0_IRQN (macro definition) of file periph_conf.h is not documented.
 warning: Member TIMER_0_ISRA (macro definition) of file default_timer_config.h is not documented.
 warning: Member TIMER_0_ISRA (macro definition) of file periph_conf.h is not documented.
 warning: Member TIMER_0_ISRB (macro definition) of file default_timer_config.h is not documented.
@@ -7702,7 +6957,6 @@ warning: Member TIMER_0_MAX_VALUE (macro definition) of file periph_conf.h is no
 warning: Member TIMER_0_PLKSEL() (macro definition) of file periph_conf.h is not documented.
 warning: Member TIMER_1_CHANNELS (macro definition) of file periph_conf.h is not documented.
 warning: Member TIMER_1_FLAG (macro definition) of file default_timer_config.h is not documented.
-warning: Member TIMER_1_IRQN (macro definition) of file periph_conf.h is not documented.
 warning: Member TIMER_1_ISRA (macro definition) of file default_timer_config.h is not documented.
 warning: Member TIMER_1_ISRA (macro definition) of file periph_conf.h is not documented.
 warning: Member TIMER_1_ISRB (macro definition) of file default_timer_config.h is not documented.
@@ -7728,35 +6982,13 @@ warning: Member TIMER_2_ISR (macro definition) of file periph_conf.h is not docu
 warning: Member TIMER_2 (macro definition) of file default_timer_config.h is not documented.
 warning: Member TIMER_2_MASK (macro definition) of file default_timer_config.h is not documented.
 warning: Member TIMER_3_ISR (macro definition) of file cfg_timer_default.h is not documented.
-warning: Member TIMER_BASE (macro definition) of file periph_conf.h is not documented.
-warning: Member TIMER_CHAN (macro definition) of file periph_conf.h is not documented.
 warning: Member TIMER_CHANNEL_NUMOF (macro definition) of file default_timer_config.h is not documented.
 warning: Member TIMER_CHANNEL_NUMOF (macro definition) of file periph_cpu.h is not documented.
-warning: Member timer_config[] (variable) of file cfg_timer_012.h is not documented.
-warning: Member timer_config[] (variable) of file cfg_timer_01.h is not documented.
-warning: Member timer_config[] (variable) of file cfg_timer_default.h is not documented.
-warning: Member timer_config[] (variable) of file cfg_timer_tim2.h is not documented.
-warning: Member timer_config[] (variable) of file cfg_timer_tim5.h is not documented.
-warning: Member timer_config[] (variable) of file periph_conf_common.h is not documented.
-warning: Member timer_config[] (variable) of file periph_conf.h is not documented.
 warning: Member timer_div_t (enumeration) of file periph_cpu_common.h is not documented.
 warning: Member TIMER_IRQ_PRIO (macro definition) of file cfg_timer_default.h is not documented.
 warning: Member TIMER_IRQ_PRIO (macro definition) of file periph_conf.h is not documented.
-warning: Member TIMER_ISR_CC0 (macro definition) of file periph_conf.h is not documented.
-warning: Member TIMER_ISR_CCX (macro definition) of file periph_conf.h is not documented.
 warning: Member TIMER_MAX_VALUE (macro definition) of file periph_cpu.h is not documented.
-warning: Member TIMER_NUMOF (macro definition) of file cfg_timer_012.h is not documented.
-warning: Member TIMER_NUMOF (macro definition) of file cfg_timer_01.h is not documented.
-warning: Member TIMER_NUMOF (macro definition) of file cfg_timer_default.h is not documented.
-warning: Member TIMER_NUMOF (macro definition) of file cfg_timer_tim2.h is not documented.
-warning: Member TIMER_NUMOF (macro definition) of file cfg_timer_tim5.h is not documented.
-warning: Member TIMER_NUMOF (macro definition) of file default_timer_config.h is not documented.
-warning: Member TIMER_NUMOF (macro definition) of file periph_conf_common.h is not documented.
-warning: Member TIMER_NUMOF (macro definition) of file periph_conf.h is not documented.
 warning: Member tlsf_malloc_gheap (variable) of file tlsf-malloc-internal.h is not documented.
-warning: Member TMP006_PARAM_ADDR (macro definition) of group boards_hamilton is not documented.
-warning: Member TMP006_PARAM_I2C (macro definition) of group boards_hamilton is not documented.
-warning: Member TMP006_PARAM_RATE (macro definition) of group boards_hamilton is not documented.
 warning: Member TPS6274X_PARAMS (macro definition) of file tps6274x_params.h is not documented.
 warning: Member TSL2561_ADDR_FLOAT (macro definition) of group drivers_tsl2561 is not documented.
 warning: Member TSL2561_ADDR_HIGH (macro definition) of group drivers_tsl2561 is not documented.
@@ -7847,13 +7079,10 @@ warning: Member TSL4531X_PSAVESKIP_ON (macro definition) of file tsl4531x_intern
 warning: Member TSL4531X_SAUL_INFO (macro definition) of file tsl4531x_params.h is not documented.
 warning: Member TX_DS (macro definition) of file nrf24l01p_settings.h is not documented.
 warning: Member TX_FULL (macro definition) of file nrf24l01p_settings.h is not documented.
-warning: Member TX_OUTPUT_SEL_PIN (macro definition) of group boards_bastwan is not documented.
-warning: Member TX_OUTPUT_SEL_PIN (macro definition) of group boards_samr34-xpro is not documented.
 warning: Member TX_PCRCEN (macro definition) of file enc28j60_regs.h is not documented.
 warning: Member TX_PHUGEEN (macro definition) of file enc28j60_regs.h is not documented.
 warning: Member TX_POVERRIDE (macro definition) of file enc28j60_regs.h is not documented.
 warning: Member TX_PPADEN (macro definition) of file enc28j60_regs.h is not documented.
-warning: Member TX_SWITCH_PWR_PIN (macro definition) of group boards_bastwan is not documented.
 warning: Member U16_F (macro definition) of group pkg_lwip_sys is not documented.
 warning: Member u16 (typedef) of file aes.h is not documented.
 warning: Member U32_F (macro definition) of group pkg_lwip_sys is not documented.
@@ -7864,7 +7093,6 @@ warning: Member UART_0_DEV (macro definition) of file periph_conf.h is not docum
 warning: Member UART_0_DMA_ISR (macro definition) of file periph_conf.h is not documented.
 warning: Member UART_0_DRE_ISR (macro definition) of file periph_conf.h is not documented.
 warning: Member UART_0_IRQ_CHAN (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_0_IRQN (macro definition) of file periph_conf.h is not documented.
 warning: Member UART_0_ISR (macro definition) of file cfg_uart_default.h is not documented.
 warning: Member UART_0_ISR (macro definition) of file periph_conf_common.h is not documented.
 warning: Member UART_0_ISR (macro definition) of file periph_conf.h is not documented.
@@ -7895,8 +7123,6 @@ warning: Member UART_3_ISR_TX (macro definition) of file periph_conf.h is not do
 warning: Member UART_4_ISR (macro definition) of file periph_conf.h is not documented.
 warning: Member UART_6_DMA_ISR (macro definition) of file periph_conf.h is not documented.
 warning: Member UART_6_ISR (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_BASE (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_SFR (macro definition) of file periph_conf.h is not documented.
 warning: Member UARTCLKGDS_CLK_EN_UART0 (macro definition) of file cc26x0_cc13x0_prcm.h is not documented.
 warning: Member UARTCLKGDS_CLK_EN_UART0 (macro definition) of file cc26x2_cc13x2_prcm.h is not documented.
 warning: Member UARTCLKGDS_CLK_EN_UART1 (macro definition) of file cc26x2_cc13x2_prcm.h is not documented.
@@ -7907,10 +7133,6 @@ warning: Member UARTCLKGS_CLK_EN_UART0 (macro definition) of file cc26x0_cc13x0_
 warning: Member UARTCLKGS_CLK_EN_UART0 (macro definition) of file cc26x2_cc13x2_prcm.h is not documented.
 warning: Member UARTCLKGS_CLK_EN_UART1 (macro definition) of file cc26x2_cc13x2_prcm.h is not documented.
 warning: Member UART_CLK (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_CLOCK_PM_BLOCKER (macro definition) of file periph_conf.h is not documented.
-warning: Member uart_config[] (variable) of file cfg_uart_default.h is not documented.
-warning: Member uart_config[] (variable) of file periph_conf_common.h is not documented.
-warning: Member uart_config[] (variable) of file periph_conf.h is not documented.
 warning: Member UART_CTL_CTSEN (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
 warning: Member UART_CTL_LBE (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
 warning: Member UART_CTL_RTSEN (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
@@ -7932,9 +7154,6 @@ warning: Member UART_FR_RXFE (macro definition) of group cpu_cc26xx_cc13xx_defin
 warning: Member UART_FR_RXFF (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
 warning: Member UART_FR_TXFE (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
 warning: Member UART_FR_TXFF (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
-warning: Member UART_IE (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_IE_RX_BIT (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_IE_TX_BIT (macro definition) of file periph_conf.h is not documented.
 warning: Member UART_IFLS_RXSEL_1_8 (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
 warning: Member UART_IFLS_RXSEL_2_8 (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
 warning: Member UART_IFLS_RXSEL_4_8 (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
@@ -7945,7 +7164,6 @@ warning: Member UART_IFLS_TXSEL_2_8 (macro definition) of group cpu_cc26xx_cc13x
 warning: Member UART_IFLS_TXSEL_4_8 (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
 warning: Member UART_IFLS_TXSEL_6_8 (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
 warning: Member UART_IFLS_TXSEL_7_8 (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
-warning: Member UART_IF (macro definition) of file periph_conf.h is not documented.
 warning: Member UART_IMSC_BEIM (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
 warning: Member UART_IMSC_CTSMIM (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
 warning: Member UART_IMSC_FEIM (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
@@ -7965,9 +7183,6 @@ warning: Member UART_LCRH_WLEN_6 (macro definition) of group cpu_cc26xx_cc13xx_d
 warning: Member UART_LCRH_WLEN_7 (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
 warning: Member UART_LCRH_WLEN_8 (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
 warning: Member UART_LCRH_WLEN_mask (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
-warning: Member UART_MAX_UNCLOCKED_BAUDRATE (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_ME_BITS (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_ME (macro definition) of file periph_conf.h is not documented.
 warning: Member UART_MIS_BEMIS (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
 warning: Member UART_MIS_CTSMMIS (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
 warning: Member UART_MIS_FEMIS (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
@@ -7976,25 +7191,7 @@ warning: Member UART_MIS_PEMIS (macro definition) of group cpu_cc26xx_cc13xx_def
 warning: Member UART_MIS_RTMIS (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
 warning: Member UART_MIS_RXMIS (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
 warning: Member UART_MIS_TXMIS (macro definition) of group cpu_cc26xx_cc13xx_definitions is not documented.
-warning: Member UART_NUMOF (macro definition) of file cfg_uart_default.h is not documented.
-warning: Member UART_NUMOF (macro definition) of file periph_conf_common.h is not documented.
-warning: Member UART_NUMOF (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_PIN_CTS (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_PIN_RTS (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_PIN_RX (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_PIN_TX (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_PORT (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_RX_ISR (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_RX_PIN (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_RX_PORT (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_TX_ISR (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_TX_PIN (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_TX_PORT (macro definition) of file periph_conf.h is not documented.
-warning: Member UART_USE_USCI (macro definition) of file periph_conf.h is not documented.
-warning: Member UB_M_RST_PIN (macro definition) of group boards_ublox-c030-u201 is not documented.
-warning: Member UB_PWRON_PIN (macro definition) of group boards_ublox-c030-u201 is not documented.
 warning: Member ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE (macro definition) of file periph_conf.h is not documented.
-warning: Member UNLOCK_TCPIP_CORE() (macro definition) of file sys_arch.h is not documented.
 warning: Member UNLOCK_TCPIP_CORE() (macro definition) of group pkg_lwip_sys is not documented.
 warning: Member UPDATE_CCA (macro definition) of file board.h is not documented.
 warning: Member UPDATE_CCA (macro definition) of group boards_common_remote is not documented.
@@ -8115,14 +7312,9 @@ warning: Member V_PERIPH_MASK (macro definition) of file board.h is not document
 warning: Member V_PERIPH_OFF (macro definition) of file board.h is not documented.
 warning: Member V_PERIPH_ON (macro definition) of file board.h is not documented.
 warning: Member V_PERIPH_PIN (macro definition) of file board.h is not documented.
-warning: Member W5100_PARAM_CS (macro definition) of group boards_common_arduino-atmega is not documented.
-warning: Member W5100_PARAM_CS (macro definition) of group boards_common_arduino_due is not documented.
-warning: Member W5100_PARAM_EVT (macro definition) of group boards_common_arduino-atmega is not documented.
-warning: Member W5100_PARAM_EVT (macro definition) of group boards_common_arduino_due is not documented.
 warning: Member W5100_PARAMS (macro definition) of file w5100_params.h is not documented.
 warning: Member Watchdog_IRQn (macro definition) of file cpu_conf.h is not documented.
 warning: Member WDT_CLOCK_HZ (macro definition) of file periph_cpu.h is not documented.
-warning: Member WDT_HAS_INIT (macro definition) of file periph_cpu.h is not documented.
 warning: Member WDT_HAS_STOP (macro definition) of file periph_cpu.h is not documented.
 warning: Member WEACT_4X1CX_NOR_FLAGS (macro definition) of file board.h is not documented.
 warning: Member WEACT_4X1CX_NOR_PAGE_SIZE (macro definition) of file board.h is not documented.
@@ -8133,7 +7325,6 @@ warning: Member WEACT_4X1CX_NOR_SPI_DEV (macro definition) of file board.h is no
 warning: Member WEACT_4X1CX_NOR_SPI_MODE (macro definition) of file board.h is not documented.
 warning: Member WHO_AM_I_VAL (macro definition) of file lis2dh12_internal.h is not documented.
 warning: Member Wire (variable) of file wireport.hpp is not documented.
-warning: Member WS281X_T_DATA_ZERO_NS (macro definition) of file ws281x_constants.h is not documented.
 warning: Member WWDT_TIME_LOWER_LIMIT (macro definition) of file periph_cpu.h is not documented.
 warning: Member WWDT_TIME_UPPER_LIMIT (macro definition) of file periph_cpu.h is not documented.
 warning: Member X16_F (macro definition) of group pkg_lwip_sys is not documented.
@@ -8170,55 +7361,14 @@ warning: Member _xtimer_periodic_wakeup(uint32_t *last_wakeup, uint32_t period) 
 warning: Member _xtimer_set64(xtimer_t *timer, uint32_t offset, uint32_t long_offset) (function) of file implementation.h is not documented.
 warning: Member _xtimer_set_wakeup64(xtimer_t *timer, uint64_t offset, kernel_pid_t pid) (function) of file implementation.h is not documented.
 warning: Member _xtimer_set_wakeup(xtimer_t *timer, uint32_t offset, kernel_pid_t pid) (function) of file implementation.h is not documented.
-warning: Member _XTSTR(x) (macro definition) of file xtstr.h is not documented.
-warning: No output formats selected! Set at least one of the main GENERATE_* options to YES.
-warning: unable to resolve reference to 'cc1312_launchpad_flashing' for \ref command
-warning: unable to resolve reference to 'cc1312_launchpad_hardware' for \ref command
-warning: unable to resolve reference to 'cc1312_launchpad_overview' for \ref command
-warning: unable to resolve reference to 'cc1312_launchpad_pinout' for \ref command
-warning: unable to resolve reference to 'cc1350_launchpad_flashing' for \ref command
-warning: unable to resolve reference to 'cc1350_launchpad_hardware' for \ref command
-warning: unable to resolve reference to 'cc1350_launchpad_overview' for \ref command
-warning: unable to resolve reference to 'cc1350_launchpad_pinout' for \ref command
-warning: unable to resolve reference to 'cc1352_launchpad_flashing' for \ref command
-warning: unable to resolve reference to 'cc1352_launchpad_hardware' for \ref command
-warning: unable to resolve reference to 'cc1352_launchpad_moreinfo' for \ref command
-warning: unable to resolve reference to 'cc1352_launchpad_overview' for \ref command
-warning: unable to resolve reference to 'cc1352_launchpad_shell' for \ref command
-warning: unable to resolve reference to 'cc1352_launcpad_pinout' for \ref command
-warning: unable to resolve reference to 'cc1352p_launchpad_flashing' for \ref command
-warning: unable to resolve reference to 'cc1352p_launchpad_hardware' for \ref command
-warning: unable to resolve reference to 'cc1352p_launchpad_overview' for \ref command
-warning: unable to resolve reference to 'cc1352p_launcpad_pinout' for \ref command
-warning: unable to resolve reference to 'cc2650_launchpad_flashing' for \ref command
-warning: unable to resolve reference to 'cc2650_launchpad_hardware' for \ref command
-warning: unable to resolve reference to 'cc2650_launchpad_overview' for \ref command
-warning: unable to resolve reference to 'cc2650_launchpad_pinout' for \ref command
 warning: unable to resolve reference to 'cc26xx_cc13xx_ccfg' for \ref command
-warning: unable to resolve reference to 'cc26xx_cc13xx_debugging' for \ref command
-warning: unable to resolve reference to 'cc26xx_cc13xx_openocd' for \ref command
-warning: unable to resolve reference to 'cc26xx_cc13xx_overview' for \ref command
 warning: unable to resolve reference to 'cc26xx_cc13xx_uniflash' for \ref command
 warning: unable to resolve reference to 'clock_config_t::clkdiv1' for \ref command
 warning: unable to resolve reference to 'clock_config_t::clkdiv1' for \ref command
 warning: unable to resolve reference to 'clock_config_t::clkdiv1' for \ref command
 warning: unable to resolve reference to 'clock_config_t' for \ref command
 warning: unable to resolve reference to 'clock_config_t' for \ref command
-warning: unable to resolve reference to 'esp32c3_devkit_optional_hardware' for \ref command
 warning: unable to resolve reference to 'esp32_esp_qemu' for \ref command
-warning: unable to resolve reference to 'esp32_ethernet_kit_v1_1_board_configuration' for \ref command
-warning: unable to resolve reference to 'esp32_ethernet_kit_v1_1_hardware' for \ref command
-warning: unable to resolve reference to 'esp32_ethernet_kit_v1_1_other-resources' for \ref command
-warning: unable to resolve reference to 'esp32_ethernet_kit_v1_1_overview' for \ref command
-warning: unable to resolve reference to 'esp32_ethernet_kit_v1_1_pinout' for \ref command
-warning: unable to resolve reference to 'esp32_ethernet_kit_v1_1_toc' for \ref command
-warning: unable to resolve reference to 'esp32s2_devkit_optional_hardware' for \ref command
-warning: unable to resolve reference to 'esp32s3_devkit_optional_hardware' for \ref command
-warning: unable to resolve reference to 'esp32_ttgo_t_beam_optional_hardware' for \ref command
-warning: unable to resolve reference to 'nrf52840dongle_flash' for \ref command
-warning: Member USBUS_MSC_BUFFER_SIZE (macro definition) of file msc.h is not documented.
-warning: Member USBUS_MSC_EXPORTED_DEV (macro definition) of file msc.h is not documented.
-warning: Member usbus_msc_state_t (enumeration) of file msc.h is not documented.
 warning: Member USBUS_MSC_VENDOR_ID (macro definition) of file scsi.h is not documented.
 warning: Member USBUS_MSC_PRODUCT_ID (macro definition) of file scsi.h is not documented.
 warning: Member USBUS_MSC_PRODUCT_REV (macro definition) of file scsi.h is not documented.
@@ -8323,7 +7473,6 @@ warning: Member LSM6DSXX_PARAM_ACC_FIFO_DEC (macro definition) of file lsm6dsxx_
 warning: Member LSM6DSXX_PARAM_GYRO_FIFO_DEC (macro definition) of file lsm6dsxx_params.h is not documented.
 warning: Member LSM6DSXX_PARAMS (macro definition) of file lsm6dsxx_params.h is not documented.
 warning: Member LSM6DSXX_SAUL_INFO (macro definition) of file lsm6dsxx_params.h is not documented.
-RIOTDoxygenLayout.xml:8: warning: the type 'topics' is not supported for the entry tag within a navindex! Check your layout file!
 warning: Member LSM6DSL_REG_SENSOR_SYNC_TIME_FRAME (macro definition) of file lsm6dsxx_internal.h is not documented.
 warning: Member LSM6DSL_REG_SENSOR_SYC_RES_RATIO (macro definition) of file lsm6dsxx_internal.h is not documented.
 warning: Member LSM6DSL_REG_DRDY_PULSE_CFG_G (macro definition) of file lsm6dsxx_internal.h is not documented.
@@ -8360,7 +7509,6 @@ warning: Member LSM6DSL_REG_X_OFS_USR (macro definition) of file lsm6dsxx_intern
 warning: Member LSM6DSL_REG_Y_OFS_USR (macro definition) of file lsm6dsxx_internal.h is not documented.
 warning: Member LSM6DSL_REG_Z_OFS_USR (macro definition) of file lsm6dsxx_internal.h is not documented.
 warning: Member LSM6DS33_REG_ORIENT_CFG_G (macro definition) of file lsm6dsxx_internal.h is not documented.
-warning: Member AT6561_STBY_PIN (macro definition) of file board.h is not documented.
 sys/include/net/gnrc/netif/pktq.h:13: warning: Potential recursion while resolving \ref command!
 sys/include/net/gnrc/netif/pktq/type.h:9: warning: Potential recursion while resolving \ref command!
 sys/include/net/gnrc/netif/pktq/type.h:12: warning: Potential recursion while resolving \ref command!
@@ -8379,40 +7527,13 @@ boards/seeeduino_xiao/include/periph_conf.h:69: warning: Member CLOCK_DIV (macro
 boards/sensebox_samd21/include/periph_conf.h:68: warning: Member CLOCK_DIV (macro definition) of file periph_conf.h is not documented.
 boards/serpente/include/periph_conf.h:67: warning: Member CLOCK_DIV (macro definition) of file periph_conf.h is not documented.
 boards/common/sodaq/include/cfg_clock_default.h:68: warning: Member CLOCK_DIV (macro definition) of file cfg_clock_default.h is not documented.
-cpu/stm32/include/periph/cpu_eth.h:139: warning: Member TX_DESC_STAT_CIC (macro definition) of file cpu_eth.h is not documented.
-cpu/stm32/include/periph/cpu_eth.h:140: warning: Member TX_DESC_STAT_CIC_NO_HW_CHECKSUM (macro definition) of file cpu_eth.h is not documented.
-drivers/include/periph/pwm.h:77: warning: Member PWM_DEV(x) (macro definition) of group drivers_periph_pwm is not documented.
-drivers/include/periph/qdec.h:93: warning: Member QDEC_DEV(x) (macro definition) of group drivers_periph_qdec is not documented.
-drivers/include/vl6180x.h:409: warning: Member VL6180X_I2C_ADDR (macro definition) of file vl6180x.h is not documented.
-sys/posix/include/semaphore.h:44: warning: Member SEM_FAILED (macro definition) of file semaphore.h is not documented.
 sys/include/net/sock/dodtls.h:132: warning: unable to resolve reference to 'sock_dtls_create()' for \ref command
 sys/include/net/sock/dtls.h:33: warning: unable to resolve reference to 'sock_dtls_create()' for \ref command
 sys/include/net/sock/dtls.h:43: warning: unable to resolve reference to 'sock_dtls_create()' for \ref command
 sys/include/net/sock/dtls.h:264: warning: unable to resolve reference to 'sock_dtls_create()' for \ref command
 sys/include/net/sock/dtls.h:431: warning: unable to resolve reference to 'sock_dtls_close()' for \ref command
 sys/include/net/sock/dtls.h:1107: warning: unable to resolve reference to 'sock_dtls_create()' for \ref command
-sys/include/net/sock/dtls.h:894: warning: Found unexpanded alias '@experimental'. Check if number of arguments passed is correct.
-sys/include/net/sock/dtls.h:850: warning: Found unexpanded alias '@experimental'. Check if number of arguments passed is correct.
-boards/esp32c6-devkit/doc.md:44: warning: unable to resolve reference to 'esp32c6_devkit_optional_hardware' for \ref command
-boards/esp32h2-devkit/doc.md:40: warning: unable to resolve reference to 'esp32h2_devkit_optional_hardware' for \ref command
-cpu/esp8266/doc.md:600: warning: explicit link request to 'PWM_DEV(0)' could not be resolved
 sys/include/net/gnrc.h:106: warning: unable to resolve reference to 'net_gnrc_netapi::GNRC_NETAPI_MSG_TYPE_RCV' for \ref command
-drivers/include/mcp23x17.h:190: warning: explicit link request to 'mcp23x17_interrupt_context_problem' could not be resolved
-boards/msbiot/doc.md:68: warning: unable to resolve reference to 'LED0_PIN' for \ref command
-boards/msbiot/doc.md:68: warning: unable to resolve reference to 'LED1_PIN' for \ref command
-boards/msbiot/doc.md:69: warning: unable to resolve reference to 'LED0_ON' for \ref command
-boards/msbiot/doc.md:69: warning: unable to resolve reference to 'LED1_ON' for \ref command
-boards/msbiot/doc.md:72: warning: unable to resolve reference to 'LED0_ON' for \ref command
-boards/msbiot/doc.md:72: warning: unable to resolve reference to 'LED0_OFF' for \ref command
-boards/msbiot/doc.md:72: warning: unable to resolve reference to 'LED0_TOGGLE' for \ref command
-boards/msbiot/doc.md:73: warning: unable to resolve reference to 'LED1_ON' for \ref command
-boards/msbiot/doc.md:73: warning: unable to resolve reference to 'LED1_OFF' for \ref command
-boards/msbiot/doc.md:73: warning: unable to resolve reference to 'LED1_TOGGLE' for \ref command
-drivers/include/vl6180x.h:338: warning: explicit link request to 'VL6180X_I2C_ADDR' could not be resolved
-boards/esp32s2-wemos-mini/doc.md:38: warning: unable to resolve reference to 'esp32s2-wemos-mini_toc' for \ref command
-drivers/include/ph_oem.h:177: warning: unable to resolve reference to 'GPIO_IN_PU' for \ref command
-drivers/include/ph_oem.h:178: warning: unable to resolve reference to 'GPIO_IN_PD' for \ref command
-drivers/include/ph_oem.h:179: warning: unable to resolve reference to 'GPIO_IN_PD' for \ref command
 sys/include/net/gnrc/netif.h:215: warning: Potential recursion while resolving \ref command!
 sys/include/net/ieee802154_security.h:66: warning: unable to resolve reference to 'ieee802154_sec_context_t::ieee802154_sec_dev_t' for \ref command
 sys/include/net/ieee802154_security.h:80: warning: unable to resolve reference to 'ieee802154_sec_context_t::ieee802154_sec_dev_t' for \ref command


### PR DESCRIPTION
<!--The RIOT community cares a lot about code quality.-->

### Contribution description

reduce the number of warning excluded from reporting without recreating the entire file

probably a bunch of them just got fixed over time 

some of them might no longer be reported due to documentation not build 

steps to reproduce the original PR:

```
#in dist/tools/dockcheck

mv exclude_simple exclude_simple.o
sort exclude_simple.o| uniq - exclude_simple.o.u 
touch exclude_simple

./check.sh > exclude_simple.new
#remove filenames ( start print at "warning:)
sed -E -e "s#^.*(warning:)#\1#" <exclude_simple.new >exclude_simple.n

sort exclude_simple.n| uniq - exclude_simple.n.u
diff -U 0 exclude_simple.o.u exclude_simple.n > exclude_simple.diff
# next awk line was recreated using duck.ai after the original PR to replace
# the use of https://kfessel.github.io/JS-helpers/regexrunner.html
awk '/^-/ { print substr($0, 2) }' exclude_simple.diff > exclude_simple.filter 

grep -Fvf exclude_simple.filter exclude_simple.o > exclude_simple
```

### Testing procedure

lets see what the ci says since this file is mostly for ci entertainment that should be good enough 

maybe one likes to check if the documentation not build is something that plays into this

A AI review might focus on documentation not build

### Issues/PRs references

#22512 
#22327
#19240

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
