### PR TITLE
build system: migrate to `echoinfo`, `echogreen`, ... for warnings and info printed to `stderr`

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -207,9 +207,8 @@ include $(RIOTMAKE)/dependencies_debug.inc.mk
 # Use TOOLCHAIN environment variable to select the toolchain to use.
 ifneq (,$(filter native native32 native64,$(BOARD)))
   ifeq ($(OS),Darwin)
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)"Buildin on macOS is not supported."\
-                          "We recommend vagrant for building:$(COLOR_RESET)"\
-                          "https://github.com/RIOT-OS/RIOT/blob/master/dist/tools/vagrant/README.md 1>&2)
+    $(call echoerr,("Building on macOS is not supported. We recommend vagrant for building:"))
+    $(call echoinfo,("https://github.com/RIOT-OS/RIOT/blob/master/dist/tools/vagrant/README.md"))
   endif
 endif
 # Use override so that we can redefine a variable set on the command line (as
@@ -800,8 +799,8 @@ endif
 	$(call check_cmd,$(CC),Compiler)
 
 ..build-message: $(if $(SHOULD_RUN_KCONFIG), check-kconfig-errors)
-	@$(COLOR_ECHO) '$(COLOR_GREEN)Building application "$(APPLICATION)" for "$(BOARD)" with CPU "$(CPU)".$(COLOR_RESET)'
-	@$(COLOR_ECHO)
+	@$(call sh_echogreen,("Building application \"$(APPLICATION)\" for \"$(BOARD)\" with CPU \"$(CPU)\"."))
+	@$(call sh_echoinfo)
 
 # The `clean` needs to be serialized before everything else.
 all $(BASELIBS) $(ARCHIVES) $(BUILDDEPS) $(GENSRC) ..in-docker-container: | $(CLEAN)
@@ -979,23 +978,23 @@ ifeq (, $(filter clean distclean generate-Makefile.ci help, $(MAKECMDGOALS)))
 
   # Test if there where dependencies against a module in DISABLE_MODULE.
   ifneq (, $(filter $(DISABLE_MODULE), $(USEMODULE)))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)Required modules were disabled using DISABLE_MODULE:$(COLOR_RESET)"\
-                          "$(sort $(filter $(DISABLE_MODULE), $(USEMODULE)))" 1>&2)
+    $(call echoinfo,($(call c_red,"Required modules were disabled using DISABLE_MODULE:")\
+                     "$(sort $(filter $(DISABLE_MODULE), $(USEMODULE)))"))
     USEMODULE := $(filter-out $(DISABLE_MODULE), $(USEMODULE))
     EXPECT_ERRORS := 1
   endif
 
   # Test if all feature requirements were met by the selected board.
   ifneq (,$(FEATURES_MISSING))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)There are unsatisfied feature requirements:$(COLOR_RESET)"\
-                          "$(FEATURES_MISSING)" 1>&2)
+    $(call echoinfo,($(call c_red,"There are unsatisfied feature requirements:")\
+                     "$(FEATURES_MISSING)"))
     EXPECT_ERRORS := 1
   endif
 
   # Test if no feature in the requirements used is blacklisted for the selected board.
   ifneq (,$(FEATURES_USED_BLACKLISTED))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)Some feature requirements are blacklisted:$(COLOR_RESET)"\
-                          "$(FEATURES_USED_BLACKLISTED)" 1>&2)
+    $(call echoinfo,($(call c_red,"Some feature requirements are blacklisted:")\
+                     "$(FEATURES_USED_BLACKLISTED)"))
     EXPECT_ERRORS := 1
   endif
 
@@ -1003,48 +1002,51 @@ ifeq (, $(filter clean distclean generate-Makefile.ci help, $(MAKECMDGOALS)))
   BOARDS_UNSUPPORTED += $(BOARD_BLACKLIST)
 
   ifneq (, $(BOARD_WHITELIST)$(BOARD_BLACKLIST))
-    $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)BOARD_WHITELIST has been renamed to"\
-      "BOARDS_SUPPORTED and BOARD_BLACKLIST to BOARDS_UNSUPPORTED.$(COLOR_RESET)" 1>&2)
-    $(shell $(COLOR_ECHO) "The contents of BOARD_WHITELIST have been appended to"\
-      "BOARDS_SUPPORTED and the contents of BOARD_BLACKLIST to BOARDS_UNSUPPORTED for compatibility." 1>&2)
+    $(call echowarn,("BOARD_WHITELIST has been renamed to BOARDS_SUPPORTED and"\
+                     "BOARD_BLACKLIST to BOARDS_UNSUPPORTED."))
+    $(call echoinfo,("The contents of BOARD_WHITELIST have been appended to BOARDS_SUPPORTED"\
+                     "and the contents of BOARD_BLACKLIST to BOARDS_UNSUPPORTED for compatibility."))
   endif
 
   # Test if any used feature conflict with another one.
   ifneq (,$(FEATURES_CONFLICTING))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)The following features conflict:$(COLOR_RESET)"\
-                          "$(FEATURES_CONFLICTING)" 1>&2)
+    $(call echoinfo,($(call c_red,"The following features conflict:")\
+                     "$(FEATURES_CONFLICTING)"))
     ifneq (, $(FEATURES_CONFLICT_MSG))
-        $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)Rationale: $(COLOR_RESET)$(FEATURES_CONFLICT_MSG)" 1>&2)
+        $(call echoinfo,($(call c_yellow,"Rationale: ")"$(FEATURES_CONFLICT_MSG)"))
     endif
     EXPECT_ERRORS := 1
   endif
   # If there is a list of supported boards, then test if the board is supported.
   ifneq (,$(strip $(BOARDS_SUPPORTED)))
     ifeq (, $(filter $(BOARDS_SUPPORTED), $(BOARD)))
-      $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected BOARD=$(BOARD) is not listed in BOARDS_SUPPORTED$(COLOR_RESET)." 1>&2)
-      $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)When the list BOARDS_SUPPORTED is not empty, only boards explicitly listed there are supported.$(COLOR_RESET)" 1>&2)
-      $(shell $(COLOR_ECHO) "BOARDS_SUPPORTED = \"$(BOARDS_SUPPORTED)\"" 1>&2)
+      $(call echoerr,("The selected BOARD=$(BOARD) is not listed in BOARDS_SUPPORTED."))
+      $(call echowarn,("When the list BOARDS_SUPPORTED is not empty, only"\
+                       "boards explicitly listed there are supported."))
+      $(call echoinfo,("BOARDS_SUPPORTED = \"$(strip $(BOARDS_SUPPORTED))\""))
       EXPECT_ERRORS := 1
     endif
   endif
 
   # If there is a list of unsupported boards, then test if the board is unsupported.
   ifneq (,$(filter $(BOARDS_UNSUPPORTED),$(BOARD)))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected BOARD=$(BOARD) is listed in BOARDS_UNSUPPORTED.$(COLOR_RESET)" 1>&2)
-    $(shell $(COLOR_ECHO) "BOARDS_UNSUPPORTED = $(BOARDS_UNSUPPORTED)" 1>&2)
+    $(call echoerr,("The selected BOARD=$(BOARD) is listed in BOARDS_UNSUPPORTED."))
+    $(call echoinfo,("BOARDS_UNSUPPORTED = \"$(strip $(BOARDS_UNSUPPORTED))\""))
     EXPECT_ERRORS := 1
   endif
 
   #  test if toolchain is supported.
   ifeq (,$(filter $(TOOLCHAIN),$(TOOLCHAINS_SUPPORTED)))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected TOOLCHAIN=$(TOOLCHAIN) is not supported.$(COLOR_RESET)\nSupported toolchains: $(TOOLCHAINS_SUPPORTED)" 1>&2)
+    $(call echoerr,("The selected TOOLCHAIN=$(TOOLCHAIN) is not supported."))
+    $(call echoinfo,("Supported toolchains: $(TOOLCHAINS_SUPPORTED)"))
     EXPECT_ERRORS := 1
   endif
 
   # If there is a blacklist, then test if the board is blacklisted.
   ifneq (,$(TOOLCHAINS_BLACKLIST))
     ifneq (,$(filter $(TOOLCHAIN),$(TOOLCHAINS_BLACKLIST)))
-      $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected TOOLCHAIN=$(TOOLCHAIN) is blacklisted:$(COLOR_RESET) $(TOOLCHAINS_BLACKLIST)" 1>&2)
+      $(call echoinfo,($(call c_red,"The selected TOOLCHAIN=$(TOOLCHAIN) is blacklisted:")\
+                       "$(TOOLCHAINS_BLACKLIST)"))
       EXPECT_ERRORS := 1
     endif
   endif
@@ -1053,16 +1055,17 @@ ifeq (, $(filter clean distclean generate-Makefile.ci help, $(MAKECMDGOALS)))
   CONTINUE_ON_EXPECTED_ERRORS ?= 0
   ifneq (, $(EXPECT_ERRORS))
     ifneq (1,$(CONTINUE_ON_EXPECTED_ERRORS))
-      $(error You can let the build continue on expected errors by setting CONTINUE_ON_EXPECTED_ERRORS=1 to the command line)
+      $(error You can let the build continue on expected errors by setting CONTINUE_ON_EXPECTED_ERRORS=1 to the command line.)
     endif
-    $(shell $(COLOR_ECHO) "\n\n$(COLOR_RED)EXPECT ERRORS!$(COLOR_RESET)\n\n" 1>&2)
+    $(call echoerr,(\n\nEXPECT ERRORS!\n\n))
   endif
 
 endif
 
+# filter all targets starting with lowercase and containing lowercase letters,
+# hyphens, or underscores; explicitly include generate-Makefile.ci
+# inspired by: https://stackoverflow.com/a/26339924
 help:
-  # filter all targets starting with lowercase and containing lowercase letters, hyphens, or underscores; explicitly include generate-Makefile.ci
-  # inspired by: https://stackoverflow.com/a/26339924
 	@LC_ALL=C $(MAKE) -pRrq -f $(firstword $(MAKEFILE_LIST)) : 2>/dev/null | sed -ne 's/\(^[a-z][a-z_-]*\|generate-Makefile.ci\):.*/\1/p' | sort -u
 
 ifeq (iotlab-m3,$(BOARD))

--- a/Makefile.include
+++ b/Makefile.include
@@ -1031,7 +1031,7 @@ ifeq (, $(filter clean distclean generate-Makefile.ci help, $(MAKECMDGOALS)))
   # If there is a list of unsupported boards, then test if the board is unsupported.
   ifneq (,$(filter $(BOARDS_UNSUPPORTED),$(BOARD)))
     $(call echoerr,("The selected BOARD=$(BOARD) is listed in BOARDS_UNSUPPORTED."))
-    $(call echoinfo,("BOARDS_UNSUPPORTED = $(BOARDS_UNSUPPORTED)"))
+    $(call echoinfo,("BOARDS_UNSUPPORTED = \"$(strip $(BOARDS_UNSUPPORTED))\""))
     EXPECT_ERRORS := 1
   endif
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -207,9 +207,8 @@ include $(RIOTMAKE)/dependencies_debug.inc.mk
 # Use TOOLCHAIN environment variable to select the toolchain to use.
 ifneq (,$(filter native native32 native64,$(BOARD)))
   ifeq ($(OS),Darwin)
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)"Buildin on macOS is not supported."\
-                          "We recommend vagrant for building:$(COLOR_RESET)"\
-                          "https://github.com/RIOT-OS/RIOT/blob/master/dist/tools/vagrant/README.md 1>&2)
+    $(call echoerr,("Building on macOS is not supported. We recommend vagrant for building:"))
+    $(call echoinfo,("https://github.com/RIOT-OS/RIOT/blob/master/dist/tools/vagrant/README.md"))
   endif
 endif
 # Use override so that we can redefine a variable set on the command line (as
@@ -800,8 +799,8 @@ endif
 	$(call check_cmd,$(CC),Compiler)
 
 ..build-message: $(if $(SHOULD_RUN_KCONFIG), check-kconfig-errors)
-	@$(COLOR_ECHO) '$(COLOR_GREEN)Building application "$(APPLICATION)" for "$(BOARD)" with CPU "$(CPU)".$(COLOR_RESET)'
-	@$(COLOR_ECHO)
+	@$(call sh_echogreen,("Building application \"$(APPLICATION)\" for \"$(BOARD)\" with CPU \"$(CPU)\"."))
+	@$(call sh_echoinfo)
 
 # The `clean` needs to be serialized before everything else.
 all $(BASELIBS) $(ARCHIVES) $(BUILDDEPS) $(GENSRC) ..in-docker-container: | $(CLEAN)
@@ -979,23 +978,23 @@ ifeq (, $(filter clean distclean generate-Makefile.ci help, $(MAKECMDGOALS)))
 
   # Test if there where dependencies against a module in DISABLE_MODULE.
   ifneq (, $(filter $(DISABLE_MODULE), $(USEMODULE)))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)Required modules were disabled using DISABLE_MODULE:$(COLOR_RESET)"\
-                          "$(sort $(filter $(DISABLE_MODULE), $(USEMODULE)))" 1>&2)
+    $(call echoinfo,($(call c_red,"Required modules were disabled using DISABLE_MODULE:")\
+                     "$(sort $(filter $(DISABLE_MODULE), $(USEMODULE)))"))
     USEMODULE := $(filter-out $(DISABLE_MODULE), $(USEMODULE))
     EXPECT_ERRORS := 1
   endif
 
   # Test if all feature requirements were met by the selected board.
   ifneq (,$(FEATURES_MISSING))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)There are unsatisfied feature requirements:$(COLOR_RESET)"\
-                          "$(FEATURES_MISSING)" 1>&2)
+    $(call echoinfo,($(call c_red,"There are unsatisfied feature requirements:")\
+                     "$(FEATURES_MISSING)"))
     EXPECT_ERRORS := 1
   endif
 
   # Test if no feature in the requirements used is blacklisted for the selected board.
   ifneq (,$(FEATURES_USED_BLACKLISTED))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)Some feature requirements are blacklisted:$(COLOR_RESET)"\
-                          "$(FEATURES_USED_BLACKLISTED)" 1>&2)
+    $(call echoinfo,($(call c_red,"Some feature requirements are blacklisted:")\
+                     "$(FEATURES_USED_BLACKLISTED)"))
     EXPECT_ERRORS := 1
   endif
 
@@ -1003,48 +1002,51 @@ ifeq (, $(filter clean distclean generate-Makefile.ci help, $(MAKECMDGOALS)))
   BOARDS_UNSUPPORTED += $(BOARD_BLACKLIST)
 
   ifneq (, $(BOARD_WHITELIST)$(BOARD_BLACKLIST))
-    $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)BOARD_WHITELIST has been renamed to"\
-      "BOARDS_SUPPORTED and BOARD_BLACKLIST to BOARDS_UNSUPPORTED.$(COLOR_RESET)" 1>&2)
-    $(shell $(COLOR_ECHO) "The contents of BOARD_WHITELIST have been appended to"\
-      "BOARDS_SUPPORTED and the contents of BOARD_BLACKLIST to BOARDS_UNSUPPORTED for compatibility." 1>&2)
+    $(call echowarn,("BOARD_WHITELIST has been renamed to BOARDS_SUPPORTED and"\
+                     "BOARD_BLACKLIST to BOARDS_UNSUPPORTED."))
+    $(call echoinfo,("The contents of BOARD_WHITELIST have been appended to BOARDS_SUPPORTED"\
+                     "and the contents of BOARD_BLACKLIST to BOARDS_UNSUPPORTED for compatibility."))
   endif
 
   # Test if any used feature conflict with another one.
   ifneq (,$(FEATURES_CONFLICTING))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)The following features conflict:$(COLOR_RESET)"\
-                          "$(FEATURES_CONFLICTING)" 1>&2)
+    $(call echoinfo,($(call c_red,"The following features conflict:")\
+                     "$(FEATURES_CONFLICTING)"))
     ifneq (, $(FEATURES_CONFLICT_MSG))
-        $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)Rationale: $(COLOR_RESET)$(FEATURES_CONFLICT_MSG)" 1>&2)
+        $(call echoinfo,($(call c_yellow,"Rationale: ")"$(FEATURES_CONFLICT_MSG)"))
     endif
     EXPECT_ERRORS := 1
   endif
   # If there is a list of supported boards, then test if the board is supported.
   ifneq (,$(strip $(BOARDS_SUPPORTED)))
     ifeq (, $(filter $(BOARDS_SUPPORTED), $(BOARD)))
-      $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected BOARD=$(BOARD) is not listed in BOARDS_SUPPORTED$(COLOR_RESET)." 1>&2)
-      $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)When the list BOARDS_SUPPORTED is not empty, only boards explicitly listed there are supported.$(COLOR_RESET)" 1>&2)
-      $(shell $(COLOR_ECHO) "BOARDS_SUPPORTED = \"$(BOARDS_SUPPORTED)\"" 1>&2)
+      $(call echoerr,("The selected BOARD=$(BOARD) is not listed in BOARDS_SUPPORTED."))
+      $(call echowarn,("When the list BOARDS_SUPPORTED is not empty, only"\
+                       "boards explicitly listed there are supported."))
+      $(call echoinfo,("BOARDS_SUPPORTED = \"$(strip $(BOARDS_SUPPORTED))\""))
       EXPECT_ERRORS := 1
     endif
   endif
 
   # If there is a list of unsupported boards, then test if the board is unsupported.
   ifneq (,$(filter $(BOARDS_UNSUPPORTED),$(BOARD)))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected BOARD=$(BOARD) is listed in BOARDS_UNSUPPORTED.$(COLOR_RESET)" 1>&2)
-    $(shell $(COLOR_ECHO) "BOARDS_UNSUPPORTED = $(BOARDS_UNSUPPORTED)" 1>&2)
+    $(call echoerr,("The selected BOARD=$(BOARD) is listed in BOARDS_UNSUPPORTED."))
+    $(call echoinfo,("BOARDS_UNSUPPORTED = $(BOARDS_UNSUPPORTED)"))
     EXPECT_ERRORS := 1
   endif
 
   #  test if toolchain is supported.
   ifeq (,$(filter $(TOOLCHAIN),$(TOOLCHAINS_SUPPORTED)))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected TOOLCHAIN=$(TOOLCHAIN) is not supported.$(COLOR_RESET)\nSupported toolchains: $(TOOLCHAINS_SUPPORTED)" 1>&2)
+    $(call echoerr,("The selected TOOLCHAIN=$(TOOLCHAIN) is not supported."))
+    $(call echoinfo,("Supported toolchains: $(TOOLCHAINS_SUPPORTED)"))
     EXPECT_ERRORS := 1
   endif
 
   # If there is a blacklist, then test if the board is blacklisted.
   ifneq (,$(TOOLCHAINS_BLACKLIST))
     ifneq (,$(filter $(TOOLCHAIN),$(TOOLCHAINS_BLACKLIST)))
-      $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected TOOLCHAIN=$(TOOLCHAIN) is blacklisted:$(COLOR_RESET) $(TOOLCHAINS_BLACKLIST)" 1>&2)
+      $(call echoinfo,($(call c_red,"The selected TOOLCHAIN=$(TOOLCHAIN) is blacklisted:")\
+                       "$(TOOLCHAINS_BLACKLIST)"))
       EXPECT_ERRORS := 1
     endif
   endif
@@ -1053,16 +1055,17 @@ ifeq (, $(filter clean distclean generate-Makefile.ci help, $(MAKECMDGOALS)))
   CONTINUE_ON_EXPECTED_ERRORS ?= 0
   ifneq (, $(EXPECT_ERRORS))
     ifneq (1,$(CONTINUE_ON_EXPECTED_ERRORS))
-      $(error You can let the build continue on expected errors by setting CONTINUE_ON_EXPECTED_ERRORS=1 to the command line)
+      $(error You can let the build continue on expected errors by setting CONTINUE_ON_EXPECTED_ERRORS=1 to the command line.)
     endif
-    $(shell $(COLOR_ECHO) "\n\n$(COLOR_RED)EXPECT ERRORS!$(COLOR_RESET)\n\n" 1>&2)
+    $(call echoerr,(\n\nEXPECT ERRORS!\n\n))
   endif
 
 endif
 
+# filter all targets starting with lowercase and containing lowercase letters,
+# hyphens, or underscores; explicitly include generate-Makefile.ci
+# inspired by: https://stackoverflow.com/a/26339924
 help:
-  # filter all targets starting with lowercase and containing lowercase letters, hyphens, or underscores; explicitly include generate-Makefile.ci
-  # inspired by: https://stackoverflow.com/a/26339924
 	@LC_ALL=C $(MAKE) -pRrq -f $(firstword $(MAKEFILE_LIST)) : 2>/dev/null | sed -ne 's/\(^[a-z][a-z_-]*\|generate-Makefile.ci\):.*/\1/p' | sort -u
 
 ifeq (iotlab-m3,$(BOARD))

--- a/boards/common/nucleo64/Makefile.dep
+++ b/boards/common/nucleo64/Makefile.dep
@@ -1,5 +1,4 @@
 # include color echo macros
-include $(RIOTMAKE)/utils/ansi.mk
 include $(RIOTMAKE)/color.inc.mk
 
 # Don't show warnings for info and generate targets
@@ -9,8 +8,8 @@ ifeq (,$(filter info-% generate-%,$(MAKECMDGOALS)))
     ifeq (,$(filter periph_init_led0,$(DISABLE_MODULE)))
       DISABLE_MODULE += periph_init_led0
 
-      MSG="Warning: Using periph_spi on Nucleo64 boards will disable LED0 due to pin conflicts."
-      $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)$(MSG)$(COLOR_RESET)" 1>&2)
+      $(call echowarn,("Warning: Using periph_spi on Nucleo64 boards will"\
+                       "disable LED0 due to pin conflicts."))
     endif
   endif
 endif

--- a/boards/seeedstudio-xiao-esp32c3/Makefile.dep
+++ b/boards/seeedstudio-xiao-esp32c3/Makefile.dep
@@ -1,11 +1,13 @@
+include $(RIOTBASE)/makefiles/color.inc.mk
+
 # Don't show warnings for info and generate targets
 ifeq (,$(filter info-% generate-%,$(MAKECMDGOALS)))
   ifneq (,$(filter periph_spi, $(USEMODULE)))
     ifeq (,$(filter periph_init_buttons, $(DISABLE_MODULE)))
       DISABLE_MODULE += periph_init_buttons
 
-      MSG="Warning: Using periph_spi on Seeed Studio Xiao ESP32C3 board will disable BUTTON0 due to pin conflict."
-      $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)$(MSG)$(COLOR_RESET)" 1>&2)
+      $(call echowarn,("Warning: Using periph_spi on a Seeed Studio Xiao"\
+                       "ESP32C3 board will disable BUTTON0 due to a pin conflict."))
     endif
   else ifneq (,$(filter saul_default,$(USEMODULE)))
     # The button is the only SAUL device. Enable it only when SPI is not enabled.

--- a/doc/guides/build-system/build_system_basics.md
+++ b/doc/guides/build-system/build_system_basics.md
@@ -128,14 +128,79 @@ A `nucleo-*` with a `SX1272MB2xA` is a different board in RIOT sense.
 
 _note_: if `devicetree` is implemented this concept will change.
 
-# Variables declaration guidelines
+## Printing Infos, Warnings and Error Messages
 
-This page contains basic guidelines about `make` variable declaration, it
+Many Makefiles perform checks of parameters, variables and other settings
+during the build process to ensure a proper operation. To inform and help the
+user, these messages are printed to the terminal.
+
+The CI (Continuous Integration) and other scripts used during build process and
+deployment of RIOT interpret the output of Make printed to `stdout`.
+This output is used to determine if a compilation was successful or how big the
+compiled binary file is.
+To avoid confusing these scripts, informative messages and colored warnings and
+errors should be printed to `stderr` instead.
+
+To make printing colored messages easy, the helper functions defined in
+`$(RIOTBASE)/makefiles/color.inc.mk` can and should be used.
+Generally you have to distinguish between two function types: One can be used
+during the initial phase of the Make process and the other one can be used in
+recipes. The latter has to be prefixed with `sh_`.
+
+```makefile
+# Remember to include the Makefile that defines the helpers!
+include $(RIOTBASE)/makefiles/color.inc.mk
+
+# During the execution of the Makefile, you have to use `echoinfo`, `echowarn`,
+# ...
+ifeq (,$(filter periph_spi,$(FEATURES_USED)))
+  $(call echoerr,("Can\'t proceed with the build!"\
+                  "The feature \"periph_spi\" is required for this"\
+                  "operation. \(You can add it to FEATURES_REQUIRED.\)"))
+endif
+
+# You can colorize parts of your text with the `c_red`, `c_yellow`, `c_green`
+# and `c_purple` functions, but be aware that this can become difficult to write.
+# If you want to have white text, always start with `echoinfo`.
+ifneq (,$(DEPRECATED_MODULES_USED))
+  $(call echoinfo,($(call c_red,"Deprecated modules are in use:")\
+                   "$(DEPRECATED_MODULES_USED)"))
+endif
+
+# In recipes you have to use the `sh_` prefixed functions.
+clean:
+  $(call sh_echowarn,("Deleting all your data now!"))
+```
+
+:::note
+You can not use `\n` or other control sequences in your text!
+
+Apostrophes `'`, quotation marks `"` and brackets `()` have to be escaped:
+`\'`, `\"`, `\(`, `\)`.
+:::
+
+### Available Functions
+ - `echoinfo` - Prints information in white text to the terminal.
+ - `echowarn` - Prints warnings in yellow text to the terminal. Warnings should
+  be used for everything that does not break the build.
+ - `echoerr`  - Prints errors in red text to the terminal. Errors should be
+  used for everything that compromises the build process or the resulting binary.
+ - `echored`  - Prints in red text.
+ - `echoyellow` - Prints in yellow text.
+ - `echogreen` - Prints in green text.
+ - `echopurple` - Prints in purple text.
+ - `sh_echoinfo` - Same as `echoinfo`, but to be used in recipes.
+ - `sh_...`
+ - `c_red`, `c_yellow`, `c_green`, `c_purple` - Colorize part of a message.
+
+## Variables Declaration Guidelines
+
+This section contains basic guidelines about `make` variable declaration, it
 summarizes some of the pros and cons as well as specifies good and bad patterns
 in our build system. You might want to refer to `gnu make` documentation
 regarding these subjects.
 
-## Avoid Unnecessary Export
+### Avoid Unnecessary Export
 
 ```makefile
 export OUTPUT = $(shell some-command)
@@ -155,9 +220,9 @@ This is why global variables need clear documentation.
 
 [gnumake doc](https://www.gnu.org/software/make/manual/html_node/Variables_002fRecursion.html)
 
-## Use Memoized for Variables Referencing a Function or Command
+### Use Memoized for Variables Referencing a Function or Command
 
-### Recursively Expanded Variable
+#### Recursively Expanded Variable
 
 ```makefile
 OUTPUT = $(shell some-command $(ANOTHER_VARIABLE))
@@ -176,7 +241,7 @@ OUTPUT = $(shell some-command $(ANOTHER_VARIABLE))
 - If the variable expansion doesn't involve evaluating a function the overhead
   is none.
 
-### Simply Expanded Variable
+#### Simply Expanded Variable
 
 ```makefile
 OUTPUT := $(shell some-command $(ANOTHER_VARIABLE))
@@ -194,7 +259,7 @@ OUTPUT := $(shell some-command $(ANOTHER_VARIABLE))
 
 - The values of variables declared with `:=` depend on the order of definition.
 
-### Memoized
+#### Memoized
 
 ```makefile
 OUTPUT = $(call memoized,OUTPUT,$(shell some-command))
@@ -209,7 +274,7 @@ OUTPUT = $(call memoized,OUTPUT,$(shell some-command))
 
 [gnumake doc](https://www.gnu.org/software/make/manual/html_node/Flavors.html)
 
-## Additional Documentation
+### Additional Documentation
 
 - Deferred vs. simple expansion: http://make.mad-scientist.net/deferred-simple-variable-expansion/
 - Tracking issue: [#10850](https://github.com/RIOT-OS/RIOT/issues/10850)

--- a/doc/guides/build-system/build_system_basics.md
+++ b/doc/guides/build-system/build_system_basics.md
@@ -128,14 +128,84 @@ A `nucleo-*` with a `SX1272MB2xA` is a different board in RIOT sense.
 
 _note_: if `devicetree` is implemented this concept will change.
 
-# Variables declaration guidelines
+## Printing Infos, Warnings and Error Messages
 
-This page contains basic guidelines about `make` variable declaration, it
+Many Makefiles perform checks of parameters, variables and other settings
+during the build process to ensure a proper operation. To inform and help the
+user, these messages are printed to the terminal.
+
+The CI (Continuous Integration) and other scripts used during build process and
+deployment of RIOT interpret the output of Make printed to `stdout`.
+This output is used to determine if a compilation was successful or how big the
+compiled binary file is.
+To avoid confusing these scripts, informative messages and colored warnings and
+errors should be printed to `stderr` instead.
+
+Typically this was done with calls such as the following:<br>
+`$(shell $(COLOR_ECHO) "$(COLOR_RED)Error: Message Text!$(COLOR_RESET)" 1>&2)`
+
+This style can be confusing and tends to hide the actual text between a lot of
+boilerplate code.
+As a replacement, some helper functions in `$(RIOTBASE)/makefiles/color.inc.mk`
+can be used.
+Generally you have to distinguish between two function types: One can be used
+during the initial phase of the Make process and the other one can be used in
+recipes. The latter has to be prefixed with `sh_`.
+
+```makefile
+# Remember to include the Makefile that defines the helpers!
+include $(RIOTBASE)/makefiles/color.inc.mk
+
+# During the execution of the Makefile, you have to use `echoinfo`, `echowarn`,
+# ...
+ifeq (,$(filter periph_spi,$(FEATURES_USED)))
+  $(call echoerr,("Can\'t proceed with the build!"\
+                  "The feature \"periph_spi\" is required for this"\
+                  "operation. \(You can add it to FEATURES_REQUIRED.\)"))
+endif
+
+# You can colorize parts of your text with the `c_red`, `c_yellow`, `c_green`
+# and `c_purple` functions, but be aware that this can become difficult to write.
+# If you want to have white text, always start with `echoinfo`.
+ifneq (,$(DEPRECATED_MODULES_USED))
+  $(call echoinfo,($(call c_red,"Deprecated modules are in use:")\
+                   "$(DEPRECATED_MODULES_USED)"))
+endif
+
+# In recipes you have to use the `sh_` prefixed functions.
+clean:
+  $(call sh_echowarn,("Deleting all your data now!"))
+```
+
+:::note
+You can not use `\n` or other control sequences in your text!
+
+Apostrophes `'`, quotation marks `"` and brackets `()` have to be escaped:
+`\'`, `\"`, `\(`, `\)`.
+:::
+
+### Available Functions
+ - `echoinfo` - Prints information in white text to the terminal.
+ - `echowarn` - Prints warnings in yellow text to the terminal. Warnings should
+  be used for everything that does not break the build.
+ - `echoerr`  - Prints errors in red text to the terminal. Errors should be
+  used for everything that compromises the build process or the resulting binary.
+ - `echored`  - Prints in red text.
+ - `echoyellow` - Prints in yellow text.
+ - `echogreen` - Prints in green text.
+ - `echopurple` - Prints in purple text.
+ - `sh_echoinfo` - Same as `echoinfo`, but to be used in recipes.
+ - `sh_...`
+ - `c_red`, `c_yellow`, `c_green`, `c_purple` - Colorize part of a message.
+
+## Variables Declaration Guidelines
+
+This section contains basic guidelines about `make` variable declaration, it
 summarizes some of the pros and cons as well as specifies good and bad patterns
 in our build system. You might want to refer to `gnu make` documentation
 regarding these subjects.
 
-## Avoid Unnecessary Export
+### Avoid Unnecessary Export
 
 ```makefile
 export OUTPUT = $(shell some-command)
@@ -155,9 +225,9 @@ This is why global variables need clear documentation.
 
 [gnumake doc](https://www.gnu.org/software/make/manual/html_node/Variables_002fRecursion.html)
 
-## Use Memoized for Variables Referencing a Function or Command
+### Use Memoized for Variables Referencing a Function or Command
 
-### Recursively Expanded Variable
+#### Recursively Expanded Variable
 
 ```makefile
 OUTPUT = $(shell some-command $(ANOTHER_VARIABLE))
@@ -176,7 +246,7 @@ OUTPUT = $(shell some-command $(ANOTHER_VARIABLE))
 - If the variable expansion doesn't involve evaluating a function the overhead
   is none.
 
-### Simply Expanded Variable
+#### Simply Expanded Variable
 
 ```makefile
 OUTPUT := $(shell some-command $(ANOTHER_VARIABLE))
@@ -194,7 +264,7 @@ OUTPUT := $(shell some-command $(ANOTHER_VARIABLE))
 
 - The values of variables declared with `:=` depend on the order of definition.
 
-### Memoized
+#### Memoized
 
 ```makefile
 OUTPUT = $(call memoized,OUTPUT,$(shell some-command))
@@ -209,7 +279,7 @@ OUTPUT = $(call memoized,OUTPUT,$(shell some-command))
 
 [gnumake doc](https://www.gnu.org/software/make/manual/html_node/Flavors.html)
 
-## Additional Documentation
+### Additional Documentation
 
 - Deferred vs. simple expansion: http://make.mad-scientist.net/deferred-simple-variable-expansion/
 - Tracking issue: [#10850](https://github.com/RIOT-OS/RIOT/issues/10850)

--- a/examples/networking/coap/nanocoap_server/Makefile
+++ b/examples/networking/coap/nanocoap_server/Makefile
@@ -61,12 +61,14 @@ USEMODULE += hashes
 # development process:
 #DEVELHELP = 1
 
+include $(RIOTBASE)/makefiles/color.inc.mk
+
 # Use different settings when compiling for one of the following (low-memory)
 # boards
 LOW_MEMORY_BOARDS := nucleo-f334r8
 
 ifneq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
-  $(shell echo 'Using low-memory configuration for nanocoap_server.' 1>&2)
+  $(call echoinfo,("Using low-memory configuration for nanocoap_server."))
   ## low-memory tuning values
   USEMODULE += prng_minstd
 endif

--- a/makefiles/board_alias.inc.mk
+++ b/makefiles/board_alias.inc.mk
@@ -27,9 +27,9 @@ ifneq (, $(_BOARD_ALIAS_USED))
   TEST_ON_CI_BLACKLIST += $(if $(filter $(_alias),$(_test_blacklist)), $(_board))
   # inform the user about the alias
   ifeq (native,$(_alias))
-    $(shell echo 'using BOARD="$(_board)" as "$(_alias)" on a $(_platform_bits)-bit system' 1>&2)
+    $(call echoinfo,("using BOARD=\"$(_board)\" as \"$(_alias)\" on a $(_platform_bits)-bit system"))
   else
-    MSG="Warning: BOARD=\"$(_alias)\" is a deprecated alias. Consider using BOARD=\"$(_board)\" instead."
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)$(MSG)$(COLOR_RESET)" 1>&2)
+    $(call echoerr,("Warning: BOARD=\"$(_alias)\" is a deprecated alias."\
+                    "Consider using BOARD=\"$(_board)\" instead."))
   endif
 endif

--- a/makefiles/color.inc.mk
+++ b/makefiles/color.inc.mk
@@ -1,3 +1,8 @@
+RIOTMAKE ?= $(RIOTBASE)/makefiles
+
+include $(RIOTMAKE)/utils/ansi.mk
+
+
 # Set colored output control sequences if the terminal supports it and if
 # not disabled by the user
 
@@ -31,7 +36,62 @@ endif
 # Colorizer functions:
 #  These functions wrap a block of text in $(COLOR_X)...$(COLOR_RESET).
 #  Do not nest calls to this functions or the colors will be wrong.
-c_green = $(COLOR_GREEN)$(1)$(COLOR_RESET)
-c_red = $(COLOR_RED)$(1)$(COLOR_RESET)
+c_green  = $(COLOR_GREEN)$(1)$(COLOR_RESET)
+c_red    = $(COLOR_RED)$(1)$(COLOR_RESET)
 c_yellow = $(COLOR_YELLOW)$(1)$(COLOR_RESET)
 c_purple = $(COLOR_PURPLE)$(1)$(COLOR_RESET)
+
+# Functions to set the shell color one way
+sh_green  = $(COLOR_ECHO) -n "$(COLOR_GREEN)" 1>&2
+sh_red    = $(COLOR_ECHO) -n "$(COLOR_RED)" 1>&2
+sh_yellow = $(COLOR_ECHO) -n "$(COLOR_YELLOW)" 1>&2
+sh_purple = $(COLOR_ECHO) -n "$(COLOR_PURPLE)" 1>&2
+sh_reset  = $(COLOR_ECHO) -n "$(COLOR_RESET)" 1>&2
+
+# CI-safe echo functions (Recipe/Shell use):
+#  These functions should be used as a substitute for `@$(COLOR_ECHO) ...` by
+#  using `@$(call sh_echoinfo,("text"))`.
+#
+# Note: No space after the comma and mandatory parenthesis and quotation!
+#
+# Warning: You can not use `\n` or other control sequences in your text!
+#  Apostrophes `'` and brackets `()` have to be escaped: `\'`, `\(`, `\)`.
+#
+# Background: The CI and other scripts interpret the output of Make printed to `stdout`.
+#  To avoid confusing these scripts, user infos and red/yellow/green warnings
+#  should be printed to `stderr` instead.
+#
+# Make interprets commata in the argument as separators, even when they are
+# enclosed by quotation marks. The only workaround is to use extra parenthesis
+# in the call and remove it afterwards with sed.
+# See: https://vasvir.wordpress.com/2021/03/25/gnu-make-function-arguments-with-comma/
+# We can't use the `c_green`, ... functions here, because the `sed` command would
+# become very complex if it has to potentially ignore the escape sequences before
+# and after the parenthesis it should remove.
+sh_echoinfo    = $(COLOR_ECHO) "$(1)" | sed -e 's/^(\|)$$//g' 1>&2
+sh_echogreen   = $(sh_green); $(sh_echoinfo); $(sh_reset)
+sh_echored     = $(sh_red); $(sh_echoinfo); $(sh_reset)
+sh_echoyellow  = $(sh_yellow); $(sh_echoinfo); $(sh_reset)
+sh_echopurple  = $(sh_purple); $(sh_echoinfo); $(sh_reset)
+sh_echoerr     = $(sh_echored)
+sh_echowarn    = $(sh_echoyellow)
+
+# CI-safe echo functions (Makefile use):
+#  These functions should be used as a substitute for `$(info ...)` by using
+#  `$(call echoinfo,("text"))`.
+#
+# Note: No space after the comma and mandatory parenthesis and quotation!
+#
+# Warning: You can not use `\n` or other control sequences in your text!
+#  Apostrophes `'` and brackets `()` have to be escaped: `\'`, `\(`, `\)`.
+#
+# Background: The CI and other scripts interpret the output of Make printed to `stdout`.
+#  To avoid confusing these scripts, user infos and red/yellow/green warnings
+#  should be printed to `stderr` instead.
+echoinfo    = $(shell $(call sh_echoinfo,$(1)))
+echogreen   = $(shell $(call sh_echogreen,$(1)))
+echored     = $(shell $(call sh_echored,$(1)))
+echoyellow  = $(shell $(call sh_echoyellow,$(1)))
+echopurple  = $(shell $(call sh_echopurple,$(1)))
+echoerr     = $(shell $(call sh_echored,$(1)))
+echowarn    = $(shell $(call sh_echoyellow,$(1)))

--- a/makefiles/color.inc.mk
+++ b/makefiles/color.inc.mk
@@ -1,3 +1,8 @@
+RIOTMAKE ?= $(RIOTBASE)/makefiles
+
+include $(RIOTMAKE)/utils/ansi.mk
+
+
 # Set colored output control sequences if the terminal supports it and if
 # not disabled by the user
 
@@ -31,7 +36,60 @@ endif
 # Colorizer functions:
 #  These functions wrap a block of text in $(COLOR_X)...$(COLOR_RESET).
 #  Do not nest calls to this functions or the colors will be wrong.
-c_green = $(COLOR_GREEN)$(1)$(COLOR_RESET)
-c_red = $(COLOR_RED)$(1)$(COLOR_RESET)
+c_green  = $(COLOR_GREEN)$(1)$(COLOR_RESET)
+c_red    = $(COLOR_RED)$(1)$(COLOR_RESET)
 c_yellow = $(COLOR_YELLOW)$(1)$(COLOR_RESET)
 c_purple = $(COLOR_PURPLE)$(1)$(COLOR_RESET)
+
+# Functions to set the shell color one way
+sh_green  = $(COLOR_ECHO) -n "$(COLOR_GREEN)" 1>&2
+sh_red    = $(COLOR_ECHO) -n "$(COLOR_RED)" 1>&2
+sh_yellow = $(COLOR_ECHO) -n "$(COLOR_YELLOW)" 1>&2
+sh_purple = $(COLOR_ECHO) -n "$(COLOR_PURPLE)" 1>&2
+sh_reset  = $(COLOR_ECHO) -n "$(COLOR_RESET)" 1>&2
+
+# CI-safe echo functions (Recipe/Shell use):
+#  These functions should be used as a substitute for `@$(COLOR_ECHO) ...` by
+#  using `@$(call sh_echoinfo,("text"))`.
+#
+# Note: No space after the comma and mandatory parenthesis and quotation!
+#
+# Warning: You can not use `\n` or other escape sequences in your text!
+#
+# Background: The CI and other scripts interpret the output of Make printed to `stdout`.
+#  To avoid confusing these scripts, user infos and red/yellow/green warnings
+#  should be printed to `stderr` instead.
+#
+# Make interprets commata in the argument as separators, even when they are
+# enclosed by quotation marks. The only workaround is to use extra parenthesis
+# in the call and remove it afterwards with sed.
+# See: https://vasvir.wordpress.com/2021/03/25/gnu-make-function-arguments-with-comma/
+# We can't use the `c_green`, ... functions here, because the `sed` command would
+# become very complex if it has to potentially ignore the escape sequences before
+# and after the parenthesis it should remove.
+sh_echoinfo    = $(COLOR_ECHO) "$(1)" | sed -e 's/^(\|)$$//g' 1>&2
+sh_echogreen   = $(sh_green); $(sh_echoinfo); $(sh_reset)
+sh_echored     = $(sh_red); $(sh_echoinfo); $(sh_reset)
+sh_echoyellow  = $(sh_yellow); $(sh_echoinfo); $(sh_reset)
+sh_echopurple  = $(sh_purple); $(sh_echoinfo); $(sh_reset)
+sh_echoerr     = $(sh_echored)
+sh_echowarn    = $(sh_echoyellow)
+
+# CI-safe echo functions (Makefile use):
+#  These functions should be used as a substitute for `$(info ...)` by using
+#  `$(call echoinfo,("text"))`.
+#
+# Note: No space after the comma and mandatory parenthesis and quotation!
+#
+# Warning: You can not use `\n` or other escape sequences in your text!
+#
+# Background: The CI and other scripts interpret the output of Make printed to `stdout`.
+#  To avoid confusing these scripts, user infos and red/yellow/green warnings
+#  should be printed to `stderr` instead.
+echoinfo    = $(shell $(call sh_echoinfo,$(1)))
+echogreen   = $(shell $(call sh_echogreen,$(1)))
+echored     = $(shell $(call sh_echored,$(1)))
+echoyellow  = $(shell $(call sh_echoyellow,$(1)))
+echopurple  = $(shell $(call sh_echopurple,$(1)))
+echoerr     = $(shell $(call sh_echored,$(1)))
+echowarn    = $(shell $(call sh_echoyellow,$(1)))

--- a/makefiles/color.inc.mk
+++ b/makefiles/color.inc.mk
@@ -54,7 +54,8 @@ sh_reset  = $(COLOR_ECHO) -n "$(COLOR_RESET)" 1>&2
 #
 # Note: No space after the comma and mandatory parenthesis and quotation!
 #
-# Warning: You can not use `\n` or other escape sequences in your text!
+# Warning: You can not use `\n` or other control sequences in your text!
+#  Apostrophes `'` and brackets `()` have to be escaped: `\'`, `\(`, `\)`.
 #
 # Background: The CI and other scripts interpret the output of Make printed to `stdout`.
 #  To avoid confusing these scripts, user infos and red/yellow/green warnings
@@ -81,7 +82,8 @@ sh_echowarn    = $(sh_echoyellow)
 #
 # Note: No space after the comma and mandatory parenthesis and quotation!
 #
-# Warning: You can not use `\n` or other escape sequences in your text!
+# Warning: You can not use `\n` or other control sequences in your text!
+#  Apostrophes `'` and brackets `()` have to be escaped: `\'`, `\(`, `\)`.
 #
 # Background: The CI and other scripts interpret the output of Make printed to `stdout`.
 #  To avoid confusing these scripts, user infos and red/yellow/green warnings

--- a/makefiles/dependency_resolution.inc.mk
+++ b/makefiles/dependency_resolution.inc.mk
@@ -68,8 +68,8 @@ else
   include $(RIOTMAKE)/deprecated_modules.inc.mk
   DEPRECATED_MODULES_USED := $(sort $(filter $(DEPRECATED_MODULES),$(USEMODULE)))
   ifneq (,$(DEPRECATED_MODULES_USED))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)Deprecated modules are in use:$(COLOR_RESET)"\
-                          "$(DEPRECATED_MODULES_USED)" 1>&2)
+    $(call echoinfo,($(call c_red,"Deprecated modules are in use:")\
+                     "$(DEPRECATED_MODULES_USED)"))
   endif
 
   # Detect provided / used / optional features that do not exist
@@ -99,35 +99,35 @@ else
     # Warn about telnet
     ifneq (,$(filter auto_init_telnet,$(USEMODULE)))
       ifneq (1,$(I_UNDERSTAND_THAT_TELNET_IS_INSECURE))
-        $(shell $(COLOR_ECHO) "$(COLOR_RED)Telnet will be started automatically, "\
-                              "make sure you understand why this almost certainly "\
-                              "is a REALLY BAD idea before proceeding!$(COLOR_RESET)" 1>&2)
-        $(error I_UNDERSTAND_THAT_TELNET_IS_INSECURE must be set to 1 to proceed)
+        $(call echoerr,("Telnet will be started automatically, make sure you"\
+                        "understand why this almost certainly is a REALLY BAD"\
+                        "idea before proceeding!"))
+        $(error I_UNDERSTAND_THAT_TELNET_IS_INSECURE must be set to 1 to proceed.)
       else
-        $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)Telnet will be started automatically,"\
-                              "don't run this on public networks!$(COLOR_RESET)" 1>&2)
+        $(call echowarn,("Telnet will be started automatically, don\'t run this"\
+                         "on public networks!"))
       endif
     endif
 
     # Warn about STDIO UDP
     ifneq (,$(filter stdio_udp,$(USEMODULE)))
       ifneq (1,$(I_UNDERSTAND_THAT_STDIO_UDP_IS_INSECURE))
-        $(shell $(COLOR_ECHO) "$(COLOR_RED)stdio via UDP will be started automatically,"\
-                              "make sure you understand why this almost certainly"\
-                              "is a REALLY BAD idea before proceeding!$(COLOR_RESET)" 1>&2)
+        $(call echoerr,("stdio via UDP will be started automatically,"\
+                        "make sure you understand why this almost certainly"\
+                        "is a REALLY BAD idea before proceeding!"))
         $(error I_UNDERSTAND_THAT_STDIO_UDP_IS_INSECURE must be set to 1 to proceed)
       else
-        $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)stdio via UDP will be started automatically,"\
-                              "don't run this on public networks!$(COLOR_RESET)" 1>&2)
+        $(call echowarn,("stdio via UDP will be started automatically,"\
+                         "don\'t run this on public networks!"))
       endif
     endif
 
     # Warn about PSA Crypto
     ifneq (,$(filter psa_crypto,$(USEMODULE)))
-      $(shell $(COLOR_ECHO) "$(COLOR_YELLOW) You are going to use the PSA Crypto module,"\
-                            "which is only partly implemented and not yet thouroughly tested.\n"\
-                            "Please do not use this module in production, as it may introduce"\
-                            "security issues!$(COLOR_RESET)" 1>&2)
+      $(call echowarn,("You are going to use the PSA Crypto module,"\
+                       "which is only partly implemented and not yet thouroughly tested."))
+      $(call echowarn,("Please do not use this module in production, as it may introduce"\
+                       "security issues!"))
     endif
   endif
 endif

--- a/makefiles/deprecated_boards.inc.mk
+++ b/makefiles/deprecated_boards.inc.mk
@@ -1,9 +1,7 @@
 # Add deprecated modules here
 # Keep this list ALPHABETICALLY SORTED!!!!
 ifeq ($(MAKELEVEL),0)
-
   ifneq (,$(filter $(DEPRECATED_BOARDS),$(BOARD)))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)Deprecated board: $(COLOR_RESET)"\
-                          "$(BOARD)" 1>&2)
+    $(call echoinfo,($(call c_red,"Deprecated board: ")"\"$(BOARD)\""))
   endif
 endif

--- a/makefiles/deprecated_cpus.inc.mk
+++ b/makefiles/deprecated_cpus.inc.mk
@@ -2,7 +2,6 @@
 # Keep this list ALPHABETICALLY SORTED!!!!
 ifeq ($(MAKELEVEL),0)
   ifneq (,$(filter $(DEPRECATED_CPUS),$(CPU)))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)Deprecated cpu: $(COLOR_RESET)"\
-                          "$(CPU)" 1>&2)
+    $(call echoinfo,($(call c_red,"Deprecated CPU: ")"\"$(CPU)\""))
   endif
 endif

--- a/makefiles/usb-codes.inc.mk
+++ b/makefiles/usb-codes.inc.mk
@@ -20,13 +20,15 @@ USB_VID_TESTING = 1209
 USB_PID_TESTING = 7D01
 usb_id_check:
 	@if grep -q -i "^$(USB_VID) $(USB_PID)$$" $(RIOTBASE)/dist/usb_id_testing; then \
-		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
-		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
+		$(call sh_echoerr,("Private testing pid.codes USB VID/PID used!, do not"\
+	                     "use it outside of test environments!")); \
+		$(call sh_echoerr,("MUST NOT be used on any device redistributed,"\
+	                     "sold or manufactured, VID/PID is not unique!")); \
 	fi
 	@if [ "$(USB_VID) $(subst D,d,$(USB_PID))" = "1209 7d00" ]; then \
-		$(COLOR_ECHO) "$(COLOR_RED)RIOT standard peripherals code (1209/7D00) cannot be set explicitly.$(COLOR_RESET)" 1>&2 ; \
-		$(COLOR_ECHO) "$(COLOR_RED)Unset USB_VID / USB_PID for the code to be picked automatically, or set$(COLOR_RESET)" 1>&2 ; \
-		$(COLOR_ECHO) "$(COLOR_RED)them to \$${USB_VID_TESTING} / \$${USB_PID_TESTING} during development.$(COLOR_RESET)" 1>&2 ; \
+		$(call sh_echoerr,("RIOT standard peripherals code \(1209/7D00\) cannot be set explicitly.")); \
+		$(call sh_echoerr,("Unset USB_VID / USB_PID for the code to be picked automatically, or set")); \
+		$(call sh_echoerr,("them to \$${USB_VID_TESTING} / \$${USB_PID_TESTING} during development.")); \
 		exit 1; \
 	fi
 .PHONY: usb_id_check

--- a/makefiles/utils/ansi.mk
+++ b/makefiles/utils/ansi.mk
@@ -4,8 +4,8 @@
 
 include $(RIOTMAKE)/utils/ansi_special.mk
 
-ANSI_GREEN  := $(ANSI_ESC)[1;32m
-ANSI_RED    := $(ANSI_ESC)[1;31m
-ANSI_YELLOW := $(ANSI_ESC)[1;33m
-ANSI_PURPLE := $(ANSI_ESC)[1;35m
-ANSI_RESET  := $(ANSI_ESC)[0m
+ANSI_GREEN  := \033[1;32m
+ANSI_RED    := \033[1;31m
+ANSI_YELLOW := \033[1;33m
+ANSI_PURPLE := \033[1;35m
+ANSI_RESET  := \033[0m

--- a/sys/net/application_layer/gcoap/Makefile.include
+++ b/sys/net/application_layer/gcoap/Makefile.include
@@ -1,6 +1,8 @@
+include $(RIOTBASE)/makefiles/color.inc.mk
+
 ifeq (2, $(words $(filter ipv4 ipv6, $(USEMODULE))))
-  $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)Due to limitations in the gcoap API it is currently not \
-                         possible to use a dual stack setup$(COLOR_RESET)" 1>&2)
+  $(call echowarn,("Due to limitations in the gcoap API it is currently"\
+                   "not possible to use a dual stack setup."))
 endif
 
 CONFIG_GCOAP_PDU_BUF_SIZE := $(or $(CONFIG_GCOAP_PDU_BUF_SIZE),128)

--- a/sys/shell_lock/Makefile.include
+++ b/sys/shell_lock/Makefile.include
@@ -1,4 +1,7 @@
-$(shell $(COLOR_ECHO) "$(COLOR_YELLOW)shell_lock is an experimental feature and only shows as a \
-  proof of concept how the shell could be protected with a password. Do not expect relevant \
-  security from it for production, since Man-in-the-Middle attacks are possible depending on the \
-  used connection method!$(COLOR_RESET)" 1>&2)
+include $(RIOTBASE)/makefiles/color.inc.mk
+
+$(call echowarn,("shell_lock is an experimental feature and only shows as a"\
+                 "proof of concept how the shell could be protected with a password."\
+                 "Do not expect relevant security from it for production, since"\
+                 "Man-in-the-Middle attacks are possible depending on the"\
+                 "used connection method!"))

--- a/tests/pkg/decadriver/Makefile.board.dep
+++ b/tests/pkg/decadriver/Makefile.board.dep
@@ -1,5 +1,4 @@
 # include color echo macros
-include $(RIOTMAKE)/utils/ansi.mk
 include $(RIOTMAKE)/color.inc.mk
 
 # The pin configuration depends on the specific board used. Wrong
@@ -21,9 +20,8 @@ else ifeq (nucleo-l452re,$(BOARD))
 
 else ifeq (,$(filter list-% info-% generate-%,$(MAKECMDGOALS)))
   ifeq (,$(DECA_WARNING_PRINTED))
-    MSG="Warning: No default decadriver configuration for \"$(BOARD)\"."\
-        "Make sure to set all CFLAGS manually!"
-    $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)$(MSG)$(COLOR_RESET)" 1>&2)
+    $(call echowarn,("Warning: No default decadriver configuration for \"$(BOARD)\"."\
+                     "Make sure to set all required CFLAGS manually!"))
 
     DECA_WARNING_PRINTED := 1 # print the warning only once
   endif

--- a/tests/pkg/microcoap/Makefile
+++ b/tests/pkg/microcoap/Makefile
@@ -15,13 +15,15 @@ USEMODULE += xtimer
 
 USEPKG += microcoap
 
+include $(RIOTBASE)/makefiles/color.inc.mk
+
 # Use different settings when compiling for one of the following (low-memory)
 # boards
 LOW_MEMORY_BOARDS := nucleo-f334r8
 
 ifneq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
-  $(shell echo 'Using low-memory configuration for microcoap_server.' 1>&2)
-  ## low-memory tuning values
+  $(call echoinfo,("Using low-memory configuration for microcoap_server."))
+  # low-memory tuning values
   USEMODULE += prng_minstd
 endif
 


### PR DESCRIPTION
### Contribution description

As outlined in #22514, it would be nice to have a macro/command to use for printing infos to `stderr` during the build process, as we have a lot of boilerplate code currently.

~~This PR is a starting point because I want to get feedback if this is the right direction and for example the function names are okay, before I migrate the rest of the code.~~

- [x] Migrate everything.
- [x] Extend the `Build System Basics` guide.

### Testing procedure

The printout of `BOARD=nucleo-g474re make -C tests/periph/spi` causes the typical green info and a yellow warning, these are currently the only two messages migrated. It should look as colorful as ever.

<img width="1154" height="221" alt="image" src="https://github.com/user-attachments/assets/36d1fc45-a490-45c1-b063-0465e0a256fd" />


### Issues/PRs references

Fixes #22514.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
