### PR TITLE
tree-wide: fix compilation issues with TOOLCHAIN=llvm [backport 2026.07]

### DIFF
--- a/boards/nucleo-l476rg/include/periph_conf.h
+++ b/boards/nucleo-l476rg/include/periph_conf.h
@@ -231,12 +231,12 @@ static const spi_conf_t spi_config[] = {
  * @{
  */
 static const adc_conf_t adc_config[] = {
-    {GPIO_PIN(PORT_A, 0), 0, 5},  /*< ADC12_IN5 */
-    {GPIO_PIN(PORT_A, 1), 0, 6},  /*< ADC12_IN6 */
-    {GPIO_PIN(PORT_A, 4), 1, 9},  /*< ADC12_IN9 */
-    {GPIO_PIN(PORT_B, 0), 1, 15}, /*< ADC12_IN15 */
-    {GPIO_PIN(PORT_C, 1), 2, 2},  /*< ADC123_IN2 */
-    {GPIO_PIN(PORT_C, 0), 2, 1},  /*< ADC123_IN1 */
+    {GPIO_PIN(PORT_A, 0), 0, 5},  /* ADC12_IN5 */
+    {GPIO_PIN(PORT_A, 1), 0, 6},  /* ADC12_IN6 */
+    {GPIO_PIN(PORT_A, 4), 1, 9},  /* ADC12_IN9 */
+    {GPIO_PIN(PORT_B, 0), 1, 15}, /* ADC12_IN15 */
+    {GPIO_PIN(PORT_C, 1), 2, 2},  /* ADC123_IN2 */
+    {GPIO_PIN(PORT_C, 0), 2, 1},  /* ADC123_IN1 */
     {GPIO_UNDEF, 0, 18}, /* VBAT */
 };
 

--- a/boards/p-nucleo-wb55/include/periph_conf.h
+++ b/boards/p-nucleo-wb55/include/periph_conf.h
@@ -189,12 +189,12 @@ static const stm32_usbdev_fs_config_t stm32_usbdev_fs_config[] = {
  * @{
  */
 static const adc_conf_t adc_config[] = {
-    {GPIO_PIN(PORT_C, 0), 0, 1},  /*< ADC1_IN1 */
-    {GPIO_PIN(PORT_C, 1), 0, 2},  /*< ADC1_IN2 */
-    {GPIO_PIN(PORT_A, 1), 0, 6},  /*< ADC1_IN6 */
-    {GPIO_PIN(PORT_A, 0), 0, 5},  /*< ADC1_IN5 */
-    {GPIO_PIN(PORT_C, 3), 0, 4},  /*< ADC1_IN4 */
-    {GPIO_PIN(PORT_C, 2), 0, 3},  /*< ADC1_IN3 */
+    {GPIO_PIN(PORT_C, 0), 0, 1},  /* ADC1_IN1 */
+    {GPIO_PIN(PORT_C, 1), 0, 2},  /* ADC1_IN2 */
+    {GPIO_PIN(PORT_A, 1), 0, 6},  /* ADC1_IN6 */
+    {GPIO_PIN(PORT_A, 0), 0, 5},  /* ADC1_IN5 */
+    {GPIO_PIN(PORT_C, 3), 0, 4},  /* ADC1_IN4 */
+    {GPIO_PIN(PORT_C, 2), 0, 3},  /* ADC1_IN3 */
     {GPIO_UNDEF, 0, 18}, /* VBAT */
 };
 

--- a/boards/stm32l476g-disco/include/periph_conf.h
+++ b/boards/stm32l476g-disco/include/periph_conf.h
@@ -106,11 +106,11 @@ static const uart_conf_t uart_config[] = {
  * @{
  */
 static const adc_conf_t adc_config[] = {
-    {GPIO_PIN(PORT_A, 0), 0, 5},  /*< ADC12_IN5  */
-    {GPIO_PIN(PORT_A, 5), 0, 10}, /*< ADC12_IN10 */
-    {GPIO_PIN(PORT_A, 1), 0, 6},  /*< ADC12_IN6  */
-    {GPIO_PIN(PORT_A, 2), 0, 7},  /*< ADC12_IN7  */
-    {GPIO_PIN(PORT_A, 3), 0, 8},  /*< ADC12_IN8  */
+    {GPIO_PIN(PORT_A, 0), 0, 5},  /* ADC12_IN5  */
+    {GPIO_PIN(PORT_A, 5), 0, 10}, /* ADC12_IN10 */
+    {GPIO_PIN(PORT_A, 1), 0, 6},  /* ADC12_IN6  */
+    {GPIO_PIN(PORT_A, 2), 0, 7},  /* ADC12_IN7  */
+    {GPIO_PIN(PORT_A, 3), 0, 8},  /* ADC12_IN8  */
     {GPIO_UNDEF, 0, 18}, /* VBAT */
 };
 

--- a/cpu/cc2538/periph/rtt.c
+++ b/cpu/cc2538/periph/rtt.c
@@ -118,7 +118,8 @@ void rtt_set_alarm(uint32_t alarm, rtt_cb_t cb, void *arg)
     alarm_cb = cb;
     alarm_arg = arg;
 
-    DEBUG("rtt_set_alarm(%lu), alarm in %lu ticks, overflow in %lu ticks\n",
+    DEBUG("rtt_set_alarm(%" PRIu32 "), alarm in %" PRIu32 " ticks, overflow in "
+          "%" PRIu32 " ticks\n",
           alarm, rtt_alarm - _rtt_get_counter(),
           rtt_offset - _rtt_get_counter());
 
@@ -200,13 +201,13 @@ void isr_sleepmode(void)
     }
 
     if (alarm_cb && (rtt_offset >= rtt_alarm)) {
-        DEBUG("rtt: next alarm in %lu ticks (RTT)\n",
+        DEBUG("rtt: next alarm in %" PRIu32 " ticks (RTT)\n",
               rtt_alarm - _rtt_get_counter());
 
         rtt_next_alarm = RTT_ALARM;
         _set_alarm(rtt_alarm);
     } else if (overflow_cb && (rtt_alarm > rtt_offset)) {
-        DEBUG("rtt: next alarm in %lu ticks (OVERFLOW)\n",
+        DEBUG("rtt: next alarm in %" PRIu32 " ticks (OVERFLOW)\n",
                rtt_offset - _rtt_get_counter());
 
         rtt_next_alarm = RTT_OVERFLOW;

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -185,7 +185,7 @@ static inline cc2538_gptimer_t *dev(tim_t tim)
  */
 int timer_init(tim_t tim, uint32_t freq, timer_cb_t cb, void *arg)
 {
-    DEBUG("%s(%u, %lu, %p, %p)\n", __FUNCTION__, tim, freq, cb, arg);
+    DEBUG("%s(%u, %" PRIu32 ", %p, %p)\n", __FUNCTION__, tim, freq, cb, arg);
 
     if (tim >= TIMER_NUMOF) {
         return -1;
@@ -362,8 +362,8 @@ void timer_start(tim_t tim)
 /**
  * @brief   timer interrupt handler
  *
- * @param[in] num   GPT instance number
- * @param[in] chn   channel number (0=A, 1=B)
+ * @param[in]   tim     timer
+ * @param[in]   channel channel number (0=A, 1=B)
  */
 static void irq_handler(tim_t tim, int channel)
 {

--- a/cpu/cc26x0_cc13x0/vendor/driverlib/aon_batmon.h
+++ b/cpu/cc26x0_cc13x0/vendor/driverlib/aon_batmon.h
@@ -115,8 +115,6 @@ extern "C"
 //! voltage detects a change on the reference value, a new measurement of the
 //! battery voltage only is performed immediately after. This has no impact on
 //! the cycle count.
-//!
-//! \return None
 //
 //*****************************************************************************
 __STATIC_INLINE void
@@ -134,8 +132,6 @@ AONBatMonEnable(void)
 //!
 //! This function will disable the measurements of the temperature and the
 //! battery voltage.
-//!
-//! \return None
 //
 //*****************************************************************************
 __STATIC_INLINE void

--- a/cpu/cc26x0_cc13x0/vendor/driverlib/aon_rtc.h
+++ b/cpu/cc26x0_cc13x0/vendor/driverlib/aon_rtc.h
@@ -166,8 +166,6 @@ extern "C"
 //! \note Event generation for each of the three channels must also be enabled
 //!  using the function AONRTCChannelEnable().
 //!
-//! \return None
-//!
 //! \sa AONRTCChannelEnable()
 //
 //*****************************************************************************
@@ -187,8 +185,6 @@ AONRTCEnable(void)
 //! \note Event generation for each of the three channels can also be disabled
 //! using the function AONRTCChannelDisable().
 //!
-//! \return None
-//!
 //! \sa AONRTCChannelDisable()
 //
 //*****************************************************************************
@@ -204,8 +200,6 @@ AONRTCDisable(void)
 //! \brief Reset the RTC.
 //!
 //! Reset the AON Real Time Clock.
-//!
-//! \return None
 //
 //*****************************************************************************
 __STATIC_INLINE void
@@ -295,8 +289,6 @@ AONRTCChannelActive(uint32_t ui32Channel)
 //! - \ref AON_RTC_CONFIG_DELAY_112
 //! - \ref AON_RTC_CONFIG_DELAY_128
 //! - \ref AON_RTC_CONFIG_DELAY_144
-//!
-//! \return None.
 //
 //*****************************************************************************
 __STATIC_INLINE void
@@ -330,8 +322,6 @@ AONRTCDelayConfig(uint32_t ui32Delay)
 //! - \ref AON_RTC_CH1
 //! - \ref AON_RTC_CH2
 //! - \ref AON_RTC_CH_NONE
-//!
-//! \return None
 //
 //*****************************************************************************
 __STATIC_INLINE void
@@ -361,8 +351,6 @@ AONRTCCombinedEventConfig(uint32_t ui32Channels)
 //! - \ref AON_RTC_CH0
 //! - \ref AON_RTC_CH1
 //! - \ref AON_RTC_CH2
-//!
-//! \return None
 //
 //*****************************************************************************
 __STATIC_INLINE void
@@ -533,8 +521,6 @@ AONRTCSubSecIncrGet(void)
 //! - \ref AON_RTC_MODE_CH1_CAPTURE
 //! - \ref AON_RTC_MODE_CH1_COMPARE
 //!
-//! \return None
-//!
 //!  \sa AONRTCModeCh1Get()
 //
 //*****************************************************************************
@@ -587,8 +573,6 @@ AONRTCModeCh1Get(void)
 //! - \ref AON_RTC_MODE_CH2_CONTINUOUS
 //! - \ref AON_RTC_MODE_CH2_NORMALCOMPARE
 //!
-//! \return None
-//!
 //! \sa AONRTCIncValueCh2Set(), AONRTCIncValueCh2Get()
 //
 //*****************************************************************************
@@ -640,8 +624,6 @@ AONRTCModeCh2Get(void)
 //! - \ref AON_RTC_CH1
 //! - \ref AON_RTC_CH2
 //!
-//! \return None
-//!
 //! \sa AONRTCEnable()
 //
 //*****************************************************************************
@@ -682,8 +664,6 @@ AONRTCChannelEnable(uint32_t ui32Channel)
 //! - \ref AON_RTC_CH0
 //! - \ref AON_RTC_CH1
 //! - \ref AON_RTC_CH2
-//!
-//! \return None
 //!
 //! \sa AONRTCDisable()
 //
@@ -729,8 +709,6 @@ AONRTCChannelDisable(uint32_t ui32Channel)
 //! - \ref AON_RTC_CH2
 //! \param ui32CompValue is the compare value to set for the specified channel.
 //! - Format: <16 sec.16 subsec>
-//!
-//! \return None
 //!
 //! \sa AONRTCCurrentCompareValueGet()
 //
@@ -847,8 +825,6 @@ extern uint64_t AONRTCCurrent64BitValueGet(void);
 //! a series of completely equidistant events.
 //!
 //! \param ui32IncValue is the increment value when operating in continuous mode.
-//!
-//! \return None
 //!
 //! \sa AONRTCIncValueCh2Get()
 //

--- a/cpu/cc26x0_cc13x0/vendor/driverlib/cc26x0_cpu.h
+++ b/cpu/cc26x0_cc13x0/vendor/driverlib/cc26x0_cpu.h
@@ -387,8 +387,6 @@ CPUbasepriSet(uint32_t ui32NewBasepri)
 //! performance of the processor because the stores to memory have to complete
 //! before the next instruction can be executed.
 //!
-//! \return None
-//!
 //! \sa \ref CPU_WriteBufferEnable()
 //
 //*****************************************************************************
@@ -404,8 +402,6 @@ CPU_WriteBufferDisable( void )
 //!
 //! Re-enables write buffer during default memory map accesses if
 //! \ref CPU_WriteBufferDisable() has been used for bus fault debugging.
-//!
-//! \return None
 //!
 //! \sa \ref CPU_WriteBufferDisable()
 //

--- a/cpu/gd32v/periph/wdt.c
+++ b/cpu/gd32v/periph/wdt.c
@@ -129,7 +129,7 @@ void wdt_setup_reboot(uint32_t min_time, uint32_t max_time)
     _set_prescaler(pre);
     _set_reload(rel);
 
-    DEBUG("[wdt]: reset time %lu [us]\n", _wdt_time(pre, rel));
+    DEBUG("[wdt]: reset time %" PRIu32 " [us]\n", _wdt_time(pre, rel));
 
     /* Refresh wdt counter */
     wdt_kick();

--- a/cpu/nrf5x_common/periph/uart.c
+++ b/cpu/nrf5x_common/periph/uart.c
@@ -112,6 +112,7 @@ static inline void set_power(uart_t uart, bool value)
 #endif
 }
 
+MAYBE_UNUSED
 static inline bool get_power(uart_t uart)
 {
     UART_TYPE *dev = uart_config[uart].dev;

--- a/cpu/qn908x/include/vendor/drivers/fsl_clock.h
+++ b/cpu/qn908x/include/vendor/drivers/fsl_clock.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2017 , NXP
  * All rights reserved.
  *
- * 
+ *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -288,15 +288,15 @@ void CLOCK_DisableClock(clock_ip_name_t clk);
 /*!
  * @brief Configure the clock selection muxes.
  *
- * @param connection: Clock to be configured.
+ * @param connection Clock to be configured.
  */
 void CLOCK_AttachClk(clock_attach_id_t connection);
 
 /*!
  * @brief Setup peripheral clock dividers.
  *
- * @param div_name: Clock divider name
- * @param divided_by_value: Value to be divided
+ * @param div_name          Clock divider name
+ * @param divided_by_value  Value to be divided
  */
 void CLOCK_SetClkDiv(clock_div_name_t div_name, uint32_t divided_by_value);
 
@@ -341,9 +341,10 @@ uint32_t CLOCK_GetFRGInputClock(void);
 /*!
  * @brief Set output of the Fractional baud rate generator
  *
- * @param  div_name: Clock divider name: kCLOCK_DivFrg0 and kCLOCK_DivFrg1
- * @param  freq: Desired output frequency
- * @return Error Code 0 - fail 1 - success
+ * @param  div_name Clock divider name: kCLOCK_DivFrg0 and kCLOCK_DivFrg1
+ * @param  freq     Desired output frequency
+ * @retval 0        fail
+ * @retval 1        success
  */
 uint32_t CLOCK_SetFRGClock(clock_div_name_t div_name, uint32_t freq);
 

--- a/cpu/qn908x/include/vendor/drivers/fsl_iocon.h
+++ b/cpu/qn908x/include/vendor/drivers/fsl_iocon.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
  * Copyright 2016-2017 NXP
  * All rights reserved.
- * 
+ *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -91,7 +91,6 @@ extern "C" {
  * @param   port            GPIO port to mux (value from 0 ~ 1)
  * @param   pin             GPIO pin to mux (value from 0 ~ 31)
  * @param   modeFunc        OR'ed values of type IOCON_*
- * @return  Nothing
  */
 __STATIC_INLINE void IOCON_PinMuxSet(SYSCON_Type *base, uint8_t port, uint8_t pin, uint32_t modeFunc)
 {
@@ -151,7 +150,6 @@ __STATIC_INLINE void IOCON_PinMuxSet(SYSCON_Type *base, uint8_t port, uint8_t pi
  * @param   base            The base of SYSCON peripheral on the chip
  * @param   pinArray        Pointer to array of pin mux selections
  * @param   arrayLength     Number of entries in pinArray
- * @return  Nothing
  */
 __STATIC_INLINE void IOCON_SetPinMuxing(SYSCON_Type *base, const iocon_group_t *pinArray, uint32_t arrayLength)
 {
@@ -169,7 +167,6 @@ __STATIC_INLINE void IOCON_SetPinMuxing(SYSCON_Type *base, const iocon_group_t *
  * @param   port            GPIO port (value from 0 ~ 1)
  * @param   pin             GPIO pin (value from 0 ~ 31)
  * @param   func            Pin fucntion (value from 0 ~ 7)
- * @return  Nothing
  */
 __STATIC_INLINE void IOCON_FuncSet(SYSCON_Type *base, uint8_t port, uint8_t pin, uint8_t func)
 {
@@ -215,7 +212,6 @@ __STATIC_INLINE void IOCON_FuncSet(SYSCON_Type *base, uint8_t port, uint8_t pin,
  *        - kIOCON_HighDriveStrength = 1U - High-drive strength is configured
  *        - kIOCON_LowDriveWithExtraStrength = 2U - Low-drive with extra strength is configured
  *        - kIOCON_HighDriveWithExtraStrength = 3U - High-drive with extra strength is configured
- * @return  Nothing
  */
 __STATIC_INLINE void IOCON_DriveSet(SYSCON_Type *base, uint8_t port, uint8_t pin, uint8_t strength)
 {
@@ -238,7 +234,6 @@ __STATIC_INLINE void IOCON_DriveSet(SYSCON_Type *base, uint8_t port, uint8_t pin
  *        - kIOCON_HighZ = 0U - High Z is configured.
  *        - kIOCON_PullDown = 1U - Pull-down is configured
  *        - kIOCON_PullUp = 2U - Pull-up is configured
- * @return  Nothing
  */
 __STATIC_INLINE void IOCON_PullSet(SYSCON_Type *base, uint8_t port, uint8_t pin, uint8_t pullMode)
 {

--- a/cpu/riscv_common/irq_arch.c
+++ b/cpu/riscv_common/irq_arch.c
@@ -15,23 +15,21 @@
  * @}
  */
 
-#include <stdio.h>
 #include <inttypes.h>
+#include <stdio.h>
 
-#include "macros/xtstr.h"
-#include "cpu.h"
+#include "architecture.h"
+#include "clic.h"
 #include "context_frame.h"
+#include "cpu.h"
 #include "irq.h"
 #include "irq_arch.h"
+#include "macros/xtstr.h"
 #include "panic.h"
-#include "sched.h"
 #include "plic.h"
-#include "clic.h"
-#include "architecture.h"
-
-#include "xh3irq.h"
-
+#include "sched.h"
 #include "vendor/riscv_csr.h"
+#include "xh3irq.h"
 
 /* Default state of mstatus register */
 #define MSTATUS_DEFAULT (MSTATUS_MPP | MSTATUS_MPIE)
@@ -122,10 +120,10 @@ __attribute((used)) static void handle_trap(uword_t mcause)
         };
 
         if (trap < ARRAY_SIZE(error_messages)) {
-            printf("Machine Cause Error 0x%lx: %s\n", trap, error_messages[trap]);
+            printf("Machine Cause Error 0x%" PRIxWORD ": %s\n", trap, error_messages[trap]);
         }
         else {
-            printf("Machine Cause Error 0x%lx: Reserved / Custom\n", trap);
+            printf("Machine Cause Error 0x%" PRIxWORD ": Reserved / Custom\n", trap);
         }
     }
 #endif

--- a/cpu/stm32/Makefile.include
+++ b/cpu/stm32/Makefile.include
@@ -94,7 +94,7 @@ ifneq (,$(filter STM32F030x4 STM32MP157Cxx,$(CPU_LINE)))
 else
   STM32CMSIS_INCLUDE_DIR = $(BUILD_DIR)/stm32/cmsis/$(CPU_FAM)/Include
   STM32FAM_INCLUDE_FILE = $(STM32CMSIS_INCLUDE_DIR)/stm32$(CPU_FAM)xx.h
-  INCLUDES += -I$(STM32CMSIS_INCLUDE_DIR)
+  INCLUDES += -isystem$(STM32CMSIS_INCLUDE_DIR)
 endif
 
 # Fetch all CMSIS headers using the package mechanism. This rule is called all

--- a/drivers/kw41zrf/kw41zrf_xcvr.c
+++ b/drivers/kw41zrf/kw41zrf_xcvr.c
@@ -884,8 +884,8 @@ int kw41zrf_xcvr_init(kw41zrf_t *dev)
     /* Load IFR trim values */
     IFR_SW_TRIM_TBL_ENTRY_T sw_trim_tbl[] =
     {
-        {TRIM_STATUS, 0, 0}, /*< Fetch the trim status word if available.*/
-        {TRIM_VERSION, 0, 0} /*< Fetch the trim version number if available.*/
+        {TRIM_STATUS, 0, 0}, /* Fetch the trim status word if available. */
+        {TRIM_VERSION, 0, 0} /* Fetch the trim version number if available. */
     };
     handle_ifr(&sw_trim_tbl[0], ARRAY_SIZE(sw_trim_tbl));
     DEBUG("[kw41zrf] sw_trim_tbl:\n");

--- a/drivers/kw41zrf/vendor/OSAbstraction/Interface/fsl_os_abstraction.h
+++ b/drivers/kw41zrf/vendor/OSAbstraction/Interface/fsl_os_abstraction.h
@@ -385,8 +385,6 @@ osaStatus_t OSA_SemaphorePost(osaSemaphoreId_t semId);
  *
  * This function creates a non-recursive mutex and sets it to unlocked status.
  *
- * @param none.
- *
  * @retval handler to the new mutex if the mutex is created successfully.
  * @retval NULL   if the mutex can not be created.
  */
@@ -488,7 +486,7 @@ osaStatus_t OSA_EventClear(osaEventId_t eventId, osaEventFlags_t flagsToClear);
  *                    If the wait condition is not met, pass osaWaitForever_c will
  *                    wait indefinitely, pass 0 will return osaStatus_Timeout
  *                    immediately.
- * @param setFlags    Flags that wakeup the waiting task are obtained by this parameter.
+ * @param pSetFlags   Flags that wakeup the waiting task are obtained by this parameter.
  *
  * @retval osaStatus_Success The wait condition met and function returns successfully.
  * @retval osaStatus_Timeout Has not met wait condition within timeout.

--- a/drivers/kw41zrf/vendor/XCVR/MKW41Z4/ifr_radio.c
+++ b/drivers/kw41zrf/vendor/XCVR/MKW41Z4/ifr_radio.c
@@ -153,8 +153,6 @@ static uint32_t read_first_ifr_word(uint32_t read_addr)
 /*! *********************************************************************************
  * \brief  Read command for reading additional 32bit words from IFR. Encapsulates multiple IFR read mechanisms.
  *
- * \param read_addr flash address
- *
  * \return 8 bytes of packed data containing radio trims only
  *
  * \remarks PRE-CONDITIONS:

--- a/pkg/nmsis_sdk/Makefile.include
+++ b/pkg/nmsis_sdk/Makefile.include
@@ -1,3 +1,3 @@
 PSEUDOMODULES += nmsis_sdk
 
-INCLUDES += -I$(PKGDIRBASE)/nmsis_sdk/NMSIS/Core/Include
+INCLUDES += -isystem$(PKGDIRBASE)/nmsis_sdk/NMSIS/Core/Include

--- a/sys/include/architecture.h
+++ b/sys/include/architecture.h
@@ -92,35 +92,55 @@ typedef int<NUM>_t  sword_t;
 
 /* end of ifdef DOXYGEN */
 #elif (ARCHITECTURE_WORD_BITS == 8)
-#define ARCHITECTURE_WORD_BYTES     (1U)
+#  define ARCHITECTURE_WORD_BYTES   (1U)
 typedef uint8_t     uword_t;
 typedef int8_t      sword_t;
-#define SWORD_MAX   (INT8_MAX)
-#define SWORD_MIN   (INT8_MIN)
-#define UWORD_MAX   (UINT8_MAX)
+#  define SWORD_MAX (INT8_MAX)
+#  define SWORD_MIN (INT8_MIN)
+#  define UWORD_MAX (UINT8_MAX)
+#  define PRIdWORD  PRId8
+#  define PRIuWORD  PRIu8
+#  define PRIiWORD  PRIu8
+#  define PRIxWORD  PRIx8
+#  define PRIoWORD  PRIo8
 #elif (ARCHITECTURE_WORD_BITS == 16)
-#define ARCHITECTURE_WORD_BYTES     (2U)
+#  define ARCHITECTURE_WORD_BYTES   (2U)
 typedef uint16_t    uword_t;
 typedef int16_t     sword_t;
-#define SWORD_MAX   (INT16_MAX)
-#define SWORD_MIN   (INT16_MIN)
-#define UWORD_MAX   (UINT16_MAX)
+#  define SWORD_MAX (INT16_MAX)
+#  define SWORD_MIN (INT16_MIN)
+#  define UWORD_MAX (UINT16_MAX)
+#  define PRIdWORD  PRId16
+#  define PRIuWORD  PRIu16
+#  define PRIiWORD  PRIu16
+#  define PRIxWORD  PRIx16
+#  define PRIoWORD  PRIo16
 #elif (ARCHITECTURE_WORD_BITS == 32)
-#define ARCHITECTURE_WORD_BYTES     (4U)
+#  define ARCHITECTURE_WORD_BYTES   (4U)
 typedef uint32_t    uword_t;
 typedef int32_t     sword_t;
-#define SWORD_MAX   (INT32_MAX)
-#define SWORD_MIN   (INT32_MIN)
-#define UWORD_MAX   (UINT32_MAX)
+#  define SWORD_MAX (INT32_MAX)
+#  define SWORD_MIN (INT32_MIN)
+#  define UWORD_MAX (UINT32_MAX)
+#  define PRIdWORD  PRId32
+#  define PRIuWORD  PRIu32
+#  define PRIiWORD  PRIu32
+#  define PRIxWORD  PRIx32
+#  define PRIoWORD  PRIo32
 #elif (ARCHITECTURE_WORD_BITS == 64)
-#define ARCHITECTURE_WORD_BYTES     (8U)
+#  define ARCHITECTURE_WORD_BYTES   (8U)
 typedef uint64_t    uword_t;
 typedef int64_t     sword_t;
-#define SWORD_MAX   (INT64_MAX)
-#define SWORD_MIN   (INT64_MIN)
-#define UWORD_MAX   (UINT64_MAX)
+#  define SWORD_MAX (INT64_MAX)
+#  define SWORD_MIN (INT64_MIN)
+#  define UWORD_MAX (UINT64_MAX)
+#  define PRIdWORD  PRId64
+#  define PRIuWORD  PRIu64
+#  define PRIiWORD  PRIu64
+#  define PRIxWORD  PRIx64
+#  define PRIoWORD  PRIo64
 #else
-#error  "Unsupported word size (check ARCHITECTURE_WORD_BITS in architecture_arch.h)"
+#  error "Unsupported word size (check ARCHITECTURE_WORD_BITS in architecture_arch.h)"
 #endif
 
 /**


### PR DESCRIPTION
# Backport of #22463

### Contribution description

This fixes a mixed bag of compilation issues with `TOOLCHAIN=llvm`. Most of those are either than LLVM is stricter with format specifiers (e.g. if `sizeof(unsigned long) == sizeof(unsigned)`, GCC accepts both `%u` and `%lu` for formatting `unsigned` and `unsigned long`, `clang` is stricter) or incorrect Doxygen documentation.

### Testing procedure

Compiling with `TOOLCHAIN=llvm` should now work for many more boards.

### Issues/PRs references

Fixes many (maybe all) of the current CI issues.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
