### PR TITLE
sys/nanocoap: handle overflow in offset calculation [backport 2026.07]

### DIFF
--- a/examples/networking/coap/gcoap_block_server/gcoap_block.c
+++ b/examples/networking/coap/gcoap_block_server/gcoap_block.c
@@ -51,7 +51,8 @@ static ssize_t _riot_block2_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len,
 {
     (void)ctx;
     coap_block_slicer_t slicer;
-    coap_block2_init(pdu, &slicer);
+    int res = coap_block2_init(pdu, &slicer);
+    if (res) { return res; }
 
     gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
     coap_opt_add_format(pdu, COAP_FORMAT_TEXT);
@@ -59,7 +60,7 @@ static ssize_t _riot_block2_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     ssize_t plen = coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);
 
     /* Add actual content */
-    int res = coap_blockwise_put_bytes_pkt(pdu, &slicer, block2_intro, sizeof(block2_intro)-1);
+    res = coap_blockwise_put_bytes_pkt(pdu, &slicer, block2_intro, sizeof(block2_intro)-1);
     if (res) { return res; }
     res = coap_blockwise_put_bytes_pkt(pdu, &slicer, RIOT_VERSION, strlen(RIOT_VERSION));
     if (res) { return res; }

--- a/examples/networking/coap/nanocoap_server/coap_handler.c
+++ b/examples/networking/coap/nanocoap_server/coap_handler.c
@@ -52,8 +52,10 @@ static ssize_t _riot_block2_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
     (void)context;
     coap_block_slicer_t slicer;
     coap_builder_t state;
-    coap_block2_init(pkt, &slicer);
-    int err;
+    int err = coap_block2_init(pkt, &slicer);
+    if (err) {
+        return err;
+    }
     err = coap_builder_init_reply(&state, buf, len, pkt, COAP_CODE_CONTENT);
     if (err) {
         return err;

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1333,8 +1333,12 @@ static inline bool coap_block2_finish(coap_block_slicer_t *slicer)
  *
  * @param[in]   pkt         packet to work on
  * @param[out]  slicer      Preallocated slicer struct to fill
+ *
+ * @retval       0          Success
+ * @retval       -EBADMSG   @p pkt contains an invalid block options
  */
-void coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer);
+WARN_UNUSED_RESULT
+int coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer);
 
 /**
  * @brief Initialize a block slicer struct from content information
@@ -1344,9 +1348,13 @@ void coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer);
                             @p blksize byte blocks
  * @param[in]    blksize    size of each block; must be a power of 2 between 16
  *                          and 2 raised to #CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX
+ * @retval       0          Success
+ * @retval       -EINVAL    @p blknum and/or @p blksize are invalid, e.g.
+ *                          because they point outside the addressable RAM
  */
-void coap_block_slicer_init(coap_block_slicer_t *slicer, size_t blknum,
-                            size_t blksize);
+WARN_UNUSED_RESULT
+int coap_block_slicer_init(coap_block_slicer_t *slicer, size_t blknum,
+                           size_t blksize);
 
 /**
  * @brief Add a byte array to a block2 reply when building the response using

--- a/sys/net/application_layer/gcoap/dns.c
+++ b/sys/net/application_layer/gcoap/dns.c
@@ -516,8 +516,11 @@ static int _do_block(coap_pkt_t *pdu, const sock_udp_ep_t *remote,
     bool more;
     coap_block_slicer_t slicer;
 
-    coap_block_slicer_init(&slicer, context->cur_blk_num++,
-                           CONFIG_GCOAP_DNS_BLOCK_SIZE);
+    int res = coap_block_slicer_init(&slicer, context->cur_blk_num++,
+                                     CONFIG_GCOAP_DNS_BLOCK_SIZE);
+    if (res) {
+        return res;
+    }
     tl_type = _req_init(pdu, &_uri_comp, true);
     if (tl_type == GCOAP_SOCKET_TYPE_UNDEF) {
         return -EINVAL;
@@ -537,9 +540,8 @@ static int _do_block(coap_pkt_t *pdu, const sock_udp_ep_t *remote,
     }
     len = coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);
 
-    int res = coap_blockwise_put_bytes_pkt(pdu, &slicer,
-                                           context->dns_buf,
-                                           context->dns_buf_len);
+    res = coap_blockwise_put_bytes_pkt(pdu, &slicer, context->dns_buf,
+                                       context->dns_buf_len);
 
     if (res) {
         return res;

--- a/sys/net/application_layer/nanocoap/fileserver.c
+++ b/sys/net/application_layer/nanocoap/fileserver.c
@@ -158,6 +158,9 @@ static size_t _error_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, int err)
             case -ENOENT:
                 code = COAP_CODE_PATH_NOT_FOUND;
                 break;
+            case -EBADMSG:
+                code = COAP_CODE_BAD_REQUEST;
+                break;
             default:
                 code = COAP_CODE_INTERNAL_SERVER_ERROR;
         };
@@ -243,7 +246,10 @@ static ssize_t _get_file(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     _calc_szx2(pdu,
                5 + 1 + 1 /* reserve BLOCK2 size + payload marker + more */,
                &block2);
-    coap_block_slicer_init(&slicer, block2.blknum, coap_szx2size(block2.szx));
+    err = coap_block_slicer_init(&slicer, block2.blknum, coap_szx2size(block2.szx));
+    if (err) {
+        return _error_handler(pdu, buf, len, err);
+    }
     coap_opt_add_block2(pdu, &slicer, true);
 
     if (request->options.exists.block2) {
@@ -484,7 +490,10 @@ static ssize_t _get_directory(coap_pkt_t *pdu, uint8_t *buf, size_t len,
     _calc_szx2(pdu,
                5 + 1 /* reserve BLOCK2 size + payload marker */,
                &block2);
-    coap_block_slicer_init(&slicer, block2.blknum, coap_szx2size(block2.szx));
+    err = coap_block_slicer_init(&slicer, block2.blknum, coap_szx2size(block2.szx));
+    if (err) {
+        return _error_handler(pdu, buf, len, err);
+    }
     coap_opt_add_block2(pdu, &slicer, true);
 
     size_t root_len = root ? strlen(root) : 0;

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -510,7 +510,9 @@ int coap_get_blockopt(coap_pkt_t *pkt, uint16_t option, uint32_t *blknum, uint8_
         return -1;
     }
 
-    if (option_len > 4) {
+    /* option is 0 to 3 bytes in length, see
+     * https://www.rfc-editor.org/info/rfc7959/#section-2.1 */
+    if (option_len > 3) {
         DEBUG("nanocoap: invalid option length\n");
         return -1;
     }
@@ -1579,15 +1581,20 @@ void coap_block_object_init(coap_block1_t *block, size_t blknum, size_t blksize,
     block->offset = block->blknum << (block->szx + 4);
 }
 
-void coap_block_slicer_init(coap_block_slicer_t *slicer, size_t blknum,
+int coap_block_slicer_init(coap_block_slicer_t *slicer, size_t blknum,
                             size_t blksize)
 {
-    slicer->start = blknum * blksize;
-    slicer->end = slicer->start + blksize;
+    if (__builtin_mul_overflow(blknum, blksize, &slicer->start) ||
+        __builtin_add_overflow(slicer->start, blksize, &slicer->end)) {
+        *slicer = (coap_block_slicer_t){0};
+        return -EINVAL;
+    }
     slicer->cur = 0;
+
+    return 0;
 }
 
-void coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer)
+int coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer)
 {
     uint32_t blknum = 0;
     uint8_t szx = CONFIG_NANOCOAP_BLOCK_SIZE_EXP_MAX - 4;
@@ -1601,7 +1608,11 @@ void coap_block2_init(coap_pkt_t *pkt, coap_block_slicer_t *slicer)
         }
     }
 
-    coap_block_slicer_init(slicer, blknum, coap_szx2size(szx));
+    if (coap_block_slicer_init(slicer, blknum, coap_szx2size(szx))) {
+        return -EBADMSG;
+    }
+
+    return 0;
 }
 
 bool coap_block_finish(coap_block_slicer_t *slicer)
@@ -1725,8 +1736,10 @@ ssize_t coap_well_known_core_default_handler(coap_pkt_t *pkt, uint8_t *buf, \
     (void)context;
     coap_block_slicer_t slicer;
     coap_builder_t state;
-    coap_block2_init(pkt, &slicer);
-    int err;
+    int err = coap_block2_init(pkt, &slicer);
+    if (err) {
+        return err;
+    }
     err = coap_builder_init_reply(&state, buf, len, pkt, COAP_CODE_CONTENT);
     if (err) {
         return err;


### PR DESCRIPTION
# Backport of #22498

### Contribution description

- add an overflow check to `coap_block_slicer_init()` and annotate it as `WARN_UNUSED_RESULT`
  - this function probably did not have untrusted arguments in mind, but `coap_block2_init()` does just that
- adapt `coap_block2_init()` to check the return value and also annotate it as `WARN_UNUSED_RESULT`
- fix coap_get_blockopt() to reject options sized 4, the standard specifies the option is at most 3 bytes in size

### Testing procedure

- The `WARN_UNUSED_RESULT` should result in build failures in the CI, if any callers are left that do not handle the return value
- The proof of concept in https://github.com/gulamovzavohir02-glitch/cve-disclosures/tree/main/cve-2026-riot-nanocoap-overflow should no longer work

### Issues/PRs references

Issue reported in https://github.com/RIOT-OS/RIOT/security/advisories/GHSA-8365-gj33-rgpf

Many thanks to https://github.com/gulamovzavohir02-glitch for reporting the issue

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- Copilot for review. Accepted some suggestions. See discussion below.

