### PR TITLE
pkg/u8g2/contrib: allow setting display rotation

### DIFF
--- a/pkg/u8g2/contrib/disp_dev/include/u8g2_display.h
+++ b/pkg/u8g2/contrib/disp_dev/include/u8g2_display.h
@@ -42,12 +42,22 @@ typedef void (*u8g2_init_function_t)(u8g2_t *u8g2, const u8g2_cb_t *rotation, u8
  * @brief   U8G2 display initialization parameters
  */
 typedef struct {
-    u8g2_init_function_t init_function;         /**< Initialization function for u8g2 */
-    u8x8_riotos_t peripheral_configuration;     /**< Peripheral configuration for RIOT-OS */
+    u8g2_init_function_t init_function;     /**< Initialization function for u8g2 */
+    u8x8_riotos_t peripheral_configuration; /**< Peripheral configuration for RIOT-OS */
+    uint8_t i2c_address;                    /**< I2C address of the display. Set to 0 when using SPI. */
     /**
-     * I2C address of the display. Set to 0 when using SPI.
+     * @brief Rotation function for u8g2, to control the display orientation.
+     *
+     * Valid values, defined in u8g2.h, are:
+     * - `U8G2_R0`: No rotation, landscape
+     * - `U8G2_R1`: 90 degree clockwise rotation
+     * - `U8G2_R2`: 180 degree clockwise rotation
+     * - `U8G2_R3`: 270 degree clockwise rotation
+     * - `U8G2_MIRROR`: No rotation, landscape, display content is mirrored
+     *
+     * @see For more details, check: https://github.com/olikraus/u8g2/wiki/u8g2setupc#setup-arguments
      */
-    uint8_t i2c_address;
+    const u8g2_cb_t *rotation_function;
 } u8g2_display_params_t;
 
 /**

--- a/pkg/u8g2/contrib/disp_dev/include/u8g2_display_params.h
+++ b/pkg/u8g2/contrib/disp_dev/include/u8g2_display_params.h
@@ -86,6 +86,24 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Default U8G2 rotation function to control the display orientation
+ *
+ * Valid values, defined in u8g2.h, are:
+ * - `U8G2_R0`: No rotation, landscape
+ * - `U8G2_R1`: 90 degree clockwise rotation
+ * - `U8G2_R2`: 180 degree clockwise rotation
+ * - `U8G2_R3`: 270 degree clockwise rotation
+ * - `U8G2_MIRROR`: No rotation, landscape, display content is mirrored
+ *
+ * @see     Check the u8g2 reference for possible rotation functions:
+ *          https://github.com/olikraus/u8g2/wiki/u8g2setupc#setup-arguments
+ */
+#ifndef U8G2_DISPLAY_PARAM_ROTATION_FUNCTION
+#  define U8G2_DISPLAY_PARAM_ROTATION_FUNCTION U8G2_R0
+#endif
+
+
+/**
  * @brief   Default configuration struct
  */
 #ifndef U8G2_DISPLAY_PARAMS
@@ -99,6 +117,7 @@ extern "C" {
                 .pin_reset = U8G2_DISPLAY_PARAM_PIN_RESET, \
             }, \
             .i2c_address = U8G2_DISPLAY_PARAM_I2C_ADDR, \
+            .rotation_function = U8G2_DISPLAY_PARAM_ROTATION_FUNCTION, \
         }
 #endif
 /**@}*/

--- a/pkg/u8g2/contrib/disp_dev/u8g2_display.c
+++ b/pkg/u8g2/contrib/disp_dev/u8g2_display.c
@@ -33,18 +33,22 @@ int u8g2_display_init(u8g2_display_t *dev, const u8g2_display_params_t *params)
 {
     assert(dev != NULL);
     assert(params != NULL);
+    assert(params->init_function != NULL);
+    assert(params->rotation_function != NULL);
 
     dev->params = *params;
 
     u8g2_init_function_t init = dev->params.init_function;
     if (IS_USED(MODULE_PERIPH_SPI) && dev->params.i2c_address == 0) {
         DEBUG("u8g2_display_init: Initializing SPI display\n");
-        init(&dev->u8g2, U8G2_R0, u8x8_byte_hw_spi_riotos, u8x8_gpio_and_delay_riotos);
+        init(&dev->u8g2, dev->params.rotation_function, u8x8_byte_hw_spi_riotos,
+             u8x8_gpio_and_delay_riotos);
     }
     else if (IS_USED(MODULE_PERIPH_I2C) && dev->params.i2c_address != 0) {
         DEBUG("u8g2_display_init: Initializing I2C display with addr: 0x%02x\n",
               dev->params.i2c_address);
-        init(&dev->u8g2, U8G2_R0, u8x8_byte_hw_i2c_riotos, u8x8_gpio_and_delay_riotos);
+        init(&dev->u8g2, dev->params.rotation_function, u8x8_byte_hw_i2c_riotos,
+             u8x8_gpio_and_delay_riotos);
         u8g2_SetI2CAddress(&dev->u8g2, dev->params.i2c_address);
     }
     else {

--- a/pkg/u8g2/doc.md
+++ b/pkg/u8g2/doc.md
@@ -1,4 +1,5 @@
 @defgroup pkg_u8g2 U8G2 graphic library for monochome displays
+@brief Provides drivers for multiple controllers of monochrome displays
 @ingroup pkg
 @ingroup drivers_display
 
@@ -57,8 +58,9 @@ FEATURES_REQUIRED += periph_i2c
 #### 2. Override Default Configurations
 
 You'll need to configure the I2C device (bus), to which the display is connected
-on your board, the I2C address, and the initialization function. To determine
-the initialization function, refer to the setup documentation of the package:
+on your board, the I2C address, the initialization function, and the rotation.
+To determine the initialization function, refer to the setup documentation of
+the package:
 https://github.com/olikraus/u8g2/wiki/u8g2setupc#setup-function-reference. You
 can set these values in your Makefile, for example:
 
@@ -73,9 +75,13 @@ CFLAGS += -DU8G2_DISPLAY_PARAM_I2C_ADDR=0x3C
 # Initialization function taken from documentation
 # https://github.com/olikraus/u8g2/wiki/u8g2setupc#ssd1306-128x64_noname-1
 CFLAGS += -DU8G2_DISPLAY_PARAM_INIT_FUNCTION=u8g2_Setup_ssd1306_i2c_128x64_noname_f
+
+# 180 degree clockwise rotation
+# https://github.com/olikraus/u8g2/wiki/u8g2setupc#setup-arguments
+CFLAGS += -DU8G2_DISPLAY_PARAM_ROTATION_FUNCTION=U8G2_R2
 ```
 
-### SPI Display #{disp-dev-usage-spi}
+### SPI Display {#disp-dev-usage-spi}
 
 Let's say you have an SPI monochrome display with the 1306 controller, and you
 want to use it with the generic display interface.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This extends the parameters of the `u8g2` `disp_dev` interface to allow configuring the display rotation. Currently display initialization is done without rotation.


### Testing procedure

You can use the `tests/pkg/lvgl` application to test this, by adding the necessary `u8g2` package and either `periph_i2c` or `periph_spi` module. Changing the rotation default parameter via `CFLAGS` should allow rotating the display like so:

<img width="1876" height="1529" alt="20260730_112933" src="https://github.com/user-attachments/assets/a961cc13-bc50-4a6c-a263-496b222cc79c" />

<img width="2250" height="1696" alt="20260730_113059" src="https://github.com/user-attachments/assets/c36a3736-1f13-4d00-b4b6-52dd32805848" />

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#21725
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
