### PR TITLE
dist/tools/licenses: fix patterns, various check script fixes

### DIFF
--- a/dist/tools/licenses/check.sh
+++ b/dist/tools/licenses/check.sh
@@ -7,14 +7,17 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-: "${RIOTBASE:=$(cd $(dirname $0)/../../../; pwd)}"
-cd $RIOTBASE
+SCRIPTREALDIR=$(realpath "$(dirname "${0}")")
+
+: "${RIOTBASE:=$(cd "$(dirname "$0")"/../../../ || exit 1; pwd)}"
+cd "$RIOTBASE" || exit 1
 
 : "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
+# shellcheck source=/dev/null
 . "${RIOTTOOLS}"/ci/changed_files.sh
 
 # customizable
-CHECKROOT=$(dirname "${0}")
+CHECKROOT="${SCRIPTREALDIR}"
 LICENSEDIR="${CHECKROOT}/patterns"
 OUTPUT="${CHECKROOT}/out"
 UNKNOWN="${OUTPUT}/unknown"
@@ -28,20 +31,17 @@ ROOT=$(git rev-parse --show-toplevel)
 LICENSES=$(ls "${LICENSEDIR}")
 EXIT_CODE=0
 
-: ${ERROR_EXIT_CODE:=1}
+: "${ERROR_EXIT_CODE:=1}"
 
 # reset output dir
 rm -fr "${OUTPUT}"
 mkdir -p "${OUTPUT}"
-for LICENSE in ${LICENSES}; do
-    echo -n '' > "${OUTPUT}/${LICENSE}"
-done
 
 # prepare license patterns
 declare -A PATTERNS
 for LICENSE in ${LICENSES}; do
     echo -n '' > "${OUTPUT}/${LICENSE}"
-    PATTERNS[${LICENSE}]="$(grep -v '^$' "${LICENSEDIR}/${LICENSE}" | paste -sd'|')"
+    PATTERNS[${LICENSE}]="$(grep -v '^$' "${LICENSEDIR}/${LICENSE}" | paste -sd' ' | sed -e 's/[[:space:]][[:space:]]*/ /g')"
 done
 
 FILES=$(FILEREGEX='\.([sSch]|cpp)$' changed_files)
@@ -49,9 +49,9 @@ FILES=$(FILEREGEX='\.([sSch]|cpp)$' changed_files)
 # categorize files
 for FILE in ${FILES}; do
     FAIL=1
-    head -100 "${ROOT}/${FILE}" | sed -e 's/[\/\*'"${TAB_CHAR}"']/ /g' -e 's/$/ /' | tr -d '\r\n' | sed -e 's/  */ /g' > "${TMP}"
+    head -100 "${ROOT}/${FILE}" | sed -e 's/[\/\*'"${TAB_CHAR}"']/ /g' | paste -sd' ' | sed -e 's/[[:space:]][[:space:]]*/ /g' > "${TMP}"
     for LICENSE in ${LICENSES}; do
-        if grep -qP "${PATTERNS[${LICENSE}]}" "${TMP}"; then
+        if grep -qE "${PATTERNS[${LICENSE}]}" "${TMP}"; then
             echo "${FILE}" >> "${OUTPUT}/${LICENSE}"
             FAIL=0
             break

--- a/dist/tools/licenses/patterns/Apache2.0
+++ b/dist/tools/licenses/patterns/Apache2.0
@@ -1,11 +1,11 @@
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
+Licensed under the Apache License, Version 2\.0 \(the "License"\);
+you may not use this file except in compliance with the License\.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    http: www\.apache\.org licenses LICENSE-2\.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.
 See the License for the specific language governing permissions and
-limitations under the License.
+limitations under the License\.

--- a/dist/tools/licenses/patterns/mit-espressif
+++ b/dist/tools/licenses/patterns/mit-espressif
@@ -4,10 +4,8 @@ documentation files \(the "Software"\), to deal in the Software without restrict
 without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
 and/or sell copies of the Software, and to permit persons to whom the Software is furnished
 to do so, subject to the following conditions:
- *
 The above copyright notice and this permission notice shall be included in all copies or
 substantial portions of the Software\.
- *
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR

--- a/dist/tools/licenses/patterns/spdx
+++ b/dist/tools/licenses/patterns/spdx
@@ -1,0 +1,2 @@
+(SPDX-FileCopyrightText:.*?)*
+SPDX-License-Identifier


### PR DESCRIPTION
### Contribution description

As previously mentioned in in #22584 and #22585, the license check currently does not work because it matches a wildcard pattern in `dist/tools/licenses/patterns/mit-espressif`.

This currently still fails because now it actually checks the licenses and therefore catches the files that don't have a license.

### Testing procedure

Behavior on `master`:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ ./dist/tools/licenses/check.sh

cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$  wc -l dist/tools/licenses/out/*
     1 dist/tools/licenses/out/1c-BSD-arm
     0 dist/tools/licenses/out/1c-BSD-ccnl
    12 dist/tools/licenses/out/1c-BSD-embunit
     2 dist/tools/licenses/out/1c-BSD-isc
     0 dist/tools/licenses/out/1c-BSD-newlibfeatures
    10 dist/tools/licenses/out/1c-BSD-stanford
     0 dist/tools/licenses/out/1c-BSD-ut
     0 dist/tools/licenses/out/2c-BSD-v1
     0 dist/tools/licenses/out/3c-BSD-atmel
     0 dist/tools/licenses/out/3c-BSD-atmel2
     0 dist/tools/licenses/out/3c-BSD-atmel3
    33 dist/tools/licenses/out/3c-BSD-atmel4
     0 dist/tools/licenses/out/3c-BSD-freescale
     0 dist/tools/licenses/out/3c-BSD-nordic
     0 dist/tools/licenses/out/3c-BSD-openbsd
     0 dist/tools/licenses/out/3c-BSD-silabs
     0 dist/tools/licenses/out/3c-BSD-stm
     0 dist/tools/licenses/out/3c-BSD-ti
     0 dist/tools/licenses/out/3c-BSD-v1
     0 dist/tools/licenses/out/3c-BSD-v2
     0 dist/tools/licenses/out/3c-BSD-v3
     4 dist/tools/licenses/out/Apache2.0
     0 dist/tools/licenses/out/bsd-short
     1 dist/tools/licenses/out/cc0
     1 dist/tools/licenses/out/chan
     0 dist/tools/licenses/out/cmsis-pal-freescale-mk60dz10
     0 dist/tools/licenses/out/gplv2-pjrc
    16 dist/tools/licenses/out/gplv2-short
    11 dist/tools/licenses/out/gplv2-short-alt
   825 dist/tools/licenses/out/lgplv2.1-short
     0 dist/tools/licenses/out/lgplv2.1-v1
     0 dist/tools/licenses/out/mcd-st-liberty
     0 dist/tools/licenses/out/mit
  4805 dist/tools/licenses/out/mit-espressif
     0 dist/tools/licenses/out/mit-short
     0 dist/tools/licenses/out/mod-BSD-avr-libc
     0 dist/tools/licenses/out/publicdomain-short
     0 dist/tools/licenses/out/publicdomain-v1
  5721 total
```

Behavior with this PR:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ ./dist/tools/licenses/check.sh
file has an unknown license header: 'cpu/arm7tdmi_gba/cartridge_header.s'
file has an unknown license header: 'cpu/arm7tdmi_gba/stdio_fb/font_terminal.h'
file has an unknown license header: 'cpu/atmega1281/include/atmega_pcint.h'
file has an unknown license header: 'cpu/atmega1284p/include/atmega_pcint.h'
file has an unknown license header: 'cpu/atmega128rfa1/include/atmega_pcint.h'
file has an unknown license header: 'cpu/atmega2560/include/atmega_pcint.h'
file has an unknown license header: 'cpu/atmega256rfr2/include/atmega_pcint.h'
file has an unknown license header: 'cpu/atmega328p/include/atmega_pcint.h'
file has an unknown license header: 'cpu/atmega32u4/include/atmega_pcint.h'
file has an unknown license header: 'cpu/avr8_common/work_around_for_shitty_ubuntu_toolchain.c'
file has an unknown license header: 'cpu/msp430/periph/usart.c'
file has an unknown license header: 'cpu/msp430/periph/usci.c'
file has an unknown license header: 'cpu/rpx0xx/boot2_w25q080_padded_checksummed.S'
file has an unknown license header: 'dist/tools/testprogs/minimal_linkable.c'
file has an unknown license header: 'drivers/include/stm32_eth.h'
file has an unknown license header: 'drivers/mrf24j40/mrf24j40_radio_hal.c'
file has an unknown license header: 'examples/lang_support/community/wasm/wasm_sample/hello.c'
file has an unknown license header: 'pkg/esp8266_sdk/bootloader/sdkconfig_default.h'
file has an unknown license header: 'pkg/libb2/include/libb2_config.h'
file has an unknown license header: 'pkg/wolfssl/include/user_settings.h'
file has an unknown license header: 'tests/build_system/blob/blob_module/blob.c'
file has an unknown license header: 'tests/build_system/external_board_native/external_boards/native32/external_native.c'
file has an unknown license header: 'tests/build_system/xfa/xfatest1.c'
file has an unknown license header: 'tests/build_system/xfa/xfatest2.c'
file has an unknown license header: 'tests/drivers/epd_bw_spi/pictures.h'
file has an unknown license header: 'tests/drivers/epd_bw_spi_disp_dev/pictures.h'
file has an unknown license header: 'tests/pkg/emlearn/model.h'
file has an unknown license header: 'tests/pkg/mcufont/fonts/DejaVuSans12.c'
file has an unknown license header: 'tests/pkg/mcufont/fonts/DejaVuSans12bw.c'
file has an unknown license header: 'tests/pkg/mcufont/fonts/fonts.h'
file has an unknown license header: 'tests/pkg/nanopb/main.c'
file has an unknown license header: 'tests/pkg/utensor/external_modules/models/deep_mlp.cpp'


cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ wc -l dist/tools/licenses/out/*
     1 dist/tools/licenses/out/1c-BSD-arm
     0 dist/tools/licenses/out/1c-BSD-ccnl
    12 dist/tools/licenses/out/1c-BSD-embunit
     2 dist/tools/licenses/out/1c-BSD-isc
     0 dist/tools/licenses/out/1c-BSD-newlibfeatures
    10 dist/tools/licenses/out/1c-BSD-stanford
     0 dist/tools/licenses/out/1c-BSD-ut
     0 dist/tools/licenses/out/2c-BSD-v1
     0 dist/tools/licenses/out/3c-BSD-atmel
     0 dist/tools/licenses/out/3c-BSD-atmel2
     0 dist/tools/licenses/out/3c-BSD-atmel3
    33 dist/tools/licenses/out/3c-BSD-atmel4
     0 dist/tools/licenses/out/3c-BSD-freescale
     0 dist/tools/licenses/out/3c-BSD-nordic
     0 dist/tools/licenses/out/3c-BSD-openbsd
     0 dist/tools/licenses/out/3c-BSD-silabs
     0 dist/tools/licenses/out/3c-BSD-stm
     0 dist/tools/licenses/out/3c-BSD-ti
     0 dist/tools/licenses/out/3c-BSD-v1
     0 dist/tools/licenses/out/3c-BSD-v2
     0 dist/tools/licenses/out/3c-BSD-v3
     4 dist/tools/licenses/out/Apache2.0
     0 dist/tools/licenses/out/bsd-short
     1 dist/tools/licenses/out/cc0
     1 dist/tools/licenses/out/chan
     0 dist/tools/licenses/out/cmsis-pal-freescale-mk60dz10
     0 dist/tools/licenses/out/gplv2-pjrc
    16 dist/tools/licenses/out/gplv2-short
    11 dist/tools/licenses/out/gplv2-short-alt
   825 dist/tools/licenses/out/lgplv2.1-short
     0 dist/tools/licenses/out/lgplv2.1-v1
     0 dist/tools/licenses/out/mcd-st-liberty
     0 dist/tools/licenses/out/mit
     0 dist/tools/licenses/out/mit-espressif
     0 dist/tools/licenses/out/mit-short
     0 dist/tools/licenses/out/mod-BSD-avr-libc
     0 dist/tools/licenses/out/publicdomain-short
     0 dist/tools/licenses/out/publicdomain-v1
  4773 dist/tools/licenses/out/spdx
    32 dist/tools/licenses/out/unknown
  5721 total
```

### Issues/PRs references

Follow up for #22585.

Also relevant for tracking issue #21515.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- Claude to create the SPDX pattern