### PR TITLE
dist/tools/print_toolchain_versions: add docker & podman

### DIFF
--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -154,6 +154,11 @@ for p in \
 done
 printf "%25s: %s\n" "clang" "$(get_cmd_version clang)"
 printf "\n"
+printf "%s\n" "Installed container tools"
+printf "%s\n" "-------------------------"
+printf "%25s: %s\n" "docker" "$(get_cmd_version docker)"
+printf "%25s: %s\n" "podman" "$(get_cmd_version podman)"
+printf "\n"
 printf "%s\n" "Installed compiler libs"
 printf "%s\n" "-----------------------"
 # platform specific newlib version


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

In #22522 I noticed that we don't print that information even though it's fairly valuable (esp. since in that issue this might be something that is broken on docker but not on podman?)

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
 
`make print-versions`

and then boom

```

RIOT version information
----------------------------
              RIOT branch: print_docker_podman
         RIOT commit hash: 9057d61e3663dbc4ad05b442dd396df38c49d422
         RIOT commit date: 2026-07-29

Operating System Environment
----------------------------
         Operating System: "EndeavourOS" 
                   Kernel: Linux 7.1.4-arch1-1 x86_64 unknown
             System shell: GNU bash, version 5.3.15(1)-release (x86_64-pc-linux-gnu)
             make's shell: GNU bash, version 5.3.15(1)-release (x86_64-pc-linux-gnu)

Installed compiler toolchains
-----------------------------
               native gcc: gcc (GCC) 16.1.1 20260625
        arm-none-eabi-gcc: arm-none-eabi-gcc (Arch Repository) 16.1.0
                  avr-gcc: missing
           msp430-elf-gcc: missing
       riscv-none-elf-gcc: missing
  riscv64-unknown-elf-gcc: missing
      riscv32-esp-elf-gcc: missing
  riscv32-unknown-elf-gcc: riscv32-unknown-elf-gcc (g95eb81363) 14.3.1 20250819
     xtensa-esp32-elf-gcc: missing
   xtensa-esp32s2-elf-gcc: missing
   xtensa-esp32s3-elf-gcc: missing
   xtensa-esp8266-elf-gcc: missing
                    clang: clang version 22.1.8

Installed container tools
-------------------------
                   docker: Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
                   podman: podman version 6.0.1

Installed compiler libs
-----------------------
     arm-none-eabi-newlib: "4.6.0"
        msp430-elf-newlib: missing
    riscv-none-elf-newlib: missing
riscv64-unknown-elf-newlib: missing
   riscv32-esp-elf-newlib: missing
riscv32-unknown-elf-newlib: "4.4.0"
  xtensa-esp32-elf-newlib: missing
xtensa-esp32s2-elf-newlib: missing
xtensa-esp32s3-elf-newlib: missing
xtensa-esp8266-elf-newlib: missing
                 avr-libc: missing (missing)

Installed development tools
---------------------------
                   ccache: ccache version 4.13.6
                    cmake: cmake version 4.4.0
                 cppcheck: missing
                  doxygen: 1.16.1
                      git: git version 2.55.0
                     make: GNU Make 4.4.1
                  openocd: Open On-Chip Debugger 0.12.0+dev-gcf9c0b41c (2025-03-19-13:40)
                   python: Python 3.14.6
                  python2: missing
                  python3: Python 3.14.6
                   rustup: rustup 1.28.2 (e4f3ad6f8 2025-04-28)
                    cargo: cargo 1.94.0-nightly (2c283a9a5 2025-12-04)
                    rustc: rustc 1.94.0-nightly (37aa2135b 2025-12-08)
                   c2rust: C2Rust 0.19.0
                     node: v24.14.1
                      npm: 11.11.0
                   flake8: missing
               coccinelle: missing
               
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- Copilot for telling me that I am stupid and on the path to completely overengineering the check instead of just doing it the simple way

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
