### PR TITLE
dist/tools/licenses: replace pcregrep with grep

### DIFF
--- a/dist/tools/ci/static_tests.sh
+++ b/dist/tools/ci/static_tests.sh
@@ -14,7 +14,7 @@
 
 declare -A DEPS
 
-DEPS["./dist/tools/licenses/check.sh"]="head pcregrep"
+DEPS["./dist/tools/licenses/check.sh"]="head"
 DEPS["./dist/tools/doccheck/check.sh"]="doxygen tput"
 DEPS["./dist/tools/cppcheck/check.sh"]="cppcheck"
 DEPS["./dist/tools/vera++/check.sh"]="vera++"

--- a/dist/tools/licenses/check.sh
+++ b/dist/tools/licenses/check.sh
@@ -44,7 +44,7 @@ for FILE in ${FILES}; do
     FAIL=1
     head -100 "${ROOT}/${FILE}" | sed -e 's/[\/\*'"${TAB_CHAR}"']/ /g' -e 's/$/ /' | tr -d '\r\n' | sed -e 's/  */ /g' > "${TMP}"
     for LICENSE in ${LICENSES}; do
-        if pcregrep -q -f "${LICENSEDIR}/${LICENSE}" "${TMP}"; then
+        if grep -qP -f "${LICENSEDIR}/${LICENSE}" "${TMP}"; then
             echo "${FILE}" >> "${OUTPUT}/${LICENSE}"
             FAIL=0
             break


### PR DESCRIPTION
### Contribution description

`pcregrep` is not part of Ubuntu 26.04 LTS anymore, but `grep` knows the syntax too.

### Testing procedure

The `make static-test` should work as before.

### Issues/PRs references

Required for https://github.com/RIOT-OS/riotdocker/pull/285

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- Claude: "replace pcregrep with something else in this script"
