### PR TITLE
pkg/wolfssl: Update pkg to version that enables off the line pinning for RPK

### DIFF
--- a/pkg/wolfssl/Makefile
+++ b/pkg/wolfssl/Makefile
@@ -1,7 +1,9 @@
 PKG_NAME=wolfssl
 PKG_URL=https://github.com/wolfssl/wolfssl.git
-# v5.9.2
-PKG_VERSION=ac01707f552c611fbd135cc723b2682b3e7f80f2
+# Past v5.9.2
+# https://github.com/wolfSSL/wolfssl/commit/addf0d4b743635a9e4c6d10d0c05458f724e56e3
+# This commit hash was used because it enables off the line pinning for raw public keys
+PKG_VERSION=addf0d4b743635a9e4c6d10d0c05458f724e56e3
 PKG_LICENSE=GPL-3.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/wolfssl/Makefile.wolfssl
+++ b/pkg/wolfssl/Makefile.wolfssl
@@ -5,6 +5,7 @@ SUBMODULES += 1
 
 ifeq (llvm,$(TOOLCHAIN))
   CFLAGS += -Wno-unused-parameter
+  CFLAGS += -Wno-unused-function
 endif
 
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

This PR adds this [patch](https://github.com/wolfSSL/wolfssl/commit/addf0d4b743635a9e4c6d10d0c05458f724e56e3) from the wolfSSL master to enable off the line pinning with raw public keys.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I compiled the wolfSSL test and the example application.
I also ran "make generate-Makefile.ci" and no new bords need to be added.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
