### PR TITLE
dist/tools/headerguards: use regex to check include guard name

### DIFF
--- a/dist/tools/headerguards/headerguards.py
+++ b/dist/tools/headerguards/headerguards.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import re
 import sys
 import difflib
 from io import BytesIO, TextIOWrapper
@@ -58,7 +59,7 @@ def fix_headerguard(filename):
                 guard_found += 1
                 guard_name = line[8:].rstrip()
                 line = "#ifndef %s\n" % (supposed)
-            elif pragma_once_found != 0 and line.startswith("#ifndef %s" % supposed):
+            elif pragma_once_found != 0 and re.match("#ifndef %s_?$" % supposed, line):
                 # check if there is pragma once *and* headerguards, but avoid false
                 # positives by narrowing in on the to-be-expected guard
                 guard_found += 1


### PR DESCRIPTION
### Contribution description

The headerguard check tried to find if classic header guards were used by matching the beginning of the line with `#ifndef $(filename_with_underscores)`. So for `drivers/abp2/include/abp2_params.h` it would try to find `#ifndef ABP2_PARAMS_H*`.

The issue arises when you have a parameter that has a word starting with H, for example `#ifndef ABP2_PARAMS_HWTIMER`, creating a false positive.

Instead of matching the line start, I changed it to a RegEx to match either `#ifndef ABP2_PARAMS_H` or `#ifndef ABP2_PARAMS_H_`, but nothing else.


### Testing procedure

#### Test for Bug Fixed
Add `#ifndef ABP2_PARAMS_HWTIMER` to `drivers/abp2/include/abp2_params.h` and it ***should not*** still complain.

Behavior on `master`, it complains:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ git diff
diff --git a/drivers/abp2/include/abp2_params.h b/drivers/abp2/include/abp2_params.h
index b5def22f3b..84ea69d97b 100644
--- a/drivers/abp2/include/abp2_params.h
+++ b/drivers/abp2/include/abp2_params.h
@@ -20,6 +20,10 @@
 #include "saul_reg.h"
 #include "abp2.h"

+#ifndef ABP2_PARAMS_HWTIMER
+#  define ABP2_PARAMS_HWTIMER
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ ./dist/tools/headerguards/check.sh
drivers/abp2/include/abp2_params.h: #pragma once and classic header guards used in the same file

cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ echo $?
1
```

Behavior with this PR, it does not complain:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ git diff
diff --git a/drivers/abp2/include/abp2_params.h b/drivers/abp2/include/abp2_params.h
index b5def22f3b..84ea69d97b 100644
--- a/drivers/abp2/include/abp2_params.h
+++ b/drivers/abp2/include/abp2_params.h
@@ -20,6 +20,10 @@
 #include "saul_reg.h"
 #include "abp2.h"

+#ifndef ABP2_PARAMS_HWTIMER
+#  define ABP2_PARAMS_HWTIMER
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ ./dist/tools/headerguards/check.sh

cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ echo $?
0

```


#### Test for Regression

1) Add `#ifndef ABP2_PARAMS_H` to `drivers/abp2/include/abp2_params.h` and it ***should*** still complain:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ git diff
diff --git a/drivers/abp2/include/abp2_params.h b/drivers/abp2/include/abp2_params.h
index b5def22f3b..9e32af8eee 100644
--- a/drivers/abp2/include/abp2_params.h
+++ b/drivers/abp2/include/abp2_params.h
@@ -20,6 +20,10 @@
 #include "saul_reg.h"
 #include "abp2.h"

+#ifndef ABP2_PARAMS_H
+#  define ABP2_PARAMS_H
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ ./dist/tools/headerguards/check.sh
drivers/abp2/include/abp2_params.h: #pragma once and classic header guards used in the same file
```

2) Add `#ifndef ABP2_PARAMS_H_` to `drivers/abp2/include/abp2_params.h` and it ***should*** still complain:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ git diff
diff --git a/drivers/abp2/include/abp2_params.h b/drivers/abp2/include/abp2_params.h
index b5def22f3b..694ab39b57 100644
--- a/drivers/abp2/include/abp2_params.h
+++ b/drivers/abp2/include/abp2_params.h
@@ -20,6 +20,10 @@
 #include "saul_reg.h"
 #include "abp2.h"

+#ifndef ABP2_PARAMS_H_
+#  define ABP2_PARAMS_H_
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ ./dist/tools/headerguards/check.sh
drivers/abp2/include/abp2_params.h: #pragma once and classic header guards used in the same file
```


### Issues/PRs references

Found in #19848.

### Declaration of AI-Tools / LLMs usage:


AI-Tools / LLMs that were used are:
- none

