### PR TITLE
dist/tools/buildsys_sanity_check: use release version for Docker check

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -390,10 +390,19 @@ check_pinned_docker_version_is_up_to_date() {
     fi
     local pinned_repo_digest
     local upstream_repo_digest
+    local -a version_args=()
+
+    # Check if a VERSION file exists (and we therefore are on a Release branch).
+    # If we are, use the version tag instead of "latest" to compare to the
+    # hash stored in $RIOTMAKE/docker.inc.mk.
+    if [ -f "${RIOTBASE}/VERSION" ]; then
+        version_args=("$(awk -F' *= *' '/^RIOT_VERSION/ { print $2; exit }' "${RIOTBASE}/VERSION")")
+    fi
+
     pinned_repo_digest="$(awk '/^DOCKER_TESTED_IMAGE_REPO_DIGEST := (.*)$/ { print substr($0, index($0, $3)); exit }' "$RIOTMAKE/docker.inc.mk")"
     # not using docker and jq here but a python script to not have to install
     # more stuff for the static test docker image
-    IFS=' ' read -r upstream_repo_digest <<< "$("$RIOTTOOLS/buildsystem_sanity_check/get_dockerhub_digests.py" "riot/riotbuild")"
+    IFS=' ' read -r upstream_repo_digest <<< "$("$RIOTTOOLS/buildsystem_sanity_check/get_dockerhub_digests.py" "riot/riotbuild" "${version_args[@]}")"
 
     if [ "$pinned_repo_digest" != "$upstream_repo_digest" ]; then
         git -C "${RIOTBASE}" grep -n '^DOCKER_TESTED_IMAGE_REPO_DIGEST :=' "$RIOTMAKE/docker.inc.mk" \

--- a/dist/tools/buildsystem_sanity_check/get_dockerhub_digests.py
+++ b/dist/tools/buildsystem_sanity_check/get_dockerhub_digests.py
@@ -84,8 +84,11 @@ def get_upstream_digests(repo, tag="latest", token=None):
 
 
 if __name__ == '__main__':
-    if len(sys.argv) != 2:
+    if (len(sys.argv) == 2):
+        _, repo_digest = get_upstream_digests(sys.argv[1])
+    elif (len(sys.argv) == 3):
+        _, repo_digest = get_upstream_digests(sys.argv[1], sys.argv[2])
+    else:
         sys.exit(f"Usage {sys.argv[0]} <REPO_NAME>")
 
-    _, repo_digest = get_upstream_digests(sys.argv[1])
     print(f"{repo_digest}")


### PR DESCRIPTION
### Contribution description

Currently, the docker image version is static and is not updated when a release happens.
If the Docker container is updated in the meantime, no backports to the release branch are possible anymore because the static test fails.

Therefore, I extended the buildsystem sanity check to check if a `VERSION` file is present in `RIOTBASE` and if it is, the version string from that file is used to fetch the hash from `docker.io` to compare to the `DOCKER_TESTED_IMAGE_REPO_DIGEST` variable in `makefiles/docker.inc.mk` instead of getting the `latest` hash.

### Testing procedure

The test should still succeed on `master`:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ ./dist/tools/buildsystem_sanity_check/check.sh
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ echo $?
0
```

The test should also succeed on a release branch. In our current situation, this will only work on the `2026.07-branch` because the Docker image happens to be at `2026.07` and hasn't been updated as thoroughly as it should've been before.
This has been addressed in the release guides though in #22214, however I might have to extend the documentation there a little bit as well as in the docker container itself.
(Added blank lines to the logs to make it easier to read).

```
cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ git checkout 2026.07-branch
Switched to branch '2026.07-branch'
Your branch is up to date with 'origin/2026.07-branch'.

cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ git cherry-pick 2f99df8777
[2026.07-branch 7e1d25c579] dist/tools/buildsys_sanity_check: use release version for Docker check
 Date: Tue Aug 18 12:57:37 2026 +0200
 2 files changed, 15 insertions(+), 3 deletions(-)

cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ echo "RIOT_VERSION = 2026.07" > VERSION

cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ cat VERSION
RIOT_VERSION = 2026.07

cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ ./dist/tools/buildsystem_sanity_check/check.sh

cbuec@W11nMate:~/RIOTstuff/riot-vanilla/RIOT$ echo $?
0
```

### Issues/PRs references

Required for https://github.com/RIOT-OS/riotdocker/issues/64 and https://github.com/RIOT-OS/riotdocker/pull/287

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- Claude to make the change in the shell script.