### PR TITLE
sys/net: fix unicoap dtls

### DIFF
--- a/sys/include/net/unicoap/transport.h
+++ b/sys/include/net/unicoap/transport.h
@@ -446,12 +446,11 @@ int unicoap_transport_dtls_add_socket(sock_dtls_t* socket, sock_udp_t* base_sock
                                       sock_udp_ep_t* local);
 #  else
 static inline
-int unicoap_transport_dtls_add_socket(sock_dtls_t* socket, sock_udp_t* base_socket,
-                                      sock_udp_ep_t* local)
+int unicoap_transport_dtls_add_socket(void* socket, void* base_socket, void* local)
 {
-    (void)socket;
-    (void)base_socket;
-    (void)local;
+    (void) socket;
+    (void) base_socket;
+    (void) local;
     return 0;
 }
 #  endif
@@ -469,9 +468,9 @@ int unicoap_transport_dtls_add_socket(sock_dtls_t* socket, sock_udp_t* base_sock
 int unicoap_transport_dtls_remove_socket(sock_dtls_t* socket);
 #  else
 static inline
-int unicoap_transport_dtls_remove_socket(sock_dtls_t* socket)
+int unicoap_transport_dtls_remove_socket(void* socket)
 {
-    (void)socket;
+    (void) socket;
     return 0;
 }
 #  endif

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -422,6 +422,7 @@ endif
 ifneq (,$(filter gnrc_udp,$(USEMODULE)))
   DEFAULT_MODULE += auto_init_gnrc_udp
   USEMODULE += gnrc_nettype_udp
+  USEMODULE += gnrc_nettype_ipv6
   USEMODULE += inet_csum
   USEMODULE += udp
 endif

--- a/tests/net/gnrc_sock_async_event/Makefile
+++ b/tests/net/gnrc_sock_async_event/Makefile
@@ -9,8 +9,7 @@ USEMODULE += sock_udp
 USEMODULE += od
 USEMODULE += xtimer
 
-# mock IPv6 gnrc_nettype
-CFLAGS += -DTEST_SUITES -DGNRC_NETTYPE_IPV6=GNRC_NETTYPE_TEST
+CFLAGS += -DTEST_SUITES
 
 include $(RIOTBASE)/Makefile.include
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hello :snail: 

this is an idea to fix a dependency issue inside unicoap.
When configuring unicoap to only use udp the build will fail due to `sock_dtls_t` being undefined.
Proposed fix is to eliminated the functions instead of providing stubs. 

In addition, this will also fail to compile `gnrc_udp` due to a missing define of `GNRC_NETTYPE_IPV6`.
Proposed fix is to add this define to the deps of `gnrc_udp`.

### Testing procedure

#### On current master
Use the hello world example and add a few deps:
`cd examples/basic/hello-world/`
`USEMODULE="gnrc unicoap unicoap_server unicoap_driver_udp" make all`

You'll get this compiler error:
```
In file included from /RIOT/sys/net/application_layer/unicoap/endpoint.c:22:
/RIOT/sys/include/net/unicoap/transport.h:449:39: error: unknown type name ‘sock_dtls_t’;
```

Applying the first commit and trying again will get you:
```
/RIOT/sys/net/gnrc/transport_layer/udp/gnrc_udp.c: In function ‘_receive’:
/RIOT/sys/net/gnrc/transport_layer/udp/gnrc_udp.c:114:42: error: ‘GNRC_NETTYPE_IPV6’ undeclared (first use in this function);
```

Finally, apply the second commit and it will happily compile (but yield linker errors which I define as unrelated to the scope of this PR):
```
/usr/bin/ld: /RIOT/examples/basic/hello-world/bin/native64/gnrc_sock/gnrc_sock.o: in function `gnrc_sock_recv':
/RIOT/sys/net/gnrc/sock/gnrc_sock.c:154:(.text.gnrc_sock_recv+0x9c): undefined reference to `gnrc_ipv6_get_header'
collect2: error: ld returned 1 exit status
```

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
