### PR TITLE
boards/nucleo-g031k8: add I2C peripheral support

### DIFF
--- a/boards/nucleo-g031k8/Makefile.features
+++ b/boards/nucleo-g031k8/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32g031k8
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/nucleo-g031k8/include/periph_conf.h
+++ b/boards/nucleo-g031k8/include/periph_conf.h
@@ -97,6 +97,43 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev            = I2C1,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_A, 9),   /* Arduino D5 */
+        .sda_pin        = GPIO_PIN(PORT_A, 10),  /* Arduino D4 */
+        .scl_af         = GPIO_AF6,
+        .sda_af         = GPIO_AF6,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APBENR1_I2C1EN,
+        .rcc_sw_mask    = RCC_CCIPR_I2C1SEL_1,   /* HSI (16 MHz) */
+        .irqn           = I2C1_IRQn,
+    },
+    {
+        .dev            = I2C2,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_A, 11),  /* Arduino A5 */
+        .sda_pin        = GPIO_PIN(PORT_A, 12),  /* Arduino A4 */
+        .scl_af         = GPIO_AF6,
+        .sda_af         = GPIO_AF6,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APBENR1_I2C2EN,
+        /* I2C2 has no kernel clock mux, it is always clocked from PCLK */
+        .irqn           = I2C2_IRQn,
+    }
+};
+
+#define I2C_0_ISR           isr_i2c1
+#define I2C_1_ISR           isr_i2c2
+
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/pkg/cryptoauthlib_internal-tests/Makefile.ci
+++ b/tests/pkg/cryptoauthlib_internal-tests/Makefile.ci
@@ -21,6 +21,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-c031c6 \
     nucleo-f030r8 \
     nucleo-f302r8 \
+    nucleo-g031k8 \
     nucleo-l011k4 \
     nucleo-l031k6 \
     sam10-xpro \


### PR DESCRIPTION
### Contribution description

add I2C peripheral support for the `nucleo-g031k8` board, based on `boards/common/stm32/include/cfg_i2c1_pb6_pb7.h` and `boards/common/stm32/include/cfg_i2c1_pb8_pb9.h`.

### Testing procedure

Compiled `BOARD=nucleo-g031k8 make -C tests/periph/i2c`. Unfortunately I have no hardware available to test it.

### Issues/PRs references

none

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none