### PR TITLE
net/unicoap: introduce optional inorder-only mode for options

### DIFF
--- a/examples/networking/coap/unicoap_message/app.config
+++ b/examples/networking/coap/unicoap_message/app.config
@@ -1,0 +1,3 @@
+# Disable this option for decreased Flash and RAM usage during option manipulation.
+# This restricts options to be added only in-order.
+CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT=y

--- a/examples/networking/coap/unicoap_message/main.c
+++ b/examples/networking/coap/unicoap_message/main.c
@@ -73,7 +73,7 @@ static void _example_handle_message(const unicoap_message_t* message)
         printf("Error: could read first Uri-Query option");
     }
 
-    printf("First URI query: '%.*s'\n", (int)res, query);
+    printf("- First URI query: '%.*s'\n", (int)res, query);
 
     /* You can also get a query by name: */
     res = unicoap_options_get_first_uri_query_by_name_string(message->options, "color", &query);
@@ -222,16 +222,32 @@ static void _example_create_message(void)
         puts("Error: could not add path component");
     }
 
+    /* Simple non-repeatable options like Content-Format can be set as follows: */
+    res = unicoap_options_set_content_format(&options, UNICOAP_FORMAT_TEXT);
+    if (res < 0) {
+        puts("Error: could not set Content-Format");
+    }
+
     /* Uri-Query is a repeatable option, and can thus also be added individually. */
     res = unicoap_options_add_uri_queries_string(&options, "unit=C&cool=yes");
     if (res < 0) {
         puts("Error: could not add URI query");
     }
 
-    /* Simple options like Content-Format can be set as follows: */
-    res = unicoap_options_set_content_format(&options, UNICOAP_FORMAT_TEXT);
+    if (IS_ACTIVE(CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT)) {
+        /* As long as this configuration is enabled, options can also be
+         * set or altered out-of-order. Otherwise options need to be set
+         * and added according to their ascending option numbers. */
+        res = unicoap_options_set_content_format(&options, UNICOAP_FORMAT_JSON);
+        if (res < 0) {
+            puts("Error: could not change Content-Format");
+        }
+    }
+
+    /* This results in unit=C&cool=yes&time=now */
+    res = unicoap_options_add_uri_query_string(&options, "time=now");
     if (res < 0) {
-        puts("Error: could not set Content-Format");
+        puts("Error: could not add URI query");
     }
 
     /* Let's see if everything has been added: */

--- a/sys/include/net/unicoap/config.h
+++ b/sys/include/net/unicoap/config.h
@@ -131,6 +131,22 @@
  * @{
  */
 /**
+ * @brief Full support for CoAP option manipulation.
+ *
+ * Allows to change, remove and add options in any order. This comes with
+ * some implementation cost and can therefore be disabled. In that case,
+ * altering or adding an option out-of-order results in a runtime error.
+ *
+ * @remark Disabling this configuration is incompatible with Client URI,
+ *         Observe and Blockwise support.
+ *
+ * **Default**: Enabled
+ */
+#if !defined(CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT) || defined(DOXYGEN)
+#  define CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT 1
+#endif
+
+ /**
  * @brief Maximum number of options that can be present in a request or response
  *
  * **Default**: 16 options

--- a/sys/include/net/unicoap/message.h
+++ b/sys/include/net/unicoap/message.h
@@ -347,7 +347,7 @@ const char* unicoap_string_from_rfc7252_type(unicoap_rfc7252_message_type_t type
  */
 static inline uint8_t* unicoap_message_options_data(const unicoap_message_t* message)
 {
-    return message->options ? message->options->entries->data : NULL;
+    return message->options ? unicoap_options_data(message->options) : NULL;
 }
 
 /**

--- a/sys/net/application_layer/unicoap/Kconfig
+++ b/sys/net/application_layer/unicoap/Kconfig
@@ -6,6 +6,14 @@ menu "CoAP Unified Suite (unicoap)"
 
     menu "Buffers"
 
+        config UNICOAP_OPTIONS_FULL_SUPPORT
+            bool "Full support for CoAP option manipulation."
+            default y
+            help
+                Allows to change, remove and add options in any order. This comes with
+                some implementation cost and can therefore be disabled. In that case,
+                altering or adding an option out-of-order results in a runtime error.
+
         config UNICOAP_OPTIONS_MAX
             int "Maximum number of options in a message"
             range 0 9999999

--- a/sys/net/application_layer/unicoap/docs/message-example.doc.md
+++ b/sys/net/application_layer/unicoap/docs/message-example.doc.md
@@ -235,7 +235,7 @@ if (res < 0) {
 The same applies to `Uri-Query`.
 
 ```c
-res = unicoap_options_add_uri_queries_string(&options, "unit=C&friendly=yes");
+res = unicoap_options_add_uri_queries_string(&options, "unit=C&cool=yes");
 if (res < 0) {
     puts("Error: could not add URI query");
 }
@@ -247,6 +247,19 @@ that require a length indication instead. Example:
 @ref unicoap_options_t::unicoap_options_add_uri_queries_string, or
 @ref unicoap_options_t::unicoap_options_add_uri_query and
 @ref unicoap_options_t::unicoap_options_add_uri_query_string.
+
+As long as `CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT` is enabled (the default),
+it is possible to alter options that were previously set,
+and to add options in any order.
+If it is disabled, options can only be added and set in ascending CoAP option number order.
+The setter functions will return a negative error code if that order is not followed.
+
+```c
+res = unicoap_options_set_content_format(&options, UNICOAP_FORMAT_JSON);
+if (res < 0) {
+    puts("Error: could not change Content-Format");
+}
+```
 
 ### Serializing a Message
 

--- a/sys/net/application_layer/unicoap/options.c
+++ b/sys/net/application_layer/unicoap/options.c
@@ -344,6 +344,7 @@ void _move_options_in_storage_buffer(unicoap_options_t* options, uint8_t* dest, 
 {
     uint8_t* start = unicoap_options_data(options);
     uint8_t* end = start + options->storage_capacity;
+    (void)end; /* unused with NDEBUG */
     assert(src >= start && src < end);
     assert(dest >= start && dest < end);
     size_t from_start = (uintptr_t)src - (uintptr_t)start;

--- a/sys/net/application_layer/unicoap/options.c
+++ b/sys/net/application_layer/unicoap/options.c
@@ -11,14 +11,16 @@
  * @author  Carl Seifert <carl.seifert@tu-dresden.de>
  */
 
+#include <stddef.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <errno.h>
 #include <assert.h>
 
-#include "ztimer.h" /* needed for generating observe value */
 #include "byteorder.h"
 #include "compiler_hints.h"
+#include "modules.h"
+#include "ztimer.h" /* needed for generating observe value */
 
 #include "net/unicoap/message.h"
 #include "net/unicoap/options.h"
@@ -46,11 +48,11 @@
  * - `VALUE`: Value attached to option, succeeding `HEAD`.
  * - `delta nibble`: Either `delta` value, if lower than 13, or sentinel value 13 (`0xe`),
  *    or 14 (`0xd`). 15 (`0xf`)  is disallowed.
- * - `delta extended`: For `delta nibble` values greater or equal 13, `delta nibble - 13`.
+ * - `delta extended`: For `delta nibble` values greater or equal 13, `delta - 13`.
  *    For `delta` values greater or equal `14 + 0xff`, `delta - 14 - 0xff`
  * - `length nibble`: Either `length` value, if lower than 13, or sentinel value 13 (`0xe`),
  *    or 14 (`0xd`). 15 (`0xf`)  is disallowed.
- * - `length extended`: For `length nibble` values greater or equal 13, `length nibble - 13`.
+ * - `length extended`: For `length nibble` values greater or equal 13, `length - 13`.
  *    For `length` values greater or equal `14 + 0xff`, `length - 14 - 0xff`
  *
  * ```
@@ -340,10 +342,13 @@ static inline void _write_head_partial(uint8_t** cursor, uint16_t delta, uint8_t
 static inline
 void _move_options_in_storage_buffer(unicoap_options_t* options, uint8_t* dest, uint8_t* src)
 {
-    size_t remainder = options->storage_size - ((uintptr_t)src - (uintptr_t)options->entries->data);
-    assert(dest < options->entries->data + options->storage_capacity);
-    assert(src < (options->entries->data + options->storage_capacity));
-    assert((src + remainder) < (options->entries->data + options->storage_capacity));
+    uint8_t* start = unicoap_options_data(options);
+    uint8_t* end = start + options->storage_capacity;
+    assert(src >= start && src < end);
+    assert(dest >= start && dest < end);
+    size_t from_start = (uintptr_t)src - (uintptr_t)start;
+    size_t remainder = options->storage_size - from_start;
+    assert((src + remainder) < end);
     memmove(dest, src, remainder);
 }
 
@@ -427,7 +432,7 @@ static int _shift_options(unicoap_options_t* options, size_t i, ssize_t data_dif
     return 0;
 }
 
-static int _find_option_index(const unicoap_options_t* options, uint16_t number)
+static int _find_option_index(const unicoap_options_t* options, unicoap_option_number_t number)
 {
     size_t count = options->option_count;
     for (size_t i = 0; i < count; i += 1) {
@@ -602,8 +607,20 @@ int unicoap_options_add(unicoap_options_t* options, unicoap_option_number_t numb
     }
 
     size_t i = 0;
-    while ((i < count) && (opts[i].number <= number)) {
-        i += 1;
+    if (IS_ACTIVE(CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT)) {
+        while ((i < count) && (opts[i].number <= number)) {
+            i += 1;
+        }
+    }
+    else if (count == 0 || opts[count-1].number <= number) {
+        /* allowed in-order addition */
+        i = count;
+    }
+    else {
+        unicoap_assist(API_ERROR("Adding option out of order not supported.")
+                        FIXIT("Enable CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT")
+                        FIXIT("Reorder option additions to ascending CoAP option numbers"));
+        return -ENOTSUP;
     }
 
     unicoap_option_entry_t* e = &opts[i];
@@ -723,7 +740,7 @@ int unicoap_options_set(unicoap_options_t* options, unicoap_option_number_t numb
     if (option_index < 0) {
         return unicoap_options_add(options, number, value, value_size);
     }
-    else {
+    else if (IS_ACTIVE(CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT)) {
         unicoap_option_entry_t* e = &opts[option_index];
         uint16_t delta = (option_index > 0) ? (number - opts[option_index - 1].number) : number;
 
@@ -737,11 +754,24 @@ int unicoap_options_set(unicoap_options_t* options, unicoap_option_number_t numb
         uint8_t* dest = e->data;
         _write_option(&dest, delta, value, value_size);
     }
+    else {
+        unicoap_assist(API_ERROR("Changing existing option not supported.")
+                       FIXIT("Enable CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT")
+                       FIXIT("Only set options once."));
+        return -ENOTSUP;
+    }
     return 0;
 }
 
 int unicoap_options_remove_all(unicoap_options_t* options, unicoap_option_number_t number)
 {
+    if (!IS_ACTIVE(CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT)) {
+        unicoap_assist(API_ERROR("Removing options not supported.")
+                       FIXIT("Enable CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT")
+                       FIXIT("Do not remove options."));
+        return -ENOTSUP;
+    }
+
     _OPTIONS_DEBUG("attempting to remove %s (nr=%u)\n", unicoap_string_from_option_number(number),
                   number);
     int option_index = _find_option_index(options, number);
@@ -1000,7 +1030,7 @@ ssize_t unicoap_options_swap_storage(unicoap_options_t* options, uint8_t* destin
     if (options->storage_size == 0) {
         return 0;
     }
-    assert(options->entries->data);
+    assert(unicoap_options_data(options));
 
     if (options->storage_size > capacity) {
         _OPTIONS_DEBUG("no buffer space to copy options\n");
@@ -1008,7 +1038,7 @@ ssize_t unicoap_options_swap_storage(unicoap_options_t* options, uint8_t* destin
     }
 
     options->storage_capacity = capacity;
-    memcpy(destination, options->entries->data, options->storage_size);
+    memcpy(destination, unicoap_options_data(options), options->storage_size);
 
     size_t offset = 0;
     for (size_t i = 0; i < options->option_count; i += 1) {

--- a/sys/net/application_layer/unicoap/server/server.c
+++ b/sys/net/application_layer/unicoap/server/server.c
@@ -157,7 +157,7 @@ int unicoap_server_process_request(unicoap_packet_t* packet, const unicoap_resou
             /* handler does not want to send response (provided No-Response is set at all) */
             /* the decision whether to honour No-Response must be made by the handler */
 
-            if (res >= 0 && IS_ACTIVE(CONFIG_UNICOAP_ASSIST)) {
+            if (res >= 0) {
                 /* Handler did not fail but did not send response. */
                 unicoap_assist(API_MISUSE("handler did not respond")
                                FIXIT("set USEMODULE += unicoap_deferred_response and"

--- a/sys/net/application_layer/unicoap/utils.c
+++ b/sys/net/application_layer/unicoap/utils.c
@@ -345,7 +345,7 @@ int unicoap_pdu_buildv_options_and_payload(uint8_t* header, size_t header_size,
     iolist_init(iolists, header, header_size, NULL);
 
     iolist_t* element = iolists;
-    if (message->options && message->options->option_count > 0) {
+    if (message->options && unicoap_message_options_size(message) > 0) {
         element->iol_next = element + 1;
         element += 1;
         iolist_init(element, unicoap_message_options_data(message),
@@ -369,7 +369,7 @@ ssize_t unicoap_pdu_build_options_and_payload(uint8_t* pdu, size_t capacity,
     assert(pdu);
     assert(message);
 
-    if (message->options && message->options->option_count > 0) {
+    if (message->options && unicoap_message_options_size(message) > 0) {
         if (capacity < unicoap_message_options_size(message)) {
             return -ENOBUFS;
         }

--- a/tests/unittests/tests-unicoap/tests-unicoap-options.c
+++ b/tests/unittests/tests-unicoap/tests-unicoap-options.c
@@ -13,6 +13,7 @@
 
 #include <stdio.h>
 
+#include "modules.h"
 #include "tests-unicoap.h"
 
 #include "net/unicoap/options.h"
@@ -69,6 +70,16 @@ static void test_in_order(void)
 static void test_out_of_order(void)
 {
     UNICOAP_OPTIONS_ALLOC_STATIC(options, 100);
+
+    if (!IS_ACTIVE(CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT)) {
+        TEST_ASSERT_EQUAL_INT(unicoap_options_set_content_format(&options, UNICOAP_FORMAT_JSON), 0);
+        TEST_ASSERT_EQUAL_INT(unicoap_options_set_accept(&options, UNICOAP_FORMAT_JSON), 0);
+        TEST_ASSERT_EQUAL_INT(unicoap_options_add_uri_path_component_string(&options, "actuators"), -ENOTSUP);
+        TEST_ASSERT_EQUAL_INT(unicoap_options_add_uri_query_string(&options, "color=g"), -ENOTSUP);
+        TEST_ASSERT_EQUAL_INT(unicoap_options_add_uri_path_component_string(&options, "leds"), -ENOTSUP);
+        return;
+    }
+
     TEST_ASSERT_EQUAL_INT(unicoap_options_set_accept(&options, UNICOAP_FORMAT_JSON), 0);
     TEST_ASSERT_EQUAL_INT(unicoap_options_add_uri_path_component_string(&options, "actuators"), 0);
     TEST_ASSERT_EQUAL_INT(unicoap_options_add_uri_query_string(&options, "color=g"), 0);
@@ -81,6 +92,13 @@ static void test_out_of_order(void)
 static void test_idempotent(void)
 {
     UNICOAP_OPTIONS_ALLOC_STATIC(options, 100);
+
+    if (!IS_ACTIVE(CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT)) {
+        TEST_ASSERT_EQUAL_INT(unicoap_options_set_accept(&options, UNICOAP_FORMAT_JSON), 0);
+        TEST_ASSERT_EQUAL_INT(unicoap_options_set_accept(&options, UNICOAP_FORMAT_JSON), -ENOTSUP);
+        return;
+    }
+
     TEST_ASSERT_EQUAL_INT(unicoap_options_set_accept(&options, UNICOAP_FORMAT_JSON), 0);
     TEST_ASSERT_EQUAL_INT(unicoap_options_set_accept(&options, UNICOAP_FORMAT_JSON), 0);
     TEST_ASSERT_EQUAL_INT(unicoap_options_add_uri_path_component_string(&options, "actuators"), 0);
@@ -109,6 +127,11 @@ static void _populate(unicoap_options_t* options)
 
 static void test_extended_uint_shifts(void)
 {
+    if (!IS_ACTIVE(CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT)) {
+        /* no shifting supported anyways */
+        return;
+    }
+
     UNICOAP_OPTIONS_ALLOC_STATIC(options, 900);
     _populate(&options);
 
@@ -177,6 +200,11 @@ static void test_extended_uint_shifts(void)
 
 static void test_remove_leading(void)
 {
+    if (!IS_ACTIVE(CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT)) {
+        /* no removal supported anyways */
+        return;
+    }
+
     UNICOAP_OPTIONS_ALLOC_STATIC(options, 900);
     _populate(&options);
 
@@ -247,6 +275,11 @@ static void test_remove_leading(void)
 
 static void test_remove_trailing(void)
 {
+    if (!IS_ACTIVE(CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT)) {
+        /* no removal supported anyways */
+        return;
+    }
+
     UNICOAP_OPTIONS_ALLOC_STATIC(options, 900);
     _populate(&options);
 
@@ -317,6 +350,11 @@ static void test_remove_trailing(void)
 
 static void test_remove_multiple(void)
 {
+    if (!IS_ACTIVE(CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT)) {
+        /* no removal supported anyways */
+        return;
+    }
+
     UNICOAP_OPTIONS_ALLOC_STATIC(options, 900);
     _populate(&options);
 
@@ -385,6 +423,11 @@ static void test_remove_multiple(void)
 
 static void test_remove_multiple_trailing(void)
 {
+    if (!IS_ACTIVE(CONFIG_UNICOAP_OPTIONS_FULL_SUPPORT)) {
+        /* no removal supported anyways */
+        return;
+    }
+
     UNICOAP_OPTIONS_ALLOC_STATIC(options, 20);
     TEST_ASSERT_EQUAL_INT(unicoap_options_set(&options, 4, (uint8_t*)poem, 1), 0);
     TEST_ASSERT_EQUAL_INT(unicoap_options_set(&options, 1, (uint8_t*)poem, 1), 0);


### PR DESCRIPTION
### Contribution description

When small build size is a concern, it might be a bad trade-off to allow user-friendly option manipulation (removal, changing, insertion in any order) which comes with a certain implementation overhead. This PR adds a configuration variable that can turn this "full support" off and aligns more closely with the behavior of the nanocoap serializer: Only in-order insertion is allowed.

This will conflict with the client URI parsing support (https://github.com/RIOT-OS/RIOT/pull/22266) and more advanced features like observe (https://github.com/RIOT-OS/RIOT/pull/22277) and blockwise support: Those need the ability for the CoAP stack to alter/add-to user-provided options. But if build size is a major concern, you would probably not want those features anyway.

Implementation size difference (in case of unittests, also includes some stripped test code):

```
$ CFLAGS+=-DCONFIG_UNICOAP_OPTIONS_FULL_SUPPORT=1 make -C tests/unittests tests-unicoap BOARD=nrf52840dk all       
...
   text    data     bss     dec     hex filename
  30116    1388    6980   38484    9654 /home/mikolai/TUD/Code/RIOT/tests/unittests/bin/nrf52840dk/tests_unittests.elf

$ CFLAGS+=-DCONFIG_UNICOAP_OPTIONS_FULL_SUPPORT=0 make -C tests/unittests tests-unicoap BOARD=nrf52840dk all       
...
   text    data     bss     dec     hex filename
  24208     688    3360   28256    6e60 /home/mikolai/TUD/Code/RIOT/tests/unittests/bin/nrf52840dk/tests_unittests.elf

$ CFLAGS+=-DCONFIG_UNICOAP_OPTIONS_FULL_SUPPORT=1 make -C examples/networking/coap/unicoap_server BOARD=nrf52840dk all
...
   text    data     bss     dec     hex filename
  89556     260   20272  110088   1ae08 /home/mikolai/TUD/Code/RIOT/examples/networking/coap/unicoap_server/bin/nrf52840dk/unicoap_server.elf

$ CFLAGS+=-DCONFIG_UNICOAP_OPTIONS_FULL_SUPPORT=0 make -C examples/networking/coap/unicoap_server BOARD=nrf52840dk all
...
   text    data     bss     dec     hex filename
  89044     260   20272  109576   1ac08 /home/mikolai/TUD/Code/RIOT/examples/networking/coap/unicoap_server/bin/nrf52840dk/unicoap_server.elf
```


### Testing procedure

```
make -C tests/unittests tests-unicoap all test
```

should still succeed (by effectively skipping all tests that require out-of-order manipulation).


### Issues/PRs references

As stated above, this conflicts with some features of https://github.com/RIOT-OS/RIOT/pull/22266 and https://github.com/RIOT-OS/RIOT/pull/22277, so those PRs should get a compile-time check to avoid invalid configurations.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none