### PR TITLE
dist/tools: fix some shellcheck errors and warnings

### DIFF
--- a/dist/tools/buildsystem_sanity_check/save_all_dependencies_resolution_variables.sh
+++ b/dist/tools/buildsystem_sanity_check/save_all_dependencies_resolution_variables.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
-#
-# Copyright (C) 2019 Freie Universität Berlin
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+
+# SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+# SPDX-License-Identifier: LGPL-2.1-only
 
 # Script to save all the dependencies resolution variables for both normal and
 # in `info-boards-supported` resolution.
@@ -61,7 +57,7 @@ main() {
 
     # Generate the aggregated files to simplify comparing both parsing
     find "${output_dir}" -type f -name 'dependencies_info_*' | sort | xargs cat > "${output_dir}"/deps_info
-    find "${output_dir}" -type f -name 'dependencies_info-boards-supported_*' | sort | xargs cat > ${output_dir}/deps_info-boards-supported
+    find "${output_dir}" -type f -name 'dependencies_info-boards-supported_*' | sort | xargs cat > "${output_dir}"/deps_info-boards-supported
 }
 
 

--- a/dist/tools/ci/changed_files.sh
+++ b/dist/tools/ci/changed_files.sh
@@ -1,25 +1,24 @@
-# Copyright 2017 Kaspar Schleiser <kaspar@schleiser.de>
-# Copyright 2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
-# Copyright 2014 Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# shellcheck shell=bash # this script is only sourced, so no shebang
+
+# SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
+# SPDX-FileCopyrightText: 2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+# SPDX-FileCopyrightText: 2014 Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
+# SPDX-License-Identifier: LGPL-2.1-only
 
 changed_files() {
-    : ${FILEREGEX:='\.([CcHh]|[ch]pp)$'}
-    : ${EXCLUDE:='^(.+/vendor/|dist/tools/coccinelle/include|dist/tools/fixdep/fixdep.c|dist/tools/lpc2k_pgm/src)'}
-    : ${DIFFFILTER:='ACMR'}
+    : "${FILEREGEX:='\.([CcHh]|[ch]pp)$'}"
+    : "${EXCLUDE:='^(.+/vendor/|dist/tools/coccinelle/include|dist/tools/fixdep/fixdep.c|dist/tools/lpc2k_pgm/src)'}"
+    : "${DIFFFILTER:=ACMR}"
 
     DIFFFILTER="--diff-filter=${DIFFFILTER}"
 
     # select either all or only touched-in-branch files, filter through FILEREGEX
     if [ -z "${BASE_BRANCH}" ]; then
-        FILES="$(git ls-tree -r --full-tree --name-only HEAD | grep -E ${FILEREGEX})"
+        FILES="$(git ls-tree -r --full-tree --name-only HEAD | grep -E "${FILEREGEX}")"
     else
-        FILES="$(git diff ${DIFFFILTER} --name-only ${BASE_BRANCH} | grep -E ${FILEREGEX})"
+        FILES="$(git diff "${DIFFFILTER}" --name-only "${BASE_BRANCH}" | grep -E "${FILEREGEX}")"
     fi
 
     # filter out negatives
-    echo "${FILES}" | grep -v -E ${EXCLUDE}
+    echo "${FILES}" | grep -v -E "${EXCLUDE}"
 }

--- a/dist/tools/ci/github_annotate.sh
+++ b/dist/tools/ci/github_annotate.sh
@@ -1,13 +1,12 @@
-# Copyright 2020 Martine S. Lenders <m.lenders@fu-berlin.sh>
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# shellcheck shell=bash # this script is only sourced, so no shebang
 
-LOG=cat
+# SPDX-FileCopyrightText: 2020 Martine S. Lenders <m.lenders@fu-berlin.de>
+# SPDX-License-Identifier: LGPL-2.1-only
+
+LOG="cat"
 LOGFILE=
 OUTFILE=github_annotate_outfile.log
-ECHO_ESC=echo
+ECHO_ESC="echo"
 
 if [ -n "${BASH_VERSION}" ]; then
     # workaround when included in bash to escape newlines and carriage returns
@@ -18,6 +17,7 @@ fi
 github_annotate_setup() {
     if [ -n "${GITHUB_RUN_ID}" ]; then
         LOGFILE=run-${GITHUB_RUN_ID}.log
+        # shellcheck disable=SC2034  # LOG can be used by the sourcing script
         LOG="tee -a ${LOGFILE}"
     fi
 }
@@ -78,7 +78,7 @@ github_annotate_parse_log_default() {
     if github_annotate_is_on; then
         PATTERN='^.\+:[0-9]\+:'
 
-        grep "${PATTERN}" "${LOGFILE}" | while read line; do
+        grep "${PATTERN}" "${LOGFILE}" | while read -r line; do
             FILENAME=$(echo "${line}" | cut -d: -f1)
             LINENUM=$(echo "${line}" | cut -d: -f2)
             DETAILS=$(echo "${line}" | cut -d: -f3- |
@@ -90,13 +90,13 @@ github_annotate_parse_log_default() {
 
 github_annotate_teardown() {
     if [ -n "${LOGFILE}" ]; then
-        rm -f ${LOGFILE}
+        rm -f "${LOGFILE}"
         LOGFILE=
     fi
 }
 
 github_annotate_report_last_run() {
-    if [ -n "${GITHUB_RUN_ID}" -a -f "${OUTFILE}" ]; then
+    if [ -n "${GITHUB_RUN_ID}" ] && [ -f "${OUTFILE}" ]; then
         # de-duplicate errors
         sort -u ${OUTFILE} >&2
     fi

--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -37,12 +37,13 @@ get_kernel_info() {
 }
 
 get_os_info() {
-    local os="$(uname -s)"
+    local os
+    os=$(uname -s)
     local osname="unknown"
     local osvers="unknown"
     if [ "$os" = "Linux" ]; then
-        osname="$(cat /etc/os-release | grep ^NAME= | awk -F'=' '{print $2}')"
-        osvers="$(cat /etc/os-release | grep ^VERSION= | awk -F'=' '{print $2}')"
+        osname="$(grep ^NAME= /etc/os-release | awk -F'=' '{print $2}')"
+        osvers="$(grep ^VERSION= /etc/os-release | awk -F'=' '{print $2}')"
     elif [ "$os" = "Darwin" ]; then
         osname="$(sw_vers -productName)"
         osvers="$(sw_vers -productVersion)"

--- a/dist/tools/ci/static_tests.sh
+++ b/dist/tools/ci/static_tests.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
-#
-# Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
-#               2020 Inria
-#               2020 Freie Universität Berlin
-#               2015 Philipp Rosenkranz <philipp.rosenkranz@fu-berlin.de>
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
 
+# SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+# SPDX-FileCopyrightText: 2020 Inria
+# SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+# SPDX-FileCopyrightText: 2015 Philipp Rosenkranz <philipp.rosenkranz@fu-berlin.de>
+# SPDX-License-Identifier: LGPL-2.1-only
+
+# shellcheck source=dist/tools/ci/github_annotate.sh
 . "$(dirname "${0}")"/github_annotate.sh
 
 declare -A DEPS
@@ -61,7 +58,7 @@ set_result() {
 
 function run {
     for dep in ${DEPS["$1"]}; do
-        if ! command -v ${dep} &>/dev/null; then
+        if ! command -v "${dep}" &>/dev/null; then
             echo -n "Required command '${dep}' for '$*' not found in PATH "
             print_warning
             set_result 1
@@ -140,4 +137,4 @@ else
 fi
 ERROR_EXIT_CODE=0 run ./dist/tools/shellcheck/check.sh
 
-exit $RESULT
+exit "$RESULT"

--- a/dist/tools/headerguards/check.sh
+++ b/dist/tools/headerguards/check.sh
@@ -1,22 +1,22 @@
 #!/bin/sh
 
-# Copyright 2017 Kaspar Schleiser <kaspar@schleiser.de>
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
+# SPDX-License-Identifier: LGPL-2.1-only
 
-: "${RIOTBASE:=$(cd $(dirname $0)/../../../; pwd)}"
-cd $RIOTBASE
+: "${RIOTBASE:=$(cd "$(dirname "$0")/../../../" || exit 1; pwd)}"
+cd "$RIOTBASE" || exit 1
 
 : "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
+
+# shellcheck source=dist/tools/ci/changed_files.sh
 . "${RIOTTOOLS}"/ci/changed_files.sh
+# shellcheck source=dist/tools/ci/github_annotate.sh
 . "${RIOTTOOLS}"/ci/github_annotate.sh
 
 EXIT_CODE=0
 
 filter() {
-    if [ $QUIET -eq 0 ]; then
+    if [ "$QUIET" -eq 0 ]; then
         cat
     else
         grep '^---' | cut -f 2 -d ' '
@@ -24,13 +24,13 @@ filter() {
 }
 
 _annotate_diff() {
-    if [ -n "$1" -a -n "$2" -a -n "$3" ]; then
+    if [ -n "$1" ] && [ -n "$2" ] && [ -n "$3" ]; then
         IFS="${OLD_IFS}" github_annotate_error "$1" "$2" "Wrong header guard format:\n\n$3"
     fi
 }
 
 _headercheck() {
-    OUT=$(${RIOTTOOLS}/headerguards/headerguards.py ${FILES} 2>&1 | filter)
+    OUT=$("${RIOTTOOLS}"/headerguards/headerguards.py "${FILES}" 2>&1 | filter)
     if [ -n "$OUT" ]; then
         EXIT_CODE=1
         if github_annotate_is_on; then
@@ -94,7 +94,7 @@ _headercheck() {
     fi
 }
 
-: ${FILES:=$(FILEREGEX='\.h$' changed_files)}
+: "${FILES:=$(FILEREGEX='\.h$' changed_files)}"
 
 if [ -z "${FILES}" ]; then
     exit
@@ -102,7 +102,7 @@ fi
 
 github_annotate_setup
 
-: ${QUIET:=0}
+: "${QUIET:=0}"
 
 if [ -z "$*" ]; then
     _headercheck
@@ -110,4 +110,4 @@ fi
 
 github_annotate_teardown
 
-exit $EXIT_CODE
+exit "$EXIT_CODE"

--- a/dist/tools/shellcheck/check.sh
+++ b/dist/tools/shellcheck/check.sh
@@ -1,15 +1,11 @@
 #!/usr/bin/env bash
-#
-# Copyright (C) 2018 Freie Universität Berlin
-#                    Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+
+# SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+# SPDX-FileCopyrightText: 2018 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 SHELLCHECK_CMD="$(command -v shellcheck)"
-export SHELLCHECK_OPTS="-e SC1090"
+export SHELLCHECK_OPTS="-x" # allow shellcheck to follow sourced files
 
 if tput colors &> /dev/null && [ "$(tput colors)" -ge 8 ]; then
     CERROR=$'\e[1;31m'
@@ -19,9 +15,16 @@ else
     CRESET=
 fi
 
+: "${RIOTBASE:=$(cd "$(dirname "$0")"/../../../ || exit 1; pwd)}"
 : "${RIOTTOOLS:=${PWD}/dist/tools}"
+
+# shellcheck source=dist/tools/ci/changed_files.sh
 . "${RIOTTOOLS}"/ci/changed_files.sh
+# shellcheck source=dist/tools/ci/github_annotate.sh
 . "${RIOTTOOLS}"/ci/github_annotate.sh
+
+# RIOTBASE should be the starting point for all sourced file paths
+SHELLCHECK_OPTS=${SHELLCHECK_OPTS}" --source-path=${RIOTBASE}"
 
 FILES=$(FILEREGEX='(.*\.sh$)' changed_files)
 

--- a/dist/tools/whitespacecheck/check.sh
+++ b/dist/tools/whitespacecheck/check.sh
@@ -1,11 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Copyright 2015 Oliver Hahm <oliver.hahm@inria.fr>
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
+# SPDX-FileCopyrightText: 2015 Oliver Hahm <oliver.hahm@inria.fr>
+# SPDX-License-Identifier: LGPL-2.1-only
 
+# shellcheck source=dist/tools/ci/github_annotate.sh
 . "$(dirname "$0")/../ci/github_annotate.sh"
 
 IGNORE=$(awk '{ printf ":!%s ", $0 }' "$(dirname "$0")/ignore_list.txt")
@@ -36,24 +34,24 @@ if [ -z "${BRANCH}" ]; then
 fi
 
 git -c core.whitespace="tab-in-indent,tabwidth=4" \
-    diff --check "$(git merge-base "${BRANCH}" HEAD)" -- *.[ch] ${IGNORE} \
+    diff --check "$(git merge-base "${BRANCH}" HEAD)" -- *.[ch] "${IGNORE}" \
             | ${LOG}
 RESULT=${PIPESTATUS[0]}
 
 # Git regards any trailing white space except `\n` as an error so `\r` is
 # checked here, too
 git -c core.whitespace="trailing-space" \
-    diff --check "$(git merge-base "${BRANCH}" HEAD)" -- . ${IGNORE} \
+    diff --check "$(git merge-base "${BRANCH}" HEAD)" -- . "${IGNORE}" \
             | ${LOG}
 
 TRAILING_RESULT=${PIPESTATUS[0]}
 
+# shellcheck disable=SC2119 # we don't want to pass arguments to this function
 github_annotate_parse_log_default
 
 github_annotate_teardown
 
-if [ ${TRAILING_RESULT} -ne 0 ] || [ ${RESULT} -ne 0 ]
-then
+if [ "${TRAILING_RESULT}" -ne 0 ] || [ "${RESULT}" -ne 0 ]; then
     echo "ERROR: This change introduces new whitespace errors"
     exit 1
 else


### PR DESCRIPTION
### Contribution description

The scripts we use in RIOT have accumulated quite a lot of shellcheck warnings and errors. This is partly due to the fact that shellcheck learns more and more things to check for with every version and our static test only tests changed files.

This can be annoying for contributors who just want to change a minor thing and then have to fix one or more or many shellcheck errors before the PR can be merged.

In the long run, I'd like to add the path comments to all sourced script files, that's why you see a lot of errors change from `note: Not following: ./ci/github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]` to `note: Not following: ./ci/github_annotate.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]`.

This is just a starting point, there are >450 shellcheck warnings remaining currently 😅 

### Testing procedure

I recommend running `shellcheck` from the Docker container, unless you have a very recent version installed:
```sh
docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v $(pwd)':/data/riotbuild/riotbase:delegated' -w '/data/riotbuild/riotbase/' 'docker.io/riot/riotbuild@sha256:61c1aa5371bd0e3a8764121671555c8b54907ad8e1eddc520f4e601bbcbcd702' ./dist/tools/shellcheck/check.sh > pr.txt

git checkout master

docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v $(pwd)':/data/riotbuild/riotbase:delegated' -w '/data/riotbuild/riotbase/' 'docker.io/riot/riotbuild@sha256:61c1aa5371bd0e3a8764121671555c8b54907ad8e1eddc520f4e601bbcbcd702' ./dist/tools/shellcheck/check.sh > master.txt
```

The fixed warnings:
```diff
buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ diff -u --color master.txt pr.txt
--- master.txt  2026-08-19 19:29:42.406689644 +0200
+++ pr.txt      2026-08-19 19:29:31.210221254 +0200
@@ -8,6 +8,9 @@
 boards/mbed_lpc1768/dist/flash.sh:27:6: note: Double quote to prevent globbing and word splitting. [SC2086]
 boards/mbed_lpc1768/dist/flash.sh:30:8: note: Double quote to prevent globbing and word splitting. [SC2086]
 boards/mbed_lpc1768/dist/flash.sh:60:4: note: Double quote to prevent globbing and word splitting. [SC2086]
+cpu/msp430/vendor/update.sh:13:7: warning: Quote this to prevent word splitting. [SC2046]
+cpu/msp430/vendor/update.sh:17:8: warning: Quote this to prevent word splitting. [SC2046]
+cpu/msp430/vendor/update.sh:17:10: warning: Don't use ls | grep. Use a glob or a for loop with a condition to allow non-alphanumeric filenames. [SC2010]
 cpu/sam0_common/dist/kconfig_gen.sh:13:15: note: Double quote to prevent globbing and word splitting. [SC2086]
 cpu/sam0_common/dist/kconfig_gen.sh:13:25: note: Use '[:lower:]' to support accents and foreign alphabets. [SC2018]
 cpu/sam0_common/dist/kconfig_gen.sh:13:29: note: Use '[:upper:]' to support accents and foreign alphabets. [SC2019]
@@ -30,32 +33,13 @@
 dist/tools/avarice/debug.sh:16:22: note: Double quote to prevent globbing and word splitting. [SC2086]
 dist/tools/avarice/debug.sh:17:50: note: Double quote to prevent globbing and word splitting. [SC2086]
 dist/tools/avarice/debug_srv.sh:4:9: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/buildsystem_sanity_check/save_all_dependencies_resolution_variables.sh:64:100: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/ci/changed_files.sh:1:1: error: Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive. [SC2148]
-dist/tools/ci/changed_files.sh:10:7: note: This default assignment may cause DoS due to globbing. Quote it. [SC2223]
-dist/tools/ci/changed_files.sh:11:7: note: This default assignment may cause DoS due to globbing. Quote it. [SC2223]
-dist/tools/ci/changed_files.sh:12:7: note: This default assignment may cause DoS due to globbing. Quote it. [SC2223]
-dist/tools/ci/changed_files.sh:18:72: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/ci/changed_files.sh:20:53: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/ci/changed_files.sh:20:78: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/ci/github_annotate.sh:1:1: error: Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive. [SC2148]
-dist/tools/ci/github_annotate.sh:7:1: warning: Use var=$(command) to assign output (or quote to assign string). [SC2209]
-dist/tools/ci/github_annotate.sh:10:1: warning: Use var=$(command) to assign output (or quote to assign string). [SC2209]
-dist/tools/ci/github_annotate.sh:21:9: warning: LOG appears unused. Verify use (or export if used externally). [SC2034]
-dist/tools/ci/github_annotate.sh:81:48: note: read without -r will mangle backslashes. [SC2162]
-dist/tools/ci/github_annotate.sh:93:15: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/ci/github_annotate.sh:99:32: warning: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined. [SC2166]
-dist/tools/ci/print_toolchain_versions.sh:40:11: warning: Declare and assign separately to avoid masking return values. [SC2155]
-dist/tools/ci/print_toolchain_versions.sh:44:23: note: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead. [SC2002]
-dist/tools/ci/print_toolchain_versions.sh:45:23: note: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead. [SC2002]
-dist/tools/ci/static_tests.sh:13:3: note: Not following: ./github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
 dist/tools/coccinelle/check.sh:9:18: warning: Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
 dist/tools/coccinelle/check.sh:9:21: warning: Quote this to prevent word splitting. [SC2046]
 dist/tools/coccinelle/check.sh:9:31: note: Double quote to prevent globbing and word splitting. [SC2086]
 dist/tools/coccinelle/check.sh:10:1: warning: Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
 dist/tools/coccinelle/check.sh:10:4: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/coccinelle/check.sh:13:3: note: Not following: ./ci/changed_files.sh was not specified as input (see shellcheck -x). [SC1091]
-dist/tools/coccinelle/check.sh:14:3: note: Not following: ./ci/github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
+dist/tools/coccinelle/check.sh:13:3: note: Not following: ./ci/changed_files.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
+dist/tools/coccinelle/check.sh:14:3: note: Not following: ./ci/github_annotate.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
 dist/tools/coccinelle/check.sh:19:10: note: Double quote to prevent globbing and word splitting. [SC2086]
 dist/tools/coccinelle/check.sh:31:18: warning: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined. [SC2166]
 dist/tools/coccinelle/check.sh:31:29: warning: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined. [SC2166]
@@ -84,10 +68,10 @@
 dist/tools/codespell/check.sh:21:68: note: Double quote to prevent globbing and word splitting. [SC2086]
 dist/tools/codespell/check.sh:24:1: warning: Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
 dist/tools/codespell/check.sh:24:4: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/codespell/check.sh:27:3: note: Not following: ./ci/changed_files.sh was not specified as input (see shellcheck -x). [SC1091]
+dist/tools/codespell/check.sh:27:3: note: Not following: ./ci/changed_files.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
 dist/tools/codespell/check.sh:49:27: note: Double quote to prevent globbing and word splitting. [SC2086]
 dist/tools/codespell/check.sh:49:45: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/codespell/check.sh:54:3: note: Not following: ./ci/github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
+dist/tools/codespell/check.sh:54:3: note: Not following: ./ci/github_annotate.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
 dist/tools/codespell/check.sh:59:27: note: Double quote to prevent globbing and word splitting. [SC2086]
 dist/tools/codespell/check.sh:59:45: note: Double quote to prevent globbing and word splitting. [SC2086]
 dist/tools/codespell/check.sh:68:19: note: read without -r will mangle backslashes. [SC2162]
@@ -99,8 +83,8 @@
 dist/tools/cppcheck/check.sh:11:31: note: Double quote to prevent globbing and word splitting. [SC2086]
 dist/tools/cppcheck/check.sh:12:1: warning: Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
 dist/tools/cppcheck/check.sh:12:4: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/cppcheck/check.sh:15:3: note: Not following: ./ci/changed_files.sh was not specified as input (see shellcheck -x). [SC1091]
-dist/tools/cppcheck/check.sh:16:3: note: Not following: ./ci/github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
+dist/tools/cppcheck/check.sh:15:3: note: Not following: ./ci/changed_files.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
+dist/tools/cppcheck/check.sh:16:3: note: Not following: ./ci/github_annotate.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
 dist/tools/cppcheck/check.sh:62:49: note: Double quote to prevent globbing and word splitting. [SC2086]
 dist/tools/cppcheck/check.sh:62:69: error: Double quote array expansions to avoid re-splitting elements. [SC2068]
 dist/tools/cppcheck/check.sh:63:10: note: Double quote to prevent globbing and word splitting. [SC2086]
@@ -193,16 +177,16 @@
 dist/tools/externc/check.sh:11:31: note: Double quote to prevent globbing and word splitting. [SC2086]
 dist/tools/externc/check.sh:12:1: warning: Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
 dist/tools/externc/check.sh:12:4: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/externc/check.sh:15:3: note: Not following: ./ci/changed_files.sh was not specified as input (see shellcheck -x). [SC1091]
-dist/tools/externc/check.sh:16:3: note: Not following: ./ci/github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
+dist/tools/externc/check.sh:15:3: note: Not following: ./ci/changed_files.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
+dist/tools/externc/check.sh:16:3: note: Not following: ./ci/github_annotate.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
 dist/tools/externc/check.sh:28:12: note: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead. [SC2002]
-dist/tools/flake8/check.sh:9:3: note: Not following: ./../ci/github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
+dist/tools/flake8/check.sh:9:3: note: Not following: ./../ci/github_annotate.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
 dist/tools/flake8/check.sh:22:18: warning: Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
 dist/tools/flake8/check.sh:22:21: warning: Quote this to prevent word splitting. [SC2046]
 dist/tools/flake8/check.sh:22:31: note: Double quote to prevent globbing and word splitting. [SC2086]
 dist/tools/flake8/check.sh:23:1: warning: Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
 dist/tools/flake8/check.sh:23:4: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/flake8/check.sh:26:3: note: Not following: ./ci/changed_files.sh was not specified as input (see shellcheck -x). [SC1091]
+dist/tools/flake8/check.sh:26:3: note: Not following: ./ci/changed_files.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
 dist/tools/flake8/check.sh:49:66: note: Double quote to prevent globbing and word splitting. [SC2086]
 dist/tools/flake8/check.sh:52:53: note: read without -r will mangle backslashes. [SC2162]
 dist/tools/fuzzing/afl.sh:10:27: note: Double quote to prevent globbing and word splitting. [SC2086]
@@ -233,20 +217,6 @@
 dist/tools/generate_c11_atomics_cpp_compat_header/generate_c11_atomics_cpp_compat_header.sh:109:54: warning: Quote parameters to tr to prevent glob expansion. [SC2060]
 dist/tools/generate_c11_atomics_cpp_compat_header/generate_c11_atomics_cpp_compat_header.sh:109:101: note: Double quote to prevent globbing and word splitting. [SC2086]
 dist/tools/generate_c11_atomics_cpp_compat_header/generate_c11_atomics_cpp_compat_header.sh:136:19: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/headerguards/check.sh:9:18: warning: Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
-dist/tools/headerguards/check.sh:9:21: warning: Quote this to prevent word splitting. [SC2046]
-dist/tools/headerguards/check.sh:9:31: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/headerguards/check.sh:10:1: warning: Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
-dist/tools/headerguards/check.sh:10:4: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/headerguards/check.sh:13:3: note: Not following: ./ci/changed_files.sh was not specified as input (see shellcheck -x). [SC1091]
-dist/tools/headerguards/check.sh:14:3: note: Not following: ./ci/github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
-dist/tools/headerguards/check.sh:19:10: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/headerguards/check.sh:27:18: warning: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined. [SC2166]
-dist/tools/headerguards/check.sh:27:29: warning: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined. [SC2166]
-dist/tools/headerguards/check.sh:33:11: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/headerguards/check.sh:33:53: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/headerguards/check.sh:97:3: note: This default assignment may cause DoS due to globbing. Quote it. [SC2223]
-dist/tools/headerguards/check.sh:105:3: note: This default assignment may cause DoS due to globbing. Quote it. [SC2223]
 dist/tools/jlink/jlink.sh:65:3: note: This default assignment may cause DoS due to globbing. Quote it. [SC2223]
 dist/tools/jlink/jlink.sh:67:3: note: This default assignment may cause DoS due to globbing. Quote it. [SC2223]
 dist/tools/jlink/jlink.sh:69:3: note: This default assignment may cause DoS due to globbing. Quote it. [SC2223]
@@ -385,8 +355,6 @@
 dist/tools/radvd/radvd.sh:86:10: note: Expressions don't expand in single quotes, use double quotes for that. [SC2016]
 dist/tools/radvd/radvd.sh:95:19: warning: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined. [SC2166]
 dist/tools/release-stats/release-stats.sh:38:6: warning: In POSIX sh, echo flags are undefined. [SC3037]
-dist/tools/shellcheck/check.sh:23:3: note: Not following: ./ci/changed_files.sh was not specified as input (see shellcheck -x). [SC1091]
-dist/tools/shellcheck/check.sh:24:3: note: Not following: ./ci/github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
 dist/tools/sliptty/start_network.sh:34:38: warning: To redirect stdout+stderr, 2>&1 must be last (or use '{ cmd > file; } 2>&1' to clarify). [SC2069]
 dist/tools/sliptty/start_network.sh:35:60: note: Double quote to prevent globbing and word splitting. [SC2086]
 dist/tools/sliptty/start_network.sh:49:34: note: Double quote to prevent globbing and word splitting. [SC2086]
@@ -477,11 +445,6 @@
 dist/tools/vera++/check.sh:49:25: note: line was modified in a subshell. That change might be lost. [SC2031]
 dist/tools/vera++/check.sh:54:23: note: See if you can use ${variable//search/replace} instead. [SC2001]
 dist/tools/vera++/check.sh:58:23: note: See if you can use ${variable//search/replace} instead. [SC2001]
-dist/tools/whitespacecheck/check.sh:9:3: note: Not following: ./../ci/github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
-dist/tools/whitespacecheck/check.sh:39:65: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/whitespacecheck/check.sh:46:60: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/whitespacecheck/check.sh:55:6: note: Double quote to prevent globbing and word splitting. [SC2086]
-dist/tools/whitespacecheck/check.sh:55:38: note: Double quote to prevent globbing and word splitting. [SC2086]
 dist/tools/zep_dispatch/start_network.sh:65:21: note: Double quote to prevent globbing and word splitting. [SC2086]
 examples/advanced/suit_update/tests-with-config/check-config.sh:26:25: note: Expansions inside ${..} need to be quoted separately, otherwise they match as patterns. [SC2295]
 examples/advanced/suit_update/tests-with-config/check-config.sh:31:25: note: Expansions inside ${..} need to be quoted separately, otherwise they match as patterns. [SC2295]
```

### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none