### PR TITLE
.clang-tidy: add two more exceptions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -66,7 +66,18 @@
 #       `return FOO;` will get a warning. But using `return (some_type)FOO;` is
 #       not more readable and explicit casts actively harm, as they mute
 #       a lot of compiler diagnostics.
-#
+# - bugprone-assignment-in-if-condition:
+#       This is idomatic C and not disallowed or discouraged by the coding
+#       convention:
+#       ```c
+#       if ((err = something()) < 0) {
+#            return err;
+#       }
+#       ```
+#       So let's not warn about it, while it still is considered acceptable.
+# - readability-isolate-declaration:
+#       Multiple declaration in a single line is not disallowed by the coding
+#       convention used a lot in the code base. So let's allow it.
 # Warning
 # -------
 #
@@ -81,11 +92,13 @@ Checks: "bugprone-*,
          misc-*,
          portability-*,
          readability-*,
+         -bugprone-assignment-in-if-condition,
          -bugprone-easily-swappable-parameters,
          -bugprone-narrowing-conversions,
          -bugprone-reserved-identifier,
          -readability-identifier-length,
          -readability-implicit-bool-conversion,
+         -readability-isolate-declaration,
          -readability-magic-numbers,
         "
 WarningsAsErrors: "bugprone-*,


### PR DESCRIPTION
### Contribution description

.clang-tidy: add two more exceptions

- bugprone-assignment-in-if-condition:
    This is idomatic C and not disallowed or discouraged by the coding
    convention:
    ```c
    if ((err = something()) < 0) {
         return err;
    }
    ```
    So let's not warn about it, while it still is considered acceptable.
- readability-isolate-declaration:
    Multiple declaration in a single line is not disallowed by the coding
    convention used a lot in the code base. So let's allow it.


### Testing procedure

This should in a better signal to noise ratio from `clangd`.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none