### PR TITLE
cpu/riscv_common: add rv64 support

### DIFF
--- a/cpu/riscv_common/Kconfig
+++ b/cpu/riscv_common/Kconfig
@@ -8,8 +8,13 @@ config CPU_CORE_RV32IMAC
     bool
     select CPU_ARCH_RISCV
 
+config CPU_CORE_RV64IMAC
+    bool
+    select CPU_ARCH_RISCV
+
 config CPU_ARCH
     default "rv32" if CPU_CORE_RV32IMAC
+    default "rv64" if CPU_CORE_RV64IMAC
 
 config PRINT_VERBOSE_TRAP_INFO
     bool "Print verbose trap information"

--- a/cpu/riscv_common/Makefile.features
+++ b/cpu/riscv_common/Makefile.features
@@ -1,8 +1,20 @@
 ifeq ($(findstring rv32,$(CPU_CORE)),rv32)
   CPU_ARCH := rv32
+else ifeq ($(findstring rv64,$(CPU_CORE)),rv64)
+  CPU_ARCH := rv64
 endif
 
-FEATURES_PROVIDED += arch_32bit
+ifeq (rv64,$(CPU_ARCH))
+  FEATURES_PROVIDED += arch_64bit
+  # rust_target is not provided: the riot crate does not support rv64 yet
+else
+  FEATURES_PROVIDED += arch_32bit
+  # picolibc is only shipped/working for rv32 in the RISC-V toolchain; a rv64
+  # target would link the rv32 libc and fail with an ABI mismatch, so only
+  # advertise it for rv32 (rv64 falls back to newlib).
+  FEATURES_PROVIDED += picolibc
+  FEATURES_PROVIDED += rust_target
+endif
 FEATURES_PROVIDED += arch_riscv
 FEATURES_PROVIDED += bug_newlib_broken_stdio
 FEATURES_PROVIDED += cpp
@@ -11,8 +23,4 @@ FEATURES_PROVIDED += newlib
 FEATURES_PROVIDED += periph_coretimer
 FEATURES_PROVIDED += periph_flashpage_aux
 FEATURES_PROVIDED += puf_sram
-FEATURES_PROVIDED += rust_target
 FEATURES_PROVIDED += ssp
-
-# RISC-V toolchain on CI does not work properly with picolibc yet
-FEATURES_PROVIDED += picolibc

--- a/cpu/riscv_common/include/architecture_arch.h
+++ b/cpu/riscv_common/include/architecture_arch.h
@@ -22,7 +22,11 @@ extern "C" {
 
 /* Doc is provided centrally in architecture.h, hide this from Doxygen */
 #ifndef DOXYGEN
-#define ARCHITECTURE_WORD_BITS      (32U)
+#  if __riscv_xlen == 64
+#    define ARCHITECTURE_WORD_BITS  (64U)
+#  else
+#    define ARCHITECTURE_WORD_BITS  (32U)
+#  endif
 #endif /* DOXYGEN */
 
 #ifdef __cplusplus

--- a/cpu/riscv_common/include/context_frame.h
+++ b/cpu/riscv_common/include/context_frame.h
@@ -23,6 +23,28 @@
 extern "C" {
 #endif
 
+#define REGSZ (__riscv_xlen / 8)    /**< size of one register in bytes */
+
+#if __riscv_xlen == 64
+/**
+ * @brief   XLEN-sized load instruction mnemonic
+ */
+#  define REG_L ld
+/**
+ * @brief   XLEN-sized store instruction mnemonic
+ */
+#  define REG_S sd
+#else
+/**
+ * @brief   XLEN-sized load instruction mnemonic
+ */
+#  define REG_L lw
+/**
+ * @brief   XLEN-sized store instruction mnemonic
+ */
+#  define REG_S sw
+#endif
+
 #if !defined(__ASSEMBLER__)
 
 /**
@@ -35,38 +57,38 @@ extern "C" {
  */
 struct context_switch_frame {
     /* Callee saved registers */
-    uint32_t s0;                    /**< s0 register */
-    uint32_t s1;                    /**< s1 register */
-    uint32_t s2;                    /**< s2 register */
-    uint32_t s3;                    /**< s3 register */
-    uint32_t s4;                    /**< s4 register */
-    uint32_t s5;                    /**< s5 register */
-    uint32_t s6;                    /**< s6 register */
-    uint32_t s7;                    /**< s7 register */
-    uint32_t s8;                    /**< s8 register */
-    uint32_t s9;                    /**< s9 register */
-    uint32_t s10;                   /**< s10 register */
-    uint32_t s11;                   /**< s11 register */
+    uintptr_t s0;                   /**< s0 register */
+    uintptr_t s1;                   /**< s1 register */
+    uintptr_t s2;                   /**< s2 register */
+    uintptr_t s3;                   /**< s3 register */
+    uintptr_t s4;                   /**< s4 register */
+    uintptr_t s5;                   /**< s5 register */
+    uintptr_t s6;                   /**< s6 register */
+    uintptr_t s7;                   /**< s7 register */
+    uintptr_t s8;                   /**< s8 register */
+    uintptr_t s9;                   /**< s9 register */
+    uintptr_t s10;                  /**< s10 register */
+    uintptr_t s11;                  /**< s11 register */
     /* Caller saved registers */
-    uint32_t ra;                    /**< ra register */
-    uint32_t t0;                    /**< t0 register */
-    uint32_t t1;                    /**< t1 register */
-    uint32_t t2;                    /**< t2 register */
-    uint32_t t3;                    /**< t3 register */
-    uint32_t t4;                    /**< t4 register */
-    uint32_t t5;                    /**< t5 register */
-    uint32_t t6;                    /**< t6 register */
-    uint32_t a0;                    /**< a0 register */
-    uint32_t a1;                    /**< a1 register */
-    uint32_t a2;                    /**< a2 register */
-    uint32_t a3;                    /**< a3 register */
-    uint32_t a4;                    /**< a4 register */
-    uint32_t a5;                    /**< a5 register */
-    uint32_t a6;                    /**< a6 register */
-    uint32_t a7;                    /**< a7 register */
+    uintptr_t ra;                   /**< ra register */
+    uintptr_t t0;                   /**< t0 register */
+    uintptr_t t1;                   /**< t1 register */
+    uintptr_t t2;                   /**< t2 register */
+    uintptr_t t3;                   /**< t3 register */
+    uintptr_t t4;                   /**< t4 register */
+    uintptr_t t5;                   /**< t5 register */
+    uintptr_t t6;                   /**< t6 register */
+    uintptr_t a0;                   /**< a0 register */
+    uintptr_t a1;                   /**< a1 register */
+    uintptr_t a2;                   /**< a2 register */
+    uintptr_t a3;                   /**< a3 register */
+    uintptr_t a4;                   /**< a4 register */
+    uintptr_t a5;                   /**< a5 register */
+    uintptr_t a6;                   /**< a6 register */
+    uintptr_t a7;                   /**< a7 register */
     /* Saved PC for return from ISR */
-    uint32_t pc;                    /**< program counter */
-    uint32_t pad[3];                /**< padding to maintain 16 byte alignment */
+    uintptr_t pc;                   /**< program counter */
+    uintptr_t pad[3];               /**< padding to maintain 16 byte alignment */
 };
 
 #endif /* __ASSEMBLER__ */
@@ -76,42 +98,42 @@ struct context_switch_frame {
  * @{
  */
 /* These values are checked for correctness in context_frame.c */
-#define s0_OFFSET     0
-#define s1_OFFSET     4
-#define s2_OFFSET     8
-#define s3_OFFSET     12
-#define s4_OFFSET     16
-#define s5_OFFSET     20
-#define s6_OFFSET     24
-#define s7_OFFSET     28
-#define s8_OFFSET     32
-#define s9_OFFSET     36
-#define s10_OFFSET    40
-#define s11_OFFSET    44
-#define ra_OFFSET     48
-#define t0_OFFSET     52
-#define t1_OFFSET     56
-#define t2_OFFSET     60
-#define t3_OFFSET     64
-#define t4_OFFSET     68
-#define t5_OFFSET     72
-#define t6_OFFSET     76
-#define a0_OFFSET     80
-#define a1_OFFSET     84
-#define a2_OFFSET     88
-#define a3_OFFSET     92
-#define a4_OFFSET     96
-#define a5_OFFSET     100
-#define a6_OFFSET     104
-#define a7_OFFSET     108
-#define pc_OFFSET     112
-#define pad_OFFSET    116
+#define s0_OFFSET     (0 * REGSZ)
+#define s1_OFFSET     (1 * REGSZ)
+#define s2_OFFSET     (2 * REGSZ)
+#define s3_OFFSET     (3 * REGSZ)
+#define s4_OFFSET     (4 * REGSZ)
+#define s5_OFFSET     (5 * REGSZ)
+#define s6_OFFSET     (6 * REGSZ)
+#define s7_OFFSET     (7 * REGSZ)
+#define s8_OFFSET     (8 * REGSZ)
+#define s9_OFFSET     (9 * REGSZ)
+#define s10_OFFSET    (10 * REGSZ)
+#define s11_OFFSET    (11 * REGSZ)
+#define ra_OFFSET     (12 * REGSZ)
+#define t0_OFFSET     (13 * REGSZ)
+#define t1_OFFSET     (14 * REGSZ)
+#define t2_OFFSET     (15 * REGSZ)
+#define t3_OFFSET     (16 * REGSZ)
+#define t4_OFFSET     (17 * REGSZ)
+#define t5_OFFSET     (18 * REGSZ)
+#define t6_OFFSET     (19 * REGSZ)
+#define a0_OFFSET     (20 * REGSZ)
+#define a1_OFFSET     (21 * REGSZ)
+#define a2_OFFSET     (22 * REGSZ)
+#define a3_OFFSET     (23 * REGSZ)
+#define a4_OFFSET     (24 * REGSZ)
+#define a5_OFFSET     (25 * REGSZ)
+#define a6_OFFSET     (26 * REGSZ)
+#define a7_OFFSET     (27 * REGSZ)
+#define pc_OFFSET     (28 * REGSZ)
+#define pad_OFFSET    (29 * REGSZ)
 /** @} */
 
 /**
  * @brief Size of context switch frame
  */
-#define CONTEXT_FRAME_SIZE (pad_OFFSET + 12)
+#define CONTEXT_FRAME_SIZE (pad_OFFSET + 3 * REGSZ)
 
 /**
  * @brief Offset of stack pointer in struct _thread

--- a/cpu/riscv_common/include/cpu_conf_common.h
+++ b/cpu/riscv_common/include/cpu_conf_common.h
@@ -22,14 +22,26 @@
  * @name Configuration of default stack sizes
  * @{
  */
-#ifndef THREAD_EXTRA_STACKSIZE_PRINTF
-#define THREAD_EXTRA_STACKSIZE_PRINTF   (256)
-#endif
-#ifndef THREAD_STACKSIZE_DEFAULT
-#define THREAD_STACKSIZE_DEFAULT        (1024)
-#endif
-#ifndef THREAD_STACKSIZE_IDLE
-#define THREAD_STACKSIZE_IDLE           (256)
+#if __riscv_xlen == 64
+#  ifndef THREAD_EXTRA_STACKSIZE_PRINTF
+#    define THREAD_EXTRA_STACKSIZE_PRINTF   (512)
+#  endif
+#  ifndef THREAD_STACKSIZE_DEFAULT
+#    define THREAD_STACKSIZE_DEFAULT        (2048)
+#  endif
+#  ifndef THREAD_STACKSIZE_IDLE
+#    define THREAD_STACKSIZE_IDLE           (512)
+#  endif
+#else
+#  ifndef THREAD_EXTRA_STACKSIZE_PRINTF
+#    define THREAD_EXTRA_STACKSIZE_PRINTF   (256)
+#  endif
+#  ifndef THREAD_STACKSIZE_DEFAULT
+#    define THREAD_STACKSIZE_DEFAULT        (1024)
+#  endif
+#  ifndef THREAD_STACKSIZE_IDLE
+#    define THREAD_STACKSIZE_IDLE           (256)
+#  endif
 #endif
 /** @} */
 

--- a/cpu/riscv_common/include/vendor/riscv_csr.h
+++ b/cpu/riscv_common/include/vendor/riscv_csr.h
@@ -22,9 +22,9 @@
 #ifndef RISCV_CSR_H
 #define RISCV_CSR_H
 
-/* Some things missing from the official encoding.h */
-#define MCAUSE_INT         0x80000000
-#define MCAUSE_CAUSE       0x7FFFFFFF
+/* The interrupt bit is the MSB of mcause, i.e. XLEN dependent. */
+#define MCAUSE_INT         (1UL << (__riscv_xlen - 1))
+#define MCAUSE_CAUSE       (MCAUSE_INT - 1)
 
 #define MSTATUS_UIE         0x00000001
 #define MSTATUS_SIE         0x00000002

--- a/cpu/riscv_common/irq_arch.c
+++ b/cpu/riscv_common/irq_arch.c
@@ -92,8 +92,9 @@ __attribute((used)) static void handle_trap(uword_t mcause)
     bool is_interrupt = (mcause & MCAUSE_INT) == MCAUSE_INT;
 
 #if CONFIG_PRINT_VERBOSE_TRAP_INFO
-    printf("Trap: mcause=0x%" PRIx32 " mepc=0x%lx mtval=0x%lx\n",
-           (uint32_t)mcause, read_csr(mepc), read_csr(mtval));
+    printf("Trap: mcause=0x%" PRIxPTR " mepc=0x%" PRIxPTR " mtval=0x%" PRIxPTR "\n",
+           (uintptr_t)mcause, (uintptr_t)read_csr(mepc),
+           (uintptr_t)read_csr(mtval));
 
     if (!is_interrupt) {
         const char *error_messages[] = {
@@ -182,9 +183,9 @@ __attribute((used)) static void handle_trap(uword_t mcause)
         default:
 #ifdef DEVELHELP
             printf("Unhandled trap:\n");
-            printf("  mcause: 0x%" PRIx32 "\n", trap);
-            printf("  mepc:   0x%lx\n", read_csr(mepc));
-            printf("  mtval:  0x%lx\n", read_csr(mtval));
+            printf("  mcause: 0x%" PRIxPTR "\n", (uintptr_t)trap);
+            printf("  mepc:   0x%" PRIxPTR "\n", (uintptr_t)read_csr(mepc));
+            printf("  mtval:  0x%" PRIxPTR "\n", (uintptr_t)read_csr(mtval));
 #endif
             /* Unknown trap */
             core_panic(PANIC_GENERAL_ERROR, "Unhandled trap");
@@ -204,26 +205,26 @@ static void __attribute__((interrupt)) trap_entry(void)
         "addi sp, sp, -"XTSTR (CONTEXT_FRAME_SIZE)"          \n"
 
         /* Save caller-saved registers */
-        "sw ra, "XTSTR (ra_OFFSET)"(sp)                      \n"
-        "sw t0, "XTSTR (t0_OFFSET)"(sp)                      \n"
-        "sw t1, "XTSTR (t1_OFFSET)"(sp)                      \n"
-        "sw t2, "XTSTR (t2_OFFSET)"(sp)                      \n"
-        "sw t3, "XTSTR (t3_OFFSET)"(sp)                      \n"
-        "sw t4, "XTSTR (t4_OFFSET)"(sp)                      \n"
-        "sw t5, "XTSTR (t5_OFFSET)"(sp)                      \n"
-        "sw t6, "XTSTR (t6_OFFSET)"(sp)                      \n"
-        "sw a0, "XTSTR (a0_OFFSET)"(sp)                      \n"
-        "sw a1, "XTSTR (a1_OFFSET)"(sp)                      \n"
-        "sw a2, "XTSTR (a2_OFFSET)"(sp)                      \n"
-        "sw a3, "XTSTR (a3_OFFSET)"(sp)                      \n"
-        "sw a4, "XTSTR (a4_OFFSET)"(sp)                      \n"
-        "sw a5, "XTSTR (a5_OFFSET)"(sp)                      \n"
-        "sw a6, "XTSTR (a6_OFFSET)"(sp)                      \n"
-        "sw a7, "XTSTR (a7_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" ra, "XTSTR (ra_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" t0, "XTSTR (t0_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" t1, "XTSTR (t1_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" t2, "XTSTR (t2_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" t3, "XTSTR (t3_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" t4, "XTSTR (t4_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" t5, "XTSTR (t5_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" t6, "XTSTR (t6_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" a0, "XTSTR (a0_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" a1, "XTSTR (a1_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" a2, "XTSTR (a2_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" a3, "XTSTR (a3_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" a4, "XTSTR (a4_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" a5, "XTSTR (a5_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" a6, "XTSTR (a6_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" a7, "XTSTR (a7_OFFSET)"(sp)                      \n"
 
         /* Save s0 and s1 extra for the active thread and the stack ptr */
-        "sw s0, "XTSTR (s0_OFFSET)"(sp)                      \n"
-        "sw s1, "XTSTR (s1_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" s0, "XTSTR (s0_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" s1, "XTSTR (s1_OFFSET)"(sp)                      \n"
 
         /* Save the user stack ptr */
         "mv s0, sp                                          \n"
@@ -237,14 +238,16 @@ static void __attribute__((interrupt)) trap_entry(void)
          * the call */
         "call handle_trap                                   \n"
 
-        /* Load the sched_context_switch_request */
+        /* Load the sched_context_switch_request. This is a 32-bit int (not a
+         * register-wide value), so it must always be loaded with lw — using
+         * the XLEN-wide REG_L (ld on RV64) would read 4 bytes past the flag. */
         "lw a0, sched_context_switch_request                \n"
 
         /* And skip the context switch if not requested */
         "beqz a0, no_sched                                  \n"
 
         /*  Get the previous active thread (could be NULL) */
-        "lw s1, sched_active_thread                         \n"
+        XTSTR(REG_L)" s1, sched_active_thread                         \n"
 
         /* Run the scheduler */
         "call sched_run                                     \n"
@@ -263,72 +266,72 @@ static void __attribute__((interrupt)) trap_entry(void)
         "beqz s1, null_thread                               \n"
 
         /* Store s2-s11 */
-        "sw s2, "XTSTR (s2_OFFSET)"(sp)                      \n"
-        "sw s3, "XTSTR (s3_OFFSET)"(sp)                      \n"
-        "sw s4, "XTSTR (s4_OFFSET)"(sp)                      \n"
-        "sw s5, "XTSTR (s5_OFFSET)"(sp)                      \n"
-        "sw s6, "XTSTR (s6_OFFSET)"(sp)                      \n"
-        "sw s7, "XTSTR (s7_OFFSET)"(sp)                      \n"
-        "sw s8, "XTSTR (s8_OFFSET)"(sp)                      \n"
-        "sw s9, "XTSTR (s9_OFFSET)"(sp)                      \n"
-        "sw s10, "XTSTR (s10_OFFSET)"(sp)                    \n"
-        "sw s11, "XTSTR (s11_OFFSET)"(sp)                    \n"
+        XTSTR(REG_S)" s2, "XTSTR (s2_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" s3, "XTSTR (s3_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" s4, "XTSTR (s4_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" s5, "XTSTR (s5_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" s6, "XTSTR (s6_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" s7, "XTSTR (s7_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" s8, "XTSTR (s8_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" s9, "XTSTR (s9_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" s10, "XTSTR (s10_OFFSET)"(sp)                    \n"
+        XTSTR(REG_S)" s11, "XTSTR (s11_OFFSET)"(sp)                    \n"
 
         /* Grab mepc to save it to the stack */
         "csrr s2, mepc                                      \n"
 
         /* Save return PC in stack frame */
-        "sw s2, "XTSTR (pc_OFFSET)"(sp)                      \n"
+        XTSTR(REG_S)" s2, "XTSTR (pc_OFFSET)"(sp)                      \n"
 
         /* Save stack pointer of current thread */
-        "sw sp, "XTSTR (SP_OFFSET_IN_THREAD)"(s1)            \n"
+        XTSTR(REG_S)" sp, "XTSTR (SP_OFFSET_IN_THREAD)"(s1)            \n"
 
         /* Context saving done, from here on the new thread is scheduled */
         "null_thread:                                       \n"
 
         /*  Get the new active thread (guaranteed to be non NULL) */
-        "lw s1, sched_active_thread                         \n"
+        XTSTR(REG_L)" s1, sched_active_thread                         \n"
 
         /*  Load the thread SP of scheduled thread */
-        "lw sp, "XTSTR (SP_OFFSET_IN_THREAD)"(s1)            \n"
+        XTSTR(REG_L)" sp, "XTSTR (SP_OFFSET_IN_THREAD)"(s1)            \n"
 
         /*  Set return PC to mepc */
-        "lw a1, "XTSTR (pc_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" a1, "XTSTR (pc_OFFSET)"(sp)                      \n"
         "csrw mepc, a1                                      \n"
 
         /* restore s2-s11 */
-        "lw s2, "XTSTR (s2_OFFSET)"(sp)                      \n"
-        "lw s3, "XTSTR (s3_OFFSET)"(sp)                      \n"
-        "lw s4, "XTSTR (s4_OFFSET)"(sp)                      \n"
-        "lw s5, "XTSTR (s5_OFFSET)"(sp)                      \n"
-        "lw s6, "XTSTR (s6_OFFSET)"(sp)                      \n"
-        "lw s7, "XTSTR (s7_OFFSET)"(sp)                      \n"
-        "lw s8, "XTSTR (s8_OFFSET)"(sp)                      \n"
-        "lw s9, "XTSTR (s9_OFFSET)"(sp)                      \n"
-        "lw s10, "XTSTR (s10_OFFSET)"(sp)                    \n"
-        "lw s11, "XTSTR (s11_OFFSET)"(sp)                    \n"
+        XTSTR(REG_L)" s2, "XTSTR (s2_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" s3, "XTSTR (s3_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" s4, "XTSTR (s4_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" s5, "XTSTR (s5_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" s6, "XTSTR (s6_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" s7, "XTSTR (s7_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" s8, "XTSTR (s8_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" s9, "XTSTR (s9_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" s10, "XTSTR (s10_OFFSET)"(sp)                    \n"
+        XTSTR(REG_L)" s11, "XTSTR (s11_OFFSET)"(sp)                    \n"
 
         "no_switch:                                         \n"
 
         /* restore the caller-saved registers */
-        "lw ra, "XTSTR (ra_OFFSET)"(sp)                      \n"
-        "lw t0, "XTSTR (t0_OFFSET)"(sp)                      \n"
-        "lw t1, "XTSTR (t1_OFFSET)"(sp)                      \n"
-        "lw t2, "XTSTR (t2_OFFSET)"(sp)                      \n"
-        "lw t3, "XTSTR (t3_OFFSET)"(sp)                      \n"
-        "lw t4, "XTSTR (t4_OFFSET)"(sp)                      \n"
-        "lw t5, "XTSTR (t5_OFFSET)"(sp)                      \n"
-        "lw t6, "XTSTR (t6_OFFSET)"(sp)                      \n"
-        "lw a0, "XTSTR (a0_OFFSET)"(sp)                      \n"
-        "lw a1, "XTSTR (a1_OFFSET)"(sp)                      \n"
-        "lw a2, "XTSTR (a2_OFFSET)"(sp)                      \n"
-        "lw a3, "XTSTR (a3_OFFSET)"(sp)                      \n"
-        "lw a4, "XTSTR (a4_OFFSET)"(sp)                      \n"
-        "lw a5, "XTSTR (a5_OFFSET)"(sp)                      \n"
-        "lw a6, "XTSTR (a6_OFFSET)"(sp)                      \n"
-        "lw a7, "XTSTR (a7_OFFSET)"(sp)                      \n"
-        "lw s0, "XTSTR (s0_OFFSET)"(sp)                      \n"
-        "lw s1, "XTSTR (s1_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" ra, "XTSTR (ra_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" t0, "XTSTR (t0_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" t1, "XTSTR (t1_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" t2, "XTSTR (t2_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" t3, "XTSTR (t3_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" t4, "XTSTR (t4_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" t5, "XTSTR (t5_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" t6, "XTSTR (t6_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" a0, "XTSTR (a0_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" a1, "XTSTR (a1_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" a2, "XTSTR (a2_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" a3, "XTSTR (a3_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" a4, "XTSTR (a4_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" a5, "XTSTR (a5_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" a6, "XTSTR (a6_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" a7, "XTSTR (a7_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" s0, "XTSTR (s0_OFFSET)"(sp)                      \n"
+        XTSTR(REG_L)" s1, "XTSTR (s1_OFFSET)"(sp)                      \n"
 
         "addi sp, sp, "XTSTR (CONTEXT_FRAME_SIZE)"           \n"
         :

--- a/cpu/riscv_common/ldscripts/riscv_base.ld
+++ b/cpu/riscv_common/ldscripts/riscv_base.ld
@@ -30,6 +30,9 @@ PHDRS
   tls PT_TLS;
 }
 
+/* Section alignment follows the word size: 4 on rv32, 8 on rv64 (set via --defsym) */
+_riscv_word_bytes = DEFINED(_riscv_word_bytes) ? _riscv_word_bytes : 4;
+
 SECTIONS
 {
   __stack_size     = DEFINED(__stack_size) ? __stack_size : 256;
@@ -167,13 +170,13 @@ SECTIONS
 
   .lalign         :
   {
-    . = ALIGN(4);
+    . = ALIGN(_riscv_word_bytes);
     PROVIDE( _data_lma = . );
   } >flash AT>flash :flash
 
   .dalign         :
   {
-    . = ALIGN(4);
+    . = ALIGN(_riscv_word_bytes);
     PROVIDE( _data = . );
   } >ram AT>flash :ram_init
 
@@ -195,7 +198,7 @@ SECTIONS
     KEEP (*(SORT(.xfa.*)))
   } >ram AT>flash :ram_init
 
-  . = ALIGN(4);
+  . = ALIGN(_riscv_word_bytes);
   PROVIDE( _edata = . );
   PROVIDE( edata = . );
 
@@ -208,7 +211,7 @@ SECTIONS
     *(.bss .bss.*)
     *(.gnu.linkonce.b.*)
     *(COMMON)
-    . = ALIGN(4);
+    . = ALIGN(_riscv_word_bytes);
   } >ram AT>ram :ram
   PROVIDE( __bss_end = . );
 

--- a/cpu/riscv_common/start.S
+++ b/cpu/riscv_common/start.S
@@ -6,6 +6,7 @@
  * directory for more details.
  */
 #include "vendor/riscv_csr.h"
+#include "context_frame.h"
 
 .section .init
 
@@ -37,10 +38,10 @@ _start_real:
     la a2, _edata
     bgeu a1, a2, 2f
 1:
-    lw t0, (a0)
-    sw t0, (a1)
-    addi a0, a0, 4
-    addi a1, a1, 4
+    REG_L t0, (a0)
+    REG_S t0, (a1)
+    addi a0, a0, REGSZ
+    addi a1, a1, REGSZ
     bltu a1, a2, 1b
 2:
 
@@ -50,8 +51,8 @@ _start_real:
     la a1, __bss_end
     bgeu a0, a1, 2f
 1:
-    sw zero, (a0)
-    addi a0, a0, 4
+    REG_S zero, (a0)
+    addi a0, a0, REGSZ
     bltu a0, a1, 1b
 2:
 

--- a/cpu/riscv_common/thread_arch.c
+++ b/cpu/riscv_common/thread_arch.c
@@ -14,6 +14,7 @@
  * @}
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <malloc.h>
@@ -74,10 +75,10 @@ char *thread_stack_init(thread_task_func_t task_func,
                         int stack_size)
 {
     struct context_switch_frame *sf;
-    uint32_t *stk_top;
+    uintptr_t *stk_top;
 
     /* calculate the top of the stack */
-    stk_top = (uint32_t *)((uintptr_t)stack_start + stack_size);
+    stk_top = (uintptr_t *)((uintptr_t)stack_start + stack_size);
 
     /* Put a marker at the top of the stack.  This is used by
      * thread_stack_print to determine where to stop dumping the
@@ -87,10 +88,10 @@ char *thread_stack_init(thread_task_func_t task_func,
     *stk_top = STACK_MARKER;
 
     /* per ABI align stack pointer to 16 byte boundary. */
-    stk_top = (uint32_t *)(((uintptr_t)stk_top) & ~((uintptr_t)0xf));
+    stk_top = (uintptr_t *)(((uintptr_t)stk_top) & ~((uintptr_t)0xf));
 
     /* reserve space for the stack frame. */
-    stk_top = (uint32_t *)((uintptr_t)stk_top - sizeof(*sf));
+    stk_top = (uintptr_t *)((uintptr_t)stk_top - sizeof(*sf));
 
     /* populate the stack frame with default values for starting the thread. */
     sf = (struct context_switch_frame *)stk_top;
@@ -120,22 +121,23 @@ void thread_print_stack(void)
     /* thread_init aligns stack pointer to 16 byte boundary, the cast below
      * is therefore safe. Use intermediate cast to uintptr_t to silence
      * -Wcast-align */
-    uint32_t *sp = (uint32_t *)(uintptr_t)active_thread->sp;
+    uintptr_t *sp = (uintptr_t *)(uintptr_t)active_thread->sp;
 
     printf("printing the current stack of thread %" PRIkernel_pid "\n",
            thread_getpid());
 
 #ifdef DEVELHELP
     printf("thread name: %s\n", active_thread->name);
-    printf("stack start: 0x%08x\n", (unsigned)(active_thread->stack_start));
-    printf("stack end  : 0x%08x\n",
-           (unsigned)(active_thread->stack_start + active_thread->stack_size));
+    printf("stack start: 0x%" PRIxPTR "\n",
+           (uintptr_t)(active_thread->stack_start));
+    printf("stack end  : 0x%" PRIxPTR "\n",
+           (uintptr_t)(active_thread->stack_start + active_thread->stack_size));
 #endif
 
     printf("  address:      data:\n");
 
     do {
-        printf("  0x%08x:   0x%08x\n", (unsigned)sp, (unsigned)*sp);
+        printf("  0x%" PRIxPTR ":   0x%" PRIxPTR "\n", (uintptr_t)sp, *sp);
         sp++;
         count++;
     } while (*sp != STACK_MARKER);
@@ -187,6 +189,7 @@ void heap_stats(void)
     long int heap_size = &_eheap - &_sheap;
     struct mallinfo minfo = mallinfo();
 
-    printf("heap: %ld (used %u, free %ld) [bytes]\n",
-           heap_size, minfo.uordblks, heap_size - minfo.uordblks);
+    printf("heap: %ld (used %lu, free %ld) [bytes]\n",
+           heap_size, (unsigned long)minfo.uordblks,
+           heap_size - (long)minfo.uordblks);
 }

--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -92,6 +92,11 @@ CFLAGS_DBG  ?= -g3
 CFLAGS_OPT  ?= -Os
 
 LINKFLAGS += -L$(RIOTCPU)/$(CPU)/ldscripts -L$(RIOTCPU)/riscv_common/ldscripts
+ifeq (rv64,$(CPU_ARCH))
+  LINKFLAGS += -Wl,--defsym=_riscv_word_bytes=8
+else
+  LINKFLAGS += -Wl,--defsym=_riscv_word_bytes=4
+endif
 LINKER_SCRIPT ?= $(CPU_MODEL).ld
 LINKFLAGS += -T$(LINKER_SCRIPT)
 

--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -51,7 +51,11 @@ endif
 
 GCC_DEFAULTS_TO_NEW_RISCV_ISA ?= 0
 
-CFLAGS_CPU := -march=rv32imac -mabi=ilp32
+ifeq (rv64,$(CPU_ARCH))
+  CFLAGS_CPU := -march=rv64imac -mabi=lp64
+else
+  CFLAGS_CPU := -march=rv32imac -mabi=ilp32
+endif
 ASFLAGS := $(CFLAGS_CPU)
 
 # Since RISC-V ISA specifications 20191213 instructions previously included in
@@ -64,9 +68,13 @@ ifeq (1,$(GCC_DEFAULTS_TO_NEW_RISCV_ISA))
   CFLAGS_CPU += -misa-spec=2.2
 endif
 
-# Always use riscv32-none-elf as target triple for clang, as some
+# Always use riscv{32,64}-none-elf as target triple for clang, as some
 # autodetected gcc target triples are incompatible with clang
-TARGET_ARCH_LLVM := riscv32-none-elf
+ifeq (rv64,$(CPU_ARCH))
+  TARGET_ARCH_LLVM := riscv64-none-elf
+else
+  TARGET_ARCH_LLVM := riscv32-none-elf
+endif
 ifneq ($(TOOLCHAIN),llvm)
   CFLAGS_NO_ASM += -mcmodel=medlow -msmall-data-limit=8
   # We cannot invoke the compiler on the host system if build in docker.
@@ -93,4 +101,8 @@ ASFLAGS += $(CFLAGS_CPU)
 LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_LINK) $(CFLAGS_DBG) $(CFLAGS_OPT) -nostartfiles -Wl,--gc-sections -static -lgcc
 
 # Platform triple as used by Rust
-RUST_TARGET = riscv32imac-unknown-none-elf
+ifeq (rv64,$(CPU_ARCH))
+  RUST_TARGET = riscv64imac-unknown-none-elf
+else
+  RUST_TARGET = riscv32imac-unknown-none-elf
+endif

--- a/tests/periph/uart/main.c
+++ b/tests/periph/uart/main.c
@@ -504,9 +504,10 @@ int main(void)
     }
 
     puts("\nUART INFO:");
-    printf("Available devices:               %i\n", UART_NUMOF);
+    printf("Available devices:               %u\n", (unsigned)UART_NUMOF);
     if (STDIO_UART_DEV != UART_UNDEF) {
-        printf("UART used for STDIO (the shell): UART_DEV(%i)\n\n", STDIO_UART_DEV);
+        printf("UART used for STDIO (the shell): UART_DEV(%u)\n\n",
+               (unsigned)STDIO_UART_DEV);
     }
 
     /* initialize ringbuffers */


### PR DESCRIPTION
### Contribution description

This add rv64 support to the common RISC-V code in preparation for a
NOEL-V (rv64imac) CPU/board port that will follow in a separate PR.
- `makefiles/arch/riscv`: select `-march=rv64imac -mabi=lp64`, the LLVM
  target triple and the Rust target when the CPU core is rv64
- `cpu/riscv_common`: parametrize the context frame and trap/context-switch
  assembly by XLEN (`REGSZ`, `REG_L`/`REG_S`), widen `MCAUSE_*` masks,
  `ARCHITECTURE_WORD_BITS` and default stack sizes for 64 bit, add the
  `CPU_CORE_RV64IMAC` Kconfig core
- `picolibc` is now only advertised on rv32 - the RISC-V toolchain ships no
  rv64 picolibc, so advertising it on rv64 would link the rv32 libc and
  fail with an ABI mismatch
- rv32 targets are unaffected - the generated code is unchanged
The `tests/periph/uart` commit fixes format specifiers that break the
build on 64 bit RISC-V (`UART_NUMOF`/`STDIO_UART_DEV` printed with `%i`).

### Testing procedure
- Murdock should show all existing RISC-V(rv32) boards building unchsnged.
- Built locally: `examples/basic/hello-world`, `tests/core/thread_basic`,
  `tests/periph/uart` for hifive1, hifive1b, gd32vf103c-start,
  sipeed-longan-nano (GCC), hifive1 with `TOOLCHAIN=llvm`, the picolibc
  path (`gnrc_minimal`), and esp32c3-devkit - all in the riotbuild docker
  image.
- The rv64 path is exercised on real hardware by the follow up NOEL-V port
  (ZedBoard FPGA, rv64imac): interactive shell over UART, ztimer accuracy
  checks and GNRC/lwIP networking all behave correctly.

### Issues/PRs references

Part 1 of upstreaming a NOEL-V (Gaisler RISC-V) port for the ZedBoard.
Part 2 (cpu/noelv + boards/zedboard-noelv + drivers/greth) depends on this.

### Declaration of AI-Tools / LLMs usage:

- ChatGPT for documentation generation, with user review, comments quality improvment, help with debugging.

