### PR TITLE
pkg/decadriver: move device configuration, add warnings, minor fixes

### DIFF
--- a/pkg/decadriver/platform/dw3000_hw_spi.c
+++ b/pkg/decadriver/platform/dw3000_hw_spi.c
@@ -132,8 +132,11 @@ int dw3000_hw_init_interrupt(void)
         _rx_thread_ptr = thread_get(pid);
     }
 
-    gpio_init_int(dw3000_params.irq, GPIO_IN, GPIO_RISING,
-                    _interrupt_callback, NULL);
+    /* the IRQ line is active high */
+    if (gpio_init_int(dw3000_params.irq, GPIO_IN_PD, GPIO_RISING,
+                      _interrupt_callback, NULL) != 0) {
+        return -ENOTSUP;
+    }
     _irq_active = true;
     return 0;
 }

--- a/pkg/decadriver/platform/include/dw3000_params.h
+++ b/pkg/decadriver/platform/include/dw3000_params.h
@@ -27,8 +27,8 @@ extern "C" {
 /**
  * @name    Set default configuration parameters
  *
- * These default values correspond to the Qorvo DWM3000EVB Evaluation Shield
- * on top of an nrf52840dk
+ * The default configuration is set to `GPIO_UNDEF` to ensure a safe behavior
+ * if the application has not configured the pins.
  * @{
  */
 /** SPI device used */
@@ -38,7 +38,7 @@ extern "C" {
 
 /** Chip Select pin for SPI */
 #ifndef DW3000_PARAM_SPI_CS
-#  define DW3000_PARAM_SPI_CS           GPIO_PIN(1, 12)
+#  define DW3000_PARAM_SPI_CS           GPIO_UNDEF
 #endif
 
 /** Mode that the SPI connection uses */
@@ -48,12 +48,12 @@ extern "C" {
 
 /** IRQ pin to receive interrupts from the DW3000 */
 #ifndef DW3000_PARAM_IRQ
-#  define DW3000_PARAM_IRQ              GPIO_PIN(1, 10)
+#  define DW3000_PARAM_IRQ              GPIO_UNDEF
 #endif
 
 /** Pin to reset the DW3000 */
 #ifndef DW3000_PARAM_RESET
-#  define DW3000_PARAM_RESET            GPIO_PIN(1, 8)
+#  define DW3000_PARAM_RESET            GPIO_UNDEF
 #endif
 
 /**
@@ -62,7 +62,7 @@ extern "C" {
  * If undefined, the DW3000 will be woken using SPI CS.
  */
 #ifndef DW3000_PARAM_WAKEUP
-#  define DW3000_PARAM_WAKEUP           GPIO_PIN(1, 11)
+#  define DW3000_PARAM_WAKEUP           GPIO_UNDEF
 #endif
 
 /** The fast SPI speed. Can be activated after IDLE_RC */

--- a/tests/pkg/decadriver/Makefile.board.dep
+++ b/tests/pkg/decadriver/Makefile.board.dep
@@ -1,0 +1,30 @@
+# include color echo macros
+include $(RIOTMAKE)/utils/ansi.mk
+include $(RIOTMAKE)/color.inc.mk
+
+# The pin configuration depends on the specific board used. Wrong
+# pin configurations can cause weird issues or even hardware damage,
+# so the default pin settings are GPIO_UNDEF in the
+# `pkg/decadriver/platform/include/dw3000_params.h` header.
+
+ifeq (nrf52840dk,$(BOARD))
+  CFLAGS += '-DDW3000_PARAM_SPI_CS=GPIO_PIN(1,12)'
+  CFLAGS += '-DDW3000_PARAM_IRQ=GPIO_PIN(1,10)'
+  CFLAGS += '-DDW3000_PARAM_RESET=GPIO_PIN(1,8)'
+  CFLAGS += '-DDW3000_PARAM_WAKEUP=GPIO_PIN(1,11)'
+
+else ifeq (nucleo-l452re,$(BOARD))
+  CFLAGS += '-DDW3000_PARAM_SPI_CS=GPIO_PIN(PORT_B,6)'
+  CFLAGS += '-DDW3000_PARAM_IRQ=GPIO_PIN(PORT_A,9)'
+  CFLAGS += '-DDW3000_PARAM_RESET=GPIO_PIN(PORT_A,8)'
+  CFLAGS += '-DDW3000_PARAM_WAKEUP=GPIO_PIN(PORT_C,7)'
+
+else ifeq (,$(filter list-% info-% generate-%,$(MAKECMDGOALS)))
+  ifeq (,$(DECA_WARNING_PRINTED))
+    MSG="Warning: No default decadriver configuration for \"$(BOARD)\"."\
+        "Make sure to set all CFLAGS manually!"
+    $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)$(MSG)$(COLOR_RESET)" 1>&2)
+
+    DECA_WARNING_PRINTED := 1 # print the warning only once
+  endif
+endif

--- a/tests/pkg/decadriver/main.c
+++ b/tests/pkg/decadriver/main.c
@@ -31,8 +31,8 @@
 #include "deca_device_api.h"
 
 /* PAN ID/short address */
-#define PAN_ID              0xDECA
-#define SHORT_ADDR_DEFAULT  0x0001
+#define PAN_ID              0xDECAU
+#define SHORT_ADDR_DEFAULT  0x0001U
 
 static dwt_config_t _config = {
     .chan = 9,
@@ -152,6 +152,7 @@ static int _dw_send(int argc, char **argv)
 
 static int _dw_addr(int argc, char **argv)
 {
+    printf("[deca] Current address: '%"PRIx16"'\n", _self_address);
     if (argc < 2) {
         puts("Usage: dw_addr <addr (hex without 0x)>");
         return 0;
@@ -203,16 +204,37 @@ SHELL_COMMAND(dw_wakeup, "Wake up the DW3000 again", _dw_wakeup);
 
 int main(void)
 {
-    dw3000_hw_init();
-    dw3000_hw_init_interrupt();
+    if (dw3000_hw_init() != 0) {
+        puts("[deca init] Error: Hardware initialization failed!");
+        return 1;
+    }
+
     dw3000_hw_reset();
 
-    dwt_probe((struct dwt_probe_s *)&dw3000_probe_interf);
+    if (dwt_probe((struct dwt_probe_s *)&dw3000_probe_interf) != DWT_SUCCESS) {
+        puts("[deca init] Device Probing failed!");
+        return 1;
+    }
+
     uint32_t dev_id = dwt_readdevid();
-    printf("[deca init] detected device id: %"PRIx32"\n", dev_id);
+    printf("[deca init] detected device id: '0x%"PRIx32"'\n", dev_id);
+    if (dev_id == 0 || dev_id == 0xFFFFFFFF) {
+        /* depending on the hardware, the level of a floating MISO pin can be
+         * low or high, so we check for both variants. `dwt_probe` should've
+         * failed before reaching this check. */
+        puts("[deca init] Error: No device present!");
+        return 1;
+    }
+
+    /* dwt_probe() initializes data structures used by the `deca tx` thread,
+     * so it has to be called first */
+    if (dw3000_hw_init_interrupt() != 0) {
+        puts("[deca init] Error: Interrupt initialization failed!");
+        return 1;
+    }
 
     /* The API guide says it is recommended to check for idle rc before
-     * dwt_initialse(), while libdeca does the other order. */
+     * dwt_initialise(), while libdeca does the other order. */
     while (!dwt_checkidlerc()) {};
     puts("[deca init] DW3xxx reached IDLE_RC");
 
@@ -230,6 +252,8 @@ int main(void)
     }
     dwt_setrxtimeout(0);
 
+    printf("[deca init] Setting PAN ID '0x%"PRIx16"' and Short Address '0x%"PRIx16"'\n",
+           (uint16_t)PAN_ID, (uint16_t)_self_address);
     dwt_setpanid(PAN_ID);
     dwt_setaddress16(_self_address);
 


### PR DESCRIPTION
### Contribution description

1) The IRQ pin was initialized without pull up or pull down, leading to spontaneous errors when no board was connected as the pin was floating.
The IRQ pin is active high, so the Pull Down option is the safe and correct option here.

2) The device configuration was stored in the headers and defaulted to `nrf52840dk`, which causes weird issues when not using that board and forgetting to set sane values. Ask me how I know 😇 

3) The test application did not check the return values of the initialization functions, so when the initialization of GPIOs for example failed, it just happily moved on and caused a crash.

4) Print the address before setting it, also print it during the initialization.

### Testing procedure

Running the application on a `nucleo-l452re` with this PR without a DWM3000EVB shield connected:
```
/home/cbuec/RIOTstuff/riot-vanillaice/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" -ln "/tmp/pyterm-cbuec" -rn "2026-07-31_14.52.45-tests_decadriver-nucleo-l452re"
2026-07-31 14:52:45,424 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2026-07-31 14:52:47,516 # main(): This is RIOT! (Version: 2026.10-devel-244-g0277e-pr/decadriver_enhancement)
2026-07-31 14:52:47,524 # [deca init] detected device id: '0x0'
2026-07-31 14:52:47,527 # [deca init] Error: No device present!
```

Running the application on a custom board with DW3000:
<img width="811" height="177" alt="image" src="https://github.com/user-attachments/assets/aec79520-06ab-4d2b-9fed-80aeb9072c49" />


### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:
AI-Tools / LLMs that were used are:
- none