### PR TITLE
sys/test_utils: fix netdev numof check

### DIFF
--- a/sys/test_utils/netdev_eth_minimal/netdev_eth_minimal.c
+++ b/sys/test_utils/netdev_eth_minimal/netdev_eth_minimal.c
@@ -100,7 +100,7 @@ void netdev_register_signal(struct netdev *dev, netdev_type_t type, uint8_t inde
 {
     (void) type;
 
-    if (index > NETDEV_ETH_MINIMAL_NUMOF) {
+    if (index >= NETDEV_ETH_MINIMAL_NUMOF) {
         return;
     }
     printf("Device %d registered (type: %d)\n", index, type);

--- a/sys/test_utils/netdev_ieee802154_minimal/netdev_ieee802154_minimal.c
+++ b/sys/test_utils/netdev_ieee802154_minimal/netdev_ieee802154_minimal.c
@@ -203,7 +203,7 @@ void netdev_register_signal(struct netdev *dev, netdev_type_t type, uint8_t inde
 {
     (void) type;
 
-    if (index > NETDEV_IEEE802154_MINIMAL_NUMOF) {
+    if (index >= NETDEV_IEEE802154_MINIMAL_NUMOF) {
         return;
     }
     printf("Device %d registered (type: %d)\n", index, type);


### PR DESCRIPTION
### Contribution description

The `index` is used to dereference `_devices[..]` in both test implementations. Clearly, the index equal to `NETDEV_.._MINIMAL_NUMOF` will access out of bounds.

### Testing procedure

This is used by several netdev tests. They should still compile. 

I did not test it by running one, because I think the fix is straight-forward.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- Claude Opus 5 identified the same issue in my own KNX branch (for `netdev_knx_minimal`), so I figured that this must be present for the others as well.
