### PR TITLE
net/ieee802154: Ensure frame is big enough for sec header [backport 2026.07]

### DIFF
--- a/sys/net/link_layer/ieee802154/security.c
+++ b/sys/net/link_layer/ieee802154/security.c
@@ -493,6 +493,11 @@ int ieee802154_sec_decrypt_frame(ieee802154_sec_context_t *ctx,
         return IEEE802154_SEC_OK;
     }
 
+    if ((uint32_t)frame_size < ((uint32_t)(*header_size) + (uint32_t)aux_size +
+                                (uint32_t)mac_size)) {
+        return -IEEE802154_SEC_UNSUPORTED;
+    }
+
     *payload_size = frame_size - *header_size - aux_size - mac_size;
     *payload = header + *header_size + aux_size;
     *mic_size = mac_size;


### PR DESCRIPTION
# Backport of #22533

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hello 🦇,

this fixes an issue where an invalid frame could wrap the payload size calculation, resulting in OOB reads.

Reported by @kbhetrr, thanks!

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
