### PR TITLE
net/gnrc/ipv6_ext_opt: fix reading of non pad1 options

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/ext/opt/gnrc_ipv6_ext_opt.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/opt/gnrc_ipv6_ext_opt.c
@@ -79,6 +79,12 @@ gnrc_pktsnip_t *gnrc_ipv6_ext_opt_process(gnrc_pktsnip_t *pkt,
             /* nothing more to do */
             continue;
         }
+
+        if (offset >= hdr_len) {
+            DEBUG("gnrc_ipv6_ext_opt: option type without length byte\n");
+            goto error;
+        }
+
         opt_len = opts[offset++];
         if (opt_len > (hdr_len - offset)) {
             DEBUG("gnrc_ipv6_ext_opt: invalid option size\n");


### PR DESCRIPTION
Co-authored-by: @SilentSobs

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hej hej :zebra: 

fixes a bug where a length check was missing. 
Reported by @SilentSobs


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

https://github.com/RIOT-OS/RIOT/security/advisories/GHSA-6hr2-r32q-5wpq

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
