### PR TITLE
examples/lwip_ipv4: fix usage of null pointer

### DIFF
--- a/examples/networking/misc/lwip_ipv4/main.c
+++ b/examples/networking/misc/lwip_ipv4/main.c
@@ -140,17 +140,29 @@ int main(void)
     char line_buf[SHELL_DEFAULT_BUFSIZE];
 
     sys_lock_tcpip_core();
-    struct netif *iface = netif_find("ET0");
+
+    /* According to the RFC 3493 interfaces are indexed from 1 */
+    struct netif *iface = netif_get_by_index(1);
+
+    if (iface == NULL) {
+#ifdef CPU_NATIVE
+        puts("To use the LWIP interface, follow the steps for setting up a tap "
+             "interface outlined in the README.md.");
+#else
+        puts("This board does not support the LWIP interface.");
+#endif
+
+        return -1;
+    }
 
 #ifndef MODULE_LWIP_DHCP_AUTO
     ip4_addr_t ip = _TEST_ADDR4_LOCAL;
     ip4_addr_t subnet = _TEST_ADDR4_MASK;
     netif_set_addr(iface, &ip, &subnet, NULL);
 #else
-    printf("Waiting for DHCP address autoconfiguration ...\n");
+    puts("Waiting for DHCP address autoconfiguration ...");
     ztimer_sleep(ZTIMER_MSEC, CONFIG_DHCP_TIMEOUT_SEC * MS_PER_SEC);
 #endif
-
     /* print network addresses */
     printf("{\"IPv4 addresses\": [\"");
     char buffer[16];

--- a/examples/networking/misc/lwip_ipv4/main.c
+++ b/examples/networking/misc/lwip_ipv4/main.c
@@ -142,33 +142,31 @@ int main(void)
     sys_lock_tcpip_core();
     struct netif *iface = netif_find("ET0");
 
-#ifndef MODULE_LWIP_DHCP_AUTO
-    if (iface != NULL) {
-        ip4_addr_t ip = _TEST_ADDR4_LOCAL;
-        ip4_addr_t subnet = _TEST_ADDR4_MASK;
-        netif_set_addr(iface, &ip, &subnet, NULL);
-    }
-    else {
-        if ( strstr(RIOT_BOARD,"native") != NULL) {
-            printf("To use LWIP interface execute program adding as parameter tap interfece name.\n");
-            printf("For more details see README.md.\n");
-        }
-        else {
-            printf("This board does not support LWIP interface.\n");
-        }
-    }
+    if (iface == NULL) {
+#ifdef CPU_NATIVE
+        puts("To use the LWIP interface, follow the steps for setting up a tap "
+             "interface outlined in the README.md.");
 #else
-    printf("Waiting for DHCP address autoconfiguration ...\n");
+        puts("This board does not support the LWIP interface.");
+#endif
+
+        return -1;
+    }
+
+#ifndef MODULE_LWIP_DHCP_AUTO
+    ip4_addr_t ip = _TEST_ADDR4_LOCAL;
+    ip4_addr_t subnet = _TEST_ADDR4_MASK;
+    netif_set_addr(iface, &ip, &subnet, NULL);
+#else
+    puts("Waiting for DHCP address autoconfiguration ...");
     ztimer_sleep(ZTIMER_MSEC, CONFIG_DHCP_TIMEOUT_SEC * MS_PER_SEC);
 #endif
-    if (iface != NULL) {
-        /* print network addresses */
-        printf("{\"IPv4 addresses\": [\"");
-        char buffer[16];
-        inet_ntop(AF_INET, netif_ip_addr4(iface), buffer, 16);
-        sys_unlock_tcpip_core();
-        printf("%s\"]}\n", buffer);
-    }
+    /* print network addresses */
+    printf("{\"IPv4 addresses\": [\"");
+    char buffer[16];
+    inet_ntop(AF_INET, netif_ip_addr4(iface), buffer, 16);
+    sys_unlock_tcpip_core();
+    printf("%s\"]}\n", buffer);
 
     thread_create(server_stack, sizeof(server_stack), THREAD_PRIORITY_MAIN - 1, 0, server_thread, NULL, "server");
 

--- a/examples/networking/misc/lwip_ipv4/main.c
+++ b/examples/networking/misc/lwip_ipv4/main.c
@@ -143,20 +143,32 @@ int main(void)
     struct netif *iface = netif_find("ET0");
 
 #ifndef MODULE_LWIP_DHCP_AUTO
-    ip4_addr_t ip = _TEST_ADDR4_LOCAL;
-    ip4_addr_t subnet = _TEST_ADDR4_MASK;
-    netif_set_addr(iface, &ip, &subnet, NULL);
+    if (iface != NULL) {
+        ip4_addr_t ip = _TEST_ADDR4_LOCAL;
+        ip4_addr_t subnet = _TEST_ADDR4_MASK;
+        netif_set_addr(iface, &ip, &subnet, NULL);
+    }
+    else {
+        if ( strstr(RIOT_BOARD,"native") != NULL) {
+            printf("To use LWIP interface execute program adding as parameter tap interfece name.\n");
+            printf("For more details see README.md.\n");
+        }
+        else {
+            printf("This board does not support LWIP interface.\n");
+        }
+    }
 #else
     printf("Waiting for DHCP address autoconfiguration ...\n");
     ztimer_sleep(ZTIMER_MSEC, CONFIG_DHCP_TIMEOUT_SEC * MS_PER_SEC);
 #endif
-
-    /* print network addresses */
-    printf("{\"IPv4 addresses\": [\"");
-    char buffer[16];
-    inet_ntop(AF_INET, netif_ip_addr4(iface), buffer, 16);
-    sys_unlock_tcpip_core();
-    printf("%s\"]}\n", buffer);
+    if (iface != NULL) {
+        /* print network addresses */
+        printf("{\"IPv4 addresses\": [\"");
+        char buffer[16];
+        inet_ntop(AF_INET, netif_ip_addr4(iface), buffer, 16);
+        sys_unlock_tcpip_core();
+        printf("%s\"]}\n", buffer);
+    }
 
     thread_create(server_stack, sizeof(server_stack), THREAD_PRIORITY_MAIN - 1, 0, server_thread, NULL, "server");
 

--- a/examples/networking/misc/lwip_ipv4/main.c
+++ b/examples/networking/misc/lwip_ipv4/main.c
@@ -140,7 +140,9 @@ int main(void)
     char line_buf[SHELL_DEFAULT_BUFSIZE];
 
     sys_lock_tcpip_core();
-    struct netif *iface = netif_find("ET0");
+
+    /* According to the RFC 3493 interfaces are indexed from 1 */
+    struct netif *iface = netif_get_by_index(1);
 
     if (iface == NULL) {
 #ifdef CPU_NATIVE


### PR DESCRIPTION
### Contribution description

Current version of the example `lwip_ipv4` contains bug - usage of null pointer when board do not support LWIP interface.
In such case execution ends with error.

For example on `nucleo-l552ze-q`:

```
main(): This is RIOT! (Version: 2021.07-devel-14795-gea7b4)

Context before hardfault:
```

or `native64`:

```
RIOT native interrupts/signals initialized.
TZ not set, setting UTC
RIOT native64 board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2021.07-devel-14795-gea7b4)
Segmentation fault
```

This PR fix this issue and shows appropriate message (see next section). 

### Testing procedure

Using this PR example do not present critical error and stops execution of program, but present useful information:

For example on `nucleo-l552ze-q`:

```
main(): This is RIOT! (Version: 2021.07-devel-14795-gea7b4-examples-lwip_ipv4-null-pointer)
This board does not support LWIP interface.
>
```

or `native64`:

```
RIOT native interrupts/signals initialized.
TZ not set, setting UTC
RIOT native64 board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2021.07-devel-14796-g4e16c-examples-lwip_ipv4-null-pointer)
To use LWIP interface exceute program adding as parametr tap interfece name.
For more details see README.md.
> 
```

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
