### PR TITLE
dist/tools/insufficient_memory: fix script name in README

### DIFF
--- a/dist/tools/insufficient_memory/README.md
+++ b/dist/tools/insufficient_memory/README.md
@@ -1,7 +1,7 @@
-add_insufficient_memory_board.sh
+update_insufficient_memory_board.sh
 ------------------
 
-Usage: `add_insufficient_memory_board.sh <board_name>`
+Usage: `update_insufficient_memory_board.sh <board_name>`
 
 Updates `Makefile.ci` to include `<board_name>` if the memory of the board is not sufficient for the test/example.
 


### PR DESCRIPTION
### Contribution description

Fix the wrong script name at `dist/tools/insufficient_memory/README.md`


### Testing procedure

- none

### Issues/PRs references

- none

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none