### PR TITLE
doc/starlight: fix pinout for nucleo-c031

### DIFF
--- a/doc/starlight/public/boards/nucleo-c031c6.svg
+++ b/doc/starlight/public/boards/nucleo-c031c6.svg
@@ -1,0 +1,1 @@
+../../../doxygen/src/pinouts/nucleo-c031c6.svg


### PR DESCRIPTION
### Contribution description

This PR is attempt to fix issue with lack of pinouts in starlight guide described in Issue #22353. 
In this PR for test purpose missing pinout for `nucleo-c031c6` was fixed, by adding symlink do 
pinouts used by doxygen documentation.

If solution works, in the following PR all remaining pinouts will be fixed.

### Testing procedure

Fix was tested locally with success:

```
make doc-starlight
```
And in other terminal connect to starlight documentation xdg-open http://localhost:4321/ .

It should be tested in production environment accessed by link [https://guide.riot-os.org/boards/](https://guide.riot-os.org/boards/).

### Issues/PRs references

Issue #22353

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
