### PR TITLE
net/unicoap/message.h: set payload_representation in message_init_*

### DIFF
--- a/sys/include/net/unicoap/message.h
+++ b/sys/include/net/unicoap/message.h
@@ -73,7 +73,7 @@ typedef struct {
     /**
      * @brief Message options
      *
-     * Key-value entries akin to HTTP headers
+     * Key-value entries akin to HTTP headers. May be NULL for no options present.
      *
      * @see @ref net_unicoap_options
      */
@@ -461,6 +461,7 @@ static inline void unicoap_message_init_empty(unicoap_message_t* message, uint8_
     message->options = NULL;
     message->payload = NULL;
     message->payload_size = 0;
+    message->payload_representation = UNICOAP_PAYLOAD_CONTIGUOUS;
 }
 
 /**
@@ -489,6 +490,7 @@ static inline void unicoap_message_init(unicoap_message_t* message, uint8_t code
     message->options = NULL;
     message->payload = payload;
     message->payload_size = payload_size;
+    message->payload_representation = UNICOAP_PAYLOAD_CONTIGUOUS;
 }
 
 /**
@@ -501,7 +503,11 @@ static inline void unicoap_message_init(unicoap_message_t* message, uint8_t code
 static inline unicoap_message_t unicoap_message_alloc(uint8_t code, uint8_t* payload,
                                                       size_t payload_size)
 {
-    return (unicoap_message_t){ .code = code, .payload = payload, .payload_size = payload_size };
+    return (unicoap_message_t){ .code = code,
+                                .options = NULL,
+                                .payload = payload,
+                                .payload_size = payload_size,
+                                .payload_representation = UNICOAP_PAYLOAD_CONTIGUOUS };
 }
 
 /**
@@ -516,10 +522,7 @@ static inline unicoap_message_t unicoap_message_alloc(uint8_t code, uint8_t* pay
 static inline void unicoap_message_init_string(unicoap_message_t* message, uint8_t code,
                                                const char* payload)
 {
-    message->code = code;
-    message->options = NULL;
-    message->payload = (uint8_t*)payload;
-    message->payload_size = payload ? strlen(payload) : 0;
+    unicoap_message_init(message, code, (uint8_t*)payload, payload ? strlen(payload) : 0);
 }
 
 /**
@@ -531,8 +534,10 @@ static inline void unicoap_message_init_string(unicoap_message_t* message, uint8
 static inline unicoap_message_t unicoap_message_alloc_string(uint8_t code, const char* payload)
 {
     return (unicoap_message_t){ .code = code,
+                                .options = NULL,
                                 .payload = (uint8_t*)payload,
-                                .payload_size = payload ? strlen(payload) : 0 };
+                                .payload_size = payload ? strlen(payload) : 0,
+                                .payload_representation = UNICOAP_PAYLOAD_CONTIGUOUS };
 }
 
 /**
@@ -555,6 +560,7 @@ static inline void unicoap_message_init_with_options(unicoap_message_t* message,
     message->options = options;
     message->payload = payload;
     message->payload_size = payload_size;
+    message->payload_representation = UNICOAP_PAYLOAD_CONTIGUOUS;
 }
 
 /**
@@ -570,9 +576,11 @@ static inline unicoap_message_t unicoap_message_alloc_with_options(uint8_t code,
                                                                    size_t payload_size,
                                                                    unicoap_options_t* options)
 {
-    return (unicoap_message_t){
-        .code = code, .options = options, .payload = payload, .payload_size = payload_size
-    };
+    return (unicoap_message_t){ .code = code,
+                                .options = options,
+                                .payload = payload,
+                                .payload_size = payload_size,
+                                .payload_representation = UNICOAP_PAYLOAD_CONTIGUOUS };
 }
 
 /**
@@ -611,7 +619,8 @@ unicoap_message_t unicoap_message_alloc_string_with_options(uint8_t code,
     return (unicoap_message_t){ .code = code,
                                 .options = options,
                                 .payload = (uint8_t*)payload,
-                                .payload_size = payload ? strlen(payload) : 0 };
+                                .payload_size = payload ? strlen(payload) : 0,
+                                .payload_representation = UNICOAP_PAYLOAD_CONTIGUOUS };
 }
 /** @} */
 

--- a/sys/include/net/unicoap/message.h
+++ b/sys/include/net/unicoap/message.h
@@ -461,6 +461,7 @@ static inline void unicoap_message_init_empty(unicoap_message_t* message, uint8_
     message->options = NULL;
     message->payload = NULL;
     message->payload_size = 0;
+    message->payload_representation = UNICOAP_PAYLOAD_CONTIGUOUS;
 }
 
 /**
@@ -489,6 +490,7 @@ static inline void unicoap_message_init(unicoap_message_t* message, uint8_t code
     message->options = NULL;
     message->payload = payload;
     message->payload_size = payload_size;
+    message->payload_representation = UNICOAP_PAYLOAD_CONTIGUOUS;
 }
 
 /**
@@ -516,10 +518,7 @@ static inline unicoap_message_t unicoap_message_alloc(uint8_t code, uint8_t* pay
 static inline void unicoap_message_init_string(unicoap_message_t* message, uint8_t code,
                                                const char* payload)
 {
-    message->code = code;
-    message->options = NULL;
-    message->payload = (uint8_t*)payload;
-    message->payload_size = payload ? strlen(payload) : 0;
+    unicoap_message_init(message, code, (uint8_t*)payload, payload ? strlen(payload) : 0);
 }
 
 /**
@@ -555,6 +554,7 @@ static inline void unicoap_message_init_with_options(unicoap_message_t* message,
     message->options = options;
     message->payload = payload;
     message->payload_size = payload_size;
+    message->payload_representation = UNICOAP_PAYLOAD_CONTIGUOUS;
 }
 
 /**


### PR DESCRIPTION
### Contribution description

Fix for https://github.com/RIOT-OS/RIOT/issues/22285, where the issue is described reasonably well:

> `unicoap` message initialisers (see `sys/include/net/unicoap/message.h`) do not set the `payload_representation` property to `UNICOAP_PAYLOAD_REPRESENTATION_CONTIGUOUS`. The point of these initialisers is that one does _not_ need to zero a message structure before. However, right now, the representation might be randomly set to the wrong representation, which trivially leads to a segfault.

I've also sneaked in a tiny code duplication reduction.


### Testing procedure

Check the code. CI should catch regressions.


### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/22285

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
