### PR TITLE
drivers/lm75: mixed bag of small fixes

### DIFF
--- a/core/lib/include/macros/math.h
+++ b/core/lib/include/macros/math.h
@@ -31,7 +31,7 @@ extern "C" {
 /**
  * @brief Calculates @p a/ @p b with arithmetic rounding (.5 away from zero)
  */
-#define DIV_ROUND(a, b)  ((SIGNOF(a) * ((SIGNOF(a) * (a)) + (SIGNOF(b) * (b)) / 2) / (b)))
+#define DIV_ROUND(a, b)  ((SIGNOF(a) * ((SIGNOF(a) * (a)) + ((SIGNOF(b) * (b)) / 2)) / (b)))
 
 /**
  * @brief Calculates @p a/ @p b, always rounding up (towards positive infinity)

--- a/drivers/include/lm75.h
+++ b/drivers/include/lm75.h
@@ -10,37 +10,40 @@
  *
  * @{
  * @file
- * @brief       Driver for the LM75 temperature sensor.
+ * @brief       Driver for the LM75 and TMP1075 temperature sensors.
  *
  * @author      Vitor Batista <vitor.batista@ml-pa.com>
  *
  */
 
 /**
- * @defgroup    drivers_lm75     LM75 Temperature Sensor driver compile configuration
+ * @defgroup    drivers_lm75     LM75 and TMP1075 Temperature Sensor Driver
  * @ingroup     drivers_sensors
- * @brief       Driver for the lm75 temperature sensors.
+ * @brief       Driver for the LM75 and TMP1075 temperature sensors.
  */
 
+#include <errno.h> /* IWYU pragma: keep needed for EIO etc. */
 #include <stdbool.h>
-#include "periph/i2c.h"
+
 #include "periph/gpio.h"
+#include "periph/i2c.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @name LM75 return values
+ * @name        Backwards compatible LM75 return values
+ * @deprecated  Use `errno` directly instead
+ * @{
  */
-enum {
-    LM75_SUCCESS = 0,
-    LM75_ERROR_I2C,
-    LM75_ERROR
-};
+#define LM75_SUCCESS   0         /**< Success */
+#define LM75_ERROR_I2C (-EIO)    /**< I2C communication error */
+#define LM75_ERROR     (-EINVAL) /**< Other error */
+/** @} */
 
 /**
- * @brief temperature reading properties/resolutions struct of the LM75 sensors
+ * @brief Temperature reading properties/resolutions struct of the LM75 sensors
  */
 typedef struct lm75_properties {
     uint16_t    os_res;      /**< resolution of the OS and HYST registers */
@@ -55,14 +58,19 @@ extern lm75_properties_t lm75a_properties;      /**< declaration present in lm75
 extern lm75_properties_t tmp1075_properties;    /**< declaration present in lm75.c */
 
 /**
- * @brief params required for initialization
+ * @brief Parameters required for initialization
  */
 typedef struct lm75_params {
     const    lm75_properties_t *res;      /**< Temperature resolutions */
-    uint16_t conv_rate;                   /**< Conversion rate in ms */
+    /**
+     * @brief   Device Conversion Rate register
+     *
+     * @warning Only configurable for the TM1075 and ignored for other devices
+     */
+    uint16_t conv_rate;
     gpio_t   gpio_alarm;                  /**< Over-temperature alarm */
     i2c_t    i2c_bus;                     /**< I2C Bus used */
-    uint8_t  i2c_addr;                    /**< i2c address */
+    uint8_t  i2c_addr;                    /**< I2C address */
     uint8_t  shutdown_mode;               /**< Shutdown mode register */
     uint8_t  tm_mode;                     /**< Thermistor Mode */
     uint8_t  polarity;                    /**< OS polarity register */
@@ -72,7 +80,7 @@ typedef struct lm75_params {
 } lm75_params_t;
 
 /**
- * @brief lm75 device descriptor
+ * @brief LM75 device descriptor
  */
 typedef struct lm75 {
     lm75_params_t    lm75_params; /**< Configuration Parameters */
@@ -81,158 +89,167 @@ typedef struct lm75 {
 /**
  * @brief Initialization of the LM75 sensor
  *
- * Initializes the sensor according to specific input parameters.
+ * Initializes the sensor according to the specified input parameters.
  *
- * @param[out] dev        device structure to initialize
- * @param[in] params      initialization parameters
+ * @param[out]  dev         device structure to initialize
+ * @param[in]   params      initialization parameters
  *
- * @return LM75_SUCCESS, on success
- * @return LM75_ERROR_I2C, on I2C related error
- * @return LM75_ERROR, on initialization related error
+ * @retval      0           success
+ * @retval      -EINVAL     Not an LM75 or TMP1075 sensor (value in ID register
+ *                          does not match)
+ * @retval      <0          Error from I2C, see @ref i2c_read_reg
  */
 int lm75_init(lm75_t *dev, const lm75_params_t *params);
 
 /**
  * @brief Temperature values of LM75 sensor
  *
- * Reads the sensor temperature values from TEMP_REG
- * the value is given with the full precision the device is capable of
- * If divided by the device's mult property, the result will be the temperature in ºC
- * and the remainder of that division will be the decimal part of the temperature,
- * at the maximum resolution the device is capable of.
+ * Reads the sensor temperature values from TEMP_REG. The value is given with
+ * the full precision the device is capable of. If divided by the device's
+ * temp_mult property, the result will be the temperature in ºC and the
+ * remainder of that division will be the decimal part of the temperature, at
+ * the maximum resolution the device is capable of.
  *
- * @param[in] dev                device structure
- * @param[in] temperature        buffer where temperature value will be written
+ * @param[in]   dev         device structure
+ * @param[out]  temperature buffer that the temperature value will be written to
  *
- * @return LM75_SUCCESS, on success
- * @return LM75_ERROR_I2C, on I2C related error
+ * @retval      0           success
+ * @retval      <0          Error from I2C, see @ref i2c_read_reg
  */
-int lm75_get_temperature_raw(lm75_t *dev, int *temperature);
+int lm75_get_temperature_raw(const lm75_t *dev, int32_t *temperature);
 
 /**
  * @brief Temperature values of LM75 sensor
  *
- * Gets the device's temperature register with the lm75_get_temperature_raw
- * function and then returns the values in mºC, truncating values smaller than this, if available
+ * Gets the device's temperature register with the @ref lm75_get_temperature_raw
+ * function and then returns the values in mºC, truncating values smaller than
+ * this, if available.
  *
- * @param[in] dev                device structure
- * @param[in] temperature        buffer where temperature value will be written in mºC
+ * @param[in]   dev         device structure
+ * @param[out]  temperature that the temperature value will be written to in mºC
  *
- * @return LM75_SUCCESS, on success
- * @return LM75_ERROR, on error
+ * @retval      0           success
+ * @retval      <0          Error from I2C, see @ref i2c_read_reg
  */
-int lm75_get_temperature(lm75_t *dev, int *temperature);
+int lm75_get_temperature(const lm75_t *dev, int32_t *temperature);
 
 /**
- * @brief Sets the values for Overtemperature shutdown(OS) and Hysteresis temperature(HYST).
- * OS gives the temperature's higher bound and HYST the lower bound
- * values are rounded to the lowest value that the device supports,
+ * @brief Sets the values for Overtemperature Shutdown (OS) and Hysteresis
+ *        Temperature (HYST).
  *
- * @param[in] dev           device structure
- * @param[in] temp_os       desired OS temperature in mºC
- * @param[in] temp_hyst     desired HYST temperature in mºC
- * @param[in] cb            callback that is called from interrupt context
- * @param[in] arg           optional arguments for the gpio_init_int function
+ * OS gives the temperature's upper bound and HYST the lower bound.
+ * The values are rounded to the lowest value that the device supports.
  *
- * @return LM75_SUCCESS, on success
- * @return LM75_ERROR_I2C, on I2C related error
- * @return LM75_ERROR, on temperature setting related error
+ * @param[in]   dev         device structure
+ * @param[in]   temp_hyst   desired HYST temperature in mºC
+ * @param[in]   temp_os     desired OS temperature in mºC
+ * @param[in]   cb          callback that is called from interrupt context
+ * @param[in]   arg         optional arguments for the @ref gpio_init_int function
+ *
+ * @retval      0           success
+ * @retval      -EINVAL     Invalid hysteresis or invalid GPIO config
+ * @retval      <0          Error from I2C, see @ref i2c_read_reg
  */
-int lm75_set_temp_limits(lm75_t *dev, int temp_hyst, int temp_os, gpio_cb_t cb, void *arg);
+int lm75_set_temp_limits(const lm75_t *dev, int32_t temp_hyst, int32_t temp_os,
+                         gpio_cb_t cb, void *arg);
 
 /**
- * @brief Overshutdown temperature value of LM75 sensor
+ * @brief Overtemperature Shutdown (OS) value of the LM75 sensor
  *
  * Reads the sensor OS temperature value from TOS_REG in ºC.
  *
- * @param[in] dev                 device structure
- * @param[out] temperature        buffer where OS temperature value will be written
+ * @param[in]   dev         device structure
+ * @param[out]  temperature buffer that the OS temperature value will be written to
  *
- * @return LM75_SUCCESS, on success
- * @return LM75_ERROR_I2C, on I2C related error
+ * @retval      0           success
+ * @retval      <0          Error from I2C, see @ref i2c_read_reg
  */
-int lm75_get_os_temp(lm75_t *dev, int *temperature);
+int lm75_get_os_temp(const lm75_t *dev, int32_t *temperature);
 
 /**
- * @brief Hysteresis temperature value of LM75 sensor
+ * @brief Hysteresis Temperature (HYST) value of the LM75 sensor
  *
  * Reads the sensor hysteresis temperature value from THYST_REG in ºC.
  *
- * @param[in] dev                 device structure
- * @param[out] temperature        buffer where HYST temperature value will be written
+ * @param[in]   dev         device structure
+ * @param[out]  temperature buffer that the HYST temperature value will be written to
  *
- * @return LM75_SUCCESS, on success
- * @return LM75_ERROR_I2C, on I2C related error
+ * @retval      0           success
+ * @retval      <0          Error from I2C, see @ref i2c_read_reg
  */
-int lm75_get_hyst_temp(lm75_t *dev, int *temperature);
+int lm75_get_hyst_temp(const lm75_t *dev, int32_t *temperature);
 
 /**
  * @brief Read the current state of the OS pin to see if it's active.
  *
- * Read the configuration register to see the OS pin's polarity and
+ * Reads the configuration register to see the OS pin's polarity and
  * then reads its state. Then outputs if the pin is active and whether
  * it's in the low and active or high and active.
  *
- * @param[in] dev               device structure
- * @param[out] os_pin_state     pointer to the state of the OS pin - 0 for inactive and 1 for active
+ * @param[in]   dev             device structure
+ * @param[out]  os_pin_state    pointer to the state of the OS pin - 0 for
+ *                              inactive and 1 for active
  *
- * @return LM75_SUCCESS, on success
- * @return LM75_ERROR, on pin reading error
+ * @retval      0               success
+ * @retval      <0              Error from I2C, see @ref i2c_read_reg
  */
-int lm75_get_os_pin(lm75_t *dev, bool *os_pin_state);
+int lm75_get_os_pin(const lm75_t *dev, bool *os_pin_state);
 
 /**
  * @brief Activate the LM75 sensor shutdown mode
  *
- * @param[in] dev      device structure to set into shutdown mode
+ * @param[in]   dev         device structure to set into shutdown mode
  *
- * @return LM75_SUCCESS, on success
- * @return LM75_ERROR, on mode switching related error
+ * @retval      0           success
+ * @retval      <0          Error from I2C, see @ref i2c_read_reg
  */
-int lm75_poweroff(lm75_t *dev);
+int lm75_poweroff(const lm75_t *dev);
 
 /**
  * @brief Deactivate the LM75 sensor shutdown mode
  *
- * @param[in] dev      device structure to wake up from shutdown mode
+ * @param[in]   dev         device structure to wake up from shutdown mode
  *
- * @return LM75_SUCCESS, on success
- * @return LM75_ERROR, on mode switching related error
+ * @retval      0           success
+ * @retval      <0          Error from I2C, see @ref i2c_read_reg
  */
-int lm75_poweron(lm75_t *dev);
+int lm75_poweron(const lm75_t *dev);
 
 /**
  * @brief Activates one shot conversion mode
  *
  * Wakes from shutdown mode, does a single temperature conversion
- * and writes in into the temperature register and then goes back into shutdown
+ * and writes in into the temperature register and then goes back into shutdown.
  *
- * @param[in] dev       device structure
+ * @param[in]   dev         device structure
  *
- * @return LM75_ERROR if unsuccessful
- * @return LM75_SUCCESS if successful
+ * @retval      0           success
+ * @retval      -ENOTSUP    feature not supported by hardware variant used
+ * @retval      <0          Error from I2C, see @ref i2c_read_reg
  */
-int tmp1075_one_shot(lm75_t *dev);
+int tmp1075_one_shot(const lm75_t *dev);
 
 /**
  * @brief Activates low power mode operation
  *
- * This function makes the device measure temperatures in a strictly discrete way
- * at a user definable rate, as opposed to performing continuous measurements
- * at the device's conversion rate.
- * It allows the device to stay in shutdown mode for the most part, therefore consuming less power.
- * In the tmp1075 and other devices which have the one shot feature this is done automatically.
- * In the LM75A sensor nd other sensors which lack the one shot mode feature this is done manually
- * by switching the device to and from shutdown mode and staying awake at least long enough
- * to perform one ne measurement.
+ * This function makes the device measure temperatures in a strictly
+ * discrete way at a user definable rate, as opposed to performing continuous
+ * measurements at the device's conversion rate.
  *
- * @param[in] dev           device structure
- * @param[in] interval      time interval in ms between measurements
+ * It allows the device to stay in shutdown mode for the most part, therefore
+ * consuming less power. In the TMP1075 and other devices which have the one
+ * shot feature this is done automatically. In the LM75A sensor and other
+ * sensors which lack the one shot mode feature this is done manually by
+ * switching the device to and from shutdown mode and staying awake at least
+ * long enough to perform one measurement.
  *
- * @return LM75_ERROR if unsuccessful
- * @return LM75_SUCCESS if successful
+ * @param[in]   dev         device structure
+ * @param[in]   interval    time interval in ms between measurements
+ *
+ * @retval      0           success
+ * @retval      <0          Error from I2C, see @ref i2c_read_reg
  */
-int lm75_low_power_mode(lm75_t *dev, uint16_t interval);
+int lm75_low_power_mode(const lm75_t *dev, uint16_t interval);
 
 #ifdef __cplusplus
 }

--- a/drivers/lm75/include/lm75_params.h
+++ b/drivers/lm75/include/lm75_params.h
@@ -102,7 +102,7 @@ extern "C" {
 #  define LM75_PARAM_INT GPIO_UNDEF /**< Pin used for Interrupts defined by the board */
 #endif
 
-#define LM75A_CONV_RATE    (100) /**< temperature register updated every 100ms */
+#define LM75A_CONV_RATE    (100)  /**< Temperature register updated every 100ms */
 
 #define LM75A_OS_RES       (5)    /**< resolution in 0.5ºC */
 #define LM75A_OS_MULT      (10)   /**< Must multiply by 10 to get temp in ºC */

--- a/drivers/lm75/include/lm75_params.h
+++ b/drivers/lm75/include/lm75_params.h
@@ -118,7 +118,6 @@ extern "C" {
 #define TMP1075_TEMP_MULT  (10000) /**< Must multiply by 10000 to get temp in ºC */
 #define TMP1075_TEMP_SHIFT (4)     /**< Only the 12 most significant bits are needed */
 
-/* Device conversion rate configuration - only available in the TMP1075 sensor */
 #if IS_ACTIVE(CONFIG_TMP1075_CONV_RATE_REG_27H)
 #  define CONFIG_TMP1075_CONV_RATE_REG TMP1075_CONV_RATE_REG_27H
 #  define TMP1075_CONV_RATE            (28)

--- a/drivers/lm75/include/lm75_params.h
+++ b/drivers/lm75/include/lm75_params.h
@@ -107,7 +107,7 @@ extern "C" {
 #define LM75A_OS_RES       (5)    /**< resolution in 0.5ºC */
 #define LM75A_OS_MULT      (10)   /**< Must multiply by 10 to get temp in ºC */
 #define LM75A_OS_SHIFT     (7)    /**< Only the 9 most significant bits are needed */
-#define LM75A_TEMP_RES     (125)  /**< resolution in 0.125ºC */
+#define LM75A_TEMP_RES     (125)  /**< Resolution in 0.125ºC */
 #define LM75A_TEMP_MULT    (1000) /**< Must multiply by 1000 to get temp in ºC */
 #define LM75A_TEMP_SHIFT   (5)    /**< Only the 11 most significant bits are needed */
 

--- a/drivers/lm75/include/lm75_params.h
+++ b/drivers/lm75/include/lm75_params.h
@@ -28,11 +28,14 @@ extern "C" {
 #  define LM75_PARAM_I2C I2C_DEV(0) /**< I2C BUS used */
 #endif
 
-/** 7-bit I2C slave address: 1-0-0-1-A2-A1-A0, where
-   the last three bits A2, A1, A0 are defined
-   by the voltage level on the ADDR pin */
+/**
+ * @brief   Default I2C address
+ *
+ * 7-bit I2C slave address: 1-0-0-1-A2-A1-A0, where the last three bits A2, A1,
+ * A0 are defined by the voltage level on the ADDR pin
+ */
 #ifndef CONFIG_LM75_I2C_ADDR
-#  define CONFIG_LM75_I2C_ADDR (0x48) /**< Default I2C address */
+#  define CONFIG_LM75_I2C_ADDR (0x48)
 #endif
 
 /* Device operation mode configuration - normal or shutdown */
@@ -44,7 +47,6 @@ extern "C" {
 
 #ifndef CONFIG_OPERATION_MODE
 #  define CONFIG_OPERATION_MODE NORMAL_MODE /**< Normal Mode is the default */
-
 #endif
 
 /* Device Overtemperature Shutdown operation mode configuration - comparator or interrupt */
@@ -87,8 +89,15 @@ extern "C" {
 #  define CONFIG_FAULT_QUEUE FAULT_6
 #endif
 
+/**
+ * @brief   Device Overtemperatue Shutdown fault queue configuration
+ *
+ * Number of faults that must occur consecutively until OS goes active
+ *
+ * Default: One
+ */
 #ifndef CONFIG_FAULT_QUEUE
-#  define CONFIG_FAULT_QUEUE FAULT_1 /**< One Fault is the default */
+#  define CONFIG_FAULT_QUEUE FAULT_1
 #endif
 
 #ifndef LM75_PARAM_INT
@@ -127,9 +136,21 @@ extern "C" {
 #endif
 
 #ifndef CONFIG_TMP1075_CONV_RATE_REG
-#  define CONFIG_TMP1075_CONV_RATE_REG TMP1075_CONV_RATE_REG_27H /**< Default conv rate is 27.5ms */
-#  define TMP1075_CONV_RATE            (28)                      /**< Default conversion rate is 27.5 ms */
-/* this was rounded up to 28ms to retain usage of integers and to keep all times in ms */
+/**
+ * @brief   Device conversion rate register value
+ *
+ * Only available in TMP1075 devices!
+ *
+ * Default: 27.5ms
+ */
+#  define CONFIG_TMP1075_CONV_RATE_REG TMP1075_CONV_RATE_REG_27H
+/**
+ * @brief   Device conversion rate in milliseconds
+ *
+ * Default is 27.5ms or about 28 ms. This is rounded up to 28ms to retain usage
+of integers and to keep all times in ms
+ */
+#  define TMP1075_CONV_RATE            (28)
 #endif
 
 #ifndef LM75_PARAMS

--- a/drivers/lm75/include/lm75_params.h
+++ b/drivers/lm75/include/lm75_params.h
@@ -15,158 +15,156 @@
  * @author      Vitor Batista <vitor.batista@ml-pa.com>
  */
 
-#include "board.h"
+#include "board.h" /* IWYU pragma: keep */
 #include "lm75.h"
 #include "lm75_regs.h"
-#include "kernel_defines.h"
+#include "modules.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #ifndef LM75_PARAM_I2C
-#define LM75_PARAM_I2C               I2C_DEV(0) /**< I2C BUS used */
+#  define LM75_PARAM_I2C I2C_DEV(0) /**< I2C BUS used */
 #endif
 
 /** 7-bit I2C slave address: 1-0-0-1-A2-A1-A0, where
    the last three bits A2, A1, A0 are defined
    by the voltage level on the ADDR pin */
 #ifndef CONFIG_LM75_I2C_ADDR
-#define CONFIG_LM75_I2C_ADDR         (0x48) /**< Default I2C address */
+#  define CONFIG_LM75_I2C_ADDR (0x48) /**< Default I2C address */
 #endif
 
 /* Device operation mode configuration - normal or shutdown */
 #if IS_ACTIVE(CONFIG_NORMAL_MODE)
-#define CONFIG_OPERATION_MODE     NORMAL_MODE
+#  define CONFIG_OPERATION_MODE NORMAL_MODE
 #elif IS_ACTIVE(CONFIG_SHUTDOWN_MODE)
-#define CONFIG_OPERATION_MODE     SHUTDOWN_MODE
+#  define CONFIG_OPERATION_MODE SHUTDOWN_MODE
 #endif
 
 #ifndef CONFIG_OPERATION_MODE
-#define CONFIG_OPERATION_MODE     NORMAL_MODE /**< Normal Mode is the default */
+#  define CONFIG_OPERATION_MODE NORMAL_MODE /**< Normal Mode is the default */
 
 #endif
 
 /* Device Overtemperature Shutdown operation mode configuration - comparator or interrupt */
 #if IS_ACTIVE(CONFIG_COMPARATOR_MODE)
-#define CONFIG_THERMOSTAT_MODE      COMPARATOR_MODE
+#  define CONFIG_THERMOSTAT_MODE COMPARATOR_MODE
 #elif IS_ACTIVE(CONFIG_INTERRUPT_MODE)
-#define CONFIG_THERMOSTAT_MODE      INTERRUPT_MODE
+#  define CONFIG_THERMOSTAT_MODE INTERRUPT_MODE
 #endif
 
 #ifndef CONFIG_THERMOSTAT_MODE
-#define CONFIG_THERMOSTAT_MODE      COMPARATOR_MODE /**< Comparator Mode is the default */
+#  define CONFIG_THERMOSTAT_MODE COMPARATOR_MODE /**< Comparator Mode is the default */
 
 #endif
 
 /* Device Overtemperature Shutdown polarity configuration - OS active low or high */
 #if IS_ACTIVE(CONFIG_OS_ACTIVE_LOW)
-#define CONFIG_OS_POLARITY     OS_ACTIVE_LOW
+#  define CONFIG_OS_POLARITY OS_ACTIVE_LOW
 #elif IS_ACTIVE(CONFIG_OS_ACTIVE_HIGH)
-#define CONFIG_OS_POLARITY     OS_ACTIVE_HIGH
+#  define CONFIG_OS_POLARITY OS_ACTIVE_HIGH
 #endif
 
 #ifndef CONFIG_OS_POLARITY
-#define CONFIG_OS_POLARITY     OS_ACTIVE_LOW  /**< OS pin active on low is the default */
+#  define CONFIG_OS_POLARITY OS_ACTIVE_LOW /**< OS pin active on low is the default */
 
 #endif
 
 /* Device Overtemperatue Shutdown fault queue configuration -
  * number of faults that must occur consecutively until OS goes active */
 #if IS_ACTIVE(CONFIG_FAULT_1)
-#define CONFIG_FAULT_QUEUE     FAULT_1
+#  define CONFIG_FAULT_QUEUE FAULT_1
 #elif IS_ACTIVE(CONFIG_FAULT_2)
-#define CONFIG_FAULT_QUEUE     FAULT_2
+#  define CONFIG_FAULT_QUEUE FAULT_2
 #elif (IS_ACTIVE(CONFIG_FAULT_3) && IS_USED(MODULE_TMP1075))
-#define CONFIG_FAULT_QUEUE     FAULT_3
+#  define CONFIG_FAULT_QUEUE FAULT_3
 #elif (IS_ACTIVE(CONFIG_FAULT_4) && IS_USED(MODULE_LM75A))
-#define CONFIG_FAULT_QUEUE     FAULT_4
+#  define CONFIG_FAULT_QUEUE FAULT_4
 #elif (IS_ACTIVE(CONFIG_FAULT_4) && IS_USED(MODULE_TMP1075))
-#define CONFIG_FAULT_QUEUE     FAULT_4_TMP1075
+#  define CONFIG_FAULT_QUEUE FAULT_4_TMP1075
 #elif (IS_ACTIVE(CONFIG_FAULT_6) && IS_USED(MODULE_LM75A))
-#define CONFIG_FAULT_QUEUE     FAULT_6
+#  define CONFIG_FAULT_QUEUE FAULT_6
 #endif
 
 #ifndef CONFIG_FAULT_QUEUE
-#define CONFIG_FAULT_QUEUE     FAULT_1     /**< One Fault is the default */
-
+#  define CONFIG_FAULT_QUEUE FAULT_1 /**< One Fault is the default */
 #endif
 
 #ifndef LM75_PARAM_INT
-#define LM75_PARAM_INT GPIO_UNDEF          /**< Pin used for Interrupts defined by the board */
+#  define LM75_PARAM_INT GPIO_UNDEF /**< Pin used for Interrupts defined by the board */
 #endif
 
-#define LM75A_CONV_RATE           (100)    /**< temperature register updated every 100ms */
+#define LM75A_CONV_RATE    (100) /**< temperature register updated every 100ms */
 
-#define LM75A_OS_RES              (5)      /**< resolution in 0.5ºC */
-#define LM75A_OS_MULT             (10)     /**< Must multiply by 10 to get temp in ºC */
-#define LM75A_OS_SHIFT            (7)      /**< Only the 9 most significant bits are needed */
-#define LM75A_TEMP_RES            (125)    /**< resolution in 0.125ºC */
-#define LM75A_TEMP_MULT           (1000)   /**< Must multiply by 1000 to get temp in ºC */
-#define LM75A_TEMP_SHIFT          (5)      /**< Only the 11 most significant bits are needed */
+#define LM75A_OS_RES       (5)    /**< resolution in 0.5ºC */
+#define LM75A_OS_MULT      (10)   /**< Must multiply by 10 to get temp in ºC */
+#define LM75A_OS_SHIFT     (7)    /**< Only the 9 most significant bits are needed */
+#define LM75A_TEMP_RES     (125)  /**< resolution in 0.125ºC */
+#define LM75A_TEMP_MULT    (1000) /**< Must multiply by 1000 to get temp in ºC */
+#define LM75A_TEMP_SHIFT   (5)    /**< Only the 11 most significant bits are needed */
 
-#define TMP1075_OS_RES            (625)    /**< resolution in 0.0625ºC */
-#define TMP1075_OS_MULT           (10000)  /**< Must multiply by 10000 to get temp in ºC */
-#define TMP1075_OS_SHIFT          (4)      /**< Only the 12 most significant bits are needed */
-#define TMP1075_TEMP_RES          (625)    /**< resolution in 0.0625ºC */
-#define TMP1075_TEMP_MULT         (10000)  /**< Must multiply by 10000 to get temp in ºC */
-#define TMP1075_TEMP_SHIFT        (4)      /**< Only the 12 most significant bits are needed */
+#define TMP1075_OS_RES     (625)   /**< resolution in 0.0625ºC */
+#define TMP1075_OS_MULT    (10000) /**< Must multiply by 10000 to get temp in ºC */
+#define TMP1075_OS_SHIFT   (4)     /**< Only the 12 most significant bits are needed */
+#define TMP1075_TEMP_RES   (625)   /**< resolution in 0.0625ºC */
+#define TMP1075_TEMP_MULT  (10000) /**< Must multiply by 10000 to get temp in ºC */
+#define TMP1075_TEMP_SHIFT (4)     /**< Only the 12 most significant bits are needed */
 
 /* Device conversion rate configuration - only available in the TMP1075 sensor */
 #if IS_ACTIVE(CONFIG_TMP1075_CONV_RATE_REG_27H)
-#define CONFIG_TMP1075_CONV_RATE_REG     TMP1075_CONV_RATE_REG_27H
-#define TMP1075_CONV_RATE                (28)
+#  define CONFIG_TMP1075_CONV_RATE_REG TMP1075_CONV_RATE_REG_27H
+#  define TMP1075_CONV_RATE            (28)
 #elif IS_ACTIVE(CONFIG_TMP1075_CONV_RATE_REG_55)
-#define CONFIG_TMP1075_CONV_RATE_REG     TMP1075_CONV_RATE_REG_55
-#define TMP1075_CONV_RATE                (55)
+#  define CONFIG_TMP1075_CONV_RATE_REG TMP1075_CONV_RATE_REG_55
+#  define TMP1075_CONV_RATE            (55)
 #elif IS_ACTIVE(CONFIG_TMP1075_CONV_RATE_REG_110)
-#define CONFIG_TMP1075_CONV_RATE_REG     TMP1075_CONV_RATE_REG_110
-#define TMP1075_CONV_RATE                (110)
+#  define CONFIG_TMP1075_CONV_RATE_REG TMP1075_CONV_RATE_REG_110
+#  define TMP1075_CONV_RATE            (110)
 #elif IS_ACTIVE(CONFIG_TMP1075_CONV_RATE_REG_220)
-#define CONFIG_TMP1075_CONV_RATE_REG     TMP1075_CONV_RATE_REG_220
-#define TMP1075_CONV_RATE                (220)
+#  define CONFIG_TMP1075_CONV_RATE_REG TMP1075_CONV_RATE_REG_220
+#  define TMP1075_CONV_RATE            (220)
 #endif
 
 #ifndef CONFIG_TMP1075_CONV_RATE_REG
-#define CONFIG_TMP1075_CONV_RATE_REG     TMP1075_CONV_RATE_REG_27H /**< Default conv rate is 27.5ms */
-#define TMP1075_CONV_RATE                (28) /**< Default conversion rate is 27.5 ms */
+#  define CONFIG_TMP1075_CONV_RATE_REG TMP1075_CONV_RATE_REG_27H /**< Default conv rate is 27.5ms */
+#  define TMP1075_CONV_RATE            (28)                      /**< Default conversion rate is 27.5 ms */
 /* this was rounded up to 28ms to retain usage of integers and to keep all times in ms */
 #endif
 
 #ifndef LM75_PARAMS
-#if IS_USED(MODULE_LM75A)
-#define LM75_PARAMS        {     .res             = &lm75a_properties, \
-                                 .gpio_alarm      = LM75_PARAM_INT, \
-                                 .conv_rate       = LM75A_CONV_RATE, \
-                                 .i2c_bus         = LM75_PARAM_I2C, \
-                                 .i2c_addr        = CONFIG_LM75_I2C_ADDR, \
-                                 .shutdown_mode   = CONFIG_OPERATION_MODE, \
-                                 .tm_mode         = CONFIG_THERMOSTAT_MODE, \
-                                 .polarity        = CONFIG_OS_POLARITY, \
-                                 .fault_q         = CONFIG_FAULT_QUEUE }
+#  if IS_USED(MODULE_LM75A)
+#    define LM75_PARAMS { .res = &lm75a_properties,               \
+                          .gpio_alarm = LM75_PARAM_INT,           \
+                          .conv_rate = LM75A_CONV_RATE,           \
+                          .i2c_bus = LM75_PARAM_I2C,              \
+                          .i2c_addr = CONFIG_LM75_I2C_ADDR,       \
+                          .shutdown_mode = CONFIG_OPERATION_MODE, \
+                          .tm_mode = CONFIG_THERMOSTAT_MODE,      \
+                          .polarity = CONFIG_OS_POLARITY,         \
+                          .fault_q = CONFIG_FAULT_QUEUE }
 
-#endif
+#  endif
 
-#if IS_USED(MODULE_TMP1075)
-#define LM75_PARAMS        {    .res                 = &tmp1075_properties, \
-                                .gpio_alarm          = LM75_PARAM_INT, \
-                                .conv_rate           = TMP1075_CONV_RATE, \
-                                .i2c_bus             = LM75_PARAM_I2C, \
-                                .i2c_addr            = CONFIG_LM75_I2C_ADDR, \
-                                .shutdown_mode       = CONFIG_OPERATION_MODE, \
-                                .tm_mode             = CONFIG_THERMOSTAT_MODE, \
-                                .polarity            = CONFIG_OS_POLARITY, \
-                                .fault_q             = CONFIG_FAULT_QUEUE, \
-                                .conv_rate_reg       = CONFIG_TMP1075_CONV_RATE_REG }
-#endif
+#  if IS_USED(MODULE_TMP1075)
+#    define LM75_PARAMS { .res = &tmp1075_properties,             \
+                          .gpio_alarm = LM75_PARAM_INT,           \
+                          .conv_rate = TMP1075_CONV_RATE,         \
+                          .i2c_bus = LM75_PARAM_I2C,              \
+                          .i2c_addr = CONFIG_LM75_I2C_ADDR,       \
+                          .shutdown_mode = CONFIG_OPERATION_MODE, \
+                          .tm_mode = CONFIG_THERMOSTAT_MODE,      \
+                          .polarity = CONFIG_OS_POLARITY,         \
+                          .fault_q = CONFIG_FAULT_QUEUE,          \
+                          .conv_rate_reg = CONFIG_TMP1075_CONV_RATE_REG }
+#  endif
 #endif /* LM75_PARAMS */
 
 /**
  * @brief LM75 power-up configuration
  */
-static const lm75_params_t lm75_params[] =
-{
-   LM75_PARAMS
+static const lm75_params_t lm75_params[] = {
+    LM75_PARAMS
 };
 
 #ifdef __cplusplus

--- a/drivers/lm75/include/lm75_params.h
+++ b/drivers/lm75/include/lm75_params.h
@@ -73,8 +73,6 @@ extern "C" {
 
 #endif
 
-/* Device Overtemperatue Shutdown fault queue configuration -
- * number of faults that must occur consecutively until OS goes active */
 #if IS_ACTIVE(CONFIG_FAULT_1)
 #  define CONFIG_FAULT_QUEUE FAULT_1
 #elif IS_ACTIVE(CONFIG_FAULT_2)

--- a/drivers/lm75/include/lm75_params.h
+++ b/drivers/lm75/include/lm75_params.h
@@ -111,7 +111,7 @@ extern "C" {
 #define LM75A_TEMP_MULT    (1000) /**< Must multiply by 1000 to get temp in ºC */
 #define LM75A_TEMP_SHIFT   (5)    /**< Only the 11 most significant bits are needed */
 
-#define TMP1075_OS_RES     (625)   /**< resolution in 0.0625ºC */
+#define TMP1075_OS_RES     (625)   /**< Resolution in 0.0625ºC */
 #define TMP1075_OS_MULT    (10000) /**< Must multiply by 10000 to get temp in ºC */
 #define TMP1075_OS_SHIFT   (4)     /**< Only the 12 most significant bits are needed */
 #define TMP1075_TEMP_RES   (625)   /**< resolution in 0.0625ºC */

--- a/drivers/lm75/include/lm75_params.h
+++ b/drivers/lm75/include/lm75_params.h
@@ -114,7 +114,7 @@ extern "C" {
 #define TMP1075_OS_RES     (625)   /**< Resolution in 0.0625ºC */
 #define TMP1075_OS_MULT    (10000) /**< Must multiply by 10000 to get temp in ºC */
 #define TMP1075_OS_SHIFT   (4)     /**< Only the 12 most significant bits are needed */
-#define TMP1075_TEMP_RES   (625)   /**< resolution in 0.0625ºC */
+#define TMP1075_TEMP_RES   (625)   /**< Resolution in 0.0625ºC */
 #define TMP1075_TEMP_MULT  (10000) /**< Must multiply by 10000 to get temp in ºC */
 #define TMP1075_TEMP_SHIFT (4)     /**< Only the 12 most significant bits are needed */
 

--- a/drivers/lm75/include/lm75_params.h
+++ b/drivers/lm75/include/lm75_params.h
@@ -104,7 +104,7 @@ extern "C" {
 
 #define LM75A_CONV_RATE    (100)  /**< Temperature register updated every 100ms */
 
-#define LM75A_OS_RES       (5)    /**< resolution in 0.5ºC */
+#define LM75A_OS_RES       (5)    /**< Resolution in 0.5ºC */
 #define LM75A_OS_MULT      (10)   /**< Must multiply by 10 to get temp in ºC */
 #define LM75A_OS_SHIFT     (7)    /**< Only the 9 most significant bits are needed */
 #define LM75A_TEMP_RES     (125)  /**< Resolution in 0.125ºC */

--- a/drivers/lm75/include/lm75_regs.h
+++ b/drivers/lm75/include/lm75_regs.h
@@ -76,7 +76,7 @@ extern "C" {
 #define TMP1075_DEVICE_ID_REG   (0x0F) /**< Device ID register */
 
 /**
- * @name    fault queue values
+ * @name    Fault Queue Values
  * @{
  */
 #define FAULT_3                 2   /**< ALERT active after 3 faults */

--- a/drivers/lm75/include/lm75_regs.h
+++ b/drivers/lm75/include/lm75_regs.h
@@ -19,48 +19,88 @@
 extern "C" {
 #endif
 
-/* LM75 register list */
+/**
+ * @name    LM75 register list
+ * @{
+ */
 #define LM75_TEMP_REG            (0x00) /**< Temperature register pointer */
 #define LM75_CONF_REG            (0x01) /**< Configuration register pointer */
 #define LM75_THYST_REG           (0x02) /**< Hysteresis register pointer */
 #define LM75_TOS_REG             (0x03) /**< Overtemperature shutdown register pointer */
+/** @} */
 
-/* Device Operation mode */
+/**
+ * @name    Device Operation mode
+ * @{
+ */
 #define NORMAL_MODE         0  /**< Continuous conversion mode */
 #define SHUTDOWN_MODE       1  /**< Shutdown mode ON */
+/** @} */
 
-/* Device Thermostat  operation mode */
+/**
+ * @name    Device Thermostat operation mode
+ * @{
+ */
 #define COMPARATOR_MODE     0  /**< OS operation in comparator mode */
 #define INTERRUPT_MODE      1  /**< OS operation in interrupt mode */
+/** @} */
 
-/* OS polarity */
+/**
+ * @name    OS polarity
+ * @{
+ */
 #define OS_ACTIVE_LOW       0  /**< OS pin active on Low voltage */
 #define OS_ACTIVE_HIGH      1  /**< OS pin active on positive voltage */
+/** @} */
 
-/* Consecutive fault measurements to trigger the alert function */
+/**
+ * @name    Consecutive fault measurements to trigger the alert function
+ * @{
+ */
 #define FAULT_1         0   /**< OS/ALERT active after 1 fault */
 #define FAULT_2         1   /**< OS/ALERT active after 2 faults */
+/** @} */
 
-/* LM75A exclusive registers */
-
+/**
+ * @name    LM75A exclusive registers
+ * @{
+ */
 #define FAULT_4         2   /**< OS active after 4 faults */
 #define FAULT_6         3   /**< OS active after 6 faults */
+/** @} */
 
-/* TMP1075 exclusive registers */
+/**
+ * @name    TMP1075 exclusive registers
+ * @{
+ */
+#define TMP1075_DEVICE_ID_REG   (0x0F) /**< Device ID register */
 
-/* Device ID register - only available in the TMP1075 sensor */
-#define TMP1075_DEVICE_ID_REG   (0x0F) /**< ID register pointer */
-
-/* fault queue values exclusive to the TMP1075 sensor */
+/**
+ * @name    fault queue values
+ * @{
+ */
 #define FAULT_3                 2   /**< ALERT active after 3 faults */
 #define FAULT_4_TMP1075         3   /**< ALERT active after 4 faults */
+/** @} */
 
-/* Conversion rate setting when device is in continuous conversion mode
- * Only configurable in the TMP1075 sensor */
+/**
+ * @name    Conversion rate setting when device is in continuous conversion mode
+ * @{
+ */
 #define TMP1075_CONV_RATE_REG_27H    0   /**< 27.5ms conversion rate */
 #define TMP1075_CONV_RATE_REG_55     1   /**< 55ms conversion rate */
 #define TMP1075_CONV_RATE_REG_110    2   /**< 110ms conversion rate */
 #define TMP1075_CONV_RATE_REG_220    3   /**< 220ms conversion rate */
+/** @} */
+/** @} *//* end of "TMP1075 exclusive registers" group */
+
+/**
+ * @name    Constants for the configuration register
+ * @{
+ */
+#define LM75_CONFIG_SHUTDOWN_MODE    0x01   /**< shut down sensor to conserve power */
+#define TMP1075_CONFIG_ONE_SHOT_MODE 0x81   /**< perform a single measurement */
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/drivers/lm75/lm75.c
+++ b/drivers/lm75/lm75.c
@@ -10,69 +10,70 @@
  * @file
  * @brief       Driver for the LM75 temperature sensor.
  *
- * A general driver for the lm75 temperature sensor including support for the
- * lm75a and tmp1075 sensors as well.
+ * A general driver for the LM75 temperature sensor including support for the
+ * LM75A and TMP1075 sensors as well.
  *
  * @author      Vitor Batista <vitor.batista@ml-pa.com>
  *
  * @}
  */
 
-#include "board.h"
-#include "lm75.h"
-#include "lm75_regs.h"
-#include "lm75_params.h"
-#include "log.h"
-#include "kernel_defines.h"
-#include "periph/gpio.h"
-#include <stdint.h>
 #include <byteorder.h>
-#include "xtimer.h"
-#include "debug.h"
+#include <stdint.h>
 
-#define I2C_BUS                        dev->lm75_params.i2c_bus
-#define I2C_ADDR                       dev->lm75_params.i2c_addr
-#define LM75_CONFIG_SHUTDOWN_MODE      0x01
-#define TMP1075_CONFIG_ONE_SHOT_MODE   0x81 /* also sets the shutdown register to 1 */
+#include "debug.h"
+#include "lm75.h"
+#include "lm75_params.h"
+#include "lm75_regs.h"
+#include "log.h"
+#include "periph/gpio.h"
+#include "xtimer.h"
+
+#define I2C_BUS                      dev->lm75_params.i2c_bus
+#define I2C_ADDR                     dev->lm75_params.i2c_addr
 
 #if IS_ACTIVE(MODULE_LM75A)
 lm75_properties_t lm75a_properties = {
-    .os_res         = LM75A_OS_RES,
-    .os_mult        = LM75A_OS_MULT,
-    .temp_res       = LM75A_TEMP_RES,
-    .temp_mult      = LM75A_TEMP_MULT,
-    .os_shift       = LM75A_OS_SHIFT,
-    .temp_shift     = LM75A_TEMP_SHIFT,
+    .os_res = LM75A_OS_RES,
+    .os_mult = LM75A_OS_MULT,
+    .temp_res = LM75A_TEMP_RES,
+    .temp_mult = LM75A_TEMP_MULT,
+    .os_shift = LM75A_OS_SHIFT,
+    .temp_shift = LM75A_TEMP_SHIFT,
 };
 #endif
 
 #if IS_ACTIVE(MODULE_TMP1075)
 lm75_properties_t tmp1075_properties = {
-    .os_res         = TMP1075_OS_RES,
-    .os_mult        = TMP1075_OS_MULT,
-    .temp_res       = TMP1075_TEMP_RES,
-    .temp_mult      = TMP1075_TEMP_MULT,
-    .os_shift       = TMP1075_OS_SHIFT,
-    .temp_shift     = TMP1075_TEMP_SHIFT,
- };
+    .os_res = TMP1075_OS_RES,
+    .os_mult = TMP1075_OS_MULT,
+    .temp_res = TMP1075_TEMP_RES,
+    .temp_mult = TMP1075_TEMP_MULT,
+    .os_shift = TMP1075_OS_SHIFT,
+    .temp_shift = TMP1075_TEMP_SHIFT,
+};
 #endif
 
-int lm75_init(lm75_t *dev, const lm75_params_t *params) {
-
+int lm75_init(lm75_t *dev, const lm75_params_t *params)
+{
     dev->lm75_params = *params;
-    uint8_t config = (params->shutdown_mode) | (params->tm_mode << 1) \
+    uint8_t config = (params->shutdown_mode) | (params->tm_mode << 1)
                    | (params->polarity << 2) | (params->fault_q << 3);
 
     i2c_acquire(I2C_BUS);
 
+    int err;
     /* read the device ID register of the TMP1075 sensor to confirm it is a TMP1075 */
     if (IS_USED(MODULE_TMP1075) && (dev->lm75_params.res == &tmp1075_properties)) {
         uint16_t deid = 0;
-        if (i2c_read_regs(I2C_BUS, I2C_ADDR, TMP1075_DEVICE_ID_REG, &deid, 2, 0) != 0) {
+        err = i2c_read_regs(I2C_BUS, I2C_ADDR, TMP1075_DEVICE_ID_REG, &deid, 2, 0);
+        if (err) {
             LOG_ERROR("lm75: error reading device ID\n");
-         }
+            i2c_release(I2C_BUS);
+            return err;
+        }
 
-        deid = (uint16_t)ntohs(deid);
+        deid = ntohs(deid);
         /* checks if the device ID corresponds to the TMP1075 sensor
          * and extends the parameter configuration if so */
         if (deid == 0x7500) {
@@ -80,9 +81,9 @@ int lm75_init(lm75_t *dev, const lm75_params_t *params) {
             config |= (params->conv_rate_reg << 5);
         }
         else {
-            LOG_ERROR("lm75: device ID Register doesnt match");
+            LOG_ERROR("lm75: device ID register doesn't match\n");
             i2c_release(I2C_BUS);
-            return LM75_ERROR;
+            return -EINVAL;
         }
     }
     else if (IS_USED(MODULE_LM75A) && (dev->lm75_params.res == &lm75a_properties)) {
@@ -91,43 +92,46 @@ int lm75_init(lm75_t *dev, const lm75_params_t *params) {
     else {
         LOG_ERROR("lm75: device not supported\n");
         i2c_release(I2C_BUS);
-        return LM75_ERROR;
+        return -EINVAL;
     }
 
     /* write the config byte into the configuration register */
-    if (i2c_write_reg(I2C_BUS, I2C_ADDR, LM75_CONF_REG, config, 0) != 0) {
+    err = i2c_write_reg(I2C_BUS, I2C_ADDR, LM75_CONF_REG, config, 0);
+    if (err) {
         i2c_release(I2C_BUS);
-        return LM75_ERROR_I2C;
+        return err;
     }
 
     i2c_release(I2C_BUS);
-    return LM75_SUCCESS;
+    return 0;
 }
 
-int lm75_get_temperature_raw(lm75_t *dev, int *temperature) {
-
+int lm75_get_temperature_raw(const lm75_t *dev, int32_t *temperature)
+{
     int16_t temp;
     i2c_acquire(I2C_BUS);
     /* read the temperature register */
-    if (i2c_read_regs(I2C_BUS, I2C_ADDR, LM75_TEMP_REG, &temp, 2, 0) != 0) {
+    int err = i2c_read_regs(I2C_BUS, I2C_ADDR, LM75_TEMP_REG, &temp, 2, 0);
+    if (err) {
         i2c_release(I2C_BUS);
-        return LM75_ERROR_I2C;
+        return err;
     }
     i2c_release(I2C_BUS);
 
     /* since the value is read in big endian, it must be converted to little endian
-    * then it must be multiplied by its resolution
-    * and then shifted so only the correct number of bits is used */
-    *temperature = (int16_t)ntohs(temp) * dev->lm75_params.res->temp_res \
-                    >> dev->lm75_params.res->temp_shift;
+     * then it must be multiplied by its resolution
+     * and then shifted so only the correct number of bits is used */
+    *temperature = (int16_t)ntohs(temp) * (int32_t)dev->lm75_params.res->temp_res;
+    *temperature >>= dev->lm75_params.res->temp_shift;
 
-    return LM75_SUCCESS;
+    return 0;
 }
 
-int lm75_get_temperature(lm75_t *dev, int *temperature) {
-
-    if (lm75_get_temperature_raw(dev, temperature) != 0) {
-        return LM75_ERROR;
+int lm75_get_temperature(const lm75_t *dev, int32_t *temperature)
+{
+    int err = lm75_get_temperature_raw(dev, temperature);
+    if (err) {
+        return err;
     }
     /* if the device's resolution is lower than mºC convert the temp to mºC */
     if (dev->lm75_params.res->temp_mult < 1000) {
@@ -140,69 +144,75 @@ int lm75_get_temperature(lm75_t *dev, int *temperature) {
         *temperature /= dev->lm75_params.res->temp_mult / 1000;
     }
 
-    return LM75_SUCCESS;
+    return 0;
 }
 
-int lm75_set_temp_limits(lm75_t *dev, int temp_hyst, int temp_os, gpio_cb_t cb, void *arg) {
-
+int lm75_set_temp_limits(const lm75_t *dev, int32_t temp_hyst, int32_t temp_os,
+                         gpio_cb_t cb, void *arg)
+{
     /* Check if the OS alert pin is valid */
     if (!gpio_is_valid(dev->lm75_params.gpio_alarm)) {
-        return LM75_ERROR;
+        return -EINVAL;
     }
 
     /* Enable OS interrupt */
-    if (gpio_init_int(dev->lm75_params.gpio_alarm, GPIO_IN, \
-        dev->lm75_params.polarity ? GPIO_FALLING : GPIO_RISING, cb, arg) != 0) {
-            return LM75_ERROR;
+    gpio_flank_t flank = dev->lm75_params.polarity ? GPIO_FALLING : GPIO_RISING;
+    if (gpio_init_int(dev->lm75_params.gpio_alarm, GPIO_IN, flank,
+                      cb, arg) != 0) {
+        return -EINVAL;
     }
 
     if (temp_hyst >= temp_os) {
         LOG_ERROR("lm75: THYST must be lower than TOS\n");
-        return LM75_ERROR;
+        return -EINVAL;
     }
-    int16_t temp_hyst_short, temp_os_short;
+    int16_t temp_hyst_short;
+    int16_t temp_os_short;
 
     /* getting into the correct precision value in units of 10 */
     temp_hyst = (temp_hyst * dev->lm75_params.res->os_mult) / 1000;
-    temp_os   = (temp_os * dev->lm75_params.res->os_mult) / 1000;
+    temp_os = (temp_os * dev->lm75_params.res->os_mult) / 1000;
 
-    /* temp must first be converted to 16 bit format, and sampled to its resolution
-     * then shifted by the number of unused bits and finally reversed
+    /* temp must first be converted to 16 bit format, and sampled to its
+     * resolution then shifted by the number of unused bits and finally reversed
      * into little endian for writing into the register.
      * NOTE: values smaller than the resolution steps are truncated */
-    temp_hyst_short = (int16_t) (temp_hyst / dev->lm75_params.res->os_res);
+    temp_hyst_short = (int16_t)(temp_hyst / dev->lm75_params.res->os_res);
     temp_hyst_short = temp_hyst_short << dev->lm75_params.res->os_shift;
     temp_hyst_short = ntohs(temp_hyst_short);
-    temp_os_short   = (int16_t) (temp_os / dev->lm75_params.res->os_res);
-    temp_os_short   = temp_os_short << dev->lm75_params.res->os_shift;
-    temp_os_short   = ntohs(temp_os_short);
+    temp_os_short = (int16_t)(temp_os / dev->lm75_params.res->os_res);
+    temp_os_short = temp_os_short << dev->lm75_params.res->os_shift;
+    temp_os_short = ntohs(temp_os_short);
 
     i2c_acquire(I2C_BUS);
 
-    if (i2c_write_regs(I2C_BUS, I2C_ADDR, LM75_THYST_REG, &temp_hyst_short, 2, 0) != 0) {
+    int err = i2c_write_regs(I2C_BUS, I2C_ADDR, LM75_THYST_REG, &temp_hyst_short, 2, 0);
+    if (err) {
         i2c_release(I2C_BUS);
-        LOG_ERROR("lm75: ERROR wrtiting Hyst temp\n");
-        return LM75_ERROR_I2C;
+        LOG_ERROR("lm75: ERROR writing Hyst temp\n");
+        return err;
     }
 
-    if (i2c_write_regs(I2C_BUS, I2C_ADDR, LM75_TOS_REG, &temp_os_short, 2, 0) != 0) {
+    err = i2c_write_regs(I2C_BUS, I2C_ADDR, LM75_TOS_REG, &temp_os_short, 2, 0);
+    if (err) {
         i2c_release(I2C_BUS);
         LOG_ERROR("lm75: ERROR writing OS temp\n");
-        return LM75_ERROR_I2C;
+        return err;
     }
 
     i2c_release(I2C_BUS);
-    return LM75_SUCCESS;
+    return 0;
 }
 
-int lm75_get_os_temp(lm75_t *dev, int *temperature) {
-
+int lm75_get_os_temp(const lm75_t *dev, int32_t *temperature)
+{
     int16_t temp;
     i2c_acquire(I2C_BUS);
     /* read the temperature register */
-    if (i2c_read_regs(I2C_BUS, I2C_ADDR, LM75_TOS_REG, &temp, 2, 0) != 0) {
+    int err = i2c_read_regs(I2C_BUS, I2C_ADDR, LM75_TOS_REG, &temp, 2, 0);
+    if (err) {
         i2c_release(I2C_BUS);
-        return LM75_ERROR_I2C;
+        return err;
     }
 
     i2c_release(I2C_BUS);
@@ -210,142 +220,149 @@ int lm75_get_os_temp(lm75_t *dev, int *temperature) {
     /* since the value is read in big endian, it must be converted into little endian
      * then it must be multiplied by its resolution
      * and then shifted by the number of unused bits that must be discarded */
-     *temperature = (int16_t)ntohs(temp) * dev->lm75_params.res->os_res \
-                   >> dev->lm75_params.res->os_shift;
+    *temperature = (int32_t)((int16_t)ntohs(temp)) * (int32_t)dev->lm75_params.res->os_res;
+    *temperature >>= dev->lm75_params.res->os_shift;
 
-    return LM75_SUCCESS;
+    return 0;
 }
 
-int lm75_get_hyst_temp(lm75_t *dev, int *temperature) {
-
+int lm75_get_hyst_temp(const lm75_t *dev, int32_t *temperature)
+{
     int16_t temp;
     i2c_acquire(I2C_BUS);
 
     /* read the temperature register */
-    if (i2c_read_regs(I2C_BUS, I2C_ADDR, LM75_THYST_REG, &temp, 2, 0) != 0) {
+    int err = i2c_read_regs(I2C_BUS, I2C_ADDR, LM75_THYST_REG, &temp, 2, 0);
+    if (err) {
         i2c_release(I2C_BUS);
-        return LM75_ERROR_I2C;
+        return err;
     }
 
     i2c_release(I2C_BUS);
-    *temperature = (int16_t)ntohs(temp) * dev->lm75_params.res->os_res \
-                   >> dev->lm75_params.res->os_shift;
+    *temperature = (int32_t)(int16_t)ntohs(temp) * (int32_t)dev->lm75_params.res->os_res;
+    *temperature >>= dev->lm75_params.res->os_shift;
 
-    return LM75_SUCCESS;
+    return 0;
 }
 
-int lm75_get_os_pin(lm75_t *dev, bool *os_pin_state) {
-
+int lm75_get_os_pin(const lm75_t *dev, bool *os_pin_state)
+{
     if (!gpio_is_valid(dev->lm75_params.gpio_alarm)) {
         LOG_ERROR("lm75: OS alert pin not connected or defined\n");
-        return LM75_ERROR;
+        return -EINVAL;
     }
 
     *os_pin_state = gpio_read(dev->lm75_params.gpio_alarm) == dev->lm75_params.polarity;
-    return LM75_SUCCESS;
+    return 0;
 }
 
-int lm75_poweroff(lm75_t *dev) {
-
+int lm75_poweroff(const lm75_t *dev)
+{
     i2c_acquire(I2C_BUS);
 
     uint8_t config;
 
-    if (i2c_read_reg(I2C_BUS, I2C_ADDR, LM75_CONF_REG, &config, 0) != 0) {
+    int err = i2c_read_reg(I2C_BUS, I2C_ADDR, LM75_CONF_REG, &config, 0);
+    if (err) {
         i2c_release(I2C_BUS);
-        return LM75_ERROR;
+        return err;
     }
 
     /* sets every register to 0 except the shutdown reg and sees if it is active */
     if ((config & LM75_CONFIG_SHUTDOWN_MODE) != 0) {
         LOG_ERROR("lm75: device already in shutdown mode\n");
         i2c_release(I2C_BUS);
-        return LM75_SUCCESS;
+        return 0;
     }
 
     /* set the shutdown register to 1 (shutdown mode) and keeps every other intact */
     config |= LM75_CONFIG_SHUTDOWN_MODE;
-    if (i2c_write_reg(I2C_BUS, I2C_ADDR, LM75_CONF_REG, config, 0) != 0) {
+    err = i2c_write_reg(I2C_BUS, I2C_ADDR, LM75_CONF_REG, config, 0);
+    if (err) {
         i2c_release(I2C_BUS);
-        return LM75_ERROR;
+        return err;
     }
 
     i2c_release(I2C_BUS);
-    return LM75_SUCCESS;
+    return 0;
 }
 
-int lm75_poweron(lm75_t *dev) {
-
+int lm75_poweron(const lm75_t *dev)
+{
     i2c_acquire(I2C_BUS);
 
     uint8_t config;
-    if (i2c_read_reg(I2C_BUS, I2C_ADDR, LM75_CONF_REG, &config, 0) != 0) {
+    int err = i2c_read_reg(I2C_BUS, I2C_ADDR, LM75_CONF_REG, &config, 0);
+    if (err) {
         i2c_release(I2C_BUS);
-        return LM75_ERROR;
+        return err;
     }
 
     /* sets every reg to 0 except the shutdown register and sees if it is active */
     if ((config & LM75_CONFIG_SHUTDOWN_MODE) == 0) {
         LOG_INFO("lm75: device is already awake\n");
         i2c_release(I2C_BUS);
-        return LM75_SUCCESS;
+        return 0;
     }
     /* set the shutdown bit to 0 (continuous conversion mode) and keep every other reg intact */
     config &= ~LM75_CONFIG_SHUTDOWN_MODE;
 
-    if (i2c_write_reg(I2C_BUS, I2C_ADDR, LM75_CONF_REG, config, 0) != 0) {
+    err = i2c_write_reg(I2C_BUS, I2C_ADDR, LM75_CONF_REG, config, 0);
+    if (err) {
         i2c_release(I2C_BUS);
-        return LM75_ERROR;
+        return err;
     }
 
     i2c_release(I2C_BUS);
-    return LM75_SUCCESS;
+    return 0;
 }
 
-/* Performs a single temperature conversion from shutdown mode and goes back into shutdown */
-int tmp1075_one_shot(lm75_t *dev) {
-
-    if (!IS_USED(MODULE_TMP1075) && (dev->lm75_params.res != &tmp1075_properties)) {
+int tmp1075_one_shot(const lm75_t *dev)
+{
+    if (!IS_USED(MODULE_TMP1075) || (dev->lm75_params.res != &tmp1075_properties)) {
         LOG_ERROR("lm75: device incompatible with the one shot conversion function\n");
-        return LM75_ERROR;
+        return -ENOTSUP;
     }
 
-    else {
-       i2c_acquire(I2C_BUS);
+    i2c_acquire(I2C_BUS);
 
-        uint8_t config;
-        if (i2c_read_reg(I2C_BUS, I2C_ADDR, LM75_CONF_REG, &config, 0) != 0) {
-            i2c_release(I2C_BUS);
-            return LM75_ERROR;
-        }
-
-        /* set the shutdown and one shot mode bits to 1 and keep every other register intact */
-        config |= TMP1075_CONFIG_ONE_SHOT_MODE;
-        if (i2c_write_reg(I2C_BUS, I2C_ADDR, LM75_CONF_REG, config, 0) != 0) {
-            i2c_release(I2C_BUS);
-            return LM75_ERROR;
-         }
-
+    uint8_t config;
+    int err = i2c_read_reg(I2C_BUS, I2C_ADDR, LM75_CONF_REG, &config, 0);
+    if (err) {
         i2c_release(I2C_BUS);
+        return err;
     }
 
-    return LM75_SUCCESS;
+    /* set the shutdown and one shot mode bits to 1 and keep every other register intact */
+    config |= TMP1075_CONFIG_ONE_SHOT_MODE;
+    err = i2c_write_reg(I2C_BUS, I2C_ADDR, LM75_CONF_REG, config, 0);
+    if (err) {
+        i2c_release(I2C_BUS);
+        return err;
+    }
+
+    i2c_release(I2C_BUS);
+
+    return 0;
 }
 
-int lm75_low_power_mode(lm75_t *dev, uint16_t interval) {
-
+int lm75_low_power_mode(const lm75_t *dev, uint16_t interval)
+{
+    int err;
     if (IS_USED(MODULE_TMP1075) && (dev->lm75_params.res == &tmp1075_properties)) {
-        if (tmp1075_one_shot(dev) != 0) {
-            return LM75_ERROR;
+        err = tmp1075_one_shot(dev);
+        if (err) {
+            return err;
         }
         xtimer_msleep(interval);
     }
     else {
-        if (lm75_poweron(dev) != 0) {
-                return LM75_ERROR;
+        err = lm75_poweron(dev);
+        if (err) {
+            return err;
         }
         /* this is required to ensure the temp register updates for followup readings
-        * otherwise the temperature register will have outdated and possibly bogus values */
+         * otherwise the temperature register will have outdated and possibly bogus values */
         if (interval < dev->lm75_params.conv_rate) {
             xtimer_msleep(dev->lm75_params.conv_rate);
         }
@@ -353,10 +370,11 @@ int lm75_low_power_mode(lm75_t *dev, uint16_t interval) {
             xtimer_msleep(interval);
         }
 
-        if (lm75_poweroff(dev) != 0) {
-            return LM75_ERROR;
+        err = lm75_poweroff(dev);
+        if (err) {
+            return err;
         }
     }
 
-    return LM75_SUCCESS;
+    return 0;
 }

--- a/drivers/lm75/lm75_saul.c
+++ b/drivers/lm75/lm75_saul.c
@@ -8,23 +8,23 @@
  * @{
  *
  * @file
- * @brief       SAUL adaption for lm75 compatible device
+ * @brief       SAUL adaption for LM75 compatible temperature sensors
  *
  * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  *
  * @}
  */
 
-#include <string.h>
-
 #include "saul.h"
 #include "lm75.h"
 
 static int read_temperature(const void *dev, phydat_t *res)
 {
-    int temperature;
+    int32_t temperature;
 
-    lm75_get_temperature((lm75_t *)dev, &temperature);
+    if (lm75_get_temperature(dev, &temperature)) {
+        return -ECANCELED;
+    }
     res->val[0] = temperature / 10; /* phydat_t is 16 bit */
     res->unit = UNIT_TEMP_C;
     res->scale = -2;

--- a/tests/drivers/lm75/Makefile
+++ b/tests/drivers/lm75/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.drivers_common
 DRIVER ?= tmp1075
 
 USEMODULE += $(DRIVER)
-USEMODULE += xtimer
+USEMODULE += fmt
+USEMODULE += tiny_strerror
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/drivers/lm75/main.c
+++ b/tests/drivers/lm75/main.c
@@ -10,129 +10,92 @@
  * @file
  * @brief       Test program for the driver for the LM75 temperature sensor.
  *
- * A test setup for the driver for the lm75 temperature sensor
- * including support for the lm75a and tmp1075 sensors as well.
+ * A test setup for the driver for the LM75 temperature sensor
+ * including support for the LM75A and TMP1075 sensors as well.
  *
  * @author      Vitor Batista <vitor.batista@ml-pa.com>
  *
  * @}
  */
 
-#include "board.h"
-#include "lm75.h"
-#include "lm75_regs.h"
-#include "lm75_params.h"
-#include "xtimer.h"
-#include "log.h"
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
+
+#include "fmt.h"
+#include "lm75.h"
+#include "lm75_params.h"
+#include "macros/math.h"
+#include "tiny_strerror.h"
 
 /* prints currently set OS and HYST temperatures */
-int lm75_check_set_temperature_limits(lm75_t *dev) {
+static int lm75_check_set_temperature_limits(lm75_t *dev)
+{
+    int32_t t_raw;
+    int32_t t_milli_c;
+    char out[16];
 
-    int t_os, t_hyst;
     /* get already set OS and HYST values */
-    lm75_get_os_temp(dev, &t_os);
-    printf("Set OS temp is %d.%dºC\n",   t_os / dev->lm75_params.res->os_mult, \
-                                         t_os % dev->lm75_params.res->os_mult);
+    lm75_get_os_temp(dev, &t_raw);
+    t_milli_c = DIV_ROUND((1000 * t_raw), dev->lm75_params.res->os_mult);
+    out[fmt_s32_dfp(out, t_milli_c, -3)] = '\0';
+    printf("Set OS temp is %s ºC\n", out);
 
-    lm75_get_hyst_temp(dev, &t_hyst);
-    printf("Set HYST temp is %d.%dºC\n", t_hyst / dev->lm75_params.res->os_mult, \
-                                         t_hyst % dev->lm75_params.res->os_mult);
+    lm75_get_hyst_temp(dev, &t_raw);
+    t_milli_c = DIV_ROUND((1000 * t_raw), dev->lm75_params.res->os_mult);
+    out[fmt_s32_dfp(out, t_milli_c, -3)] = '\0';
+    printf("Set HYST temp is %s ºC\n", out);
     return 0;
 }
 
 /* This function prints the current temperature with maximum precision */
-int lm75_print_temperature_raw(lm75_t *dev) {
-
-    int temp;
-    if (lm75_get_temperature_raw(dev, &temp) != 0) {
-        return -1;
-    }
-
-    printf("%d.%04dºC\n", temp / dev->lm75_params.res->temp_mult, \
-                             temp % dev->lm75_params.res->temp_mult);
-
-    return 0;
-}
-
-/* This function prints the current temperature with maximum precision */
-int lm75_print_temperature(lm75_t *dev) {
-
-    int temp;
+static int lm75_print_temperature(lm75_t *dev)
+{
+    int32_t temp;
     if (lm75_get_temperature(dev, &temp) != 0) {
         return -1;
     }
-    printf("%d.%dºC\n", temp / 1000, temp % 1000);
-
-    return 0;
-}
-
-/* This function is implemented to make an explicit call
- * for the comparison functionality of the sensor */
-int lm75_check_alarm_state(lm75_t *dev) {
-
-    int temp, t_os, t_hyst;
-
-    /* read the current temperature on the device's register */
-    lm75_get_temperature_raw(dev, &temp);
-    lm75_get_os_temp(dev, &t_os);
-    lm75_get_hyst_temp(dev, &t_hyst);
-
-    /* this is required not to discard the leading zero and
-    * output a false result in the case the temperature is x.0625 */
-
-    if ((temp / dev->lm75_params.res->temp_mult > t_os / dev->lm75_params.res->os_mult) || \
-       ((temp / dev->lm75_params.res->temp_mult == t_os / dev->lm75_params.res->os_mult) && \
-       (temp % dev->lm75_params.res->temp_mult > t_os % dev->lm75_params.res->os_mult))) {
-                LOG_INFO("OS Limit exceeded\n");
-    }
-
-    else if ((temp / dev->lm75_params.res->temp_mult < t_hyst / dev->lm75_params.res->os_mult) || \
-            ((temp / dev->lm75_params.res->temp_mult == t_hyst / dev->lm75_params.res->os_mult) && \
-            (temp % dev->lm75_params.res->temp_mult < t_hyst % dev->lm75_params.res->os_mult))) {
-                LOG_INFO("HYST Limit exceeded\n");
-    }
+    char out[16];
+    out[fmt_s32_dfp(out, temp, -3)] = '\0';
+    printf("%s ºC\n", out);
 
     return 0;
 }
 
 static void cb(void *arg);
 
-int main(void) {
-
+int main(void)
+{
     lm75_t descriptor;
     lm75_t *dev = &descriptor;
     bool alert_state;
-    puts("Sensor test...");
+    puts("LM75 / TMP1075 sensor test...");
     /* LM75 Sensor initialization */
     puts("Initialization...");
-    if (lm75_init(dev, lm75_params) != LM75_SUCCESS) {
-        puts("Initialization  failed");
+    int err = lm75_init(dev, lm75_params);
+    if (err) {
+        printf("Initialization failed: %s\n", tiny_strerror(err));
         return -1;
     }
-    else {
-        puts("Initialization succeeded");
-    }
+
+    puts("Initialization succeeded");
 
     /* Set the hysteresis and overtemperature shutdown */
-    if (lm75_set_temp_limits(dev, 24500, 29000, cb, NULL) != LM75_SUCCESS) {
-        puts("error setting Hyst and/or OS temps");
+    err = lm75_set_temp_limits(dev, 24500, 29000, cb, NULL);
+    if (err) {
+        printf("error setting Hyst and/or OS temps: %s\n", tiny_strerror(err));
     }
 
     lm75_check_set_temperature_limits(dev);
 
     /* Check already set values */
     while (1) {
-
-        /* lm75_print_temperature_raw(dev); prints raw temp */
         lm75_print_temperature(dev); /* prints temp in mºC */
         lm75_check_set_temperature_limits(dev);
         lm75_low_power_mode(dev, 3000); /* testing in low power mode */
-        /* xtimer_msleep(1000); testing in continuous mode */
-        /* lm75_check_alarm_state(dev); checking if temp is within limits implicitly */
-        if (lm75_get_os_pin(dev, &alert_state) != 0) {
-            LOG_ERROR("Error reading OS pin state\n");
+
+        err = lm75_get_os_pin(dev, &alert_state);
+        if (err) {
+            printf("Error reading OS pin state: %s\n", tiny_strerror(err));
         }
         else if (alert_state == 1) {
             puts("OS pin is active");
@@ -142,7 +105,8 @@ int main(void) {
     return 0;
 }
 
-static void cb(void *arg) {
+static void cb(void *arg)
+{
     (void)arg;
     puts("INTERRUPT");
 }


### PR DESCRIPTION
### Contribution description

- use explicit width types over `int` for values
  - The TMP1075 claims to be +/- 1 ºC within -40 ºC to 110 ºC; this won't fit into an `int` on 8-bit and 16-bit systems when using mºC as unit. `int32_t` is portable.
- Improve Doxygen markup
- Add `const` qualifiers where possible
- Use negative `errno` constants as required per coding convention and pass negative `errno` codes from I2C through to allow better error handling
- Fix same error handling
- Fix output of the test app (previous use of `printf("%d.%d C", 20, 50)` would print `20.50 C` but correct would have been `20.050 C`).

> [!NOTE]
> I sneaked in a commit to add braces to core. I don't think that needs two ACKs, as it doesn't change the code. It only make `clang-tidy` happy, which in turn makes me happy.

### Testing procedure

There should be no changes in behavior on 32 bit MCUs.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none additionally to the interactions with copilot that will follow in this PR