### PR TITLE
sys/net/ipv4: fix internet header length

### DIFF
--- a/sys/include/net/ipv4/hdr.h
+++ b/sys/include/net/ipv4/hdr.h
@@ -15,17 +15,22 @@
  * @brief   IPv4 header type and helper function definitions
  *
  * @author  José Ignacio Alamos <jialamos@uc.cl>
+ * @author  Bas Stottelaar <basstottelaar@gmail.com>
  */
+
+#include <assert.h>
 
 #include "byteorder.h"
 #include "net/ipv4/addr.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 /**
- * @brief Data type to represent an IPv4 packet header.
+ * @brief   Data type to represent an IPv4 packet header.
  *
- * @details The structure of the header is as follows:
+ * The structure of the header is as follows:
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.unparsed}
  *  0                   1                   2                   3
@@ -51,29 +56,36 @@ extern "C" {
  */
 typedef struct __attribute__((packed)) {
     /**
-     * @brief Version and Internet Header Length.
+     * @brief   Version and Internet Header Length.
      *
-     * @details The version are the 4 most significant bits and the Internet Header Length
-     * the 4 next bit (see above).
+     * The version is encoded in the four most significant bits and the
+     * Internet Header Length in the four least significant bits (see above).
+     *
+     * The Internet Header Length is the length of the header in 32-bit words,
+     * so it must be multiplied by 4 to get the length in bytes. The minimum
+     * value is 5 (20 bytes) and the maximum is 15 (60 bytes).
      *
      * This module provides helper functions to set, get, and check these
      * fields accordingly:
+     *
      * * ipv4_hdr_set_version()
      * * ipv4_hdr_get_version()
      * * ipv4_hdr_set_ihl()
      * * ipv4_hdr_get_ihl()
      */
-    uint8_t v_ih;
-    uint8_t ts;             /**< type of service of packet*/
+    uint8_t v_ihl;
+    uint8_t ts;             /**< type of service of packet */
     network_uint16_t tl;    /**< total length of the datagram */
     network_uint16_t id;    /**< identification value of packet */
     /**
-     * @brief version control flags and Fragment Offset.
+     * @brief   Version control flags and Fragment Offset.
      *
-     * @details The flags are the 3 most significant bits, and the remaining 13 bits are the fragment offset
+     * The flags are the 3 most significant bits, and the remaining 13 bits are
+     * the fragment offset.
      *
      * This module provides helper functions to set, get, and check these
      * fields accordingly:
+     *
      * * ipv4_hdr_set_flags()
      * * ipv4_hdr_get_flags()
      * * ipv4_hdr_set_fo()
@@ -88,57 +100,60 @@ typedef struct __attribute__((packed)) {
 } ipv4_hdr_t;
 
 /**
- * @brief   Sets the version field of @p hdr to 6
+ * @brief   Sets the version field of @p hdr to 4
  *
- * @param[out] hdr  Pointer to an IPv4 header.
+ * @param[out]  hdr     Pointer to an IPv4 header.
  */
 static inline void ipv4_hdr_set_version(ipv4_hdr_t *hdr)
 {
-    hdr->v_ih &= 0x0f;
-    hdr->v_ih |= 0x40;
+    hdr->v_ihl &= 0x0f;
+    hdr->v_ihl |= 0x40;
 }
 
 /**
  * @brief   Gets the value of the version field of @p hdr
  *
- * @param[in] hdr   Pointer to an IPv4 header.
+ * @param[in]   hdr     Pointer to an IPv4 header.
  *
  * @return  Value of the version field of @p hdr.
  */
 static inline uint8_t ipv4_hdr_get_version(ipv4_hdr_t *hdr)
 {
-    return ((hdr->v_ih) >> 4);
+    return ((hdr->v_ihl) >> 4);
 }
 
 /**
  * @brief   Sets the Internet Header Length field of @p hdr
  *
- * @param[out] hdr  Pointer to an IPv4 header.
- * @param[in] ihl  Size in bytes of the Internet Header Length (including padding)
+ * @param[out]  hdr     Pointer to an IPv4 header.
+ * @param[in]   ihl     Size in bytes of the Internet Header Length (including padding)
  */
 static inline void ipv4_hdr_set_ihl(ipv4_hdr_t *hdr, uint16_t ihl)
 {
-    hdr->v_ih &= 0xf0;
-    hdr->v_ih |= 0x0f & (ihl >> 5);
+    assert(ihl >= 20 && ihl <= 60);
+    assert(ihl % 4 == 0);
+
+    hdr->v_ihl &= 0xf0;
+    hdr->v_ihl |= 0x0f & (ihl >> 2);
 }
 
 /**
- * brief Gets the value of the Internet Header Length field of @p hdr
+ * @brief   Gets the value of the Internet Header Length field of @p hdr
  *
- * @param[in] hdr   Pointer to an IPv4 header.
+ * @param[in]   hdr     Pointer to an IPv4 header.
  *
  * @return Size in bytes of the Internet Header Length field of @p hdr
  */
 static inline uint16_t ipv4_hdr_get_ihl(ipv4_hdr_t *hdr)
 {
-    return (hdr->v_ih & 0x0f) << 5;
+    return (hdr->v_ihl & 0x0f) << 2;
 }
 
 /**
  * @brief   Sets the Version Control Flags field of @p hdr
  *
- * @param[out] hdr  Pointer to an IPv4 header.
- * @param[in] flags  The new value of flags
+ * @param[out]  hdr     Pointer to an IPv4 header.
+ * @param[in]   flags   The new value of flags
  */
 static inline void ipv4_hdr_set_flags(ipv4_hdr_t *hdr, uint8_t flags)
 {
@@ -147,9 +162,9 @@ static inline void ipv4_hdr_set_flags(ipv4_hdr_t *hdr, uint8_t flags)
 }
 
 /**
- * brief Gets the value of the Version Control Flags field of @p hdr
+ * @brief   Gets the value of the Version Control Flags field of @p hdr
  *
- * @param[in] hdr   Pointer to an IPv4 header.
+ * @param[in]   hdr     Pointer to an IPv4 header.
  *
  * @return Value of the Version Control field of @p hdr
  */
@@ -161,8 +176,8 @@ static inline uint8_t ipv4_hdr_get_flags(ipv4_hdr_t *hdr)
 /**
  * @brief   Sets the Fragment Offset field of @p hdr
  *
- * @param[out] hdr  Pointer to an IPv4 header.
- * @param[in] fo  The new value of fragment offset
+ * @param[out]  hdr     Pointer to an IPv4 header.
+ * @param[in]   fo      The new value of fragment offset
  */
 static inline void ipv4_hdr_set_fo(ipv4_hdr_t *hdr, uint16_t fo)
 {
@@ -172,9 +187,9 @@ static inline void ipv4_hdr_set_fo(ipv4_hdr_t *hdr, uint16_t fo)
 }
 
 /**
- * brief Gets the value of the Fragment Offset field of @p hdr
+ * @brief   Gets the value of the Fragment Offset field of @p hdr
  *
- * @param[in] hdr   Pointer to an IPv4 header.
+ * @param[in]   hdr     Pointer to an IPv4 header.
  *
  * @return Value of the Fragment Offset field of @p hdr
  */

--- a/tests/unittests/tests-ipv4_hdr/Makefile
+++ b/tests/unittests/tests-ipv4_hdr/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-ipv4_hdr/tests-ipv4_hdr.c
+++ b/tests/unittests/tests-ipv4_hdr/tests-ipv4_hdr.c
@@ -1,0 +1,180 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup unittests
+ *
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the `ipv4_hdr` module
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ */
+
+#include <stdint.h>
+
+#include "embUnit.h"
+
+#include "net/ipv4/hdr.h"
+
+#include "unittests-constants.h"
+#include "tests-ipv4_hdr.h"
+
+static void test_ipv4_hdr_set_version(void)
+{
+    uint8_t val[sizeof(ipv4_hdr_t)] = { TEST_UINT8 };
+
+    ipv4_hdr_set_version((ipv4_hdr_t *)val);
+
+    TEST_ASSERT_EQUAL_INT(0x40, val[0] & 0xf0);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 & 0x0f, val[0] & 0x0f);
+}
+
+static void test_ipv4_hdr_get_version(void)
+{
+    uint8_t val[sizeof(ipv4_hdr_t)] = { TEST_UINT8 };
+
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 >> 4, ipv4_hdr_get_version((ipv4_hdr_t *)val));
+}
+
+static void test_ipv4_hdr_set_ihl(void)
+{
+    uint8_t val[sizeof(ipv4_hdr_t)] = { TEST_UINT8 };
+
+    /* minimum internet header length */
+    ipv4_hdr_set_ihl((ipv4_hdr_t *)val, 20);
+
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 & 0xf0, val[0] & 0xf0);
+    TEST_ASSERT_EQUAL_INT(5, val[0] & 0x0f);
+
+    /* maximum internet header length */
+    ipv4_hdr_set_ihl((ipv4_hdr_t *)val, 60);
+
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 & 0xf0, val[0] & 0xf0);
+    TEST_ASSERT_EQUAL_INT(15, val[0] & 0x0f);
+}
+
+static void test_ipv4_hdr_get_ihl(void)
+{
+    uint8_t val[sizeof(ipv4_hdr_t)];
+
+    /* minimum internet header length */
+    val[0] = 0x45;
+
+    TEST_ASSERT_EQUAL_INT(20, ipv4_hdr_get_ihl((ipv4_hdr_t *)val));
+
+    /* maximum internet header length */
+    val[0] = 0x4f;
+
+    TEST_ASSERT_EQUAL_INT(60, ipv4_hdr_get_ihl((ipv4_hdr_t *)val));
+}
+
+static void test_ipv4_hdr_set_flags(void)
+{
+    uint8_t val[sizeof(ipv4_hdr_t)] = { 0 };
+
+    val[6] = TEST_UINT8;
+
+    /* no flags set */
+    ipv4_hdr_set_flags((ipv4_hdr_t *)val, 0);
+
+    TEST_ASSERT_EQUAL_INT(0x00, val[6] & 0xe0);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 & 0x1f, val[6] & 0x1f);
+
+    /* all flags set */
+    ipv4_hdr_set_flags((ipv4_hdr_t *)val, 0x07);
+
+    TEST_ASSERT_EQUAL_INT(0xe0, val[6] & 0xe0);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 & 0x1f, val[6] & 0x1f);
+}
+
+static void test_ipv4_hdr_get_flags(void)
+{
+    uint8_t val[sizeof(ipv4_hdr_t)] = { 0 };
+
+    /* no flags set */
+    val[6] = 0x00;
+
+    TEST_ASSERT_EQUAL_INT(0, ipv4_hdr_get_flags((ipv4_hdr_t *)val));
+
+    /* all flags set */
+    val[6] = 0xe0;
+
+    TEST_ASSERT_EQUAL_INT(0x07, ipv4_hdr_get_flags((ipv4_hdr_t *)val));
+
+    /* mixed: only MSB of flags set */
+    val[6] = 0x80;
+
+    TEST_ASSERT_EQUAL_INT(0x04, ipv4_hdr_get_flags((ipv4_hdr_t *)val));
+}
+
+static void test_ipv4_hdr_set_fo(void)
+{
+    uint8_t val[sizeof(ipv4_hdr_t)] = { 0 };
+
+    val[6] = TEST_UINT8;
+
+    /* zero fragment offset */
+    ipv4_hdr_set_fo((ipv4_hdr_t *)val, 0);
+
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 & 0xe0, val[6] & 0xe0);
+    TEST_ASSERT_EQUAL_INT(0x00, val[6] & 0x1f);
+    TEST_ASSERT_EQUAL_INT(0x00, val[7]);
+
+    /* maximum fragment offset (8191) */
+    ipv4_hdr_set_fo((ipv4_hdr_t *)val, 0x1fff);
+
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 & 0xe0, val[6] & 0xe0);
+    TEST_ASSERT_EQUAL_INT(0x1f, val[6] & 0x1f);
+    TEST_ASSERT_EQUAL_INT(0xff, val[7]);
+}
+
+static void test_ipv4_hdr_get_fo(void)
+{
+    uint8_t val[sizeof(ipv4_hdr_t)] = { 0 };
+
+    /* zero fragment offset */
+    val[6] = 0x00;
+    val[7] = 0x00;
+
+    TEST_ASSERT_EQUAL_INT(0, ipv4_hdr_get_fo((ipv4_hdr_t *)val));
+
+    /* maximum fragment offset (8191) */
+    val[6] = 0x1f;
+    val[7] = 0xff;
+
+    TEST_ASSERT_EQUAL_INT(0x1fff, ipv4_hdr_get_fo((ipv4_hdr_t *)val));
+
+    /* value spanning both bytes */
+    val[6] = 0x0a;
+    val[7] = 0xbc;
+
+    TEST_ASSERT_EQUAL_INT(0x0abc, ipv4_hdr_get_fo((ipv4_hdr_t *)val));
+}
+
+Test *tests_ipv4_hdr_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_ipv4_hdr_set_version),
+        new_TestFixture(test_ipv4_hdr_get_version),
+        new_TestFixture(test_ipv4_hdr_set_ihl),
+        new_TestFixture(test_ipv4_hdr_get_ihl),
+        new_TestFixture(test_ipv4_hdr_set_flags),
+        new_TestFixture(test_ipv4_hdr_get_flags),
+        new_TestFixture(test_ipv4_hdr_set_fo),
+        new_TestFixture(test_ipv4_hdr_get_fo),
+    };
+
+    EMB_UNIT_TESTCALLER(ipv4_hdr_tests, NULL, NULL, fixtures);
+
+    return (Test *)&ipv4_hdr_tests;
+}
+
+void tests_ipv4_hdr(void)
+{
+    TESTS_RUN(tests_ipv4_hdr_tests());
+}
+/** @} */

--- a/tests/unittests/tests-ipv4_hdr/tests-ipv4_hdr.h
+++ b/tests/unittests/tests-ipv4_hdr/tests-ipv4_hdr.h
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the `ipv4_hdr` module
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ */
+
+#include "embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The entry point of this test suite.
+ */
+void tests_ipv4_hdr(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */


### PR DESCRIPTION
### Contribution description

The internet header length field is incorrectly stored in the `v_ihl` field. According to the documentation, it expects bytes as input. 

Also renamed `v_ih` to `v_ihl` to be consistent, and added unit tests for this header.


### Testing procedure

Run the unit tests: `make -C tests/unittests tests-ipv4_hdr term`


### Issues/PRs references

#22676


### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- Claude Code Sonnet 5 to find the issue, which I then fixed myself
- Claude Code Sonnet 5 to generate unit tests.
