### PR TITLE
sys/nanocoap: fix handling blockwise transfer

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -18,6 +18,10 @@
  *
  */
 
+#include <stdbool.h>
+
+#include "bitarithm.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -622,7 +626,7 @@ typedef enum {
 /** @} */
 
 /**
- * @brief Coap block-wise-transfer size SZX
+ * @brief CoAP block-wise-transfer size SZX
  */
 typedef enum {
     COAP_BLOCKSIZE_16 = 0,
@@ -633,6 +637,70 @@ typedef enum {
     COAP_BLOCKSIZE_512,
     COAP_BLOCKSIZE_1024,
 } coap_blksize_t;
+
+/**
+ * @brief   Convert a @ref coap_blksize_t constant to a size in bytes without
+ *          error checking
+ *
+ * @param[in]   szx     Constant to convert
+ *
+ * @return      The number of bytes that constant encodes.
+ *
+ * From [RFC7959](https://www.rfc-editor.org/info/rfc7959/#section-2.2):
+ *
+ * > The block size is represented as a three-bit
+ * > unsigned integer indicating the size of a block to the power of
+ * > two.  Thus, block size = 2**(SZX + 4).
+ */
+#define COAP_SZX2SIZE(szx) \
+    (1U << (4U + (szx)))
+
+/**
+ * @brief   Convert a @ref coap_blksize_t constant to a size in bytes
+ *
+ * @param[in]   szx     Constant to convert
+ *
+ * @return      The number of bytes that constant encodes.
+ * @retval      0       @p szx was invalid
+ *
+ * Example usage:
+ * ```c
+ * assert(coap_blksize_to_bytes(COAP_BLOCKSIZE_128) == 128);
+ * ```
+ */
+static inline unsigned coap_szx2size(coap_blksize_t szx)
+{
+    if ((unsigned)szx > (unsigned)COAP_BLOCKSIZE_1024) {
+        return 0;
+    }
+
+    return COAP_SZX2SIZE(szx);
+}
+
+/**
+ * @brief   Get the closest blocksize enum for given size
+ *
+ * @param[in]   size    Target size in bytes
+ *
+ * @warning If @p size is smaller than 16, `COAP_BLOCKSIZE_16` is returned
+ *          as there is no smaller blocksize than that.
+ *
+ * @return  The largest blocksize fitting into @p size bytes
+ * @retval  COAP_BLOCKSIZE_16       @p size was smaller than 32
+ * @retval  COAP_BLOCKSIZE_1024     @p size was at least 1024
+ */
+static inline coap_blksize_t coap_size2szx(unsigned size)
+{
+    if (size < 32) {
+        return COAP_BLOCKSIZE_16;
+    }
+
+    if (size >= 1024) {
+        return COAP_BLOCKSIZE_1024;
+    }
+
+    return bitarithm_msb(size >> 4);
+}
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -619,10 +619,11 @@ typedef enum {
  * @name Blockwise transfer (RFC7959)
  * @{
  */
-#define COAP_BLOCKWISE_NUM_OFF  (4)
-#define COAP_BLOCKWISE_MORE_OFF (3)
-#define COAP_BLOCKWISE_SZX_MASK (0x07)
-#define COAP_BLOCKWISE_SZX_MAX  (7)
+#define COAP_BLOCKWISE_NUM_OFF  (4)         /**< offset of the NUM field in bits */
+#define COAP_BLOCKWISE_NUM_MAX  (0xfffffU)  /**< highest possible block number (20 bits) */
+#define COAP_BLOCKWISE_MORE_OFF (3)         /**< offset of the more field in bits */
+#define COAP_BLOCKWISE_SZX_MASK (0x07)      /**< bitmask to get the SZX field */
+#define COAP_BLOCKWISE_SZX_MAX  (7)         /**< largest valid SZX value */
 /** @} */
 
 /**

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -128,7 +128,7 @@ extern "C" {
  */
 /** @brief   Maximum number of Options in a message */
 #ifndef CONFIG_NANOCOAP_NOPTS_MAX
-#define CONFIG_NANOCOAP_NOPTS_MAX          (16)
+#  define CONFIG_NANOCOAP_NOPTS_MAX             (16)
 #endif
 
 /**
@@ -136,26 +136,26 @@ extern "C" {
  *           a message
  */
 #ifndef CONFIG_NANOCOAP_URI_MAX
-#define CONFIG_NANOCOAP_URI_MAX            (64)
+#  define CONFIG_NANOCOAP_URI_MAX               (64)
 #endif
 
 /**
  * @brief    Maximum size for a blockwise transfer as a power of 2
  */
-#ifndef CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX
-#define CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX  (6)
+#ifndef CONFIG_NANOCOAP_BLOCK_SIZE_MAX
+#  define CONFIG_NANOCOAP_BLOCK_SIZE_MAX        COAP_BLOCKSIZE_64
 #endif
 
 /**
  * @brief CoAP block-wise-transfer size that should be used by default
  */
 #ifndef CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT
-#define CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT  COAP_BLOCKSIZE_64
+#  define CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT     COAP_BLOCKSIZE_64
 #endif
 
 /** @brief   Maximum length of a query string written to a message */
 #ifndef CONFIG_NANOCOAP_QS_MAX
-#define CONFIG_NANOCOAP_QS_MAX             (64)
+#  define CONFIG_NANOCOAP_QS_MAX                (64)
 #endif
 /** @} */
 
@@ -165,7 +165,7 @@ extern "C" {
  *           Value obtained experimentally when using SUIT
  */
 #ifndef CONFIG_NANOCOAP_BLOCK_HEADER_MAX
-#define CONFIG_NANOCOAP_BLOCK_HEADER_MAX   (80)
+#  define CONFIG_NANOCOAP_BLOCK_HEADER_MAX      (80)
 #endif
 
 /**
@@ -1193,7 +1193,7 @@ static inline ssize_t coap_get_proxy_uri(coap_pkt_t *pkt, char **target)
  * @param[in]    blknum     offset from the beginning of content, in terms of
                             @p blksize byte blocks
  * @param[in]    blksize    size of each block; must be a power of 2 between 16
- *                          and 2 raised to #CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX
+ *                          and `coap_szx2size(CONFIG_NANOCOAP_BLOCK_SIZE_MAX)`
  * @param[in]    more       more blocks? use 1 if yes; 0 if no or unknown
  */
 void coap_block_object_init(coap_block1_t *block, size_t blknum, size_t blksize,
@@ -1275,7 +1275,7 @@ int coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer);
  * @param[in]    blknum     offset from the beginning of content, in terms of
                             @p blksize byte blocks
  * @param[in]    blksize    size of each block; must be a power of 2 between 16
- *                          and 2 raised to #CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX
+ *                          `coap_szx2size(CONFIG_NANOCOAP_BLOCK_SIZE_MAX)`
  * @retval       0          Success
  * @retval       -EINVAL    @p blknum and/or @p blksize are invalid, e.g.
  *                          because they point outside the addressable RAM

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1448,28 +1448,6 @@ int coap_get_blockopt(coap_pkt_t *pkt, uint16_t option, uint32_t *blknum, uint8_
  * @returns false if there are no critical options, or all have been accessed.
  */
 bool coap_has_unprocessed_critical_options(const coap_pkt_t *pkt);
-
-/**
- * @brief   Helper to decode SZX value to size in bytes
- *
- * @param[in]   szx     SZX value to decode
- *
- * @returns     SZX value decoded to bytes
- */
-#define coap_szx2size(szx) (1U << ((szx) + 4))
-
-/**
- * @brief   Helper to encode byte size into next equal or smaller SZX value
- *
- * @param[in]   len     Size in bytes
- *
- * @returns     closest SZX value that fits into a buffer of @p len
- */
-static inline unsigned coap_size2szx(unsigned len)
-{
-    assert(len >= 16);
-    return bitarithm_msb(len >> 4);
-}
 /**@}*/
 
 /**

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -136,13 +136,15 @@
 #include <stdint.h>
 #include <unistd.h>
 
-#include "random.h"
+#include "event/thread.h"
 #include "net/nanocoap.h"
 #include "net/sock/udp.h"
 #include "net/sock/util.h"
+#include "random.h"
+
 #if IS_USED(MODULE_NANOCOAP_DTLS)
-#include "net/credman.h"
-#include "net/sock/dtls.h"
+#  include "net/credman.h"
+#  include "net/sock/dtls.h"
 #endif
 
 #ifdef __cplusplus
@@ -913,8 +915,8 @@ int nanocoap_sock_get_blockwise(nanocoap_sock_t *sock, const char *path,
  * @param[in]   dst        Target buffer
  * @param[in]   len        Target buffer length
  *
- * @returns     <0 on error
- * @returns     -EINVAL    if an invalid url is provided
+ * @retval      <0         error
+ * @retval      -EINVAL    if an invalid url is provided or @p blksize is invalid
  * @returns     size of the response payload on success
  */
 int nanocoap_sock_get_slice(nanocoap_sock_t *sock, const char *path,

--- a/sys/net/application_layer/nanocoap/fileserver.c
+++ b/sys/net/application_layer/nanocoap/fileserver.c
@@ -212,7 +212,7 @@ static ssize_t _get_file(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     int err;
     uint32_t etag, size_total;
 
-    coap_block1_t block2 = { .szx = CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX };
+    coap_block1_t block2 = { .szx = CONFIG_NANOCOAP_BLOCK_SIZE_MAX };
     {
         struct stat stat;
         if ((err = vfs_stat(request->namebuf, &stat)) < 0) {
@@ -473,7 +473,7 @@ static ssize_t _get_directory(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     int err;
     vfs_DIR dir;
     coap_block_slicer_t slicer;
-    coap_block1_t block2 = { .szx = CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX };
+    coap_block1_t block2 = { .szx = CONFIG_NANOCOAP_BLOCK_SIZE_MAX };
     if (request->options.exists.block2 && !coap_get_block2(pdu, &block2)) {
         return _error_handler(pdu, buf, len, COAP_OPT_FINISH_NONE);
     }

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -1555,14 +1555,23 @@ int coap_block_slicer_init(coap_block_slicer_t *slicer, size_t blknum,
 int coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer)
 {
     uint32_t blknum = 0;
-    uint8_t szx = CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX - 4;
+    const uint8_t szx_default = CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX - 4;
+    uint8_t szx = szx_default;
 
     /* Retrieve the block2 option from the client request */
     if (coap_get_blockopt(pkt, COAP_OPT_BLOCK2, &blknum, &szx) >= 0) {
-        /* Use the client requested block size if it is smaller than our own
-         * maximum block size */
-        if (CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX - 4 < szx) {
-            szx = CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX - 4;
+        /* If the client's requested block size is not acceptable (too large),
+         * we go with the maximum we are willing to do and recompute the
+         * block number to stay at the same offset. */
+        if (szx > szx_default) {
+            unsigned shift = szx - szx_default;
+            szx = szx_default;
+            uint64_t tmp = blknum;
+            tmp <<= shift;
+            if (tmp > COAP_BLOCKWISE_NUM_MAX) {
+                return -EBADMSG;
+            }
+            blknum = tmp;
         }
     }
 

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -1555,17 +1555,16 @@ int coap_block_slicer_init(coap_block_slicer_t *slicer, size_t blknum,
 int coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer)
 {
     uint32_t blknum = 0;
-    const uint8_t szx_default = CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX - 4;
-    uint8_t szx = szx_default;
+    uint8_t szx = CONFIG_NANOCOAP_BLOCK_SIZE_MAX;
 
     /* Retrieve the block2 option from the client request */
     if (coap_get_blockopt(pkt, COAP_OPT_BLOCK2, &blknum, &szx) >= 0) {
         /* If the client's requested block size is not acceptable (too large),
          * we go with the maximum we are willing to do and recompute the
          * block number to stay at the same offset. */
-        if (szx > szx_default) {
-            unsigned shift = szx - szx_default;
-            szx = szx_default;
+        if (szx > CONFIG_NANOCOAP_BLOCK_SIZE_MAX) {
+            unsigned shift = szx - CONFIG_NANOCOAP_BLOCK_SIZE_MAX;
+            szx = CONFIG_NANOCOAP_BLOCK_SIZE_MAX;
             uint64_t tmp = blknum;
             tmp <<= shift;
             if (tmp > COAP_BLOCKWISE_NUM_MAX) {

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -21,23 +21,22 @@
  * @}
  */
 
-#include <errno.h>
+#include <errno.h> /* IWYU pragma: keep (exports EINVAL, ...) */
 #include <string.h>
 #include <stdio.h>
 
-#include "container.h"
-#include "event/thread.h"
 #include "net/credman.h"
 #include "net/nanocoap.h"
 #include "net/nanocoap_sock.h"
-#ifdef MODULE_SOCK_ASYNC_EVENT
-#include "net/sock/async/event.h"
-#endif
 #include "net/sock/udp.h"
 #include "net/sock/util.h"
 #include "random.h"
 #include "sys/uio.h" /* IWYU pragma: keep (exports struct iovec) */
 #include "ztimer.h"
+
+#ifdef MODULE_SOCK_ASYNC_EVENT
+#  include "net/sock/async/event.h"
+#endif
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
@@ -66,8 +65,9 @@ enum {
 typedef struct {
     coap_blockwise_cb_t callback;
     void *arg;
-    uint32_t blknum;
+    uint32_t offset;
     bool more;
+    coap_blksize_t blocksize;
 #if CONFIG_NANOCOAP_SOCK_BLOCK_TOKEN
     uint8_t token[4];
 #endif
@@ -584,7 +584,7 @@ ssize_t nanocoap_sock_unobserve_url(const char *url, coap_observe_client_t *ctx)
 }
 #endif /* MODULE_NANOCOAP_SOCK_OBSERVE */
 
-ssize_t _sock_put_post(nanocoap_sock_t *sock, const char *path, unsigned code,
+static ssize_t _sock_put_post(nanocoap_sock_t *sock, const char *path, unsigned code,
                        uint8_t type, const void *request, size_t len,
                        void *response, size_t max_len)
 {
@@ -788,28 +788,45 @@ static int _block_cb(void *arg, coap_pkt_t *pkt)
 
     /* response was not block-wise */
     if (!coap_get_block2(pkt, &block2)) {
-        block2.offset = 0;
-        block2.more = false;
+        block2 = (coap_block1_t){ .offset = 0 };
     }
 
     DEBUG("nanocoap: got block %"PRIu32" (offset %u)\n",
           block2.blknum, (unsigned)block2.offset);
 
-    if (block2.blknum != ctx->blknum) {
+    if (block2.szx > ctx->blocksize) {
+        /* The server MUST not answer with larger blocks than requested, it MAY
+         * only reply with blocks smaller than requested. The client may have
+         * selected blocksize to fit some buffer and we don't want to overflow
+         * it */
+        return -EBADMSG;
+    }
+    ctx->blocksize = block2.szx;
+
+    if (block2.offset != ctx->offset) {
         return -EAGAIN;
     }
 
     ctx->more = block2.more;
+    ctx->offset += coap_szx2size(block2.szx);
     return ctx->callback(ctx->arg, block2.offset, pkt->payload, pkt->payload_len, block2.more);
 }
 
 static int _fetch_block(nanocoap_sock_t *sock,
-                        const char *path, coap_blksize_t blksize,
-                        _block_ctx_t *ctx)
+                        const char *path,_block_ctx_t *ctx)
 {
 
     void *token = NULL;
     size_t token_len = 0;
+
+    if ((unsigned)ctx->blocksize > COAP_BLOCKSIZE_1024) {
+        assert(0);
+        return -EINVAL;
+    }
+
+    if (!ctx->more) {
+        return -ENODATA;
+    }
 
 #if CONFIG_NANOCOAP_SOCK_BLOCK_TOKEN
     /* HACK: Older versions of go-coap always expected a token
@@ -829,7 +846,8 @@ static int _fetch_block(nanocoap_sock_t *sock,
     }
 
     coap_opt_put_uri_pathquery(&state, path);
-    coap_opt_put_uint(&state, COAP_OPT_BLOCK2, (ctx->blknum << 4) | blksize);
+    uint32_t blocknum = ctx->offset >> ((unsigned)ctx->blocksize + 4);
+    coap_opt_put_uint(&state, COAP_OPT_BLOCK2, (blocknum << 4) | ctx->blocksize);
 
     if (coap_builder_has_overflown(&state)) {
         return -EOVERFLOW;
@@ -900,6 +918,7 @@ int nanocoap_sock_get_blockwise(nanocoap_sock_t *sock, const char *path,
         .callback = callback,
         .arg = arg,
         .more = true,
+        .blocksize = blksize,
     };
 
 #if CONFIG_NANOCOAP_SOCK_BLOCK_TOKEN
@@ -908,9 +927,9 @@ int nanocoap_sock_get_blockwise(nanocoap_sock_t *sock, const char *path,
 
     uint8_t retries = CONFIG_COAP_MAX_RETRANSMIT;
     while (ctx.more) {
-        DEBUG("nanocoap: fetching block %"PRIu32"\n", ctx.blknum);
+        DEBUG("nanocoap: fetching block at offset %" PRIu32 "\n", ctx.offset);
 
-        int res = _fetch_block(sock, path, blksize, &ctx);
+        int res = _fetch_block(sock, path, &ctx);
         if (res == -EAGAIN) {
             if (--retries) {
                 continue;
@@ -918,11 +937,11 @@ int nanocoap_sock_get_blockwise(nanocoap_sock_t *sock, const char *path,
             res = -EBADMSG;
         }
         if (res < 0) {
-            DEBUG("nanocoap: error fetching block %"PRIu32": %d\n", ctx.blknum, res);
+            DEBUG("nanocoap: error fetching block at offset %" PRIu32 ": %d\n",
+                  ctx.offset, res);
             return res;
         }
 
-        ctx.blknum += 1;
         retries = CONFIG_COAP_MAX_RETRANSMIT;
     }
 
@@ -938,13 +957,14 @@ typedef struct {
 
 static int _2buf_slice(void *arg, size_t offset, uint8_t *buf, size_t len, int more)
 {
+    (void)more;
     _buf_slice_t *ctx = arg;
 
     if (offset + len < ctx->offset) {
         return 0;
     }
 
-    if (offset > ctx->offset + ctx->len) {
+    if (offset > ctx->offset) {
         return 0;
     }
 
@@ -965,10 +985,6 @@ static int _2buf_slice(void *arg, size_t offset, uint8_t *buf, size_t len, int m
     DEBUG("nanocoap: got %"PRIuSIZE" bytes, %"PRIuSIZE" bytes left (offset: %"PRIuSIZE")\n",
           len, ctx->len, offset);
 
-    if (!more) {
-        ctx->len = 0;
-    }
-
     return 0;
 }
 
@@ -987,9 +1003,18 @@ int nanocoap_sock_get_slice(nanocoap_sock_t *sock, const char *path,
                             coap_blksize_t blksize, size_t offset,
                             void *dst, size_t len)
 {
+    /* On 8-bit and 16-bit,adding to 16-bit size_t numbers will never be
+     * beyond UINT32_MAX. The compiler does also detect this, but it sadly barks
+     * when it does detect this. */
+#if SIZE_MAX >= UINT32_MAX
+    if ((offset >= UINT32_MAX) || (len > UINT32_MAX - offset)) {
+        return -EOVERFLOW;
+    }
+#endif
+
     /* try to find optimal blocksize */
     unsigned num_blocks = _num_blks(offset, len, blksize);
-    for (uint8_t szx = 0; szx < blksize; ++szx) {
+    for (uint8_t szx = 0; szx < (uint8_t)blksize; ++szx) {
         if (_num_blks(offset, len, szx) <= num_blocks) {
             blksize = szx;
             break;
@@ -1000,13 +1025,17 @@ int nanocoap_sock_get_slice(nanocoap_sock_t *sock, const char *path,
         .ptr = dst,
         .len = len,
         .offset = offset,
+        .res = 0,
     };
 
     _block_ctx_t ctx = {
         .callback = _2buf_slice,
         .arg = &dst_ctx,
-        .blknum = offset >> (blksize + 4),
+        /* rounding down to the start of the first block containing (parts) of
+         * the target slice */
+        .offset = offset & ~((uint32_t)coap_szx2size(blksize) - 1),
         .more = true,
+        .blocksize = blksize,
     };
 
 #if CONFIG_NANOCOAP_SOCK_BLOCK_TOKEN
@@ -1014,10 +1043,10 @@ int nanocoap_sock_get_slice(nanocoap_sock_t *sock, const char *path,
 #endif
 
     uint8_t retries = CONFIG_COAP_MAX_RETRANSMIT;
-    while (dst_ctx.len) {
-        DEBUG("nanocoap: fetching block %"PRIu32"\n", ctx.blknum);
+    while (ctx.more && (dst_ctx.len > 0)) {
+        DEBUG("nanocoap: fetching block at offset %" PRIu32 "\n", ctx.offset);
 
-        int res = _fetch_block(sock, path, blksize, &ctx);
+        int res = _fetch_block(sock, path, &ctx);
         if (res == -EAGAIN) {
             if (--retries) {
                 continue;
@@ -1025,11 +1054,11 @@ int nanocoap_sock_get_slice(nanocoap_sock_t *sock, const char *path,
             res = -EBADMSG;
         }
         if (res < 0) {
-            DEBUG("nanocoap: error fetching block %"PRIu32": %d\n", ctx.blknum, res);
+            DEBUG("nanocoap: error fetching block at offset %" PRIu32 ": %d\n",
+                  ctx.offset, res);
             return res;
         }
 
-        ctx.blknum += 1;
         retries = CONFIG_COAP_MAX_RETRANSMIT;
     }
 

--- a/sys/shell/cmds/nanocoap_vfs.c
+++ b/sys/shell/cmds/nanocoap_vfs.c
@@ -161,7 +161,7 @@ static int _nanocoap_put_handler(int argc, char **argv)
 {
     int res;
     char *file, *url;
-    static char work_buf[coap_szx2size(CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT) + 1];
+    static char work_buf[COAP_SZX2SIZE(CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT) + 1];
 
     if (argc < 3) {
         printf("Usage: %s <file> <url>\n", argv[0]);

--- a/tests/net/nanocoap_cli/Makefile
+++ b/tests/net/nanocoap_cli/Makefile
@@ -39,6 +39,7 @@ endif
 USEMODULE += nanocoap_sock
 USEMODULE += nanocoap_resources
 USEMODULE += fmt # scn_buf_hex() for shell cmd client_token
+USEMODULE += tiny_strerror
 
 # boards where basic nanocoap functionality fits, but no VFS
 LOW_MEMORY_BOARDS := \

--- a/tests/net/nanocoap_cli/Makefile.ci
+++ b/tests/net/nanocoap_cli/Makefile.ci
@@ -1,4 +1,5 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    airfy-beacon \
     arduino-duemilanove \
     arduino-leonardo \
     arduino-mega2560 \
@@ -10,13 +11,16 @@ BOARD_INSUFFICIENT_MEMORY := \
     atxmega-a1-xplained \
     atxmega-a1u-xpro \
     bluepill-stm32f030c8 \
+    calliope-mini \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \
     mega-xplained \
+    microbit \
     microduino-corerf \
     msb-430 \
     msb-430h \
+    nrf51dongle \
     nucleo-c031c6 \
     nucleo-f030r8 \
     nucleo-f031k6 \
@@ -41,6 +45,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32l0538-disco \
     telosb \
     weact-g030f6 \
+    yunjia-nrf51822 \
     z1 \
     zigduino \
     #

--- a/tests/net/nanocoap_cli/nanocli_client.c
+++ b/tests/net/nanocoap_cli/nanocli_client.c
@@ -364,7 +364,7 @@ static int _cmd_get_non(int argc, char **argv)
 {
     int res;
 
-    uint8_t response[coap_szx2size(CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT)];
+    uint8_t response[COAP_SZX2SIZE(CONFIG_NANOCOAP_BLOCKSIZE_DEFAULT)];
 
     if (argc < 2) {
         printf("usage: %s <url>\n", argv[0]);

--- a/tests/net/nanocoap_cli/nanocli_client.c
+++ b/tests/net/nanocoap_cli/nanocli_client.c
@@ -31,6 +31,7 @@
 #include "net/sock/util.h"
 #include "od.h"
 #include "shell.h"
+#include "tiny_strerror.h"
 
 #ifdef MODULE_GNRC_IPV6
 static ssize_t _send(coap_pkt_t *pkt, size_t len,
@@ -84,12 +85,12 @@ static ssize_t _send(coap_pkt_t *pkt, size_t len,
 
 static uint8_t _client_token[COAP_TOKEN_LENGTH_MAX] = { 0xDA, 0xEC };
 static uint8_t _client_token_len = 2;
+static uint8_t _client_buf[512];
 
 static int _cmd_client(int argc, char **argv)
 {
     /* Ordered like the RFC method code numbers, but off by 1. GET is code 0. */
     const char *method_codes[] = {"get", "post", "put"};
-    uint8_t buf[128];
     coap_pkt_t pkt;
     size_t len;
 
@@ -108,14 +109,14 @@ static int _cmd_client(int argc, char **argv)
         goto end;
     }
 
-    pkt.buf = buf;
+    pkt.buf = _client_buf;
 
     /* parse options */
     if (argc == 5 || argc == 6) {
-        ssize_t hdrlen = coap_build_udp_hdr(buf, sizeof(buf), COAP_TYPE_CON,
+        ssize_t hdrlen = coap_build_udp_hdr(_client_buf, sizeof(_client_buf), COAP_TYPE_CON,
                                             _client_token, _client_token_len,
                                             code_pos + 1, 1);
-        coap_pkt_init(&pkt, &buf[0], sizeof(buf), hdrlen);
+        coap_pkt_init(&pkt, &_client_buf[0], sizeof(_client_buf), hdrlen);
         coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, argv[4], '/');
         if (argc == 6) {
             coap_opt_add_uint(&pkt, COAP_OPT_CONTENT_FORMAT, COAP_FORMAT_TEXT);
@@ -132,7 +133,7 @@ static int _cmd_client(int argc, char **argv)
         printf("nanocli: sending msg ID %u, %" PRIuSIZE " bytes\n", coap_get_id(&pkt),
                len);
 
-        ssize_t res = _send(&pkt, sizeof(buf), argv[2], argv[3]);
+        ssize_t res = _send(&pkt, sizeof(_client_buf), argv[2], argv[3]);
         if (res < 0) {
             printf("nanocli: msg send failed: %" PRIdSIZE "\n", res);
         }
@@ -435,3 +436,69 @@ static int _cmd_observe(int argc, char **argv)
 }
 SHELL_COMMAND(observe, "observe URL", _cmd_observe);
 #endif /* MODULE_NANOCOAP_SOCK_OBSERVE */
+
+static int _cmd_get_slice(int argc, char **argv)
+{
+    if ((argc < 3) || (argc > 5)) {
+        printf("Usage: %s <URI> <LEN_BYTE> [OFFSET_BYTE] [BLOCK_SIZE_BYTE]\n",
+               argv[0]);
+        return 1;
+    }
+
+    size_t len = atoi(argv[2]);
+    if (len > sizeof(_client_buf)) {
+        printf("LEN_BYTE must be <= %u\n", (unsigned)sizeof(_client_buf));
+        return 1;
+    }
+    size_t offset = 0;
+    size_t blocksize = 64;
+    coap_blksize_t szx = COAP_BLOCKSIZE_64;
+    if (argc >= 4) {
+        offset = atoi(argv[3]);
+    }
+
+    if (argc >= 5) {
+        blocksize = atoi(argv[4]);
+        szx = coap_size2szx(blocksize);
+        if (blocksize != coap_szx2size(szx)) {
+            printf("Blocksize \"%s\" invalid. Use a power of two with "
+                "16 <= blocksize <= 1024.\n",
+                argv[4]);
+            return 1;
+        }
+    }
+
+
+    nanocoap_sock_t sock;
+    int res = nanocoap_sock_url_connect(argv[1], &sock);
+    if (res) {
+        printf("nanocoap_sock_url_connect(\"%s\", &sock): %s\n",
+               argv[1], tiny_strerror(res));
+        return 1;
+    }
+
+    const char *path = sock_urlpath(argv[1]);
+
+    res = nanocoap_sock_get_slice(&sock, path, szx, offset, _client_buf,
+                                  len);
+    nanocoap_sock_close(&sock);
+
+    if (res < 0) {
+        printf("nanocoap_sock_get_slice(&sock, \"%s\", %u, %u, buf, %u): %s\n",
+               path, (unsigned)blocksize, (unsigned)offset, (unsigned)len,
+               tiny_strerror(res));
+        return 1;
+    }
+
+    assert((size_t)res <= len);
+    if (res == 0) {
+        puts("No data received (requested slice behind payload)");
+        return 0;
+    }
+
+    od_hex_dump(_client_buf, res, 0);
+
+    return 0;
+}
+
+SHELL_COMMAND(get_slice, "GET-Request with given range", _cmd_get_slice);

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -1365,7 +1365,36 @@ static void test_nanocoap__coap_build_reply_header(void)
     TEST_ASSERT(0 == memcmp(response, response_expected, response_expected_hdr_len));
 }
 
-Test *tests_nanocoap_tests(void)
+/* Test if coap_szx2size() and coap_size2szx() */
+static void test_nanocoap__coap_szx2size(void)
+{
+    struct {
+        coap_blksize_t szx;
+        unsigned bytes;
+    } expected[] = {
+        { COAP_BLOCKSIZE_16, 16 },
+        { COAP_BLOCKSIZE_32, 32 },
+        { COAP_BLOCKSIZE_64, 64 },
+        { COAP_BLOCKSIZE_128, 128 },
+        { COAP_BLOCKSIZE_256, 256 },
+        { COAP_BLOCKSIZE_512, 512 },
+        { COAP_BLOCKSIZE_1024, 1024 },
+    };
+
+    for (size_t i = 0; i < ARRAY_SIZE(expected); i++) {
+        TEST_ASSERT_EQUAL_INT(expected[i].bytes, coap_szx2size(expected[i].szx));
+        TEST_ASSERT_EQUAL_INT(expected[i].szx, coap_size2szx(expected[i].bytes));
+    }
+
+    /* smaller than 16 --> COAP_BLOCKSIZE_16 */
+    TEST_ASSERT_EQUAL_INT(COAP_BLOCKSIZE_16, coap_size2szx(3));
+    /* larger than 1024 --> COAP_BLOCKSIZE_1024 */
+    TEST_ASSERT_EQUAL_INT(COAP_BLOCKSIZE_1024, coap_size2szx(4096));
+    /* no power of two is rounded down */
+    TEST_ASSERT_EQUAL_INT(COAP_BLOCKSIZE_32, coap_size2szx(63));
+}
+
+static Test *tests_nanocoap_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_nanocoap__hdr),
@@ -1406,6 +1435,7 @@ Test *tests_nanocoap_tests(void)
         new_TestFixture(test_nanocoap___rst_message),
         new_TestFixture(test_nanocoap__out_of_bounds_option),
         new_TestFixture(test_nanocoap__coap_build_reply_header),
+        new_TestFixture(test_nanocoap__coap_szx2size),
     };
 
     EMB_UNIT_TESTCALLER(nanocoap_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description

- the code was written under the assumption that server never replies with an SZX different to what was requested. But e.g. the nanocoap server does just that for e.g. a blocksize of 512 B.
- the nanocoap server, when dialing down the blocksize, did not recompute the block number to stay at the same position as requested. This adds the recomputation

### Testing procedure

With the new `get_slice` shell command in `tests/net/nanocoap_cli`, one can easily test the functionality. I used `tshark` with this https://gitlab.com/wireshark/wireshark/-/merge_requests/25979 applied.

#### client and server from master

(But with the first two commits of this PR, so that the new `get_slice` command is available.)

```console
> get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 256 128 128
2026-07-29 18:31:57,789 # get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 256 128 128
2026-07-29 18:31:57,792 # No data received (requested slice behind payload)
```

```console
$ ./tshark -i tap0 -Y 'coap'
Capturing on 'tap0'
    1 0.000000000 fe80::24de:d0ff:fe85:bdb2 64635 5683 fe80::9826:30ff:feb8:31f4 CoAP 85 CON, MID:51609, GET, Bock2: 1/0/128, /.well-known/core
    2 0.000677098 fe80::9826:30ff:feb8:31f4 5683 64635 fe80::24de:d0ff:fe85:bdb2 CoAP 112 ACK, MID:51609, 2.05 Content, Bock2: 1/0/64, /.well-known/core
    3 0.001409109 fe80::24de:d0ff:fe85:bdb2 64635 5683 fe80::9826:30ff:feb8:31f4 CoAP 85 CON, MID:51610, GET, Bock2: 2/0/128, /.well-known/core
    4 0.001787187 fe80::9826:30ff:feb8:31f4 5683 64635 fe80::24de:d0ff:fe85:bdb2 CoAP 71 ACK, MID:51610, 2.05 Content, Bock2: 2/0/64, /.well-known/core
```

Note that the client iterates in steps of 128 byte, the server in steps of 64 byte, and nobody notices the mismatch in block sizes. They just happily march on without ever noticing the misalignment.

#### Client from this PR, server from `master`

```console
> get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 256 128 128
2026-07-29 18:44:55,039 # get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 256 128 128
2026-07-29 18:44:55,043 # No data received (requested slice behind payload)
```

```console
$ ./tshark -i tap0 -Y 'coap'
Capturing on 'tap0'
    4 0.172713020 fe80::24de:d0ff:fe85:bdb2 60987 5683 fe80::9826:30ff:feb8:31f4 CoAP 85 CON, MID:3850, GET, Bock2: 1/0/128, /.well-known/core
    5 0.173160990 fe80::9826:30ff:feb8:31f4 5683 60987 fe80::24de:d0ff:fe85:bdb2 CoAP 112 ACK, MID:3850, 2.05 Content, Bock2: 1/0/64, /.well-known/core
    6 0.173748192 fe80::24de:d0ff:fe85:bdb2 60987 5683 fe80::9826:30ff:feb8:31f4 CoAP 85 CON, MID:3851, GET, Bock2: 2/0/64, /.well-known/core
    7 0.174238482 fe80::9826:30ff:feb8:31f4 5683 60987 fe80::24de:d0ff:fe85:bdb2 CoAP 71 ACK, MID:3851, 2.05 Content, Bock2: 2/0/64, /.well-known/core
```

Note that the client asks for an 128 B block at index 1, so 128 B at offset 128 B. The server replies with an 64 B block at index 1, so 64 B at offset 64 B. The client notices the different offset and that the server prefers 64 B and asks for an 64 B block at index 2, so 64 B at offset 128 B. The server now gives what was asked for and the client is happy.

(The actual payload is less than 128 B, so offset 128B gives no data back.)

#### Client and server from this PR

```console
> get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 256 128 128
2026-07-29 18:49:47,927 # get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 256 128 128
2026-07-29 18:49:47,930 # No data received (requested slice behind payload)
```

```
./tshark -i tap0 -Y 'coap'
Capturing on 'tap0'
    4 2.059165512 fe80::24de:d0ff:fe85:bdb2 52522 5683 fe80::9826:30ff:feb8:31f4 CoAP 85 CON, MID:41387, GET, Bock2: 1/0/128, /.well-known/core
    5 2.060156340 fe80::9826:30ff:feb8:31f4 5683 52522 fe80::24de:d0ff:fe85:bdb2 CoAP 71 ACK, MID:41387, 2.05 Content, Bock2: 2/0/64, /.well-known/core
```

Now here the client again asks for an 128 B block at index 1, so 128 B from offset 128 B. The server replies with 64 B from index 2, so 64 B at offset 128 B. This is directly the position the client asked for. And given that there are no more blocks, the client is directly happy. (In fact, even that block is empty, as it already is past the payload.)

#### Requests with actual content

Here client and server from this PR. A number of requests within the range of the actual payload are made, so that there is something to print:

```console
> get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 512
2026-07-29 19:16:45,892 # get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 512
2026-07-29 19:16:45,899 # 00000000  3C  2F  76  66  73  3E  2C  3C  2F  74  69  6D  65  3E  2C  3C
2026-07-29 19:16:45,899 # 00000010  2F  73  65  70  61  72  61  74  65  3E  2C  3C  2F  73  68  61
2026-07-29 19:16:45,900 # 00000020  32  35  36  3E  2C  3C  2F  72  69  6F  74  2F  76  65  72  3E
2026-07-29 19:16:45,900 # 00000030  2C  3C  2F  72  69  6F  74  2F  76  61  6C  75  65  3E  2C  3C
2026-07-29 19:16:45,900 # 00000040  2F  72  69  6F  74  2F  62  6F  61  72  64  3E  2C  3C  2F  65
2026-07-29 19:16:45,901 # 00000050  63  68  6F  2F  3E  2C  3C  2F  2E  77  65  6C  6C  2D  6B  6E
2026-07-29 19:16:45,901 # 00000060  6F  77  6E  2F  63  6F  72  65  3E
> get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 8 1
2026-07-29 19:16:53,023 # get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 8 1
2026-07-29 19:16:53,024 # 00000000  2F  76  66  73  3E  2C  3C  2F
> get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 16 16
2026-07-29 19:16:56,341 # get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 16 16
2026-07-29 19:16:56,342 # 00000000  2F  73  65  70  61  72  61  74  65  3E  2C  3C  2F  73  68  61
> get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 16 32
2026-07-29 19:16:59,185 # get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 16 32
2026-07-29 19:16:59,188 # 00000000  32  35  36  3E  2C  3C  2F  72  69  6F  74  2F  76  65  72  3E
> get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 16 48
2026-07-29 19:17:03,435 # get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 16 48
2026-07-29 19:17:03,436 # 00000000  2C  3C  2F  72  69  6F  74  2F  76  61  6C  75  65  3E  2C  3C
> get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 16 63
2026-07-29 19:17:09,014 # get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 16 63
2026-07-29 19:17:09,017 # 00000000  3C  2F  72  69  6F  74  2F  62  6F  61  72  64  3E  2C  3C  2F
> get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 1 1
2026-07-29 19:17:14,925 # get_slice coap://[fe80::9826:30ff:feb8:31f4]/.well-known/core 1 1
2026-07-29 19:17:14,928 # 00000000  2F
```

```console
./tshark -i tap0 -Y 'coap'
Capturing on 'tap0'
   11 8.543193301 fe80::24de:d0ff:fe85:bdb2 65022 5683 fe80::9826:30ff:feb8:31f4 CoAP 85 CON, MID:31935, GET, Bock2: 0/0/64, /.well-known/core
   12 8.544713291 fe80::9826:30ff:feb8:31f4 5683 65022 fe80::24de:d0ff:fe85:bdb2 CoAP 135 ACK, MID:31935, 2.05 Content, Bock2: 0/1/64, /.well-known/core
   13 8.546228110 fe80::24de:d0ff:fe85:bdb2 65022 5683 fe80::9826:30ff:feb8:31f4 CoAP 85 CON, MID:31936, GET, Bock2: 1/0/64, /.well-known/core
   14 8.546494820 fe80::9826:30ff:feb8:31f4 5683 65022 fe80::24de:d0ff:fe85:bdb2 CoAP 112 ACK, MID:31936, 2.05 Content, Bock2: 1/0/64, /.well-known/core
   19 15.670966630 fe80::24de:d0ff:fe85:bdb2 60891 5683 fe80::9826:30ff:feb8:31f4 CoAP 84 CON, MID:60107, GET, Bock2: 0/0/16, /.well-known/core
   20 15.671578406 fe80::9826:30ff:feb8:31f4 5683 60891 fe80::24de:d0ff:fe85:bdb2 CoAP 87 ACK, MID:60107, 2.05 Content, Bock2: 0/1/16, /.well-known/core
   21 18.988773240 fe80::24de:d0ff:fe85:bdb2 59515 5683 fe80::9826:30ff:feb8:31f4 CoAP 85 CON, MID:34744, GET, Bock2: 0/0/32, /.well-known/core
   22 18.989354360 fe80::9826:30ff:feb8:31f4 5683 59515 fe80::24de:d0ff:fe85:bdb2 CoAP 103 ACK, MID:34744, 2.05 Content, Bock2: 0/1/32, /.well-known/core
   23 21.832880121 fe80::24de:d0ff:fe85:bdb2 63257 5683 fe80::9826:30ff:feb8:31f4 CoAP 85 CON, MID:29838, GET, Bock2: 0/0/64, /.well-known/core
   24 21.833499843 fe80::9826:30ff:feb8:31f4 5683 63257 fe80::24de:d0ff:fe85:bdb2 CoAP 135 ACK, MID:29838, 2.05 Content, Bock2: 0/1/64, /.well-known/core
   25 26.082930540 fe80::24de:d0ff:fe85:bdb2 60669 5683 fe80::9826:30ff:feb8:31f4 CoAP 85 CON, MID:5963, GET, Bock2: 1/0/32, /.well-known/core
   26 26.083520266 fe80::9826:30ff:feb8:31f4 5683 60669 fe80::24de:d0ff:fe85:bdb2 CoAP 103 ACK, MID:5963, 2.05 Content, Bock2: 1/1/32, /.well-known/core
   27 31.661920823 fe80::24de:d0ff:fe85:bdb2 61102 5683 fe80::9826:30ff:feb8:31f4 CoAP 85 CON, MID:58294, GET, Bock2: 3/0/16, /.well-known/core
   28 31.662497814 fe80::9826:30ff:feb8:31f4 5683 61102 fe80::24de:d0ff:fe85:bdb2 CoAP 87 ACK, MID:58294, 2.05 Content, Bock2: 3/1/16, /.well-known/core
   29 31.663162170 fe80::24de:d0ff:fe85:bdb2 61102 5683 fe80::9826:30ff:feb8:31f4 CoAP 85 CON, MID:58295, GET, Bock2: 4/0/16, /.well-known/core
   30 31.663631089 fe80::9826:30ff:feb8:31f4 5683 61102 fe80::24de:d0ff:fe85:bdb2 CoAP 87 ACK, MID:58295, 2.05 Content, Bock2: 4/1/16, /.well-known/core
   33 37.573503969 fe80::24de:d0ff:fe85:bdb2 56474 5683 fe80::9826:30ff:feb8:31f4 CoAP 84 CON, MID:40874, GET, Bock2: 0/0/16, /.well-known/core
   34 37.574071934 fe80::9826:30ff:feb8:31f4 5683 56474 fe80::24de:d0ff:fe85:bdb2 CoAP 87 ACK, MID:40874, 2.05 Content, Bock2: 0/1/16, /.well-known/core
```

### Issues/PRs references

In addition to the issue in behavior, this also fixes the issue reported in https://github.com/RIOT-OS/RIOT/security/advisories/GHSA-x924-p5fq-26pc

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- will request a review from Copilot now
