### PR TITLE
dist/tools/licenses: fix grep patterns

### DIFF
--- a/dist/tools/licenses/check.sh
+++ b/dist/tools/licenses/check.sh
@@ -37,6 +37,13 @@ for LICENSE in ${LICENSES}; do
     echo -n '' > "${OUTPUT}/${LICENSE}"
 done
 
+# prepare license patterns
+declare -A PATTERNS
+for LICENSE in ${LICENSES}; do
+    echo -n '' > "${OUTPUT}/${LICENSE}"
+    PATTERNS[${LICENSE}]="$(grep -v '^$' "${LICENSEDIR}/${LICENSE}" | paste -sd'|')"
+done
+
 FILES=$(FILEREGEX='\.([sSch]|cpp)$' changed_files)
 
 # categorize files
@@ -44,7 +51,7 @@ for FILE in ${FILES}; do
     FAIL=1
     head -100 "${ROOT}/${FILE}" | sed -e 's/[\/\*'"${TAB_CHAR}"']/ /g' -e 's/$/ /' | tr -d '\r\n' | sed -e 's/  */ /g' > "${TMP}"
     for LICENSE in ${LICENSES}; do
-        if grep -qP -f "${LICENSEDIR}/${LICENSE}" "${TMP}"; then
+        if grep -qP "${PATTERNS[${LICENSE}]}" "${TMP}"; then
             echo "${FILE}" >> "${OUTPUT}/${LICENSE}"
             FAIL=0
             break


### PR DESCRIPTION
### Contribution description

In #22584 I changed `pcregrep` to `grep` and tested it with `make static-test`, however that only checks modified files.
Calling the script explicitly uncovered that my changes broke it.

This also includes a smöl performance improvement because opening every license file for every file checked is INCREDIBLY inefficient.

Please note that the check script is still broken (as in: it matches everything to the `mit-espressif` license, but that has been broken for the last 8 years, so it's out of scope to fix it here.

### Testing procedure

Before #22584:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ ./dist/tools/licenses/check.sh
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ wc -l dist/tools/licenses/out/*
     1 dist/tools/licenses/out/1c-BSD-arm
     0 dist/tools/licenses/out/1c-BSD-ccnl
    12 dist/tools/licenses/out/1c-BSD-embunit
     2 dist/tools/licenses/out/1c-BSD-isc
     0 dist/tools/licenses/out/1c-BSD-newlibfeatures
    10 dist/tools/licenses/out/1c-BSD-stanford
     0 dist/tools/licenses/out/1c-BSD-ut
     0 dist/tools/licenses/out/2c-BSD-v1
     0 dist/tools/licenses/out/3c-BSD-atmel
     0 dist/tools/licenses/out/3c-BSD-atmel2
     0 dist/tools/licenses/out/3c-BSD-atmel3
    33 dist/tools/licenses/out/3c-BSD-atmel4
     0 dist/tools/licenses/out/3c-BSD-freescale
     0 dist/tools/licenses/out/3c-BSD-nordic
     0 dist/tools/licenses/out/3c-BSD-openbsd
     0 dist/tools/licenses/out/3c-BSD-silabs
     0 dist/tools/licenses/out/3c-BSD-stm
     0 dist/tools/licenses/out/3c-BSD-ti
     0 dist/tools/licenses/out/3c-BSD-v1
     0 dist/tools/licenses/out/3c-BSD-v2
     0 dist/tools/licenses/out/3c-BSD-v3
     4 dist/tools/licenses/out/Apache2.0
     0 dist/tools/licenses/out/bsd-short
     1 dist/tools/licenses/out/cc0
     1 dist/tools/licenses/out/chan
     0 dist/tools/licenses/out/cmsis-pal-freescale-mk60dz10
     0 dist/tools/licenses/out/gplv2-pjrc
    16 dist/tools/licenses/out/gplv2-short
    11 dist/tools/licenses/out/gplv2-short-alt
   825 dist/tools/licenses/out/lgplv2.1-short
     0 dist/tools/licenses/out/lgplv2.1-v1
     0 dist/tools/licenses/out/mcd-st-liberty
     0 dist/tools/licenses/out/mit
  4805 dist/tools/licenses/out/mit-espressif
     0 dist/tools/licenses/out/mit-short
     0 dist/tools/licenses/out/mod-BSD-avr-libc
     0 dist/tools/licenses/out/publicdomain-short
     0 dist/tools/licenses/out/publicdomain-v1
  5721 total
```

Current `master`:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ ./dist/tools/licenses/check.sh
grep: the -P option only supports a single pattern
grep: the -P option only supports a single pattern
grep: the -P option only supports a single pattern
grep: the -P option only supports a single pattern
file has an unknown license header: 'boards/acd52832/include/board.h'
grep: the -P option only supports a single pattern
grep: the -P option only supports a single pattern
grep: the -P option only supports a single pattern
grep: the -P option only supports a single pattern
file has an unknown license header: 'boards/acd52832/include/gpio_params.h'
grep: the -P option only supports a single pattern
grep: the -P option only supports a single pattern
grep: the -P option only supports a single pattern
grep: the -P option only supports a single pattern
file has an unknown license header: 'boards/acd52832/include/periph_conf.h'
grep: the -P option only supports a single pattern
grep: the -P option only supports a single pattern
grep: the -P option only supports a single pattern
grep: the -P option only supports a single pattern
...
```

This PR:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ ./dist/tools/licenses/check.sh
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ wc -l dist/tools/licenses/out/*
     1 dist/tools/licenses/out/1c-BSD-arm
     0 dist/tools/licenses/out/1c-BSD-ccnl
    12 dist/tools/licenses/out/1c-BSD-embunit
     2 dist/tools/licenses/out/1c-BSD-isc
     0 dist/tools/licenses/out/1c-BSD-newlibfeatures
    10 dist/tools/licenses/out/1c-BSD-stanford
     0 dist/tools/licenses/out/1c-BSD-ut
     0 dist/tools/licenses/out/2c-BSD-v1
     0 dist/tools/licenses/out/3c-BSD-atmel
     0 dist/tools/licenses/out/3c-BSD-atmel2
     0 dist/tools/licenses/out/3c-BSD-atmel3
    33 dist/tools/licenses/out/3c-BSD-atmel4
     0 dist/tools/licenses/out/3c-BSD-freescale
     0 dist/tools/licenses/out/3c-BSD-nordic
     0 dist/tools/licenses/out/3c-BSD-openbsd
     0 dist/tools/licenses/out/3c-BSD-silabs
     0 dist/tools/licenses/out/3c-BSD-stm
     0 dist/tools/licenses/out/3c-BSD-ti
     0 dist/tools/licenses/out/3c-BSD-v1
     0 dist/tools/licenses/out/3c-BSD-v2
     0 dist/tools/licenses/out/3c-BSD-v3
     4 dist/tools/licenses/out/Apache2.0
     0 dist/tools/licenses/out/bsd-short
     1 dist/tools/licenses/out/cc0
     1 dist/tools/licenses/out/chan
     0 dist/tools/licenses/out/cmsis-pal-freescale-mk60dz10
     0 dist/tools/licenses/out/gplv2-pjrc
    16 dist/tools/licenses/out/gplv2-short
    11 dist/tools/licenses/out/gplv2-short-alt
   825 dist/tools/licenses/out/lgplv2.1-short
     0 dist/tools/licenses/out/lgplv2.1-v1
     0 dist/tools/licenses/out/mcd-st-liberty
     0 dist/tools/licenses/out/mit
  4805 dist/tools/licenses/out/mit-espressif
     0 dist/tools/licenses/out/mit-short
     0 dist/tools/licenses/out/mod-BSD-avr-libc
     0 dist/tools/licenses/out/publicdomain-short
     0 dist/tools/licenses/out/publicdomain-v1
  5721 total
```


### Issues/PRs references

fixes a regression introduced in #22584

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- Claude