### PR TITLE
sys/string_utils: fix compilation when used in host tools [backport 2026.07]

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -2584,7 +2584,8 @@ PREDEFINED             = DOXYGEN \
                          MODULE_GNRC_SIXLOWPAN \
                          MODULE_GNRC_SIXLOWPAN_ND_ROUTER \
                          MODULE_GNRC_SIXLOWPAN_ND_BORDER_ROUTER \
-                         MODULE_GNRC_UDP
+                         MODULE_GNRC_UDP \
+                         RIOT_OS=1
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/sys/include/string_utils.h
+++ b/sys/include/string_utils.h
@@ -119,14 +119,15 @@ int swprintf(string_writer_t *sw, FLASH_ATTR const char *restrict format, ...);
 #endif
 
 /* explicit_bzero is provided if:
- * - glibc is used as C lib (only with board natvie)
- * - newlib is used and __BSD_VISIBLE is set
- *      - except for ESP8266, which is using an old version of newlib without it
- * - picolibc is used and __BSD_VISIBLE is set
+ * - the system is compiled for RIOT *and* any of the following:
+ *   - glibc is used as C lib (only with board native)
+ *   - newlib is used and __BSD_VISIBLE is set
+ *     - except for ESP8266, which is using an old version of newlib without it
+ *   - picolibc is used and __BSD_VISIBLE is set
  *
  * for all other cases, we provide it here
  */
-#if !defined(CPU_NATIVE) \
+#if defined(RIOT_OS) && !defined(CPU_NATIVE) \
     && !(IS_USED(MODULE_PICOLIBC) && __BSD_VISIBLE) \
     && !(IS_USED(MODULE_NEWLIB) && __BSD_VISIBLE && !defined(CPU_ESP8266))
 


### PR DESCRIPTION
# Backport of #22540

### Contribution description

Compilation of zep_dispatch seems to currently fail on Debian due to conflicting declarations of `explicit_bzero()`, which we provide as part of `string_utils()` on systems that do not have it.

This adds a check for `RIOT_OS`, so that in case of either `native` board or host tool, the native OS's implementation is used.

### Testing procedure

```
$ BUILD_IN_DOCKER=1 make -C examples/networking/gnrc/border_router BOARD=nrf52840dk clean flash term
```

Should now work on Debian. (Note: On Ubuntu it already compiled fine before, so this cannot be reasonably tested on an Ubuntu system.)

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/22465

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none