### PR TITLE
.clang-tidy: sort alphabetically and add two more exceptions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -56,6 +56,16 @@
 #       still self-explanatory. Adding `#define BITS_PER_BYTE 8` and
 #       `#define BIT_POS_IN_BYTE_MASK 7` to silence the warning would not
 #       improve the readability here, but instead reduce it.
+# - readability-implicit-bool-conversion:
+#       Conversion to bool is well defined and happens in a lot of places. With
+#       this enabled, the source code in the editor lights up like a christmas
+#       tree due to the amount of warnings.
+# - bugprone-narrowing-conversions:
+#       This warning is too aggressive: Even when returning e.g. a compile time
+#       constant that is known to fit the return type of a function, a simple
+#       `return FOO;` will get a warning. But using `return (some_type)FOO;` is
+#       not more readable and explicit casts actively harm, as they mute
+#       a lot of compiler diagnostics.
 #
 # Warning
 # -------
@@ -65,16 +75,18 @@
 # helpful. If you modify this file to improve your experience, please consider
 # upstreaming the changes.
 ---
-Checks: "clang-analyzer-*,
-         bugprone-*,
+Checks: "bugprone-*,
+         clang-analyzer-*,
+         linuxkernel-*,
+         misc-*,
          portability-*,
          readability-*,
-         misc-*,
-         linuxkernel-*,
-         -bugprone-reserved-identifier,
          -bugprone-easily-swappable-parameters,
+         -bugprone-narrowing-conversions,
+         -bugprone-reserved-identifier,
          -readability-identifier-length,
-         -readability-magic-numbers
+         -readability-implicit-bool-conversion,
+         -readability-magic-numbers,
         "
 WarningsAsErrors: "bugprone-*,
                    portability-*,


### PR DESCRIPTION
### Contribution description

Sorted the content alphabetically and added the following two exceptions:

- `readability-implicit-bool-conversion`:
      Conversion to bool is well defined and happens at a lot of places. With this enabled, the source code in the editor lights up like a christmas tree due to the amount of warnings.
- `bugprone-narrowing-conversions`:
      This warning is too aggressive: Even when returning e.g. a compile time constant that is known to fit the return type of a function, a simple `return FOO;` will get a warning. But using `return (some_type)FOO;` is not more readable and explicit conversion actively harm, as they mute a lot of compiler diagnostics.

### Testing procedure

1. Run `make compile-commands` in some app
2. Open a larger source file used by that app in an LSP enabled editor with clang-tidy and clangd installed
3. It will be full of colorful warnings in `master`; it will look less like Christmas tree lighting with this PR

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none