### PR TITLE
drivers/periph: document qdec and gpio re-init constraints

### DIFF
--- a/drivers/include/periph/doc.txt
+++ b/drivers/include/periph/doc.txt
@@ -52,15 +52,15 @@
  * | `periph_dac`       | user / driver     | Partial (no concurrent use of the same DAC line allowed)                      |
  * | `periph_eeprom`    | not needed        | None (no concurrency whatsoever)                                              |
  * | `periph_flashpage` | not needed        | None (no concurrency whatsoever)                                              |
- * | `periph_gpio`      | not needed        | Limited (reads are fine, concurrent writes to pins on distinct ports work)    |
- * | `periph_gpio_ll`   | not needed        | Yes, except for concurrent initialization of the GPIO pin                     |
+ * | `periph_gpio`      | not needed        | Limited (reads are fine, concurrent writes to pins on distinct ports work; no reconfiguration of an active interrupt pin) |
+ * | `periph_gpio_ll`   | not needed        | Yes, except for concurrent initialization of the GPIO pin or an active IRQ    |
  * | `periph_hwrng`     | `periph_init`     | None (no concurrency whatsoever)                                              |
  * | `periph_i2c`       | `periph_init`     | Full Thread Safety (except for initialization)                                |
  * | `periph_pio`       | `periph_init`     | Full Thread Safety (except for initialization)                                |
  * | `periph_pm`        | not needed        | Full Thread Safety                                                            |
  * | `periph_ptp`       | `periph_init`     | Full Thread Safety (except for initialization)                                |
  * | `periph_pwm`       | user / driver     | Partial (no concurrent use of the same PWM device)                            |
- * | `periph_qdec`      | user / driver     | Partial (no concurrent use of the same QDEC device)                           |
+ * | `periph_qdec`      | user / driver     | Partial (no concurrent use of the same QDEC; no re-init of an active QDEC)    |
  * | `periph_rtc`       | `periph_init`     | None (no concurrency whatsoever)                                              |
  * | `periph_rtt`       | `periph_init`     | None (no concurrency whatsoever)                                              |
  * | `periph_spi`       | `periph_init`     | Full Thread Safety (except for initialization)                                |

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -180,6 +180,10 @@ int gpio_init(gpio_t pin, gpio_mode_t mode);
  *          enable this function
  *
  * @pre     @p cb must not be NULL
+ * @pre     The pin interrupt must not be active when calling
+ *          `gpio_init_int()`. The pin must either not have been configured as
+ *          an interrupt source before, or the interrupt must be disabled with
+ *          @ref gpio_irq_disable before calling `gpio_init_int()` again.
  *
  * @param[in] pin       pin to initialize
  * @param[in] mode      mode of the pin, see @c gpio_mode_t

--- a/drivers/include/periph/gpio_ll_irq.h
+++ b/drivers/include/periph/gpio_ll_irq.h
@@ -95,6 +95,9 @@ typedef void (*gpio_ll_cb_t)(void *arg);
  * @pre     The given GPIO pin has been initialized using
  *          @ref gpio_ll_init prior to this call
  * @pre     The trigger in @p trig is supported by the MCU
+ * @pre     IRQs on the given pin must not be active when calling
+ *          `gpio_ll_irq()`. The pin must either not have been configured yet,
+ *          or IRQs must be disabled with @ref gpio_ll_irq_off first.
  *
  * @retval  0           Success
  * @retval  -ENOTSUP    No external IRQs supported for @p port and @p pin

--- a/drivers/include/periph/qdec.h
+++ b/drivers/include/periph/qdec.h
@@ -145,6 +145,10 @@ typedef struct {
  * On QDEC counter overflow, an interrupt is triggered.
  * The interruption calls the callback defined.
  *
+ * @pre     The QDEC device must not be active when calling `qdec_init()`. It
+ *          must either not have been initialized before or it must be stopped
+ *          with @ref qdec_stop before calling `qdec_init()` again.
+ *
  * @param[in] dev           QDEC device to initialize
  * @param[in] mode          QDEC mode : X1, X2 or X4
  * @param[in] cb            Callback on QDEC timer overflow


### PR DESCRIPTION
### Contribution description

This PR follows the same approach as #22385.

#22406 and #22407 point out that `qdec_init()` and GPIO interrupt setup
functions lack documentation about whether they may be called again
on an already active device or pin.

This PR adds caller-side precondition documentation:
- `qdec_init()` must not be called again while the QDEC peripheral is active;
  stop the peripheral beforehand.
- `gpio_init_int()` / `gpio_ll_irq()` must not be called again while the pin IRQ
  is active; disable the interrupt first.

This is a documentation-only change. No driver implementation code is modified.

### Testing procedure

Documentation-only change.

Review steps:
1. Inspect the new `@pre` documentation entries in
   - `drivers/include/periph/qdec.h`
   - `drivers/include/periph/gpio.h`
   - `drivers/include/periph/gpio_ll_irq.h`
2. Check updated `periph_qdec` / `periph_gpio` / `periph_gpio_ll` descriptions within
   `drivers/include/periph/doc.txt`.
3. Confirm no driver implementation source files are altered.

### Issues/PRs references

Refs #22406
Refs #22407
See also #22385

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- Grok 4.6 for wording polish of the PR description, with user review
- Grok 4.6 for polishing the documentation wording, with user review