### PR TITLE
makefiles/docker: fix builds with external `BUILD_DIR`

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -301,7 +301,16 @@ DOCKER_VOLUMES_AND_ENV += -e 'TZ=$(HOST_TIMEZONE)'
 DOCKER_VOLUMES_AND_ENV += -e 'RIOTBASE=$(DOCKER_RIOTBASE)'
 DOCKER_VOLUMES_AND_ENV += -e 'CCACHE_BASEDIR=$(DOCKER_RIOTBASE)'
 
-DOCKER_VOLUMES_AND_ENV += $(call docker_volume_and_env,BUILD_DIR,,build)
+# For a BUILD_DIR outside of RIOTBASE, we have to create an empty $(RIOTBASE)/build folder
+# for Docker to bind the BUILD_DIR folder to. Otherwise it will create one with
+# root ownership, causing problems when doing non-Docker builds or builds
+# without an external BUILD_DIR.
+ifeq (0,$(INSIDE_DOCKER))
+  ifneq (,$(call dir_is_outside_riotbase,$(BUILD_DIR)))
+    $(shell mkdir -p $(RIOTBASE)/build)
+  endif
+endif
+DOCKER_VOLUMES_AND_ENV += $(call docker_volume_and_env,BUILD_DIR,$(DOCKER_RIOTBASE),build)
 
 # Prevent recursive invocation of docker by explicitly disabling docker via env variable,
 # overwriting potential default in application Makefile


### PR DESCRIPTION
### Contribution description

See #22522.


### Testing procedure

See #22522.

Compiling in Docker with `BUILD_DIR` set will fail on current master:
```
buechse@skyleaf:~/RIOTstuff/riot-vanillaice/RIOT$ BUILD_IN_DOCKER=1 BUILD_DIR=~/.riot BOARD=rpi-pico-2-arm make -C examples/basic/blinky/
make: Entering directory '/home/buechse/RIOTstuff/riot-vanillaice/RIOT/examples/basic/blinky'
Launching build container using image "docker.io/riot/riotbuild@sha256:84746b38b9a6248a21bfa2f9bd4d7a052870c35a689d9b32a06be2f5d7042156".
docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-vanillaice/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -v '/home/buechse/.riot:/data/riotbuild/build:delegated' -e 'BUILD_DIR=/data/riotbuild/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/buechse/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'    -e 'BOARD=rpi-pico-2-arm' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=periph_timer' -e 'USEMODULE=' -e 'USEPKG='  -w '/data/riotbuild/riotbase/examples/basic/blinky/' 'docker.io/riot/riotbuild@sha256:84746b38b9a6248a21bfa2f9bd4d7a052870c35a689d9b32a06be2f5d7042156' make
Building application "blinky" for "rpi-pico-2-arm" with CPU "rp2350_arm".

Cloning into '/data/riotbuild/build/pkg/cmsis'...
done.
HEAD is now at 2b7495b85 Merge branch 'develop'
Cloning into '/data/riotbuild/build/pkg/mpaland-printf'...
done.
HEAD is now at 0dd4b64 test(test_suite): added support for PRINTF_DISABLE_SUPPORT_EXPONENTIAL
Cloning into '/data/riotbuild/build/pkg/picosdk'...
done.
HEAD is now at a1438dff SDK 2.2.0 Release
"make" -C /data/riotbuild/riotbase/pkg/cmsis/
"make" -C /data/riotbuild/riotbase/pkg/mpaland-printf/
"make" -C /data/riotbuild/build/pkg/mpaland-printf -f /data/riotbuild/riotbase/pkg/mpaland-printf/mpaland-printf.mk
cc1: error: /data/riotbuild/riotbase/build/pkg/picosdk/src/rp2_common/cmsis/stub/CMSIS/Core/Include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /data/riotbuild/riotbase/build/pkg/picosdk/src/rp2_common/cmsis/stub/CMSIS/Device/RP2350/Include: No such file or directory [-Werror=missing-include-dirs]
cc1: error: /data/riotbuild/riotbase/build/pkg/picosdk/src/rp2350/hardware_regs/include/hardware: No such file or directory [-Werror=missing-include-dirs]
In file included from /data/riotbuild/riotbase/core/lib/include/thread_config.h:21,
                 from /data/riotbuild/riotbase/core/include/thread.h:125,
                 from /data/riotbuild/riotbase/core/include/mutex.h:27,
                 from /data/riotbuild/riotbase/sys/include/isrpipe.h:23,
                 from /data/riotbuild/riotbase/sys/include/stdio_base.h:23,
                 from /data/riotbuild/build/pkg/mpaland-printf/printf.c:40:
/data/riotbuild/riotbase/cpu/rp2350_arm/include/cpu_conf.h:18:10: fatal error: RP2350.h: No such file or directory
   18 | #include "RP2350.h"
      |          ^~~~~~~~~~
cc1: all warnings being treated as errors
compilation terminated.
make[2]: *** [/data/riotbuild/riotbase/Makefile.base:162: /data/riotbuild/riotbase/examples/basic/blinky/bin/rpi-pico-2-arm/mpaland-printf/printf.o] Error 1
make[1]: *** [Makefile:10: all] Error 2
make: *** [/data/riotbuild/riotbase/Makefile.include:816: pkg-build] Error 2
make: *** [/home/buechse/RIOTstuff/riot-vanillaice/RIOT/makefiles/docker.inc.mk:397: ..in-docker-container] Error 2
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanillaice/RIOT/examples/basic/blinky'
```

With this PR it works:
```
buechse@skyleaf:~/RIOTstuff/riot-vanillaice/RIOT$ BUILD_IN_DOCKER=1 BUILD_DIR=~/.riot BOARD=rpi-pico-2-arm make -C examples/basic/blinky/
make: Entering directory '/home/buechse/RIOTstuff/riot-vanillaice/RIOT/examples/basic/blinky'
Launching build container using image "docker.io/riot/riotbuild@sha256:84746b38b9a6248a21bfa2f9bd4d7a052870c35a689d9b32a06be2f5d7042156".
docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-vanillaice/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -v '/home/buechse/.riot:/data/riotbuild/riotbase/build:delegated' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/buechse/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'    -e 'BOARD=rpi-pico-2-arm' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=periph_timer' -e 'USEMODULE=' -e 'USEPKG='  -w '/data/riotbuild/riotbase/examples/basic/blinky/' 'docker.io/riot/riotbuild@sha256:84746b38b9a6248a21bfa2f9bd4d7a052870c35a689d9b32a06be2f5d7042156' make
Building application "blinky" for "rpi-pico-2-arm" with CPU "rp2350_arm".

Cloning into '/data/riotbuild/riotbase/build/pkg/cmsis'...
done.
HEAD is now at 2b7495b85 Merge branch 'develop'
Cloning into '/data/riotbuild/riotbase/build/pkg/mpaland-printf'...
done.
HEAD is now at 0dd4b64 test(test_suite): added support for PRINTF_DISABLE_SUPPORT_EXPONENTIAL
Cloning into '/data/riotbuild/riotbase/build/pkg/picosdk'...
done.
HEAD is now at a1438dff SDK 2.2.0 Release
"make" -C /data/riotbuild/riotbase/pkg/cmsis/
...
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
   text    data     bss     dec     hex filename
   6596       0    2284    8880    22b0 /data/riotbuild/riotbase/examples/basic/blinky/bin/rpi-pico-2-arm/blinky.elf
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanillaice/RIOT/examples/basic/blinky

```


### Issues/PRs references

Fixes #22522.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none