### PR TITLE
cpu/riscv_common/irq_arch: fix wrong print kconfig check

### DIFF
--- a/cpu/riscv_common/irq_arch.c
+++ b/cpu/riscv_common/irq_arch.c
@@ -91,7 +91,7 @@ __attribute((used)) static void handle_trap(uword_t mcause)
     /* Check if this is an interrupt or a trap, indicated by the left most bit */
     bool is_interrupt = (mcause & MCAUSE_INT) == MCAUSE_INT;
 
-#ifdef CONFIG_PRINT_VERBOSE_TRAP_INFO
+#if CONFIG_PRINT_VERBOSE_TRAP_INFO
     printf("Trap: mcause=0x%" PRIx32 " mepc=0x%lx mtval=0x%lx\n",
            (uint32_t)mcause, read_csr(mepc), read_csr(mtval));
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

While working on reviewing #22547 I noticed that the verbose print check didn't actually properly work, since we check for #ifdef but CONFIG_PRINT_VERBOSE_TRAP_INFO will be defined by KCONFIG even if it's turned off.

By checking #if it should only print when it's actually directly enabled.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Do something that would print ISRs, e.g. `tests/sys/timer_msg`

#### Before:

```
2026-08-11 13:43:09,464 # Machine Cause Error 0xb: Environment call from M-mode
2026-08-11 13:43:09,946 # Trap: mcause=0x8000000b mepc=0x100009e2 mtval=0x0
2026-08-11 13:43:09,947 # Calling isr 0x100016ea for irq 0
2026-08-11 13:43:09,947 # Trap: mcause=0xb mepc=0x100004fa mtval=0x0
2026-08-11 13:43:09,947 # Machine Cause Error 0xb: Environment call from M-mode
2026-08-11 13:43:09,948 # sec=35 min=0 hour=0
2026-08-11 13:43:09,948 # Trap: mcause=0xb mepc=0x10000408 mtval=0x0
2026-08-11 13:43:09,958 # Machine Cause Error 0xb: Environment call from M-mode
2026-08-11 13:43:09,958 # Trap: mcause=0xb mepc=0x100005e4 mtval=0x0
2026-08-11 13:43:09,959 # Machine Cause Error 0xb: Environment call from M-mode
2026-08-11 13:43:10,973 # Trap: mcause=0x8000000b mepc=0x100009e2 mtval=0x0
2026-08-11 13:43:10,973 # Calling isr 0x100016ea for irq 0
2026-08-11 13:43:10,974 # Trap: mcause=0xb mepc=0x100004fa mtval=0x0
2026-08-11 13:43:10,974 # Machine Cause Error 0xb: Environment call from M-mode
```

#### After:

(This PR didn't include #22557 )

```
2026-08-11 13:43:47,618 # now=6:937607 -> every 5.0s: This is a Test
2026-08-11 13:43:47,634 # Calling isr 0x100016ea for irq 0
2026-08-11 13:43:47,635 # sec=6 min=0 hour=0
2026-08-11 13:43:48,624 # Calling isr 0x100016ea for irq 0
2026-08-11 13:43:48,625 # now=7:945019 -> every 2.0s: Hello World
2026-08-11 13:43:48,639 # Calling isr 0x100016ea for irq 0
2026-08-11 13:43:48,639 # sec=7 min=0 hour=0
2026-08-11 13:43:49,644 # Calling isr 0x100016ea for irq 0
2026-08-11 13:43:49,645 # sec=8 min=0 hour=0
2026-08-11 13:43:50,630 # Calling isr 0x100016ea for irq 0
2026-08-11 13:43:50,631 # now=9:951281 -> every 2.0s: Hello World
2026-08-11 13:43:50,648 # Calling isr 0x100016ea for irq 0
2026-08-11 13:43:50,648 # sec=9 min=0 hour=0
2026-08-11 13:43:51,652 # Calling isr 0x100016ea for irq 0
2026-08-11 13:43:51,653 # sec=10 min=0 hour=0
2026-08-11 13:43:52,624 # Calling isr 0x100016ea for irq 0
2026-08-11 13:43:52,624 # now=11:944130 -> every 5.0s: This is a Test
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
