### PR TITLE
sys/nanocoap: fix potential oob read in coap_find_uri_query [backport 2026.07]

### DIFF
--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -528,6 +528,7 @@ int coap_get_blockopt(coap_pkt_t *pkt, uint16_t option, uint32_t *blknum, uint8_
 bool coap_find_uri_query(coap_pkt_t *pkt, const char *key, const char **value, size_t *len)
 {
     uint8_t *opt_pos = NULL;
+    size_t len_key = strlen(key);
 
     while (1) {
         int len_query;
@@ -538,11 +539,11 @@ bool coap_find_uri_query(coap_pkt_t *pkt, const char *key, const char **value, s
         }
 
         const char *separator = memchr(key_data, '=', len_query);
-        size_t len_key = separator
-                       ? (separator - (char *)key_data)
-                       : len_query;
+        size_t len_query_key = separator
+                             ? (separator - (char *)key_data)
+                             : len_query;
 
-        if (memcmp(key, key_data, len_key)) {
+        if (len_key != len_query_key || memcmp(key, key_data, len_query_key)) {
             continue;
         }
 
@@ -553,7 +554,7 @@ bool coap_find_uri_query(coap_pkt_t *pkt, const char *key, const char **value, s
         assert(len);
         if (separator) {
             *value = separator + 1;
-            *len = len_query - len_key - 1;
+            *len = len_query - len_query_key - 1;
         } else {
             *value = NULL;
             *len   = 0;


### PR DESCRIPTION
# Backport of #22502

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description
Fix a potential oob read in `memcmp` inside `coap_find_uri_query` when the query key we are comparing against is bigger than the one we are looking for.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
All unittests under `unittests/tests-nanocoap` should still pass.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
