### PR TITLE
doc/pinouts: fix pinouts path for nucleo-c031c6 & f401re [backport 2026.07]

### DIFF
--- a/boards/nucleo-c031c6/doc.md
+++ b/boards/nucleo-c031c6/doc.md
@@ -12,7 +12,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-c031c6.svg" alt="Pinout for the Nucleo-C031C6 (from STM user manual UM2953, https://www.st.com/resource/en/user_manual/um2953-stm32-nucleo64-board-mb1717-stmicroelectronics.pdf, page 19)" width=50% />
+<img src="nucleo-c031c6.svg" alt="Pinout for the Nucleo-C031C6 (from STM user manual UM2953, https://www.st.com/resource/en/user_manual/um2953-stm32-nucleo64-board-mb1717-stmicroelectronics.pdf, page 19)" width=50% />
 
 ### MCU
 

--- a/boards/nucleo-f401re/doc.md
+++ b/boards/nucleo-f401re/doc.md
@@ -16,7 +16,7 @@ You can find general information about the Nucleo64 boards on the
 
 ## Pinout
 
-<img src="pinouts/nucleo-f401re.svg" alt="Pinout for the Nucleo-F401RE (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 32)" width=50% />
+<img src="nucleo-f401re.svg" alt="Pinout for the Nucleo-F401RE (from STM user manual UM1724, http://www.st.com/resource/en/user_manual/dm00105823.pdf, page 32)" width=50% />
 
 ### MCU
 


### PR DESCRIPTION
# Backport of #22495

### Contribution description

In Issue #22353 ([crasbe comment](https://github.com/RIOT-OS/RIOT/issues/22353#issuecomment-4789662080)) it was observed that pinouts diagrams in doxygen documentation for the Nucleo boards "disapperd". 

After investigation It was found that in the generated from Doxygen html files  
use `pinouts/<file>` for svg pinouts, but in the `https://api.riot-os.org` server they are provided in root
directory. For example, pinout for `nucleo-c031c6` in html use link to `pinouts/nucleo-c031c6.svg`
but is provided in WWW server as [https://api.riot-os.org/nucleo-c031c6.svg](https://api.riot-os.org/nucleo-c031c6.svg).

This WIP PR test fix for two boards - `nucleo-c031c6` and `nucleo-f401re`. 
If it success ... I will fix all Nucleo boards accordingly.

### Testing procedure

I test this solution locally using Doxygen 1.9.8.

```
make doc
xdg-open doc/doxygen/html/group__boards__nucleo-c031c6.html 
xdg-open doc/doxygen/html/group__boards__nucleo-f401re.html 
```

But for further test this PR need `CI: ready for build ` label and if this solution works documentation
generated by Murdock will show pinouts for this two test boards - `nucleo-c031c6` and `nucleo-f401re`. 

### Issues/PRs references

Issue #22353 

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none