### PR TITLE
dist/tools: fix regressions from #22597

### DIFF
--- a/dist/tools/ci/changed_files.sh
+++ b/dist/tools/ci/changed_files.sh
@@ -6,8 +6,8 @@
 # SPDX-License-Identifier: LGPL-2.1-only
 
 changed_files() {
-    : "${FILEREGEX:='\.([CcHh]|[ch]pp)$'}"
-    : "${EXCLUDE:='^(.+/vendor/|dist/tools/coccinelle/include|dist/tools/fixdep/fixdep.c|dist/tools/lpc2k_pgm/src)'}"
+    : "${FILEREGEX:=\.([CcHh]|[ch]pp)$}"
+    : "${EXCLUDE:=^(.+/vendor/|dist/tools/coccinelle/include|dist/tools/fixdep/fixdep.c|dist/tools/lpc2k_pgm/src)}"
     : "${DIFFFILTER:=ACMR}"
 
     DIFFFILTER="--diff-filter=${DIFFFILTER}"

--- a/dist/tools/headerguards/check.sh
+++ b/dist/tools/headerguards/check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
 # SPDX-License-Identifier: LGPL-2.1-only
@@ -30,7 +30,11 @@ _annotate_diff() {
 }
 
 _headercheck() {
-    OUT=$("${RIOTTOOLS}"/headerguards/headerguards.py "${FILES}" 2>&1 | filter)
+    if [ "${#FILES_ARR[@]}" -eq 0 ] || [ -z "${FILES_ARR[0]}" ]; then
+        return 0
+    fi
+
+    OUT=$("${RIOTTOOLS}"/headerguards/headerguards.py "${FILES_ARR[@]}" 2>&1 | filter)
     if [ -n "$OUT" ]; then
         EXIT_CODE=1
         if github_annotate_is_on; then
@@ -44,7 +48,7 @@ _headercheck() {
                 IFS=''  # keep leading and trailing spaces
                 while read -r line; do
                     # file has no or broken header guard
-                    if echo "$line" | grep -q '^.*: no / broken header guard$'; then
+                    if [[ "$line" == *": no / broken header guard" ]]; then
                         # this output comes outside of a diff, so reset diff parser
                         _annotate_diff "$DIFFFILE" "$DIFFLINE" "$DIFF"
                         DIFF=""
@@ -55,10 +59,10 @@ _headercheck() {
                         MESSAGE=$(echo "$line" | cut -d: -f2 | xargs echo)
                         github_annotate_error "$FILE" 0 "$MESSAGE"
                     # parse beginning of new diff
-                    elif echo "$line" | grep -q '^--- .\+$'; then
+                    elif [[ "$line" == "--- "* ]]; then
                         _annotate_diff "$DIFFFILE" "$DIFFLINE" "$DIFF"
                         DIFF="$line"
-                        DIFFFILE=$(echo "$line" | sed 's/^--- \(.\+\)$/\1/g')
+                        DIFFFILE="${line#--- }"
                         DIFFLINE=""
                     # we are in a diff currently
                     elif [ -n "$DIFF" ]; then
@@ -71,9 +75,11 @@ _headercheck() {
                                _annotate_diff "$DIFFFILE" "$DIFFLINE" "$DIFF"
                                DIFF="--- $DIFFFILE\n+++ $DIFFFILE"
                            fi
-                           DIFFLINE="$(echo "$line" | sed 's/@@ -\([0-9]\+\).*$/\1/')"
+                           DIFFLINE="${line#@@ -}"
+                           DIFFLINE="${DIFFLINE%%[!0-9]*}"
                            # Parse
                            # @@ -<DIFFLINE>,<DIFFOFFSET> ...
+                           # shellcheck disable=SC2001 # cond. expr. can't easily be done without sed
                            DIFFOFFSET="$(echo "$line" |
                                sed 's/@@ -[0-9]\+\(,\([0-9]\)\+\)\?.*$/\2/')"
                            if [ -n "$DIFFOFFSET" ]; then
@@ -83,7 +89,8 @@ _headercheck() {
                                DIFFLINE=$(( DIFFLINE + DIFFOFFSET - 1 ))
                            fi
                         fi
-                        DIFF="$DIFF\n$(echo "${line}"| sed 's/\\/\\\\/g' )"
+                        # replace all \ by \\
+                        DIFF="$DIFF\n${line//\\/\\\\}"
                     fi
                 done
                 _annotate_diff "$DIFFFILE" "$DIFFLINE" "$DIFF"
@@ -94,7 +101,9 @@ _headercheck() {
     fi
 }
 
+# create an array from the changed files list
 : "${FILES:=$(FILEREGEX='\.h$' changed_files)}"
+mapfile -t FILES_ARR <<< "${FILES}"
 
 if [ -z "${FILES}" ]; then
     exit

--- a/dist/tools/whitespacecheck/check.sh
+++ b/dist/tools/whitespacecheck/check.sh
@@ -6,7 +6,8 @@
 # shellcheck source=dist/tools/ci/github_annotate.sh
 . "$(dirname "$0")/../ci/github_annotate.sh"
 
-IGNORE=$(awk '{ printf ":!%s ", $0 }' "$(dirname "$0")/ignore_list.txt")
+# read the ignore list into an array and generate a pattern that `git diff` understands
+mapfile -t IGNORE < <(awk '{ printf ":!%s\n", $0 }' "$(dirname "$0")/ignore_list.txt")
 
 # If no branch but an option is given, unset BRANCH.
 # Otherwise, consume this parameter.
@@ -33,15 +34,15 @@ if [ -z "${BRANCH}" ]; then
     BRANCH=$(git rev-list HEAD | tail -n 1)
 fi
 
-git -c core.whitespace="tab-in-indent,tabwidth=4" \
-    diff --check "$(git merge-base "${BRANCH}" HEAD)" -- *.[ch] "${IGNORE}" \
+git -c core.whitespace="tab-in-indent,tabwidth=4" -c diff.renameLimit=20000  \
+    diff --check "$(git merge-base "${BRANCH}" HEAD)" -- *.[ch] "${IGNORE[@]}" \
             | ${LOG}
 RESULT=${PIPESTATUS[0]}
 
 # Git regards any trailing white space except `\n` as an error so `\r` is
 # checked here, too
-git -c core.whitespace="trailing-space" \
-    diff --check "$(git merge-base "${BRANCH}" HEAD)" -- . "${IGNORE}" \
+git -c core.whitespace="trailing-space" -c diff.renameLimit=20000 \
+    diff --check "$(git merge-base "${BRANCH}" HEAD)" -- . "${IGNORE[@]}" \
             | ${LOG}
 
 TRAILING_RESULT=${PIPESTATUS[0]}


### PR DESCRIPTION
### Contribution description

I'll provide a "review" below that explains what went wrong for each regression.

One thing to note for future reference: it is important to run the static tests the way our GitHub workflow would and define `GITHUB_RUN_ID=5` and `CI_BASE_BRANCH`. The `5` is just arbitrary and doesn't change the output, it can be anything and is only used for temporary files.

### Testing procedure

Start with the current `master` and go to the commit *before* #22597 and run `make static-test` in the `static-test-tools` docker container (or `riotbuild` would work too).
```
buechse@skyleaf:~/RIOTstuff$ mkdir riot-upstream2
buechse@skyleaf:~/RIOTstuff$ cd riot-upstream2
buechse@skyleaf:~/RIOTstuff/riot-upstream2$ gh repo clone RIOT-OS/RIOT
Cloning into 'RIOT'...
remote: Enumerating objects: 407680, done.
remote: Counting objects: 100% (1280/1280), done.
remote: Compressing objects: 100% (759/759), done.
remote: Total 407680 (delta 943), reused 540 (delta 520), pack-reused 406400 (from 4)
Receiving objects: 100% (407680/407680), 181.35 MiB | 32.93 MiB/s, done.
Resolving deltas: 100% (281096/281096), done.
Updating files: 100% (16083/16083), done.

buechse@skyleaf:~/RIOTstuff/riot-upstream2$ cd RIOT/

buechse@skyleaf:~/RIOTstuff/riot-upstream2/RIOT$ git log --oneline -n12
1119191c03 (HEAD -> master, origin/master, origin/HEAD) Merge pull request #22583 from MrKevinWeiss/doc/release-notes-2026-07
e509b8f481 release-notes.txt: 2026.07
c6d9063d99 Merge pull request #22521 from crasbe/pr/safeinfo
17e33b3932 doc/guides: add info about echoinfo,... functions to build system guide
bb5adc84ab treewide: migrate to echoinfo, echowarn, echocolor, ...
05b1f3bc8e makefiles/color: introduce echoinfo, echo functions
e6a9b6f278 Merge pull request #22595 from mguetschow/unicoap-unittest-sort-assert-equal
6ce4bee29f tests/unicoap: run clang-format with ColumnLimit: 80
909477cdb8 tests/unicoap: correct order of exp and act in TEST_ASSERT_*
f138c79164 Merge pull request #22597 from crasbe/pr/dist_tools_shellcheck
c762dfd415 dist/tools: fix some shellcheck errors and warnings
e624236f94 Merge pull request #22596 from kfessel/p-C-maribu

buechse@skyleaf:~/RIOTstuff/riot-upstream2/RIOT$ git checkout e624236f94
Note: switching to 'e624236f94'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at e624236f94 Merge pull request #22596 from kfessel/p-C-maribu

buechse@skyleaf:~/RIOTstuff/riot-upstream2/RIOT$ time docker run --rm -e GITHUB_RUN_ID=5 -e CI_BASE_BRANCH -v $(pwd):/data/riotbuild riot/static-test-tools:latest make static-test > master.txt
```

Do the same for this PR and compare the diff (you'll have to adjust the paths):
```
buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ time docker run --rm -e GITHUB_RUN_ID=5 -e CI_BASE_BRANCH -v $(pwd):/data/riotbuild riot/static-test-tools:latest make static-test &> pr.txt

buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ diff -u --color ../../riot-upstream2/RIOT/master.txt pr.txt
```

As you can see, no new errors were introduced. The fact that only shellcheck output is shown means that the other static test outputs have not changed.

```diff
buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ diff -u --color ../../riot-upstream2/RIOT/master.txt pr.txt
--- ../../riot-upstream2/RIOT/master.txt        2026-08-20 18:54:35.499371871 +0200
+++ pr.txt      2026-08-20 18:54:54.639133367 +0200
@@ -1,10 +1,5 @@
 ./dist/tools/ci/static_tests.sh
 ::group::./dist/tools/whitespacecheck/check.sh ✓
-Command output:
-
-       warning: exhaustive rename detection was skipped due to too many files.
-       warning: you may want to set your diff.renameLimit variable to at least 13659 and retry the command.
-
 ::endgroup::
 ::group::./dist/tools/licenses/check.sh ✓
 Command output:
@@ -675,8 +670,6 @@
 ::warning file=sys/riotboot/serial.c,line=67::Uncrustify proposes the following patch:%0A%0A--- a/sys/riotboot/serial.c%0A+++ b/sys/riotboot/serial.c%0A@@ -61,7 +61,7 @@ static inline bool _boot_pin(void)%0A     /* Reverts the logic if the button has an internal or external pullup and%0A        thus, is an active-low button */%0A     if (BTN_BOOTLOADER_EXT_PULLUP || BTN_BOOTLOADER_MODE == GPIO_IN_PU ||%0A-        BTN_BOOTLOADER_MODE == GPIO_OD_PU ) {%0A+        BTN_BOOTLOADER_MODE == GPIO_OD_PU) {%0A         return !gpio_read(BTN_BOOTLOADER_PIN);%0A     }%0A     else {
 ::endgroup::
 ::group::./dist/tools/shellcheck/check.sh ✓
-::error file=dist/tools/ci/changed_files.sh,line=1::Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive. [SC2148]
-::error file=dist/tools/ci/github_annotate.sh,line=1::Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive. [SC2148]
 ::error file=dist/tools/cppcheck/check.sh,line=62::Double quote array expansions to avoid re-splitting elements. [SC2068]
 ::error file=dist/tools/genconfigheader/genconfigheader.sh,line=19::Argument mixes string and array. Use * or separate argument. [SC2145]
 ::error file=dist/tools/lpc2k_pgm/flashutil.sh,line=106::Since you double quoted this, it will not word split, and the loop will only run once. [SC2066]
@@ -712,22 +705,6 @@
 ::warning file=dist/tools/avarice/debug.sh,line=17::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/avarice/debug.sh,line=4::This default assignment may cause DoS due to globbing. Quote it. [SC2223]
 ::warning file=dist/tools/avarice/debug_srv.sh,line=4::Double quote to prevent globbing and word splitting. [SC2086]
-::warning file=dist/tools/buildsystem_sanity_check/save_all_dependencies_resolution_variables.sh,line=64::Double quote to prevent globbing and word splitting. [SC2086]
-::warning file=dist/tools/ci/changed_files.sh,line=10::This default assignment may cause DoS due to globbing. Quote it. [SC2223]
-::warning file=dist/tools/ci/changed_files.sh,line=11::This default assignment may cause DoS due to globbing. Quote it. [SC2223]
-::warning file=dist/tools/ci/changed_files.sh,line=12::This default assignment may cause DoS due to globbing. Quote it. [SC2223]
-::warning file=dist/tools/ci/changed_files.sh,line=18::Double quote to prevent globbing and word splitting. [SC2086]
-::warning file=dist/tools/ci/changed_files.sh,line=20::Double quote to prevent globbing and word splitting. [SC2086]
-::warning file=dist/tools/ci/github_annotate.sh,line=10::Use var=$(command) to assign output (or quote to assign string). [SC2209]
-::warning file=dist/tools/ci/github_annotate.sh,line=21::LOG appears unused. Verify use (or export if used externally). [SC2034]
-::warning file=dist/tools/ci/github_annotate.sh,line=7::Use var=$(command) to assign output (or quote to assign string). [SC2209]
-::warning file=dist/tools/ci/github_annotate.sh,line=81::read without -r will mangle backslashes. [SC2162]
-::warning file=dist/tools/ci/github_annotate.sh,line=93::Double quote to prevent globbing and word splitting. [SC2086]
-::warning file=dist/tools/ci/github_annotate.sh,line=99::Prefer [ p ] && [ q ] as [ p -a q ] is not well defined. [SC2166]
-::warning file=dist/tools/ci/print_toolchain_versions.sh,line=40::Declare and assign separately to avoid masking return values. [SC2155]
-::warning file=dist/tools/ci/print_toolchain_versions.sh,line=44::Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead. [SC2002]
-::warning file=dist/tools/ci/print_toolchain_versions.sh,line=45::Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead. [SC2002]
-::warning file=dist/tools/ci/static_tests.sh,line=13::Not following: ./github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
 ::warning file=dist/tools/coccinelle/check.sh,line=10::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/coccinelle/check.sh,line=10::Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
 ::warning file=dist/tools/coccinelle/check.sh,line=113::warn appears unused. Verify use (or export if used externally). [SC2034]
@@ -735,8 +712,8 @@
 ::warning file=dist/tools/coccinelle/check.sh,line=121::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/coccinelle/check.sh,line=125::This default assignment may cause DoS due to globbing. Quote it. [SC2223]
 ::warning file=dist/tools/coccinelle/check.sh,line=131::This default assignment may cause DoS due to globbing. Quote it. [SC2223]
-::warning file=dist/tools/coccinelle/check.sh,line=13::Not following: ./ci/changed_files.sh was not specified as input (see shellcheck -x). [SC1091]
-::warning file=dist/tools/coccinelle/check.sh,line=14::Not following: ./ci/github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
+::warning file=dist/tools/coccinelle/check.sh,line=13::Not following: ./ci/changed_files.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
+::warning file=dist/tools/coccinelle/check.sh,line=14::Not following: ./ci/github_annotate.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
 ::warning file=dist/tools/coccinelle/check.sh,line=19::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/coccinelle/check.sh,line=31::Prefer [ p ] && [ q ] as [ p -a q ] is not well defined. [SC2166]
 ::warning file=dist/tools/coccinelle/check.sh,line=33::Double quote to prevent globbing and word splitting. [SC2086]
@@ -759,9 +736,9 @@
 ::warning file=dist/tools/codespell/check.sh,line=21::Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
 ::warning file=dist/tools/codespell/check.sh,line=24::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/codespell/check.sh,line=24::Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
-::warning file=dist/tools/codespell/check.sh,line=27::Not following: ./ci/changed_files.sh was not specified as input (see shellcheck -x). [SC1091]
+::warning file=dist/tools/codespell/check.sh,line=27::Not following: ./ci/changed_files.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
 ::warning file=dist/tools/codespell/check.sh,line=49::Double quote to prevent globbing and word splitting. [SC2086]
-::warning file=dist/tools/codespell/check.sh,line=54::Not following: ./ci/github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
+::warning file=dist/tools/codespell/check.sh,line=54::Not following: ./ci/github_annotate.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
 ::warning file=dist/tools/codespell/check.sh,line=59::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/codespell/check.sh,line=68::read without -r will mangle backslashes. [SC2162]
 ::warning file=dist/tools/compile_test/tests/test.sh,line=34::Double quote to prevent globbing and word splitting. [SC2086]
@@ -772,8 +749,8 @@
 ::warning file=dist/tools/cppcheck/check.sh,line=11::Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
 ::warning file=dist/tools/cppcheck/check.sh,line=12::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/cppcheck/check.sh,line=12::Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
-::warning file=dist/tools/cppcheck/check.sh,line=15::Not following: ./ci/changed_files.sh was not specified as input (see shellcheck -x). [SC1091]
-::warning file=dist/tools/cppcheck/check.sh,line=16::Not following: ./ci/github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
+::warning file=dist/tools/cppcheck/check.sh,line=15::Not following: ./ci/changed_files.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
+::warning file=dist/tools/cppcheck/check.sh,line=16::Not following: ./ci/github_annotate.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
 ::warning file=dist/tools/cppcheck/check.sh,line=62::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/cppcheck/check.sh,line=63::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/cppcheck/check.sh,line=68::Double quote to prevent globbing and word splitting. [SC2086]
@@ -847,18 +824,18 @@
 ::warning file=dist/tools/externc/check.sh,line=11::Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
 ::warning file=dist/tools/externc/check.sh,line=12::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/externc/check.sh,line=12::Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
-::warning file=dist/tools/externc/check.sh,line=15::Not following: ./ci/changed_files.sh was not specified as input (see shellcheck -x). [SC1091]
-::warning file=dist/tools/externc/check.sh,line=16::Not following: ./ci/github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
+::warning file=dist/tools/externc/check.sh,line=15::Not following: ./ci/changed_files.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
+::warning file=dist/tools/externc/check.sh,line=16::Not following: ./ci/github_annotate.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
 ::warning file=dist/tools/externc/check.sh,line=28::Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead. [SC2002]
 ::warning file=dist/tools/flake8/check.sh,line=22::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/flake8/check.sh,line=22::Quote this to prevent word splitting. [SC2046]
 ::warning file=dist/tools/flake8/check.sh,line=22::Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
 ::warning file=dist/tools/flake8/check.sh,line=23::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/flake8/check.sh,line=23::Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
-::warning file=dist/tools/flake8/check.sh,line=26::Not following: ./ci/changed_files.sh was not specified as input (see shellcheck -x). [SC1091]
+::warning file=dist/tools/flake8/check.sh,line=26::Not following: ./ci/changed_files.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
 ::warning file=dist/tools/flake8/check.sh,line=49::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/flake8/check.sh,line=52::read without -r will mangle backslashes. [SC2162]
-::warning file=dist/tools/flake8/check.sh,line=9::Not following: ./../ci/github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
+::warning file=dist/tools/flake8/check.sh,line=9::Not following: ./../ci/github_annotate.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
 ::warning file=dist/tools/fuzzing/afl.sh,line=10::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/generate_c11_atomics_cpp_compat_header/generate_c11_atomics_cpp_compat_header.sh,line=108::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/generate_c11_atomics_cpp_compat_header/generate_c11_atomics_cpp_compat_header.sh,line=108::Quote parameters to tr to prevent glob expansion. [SC2060]
@@ -882,18 +859,6 @@
 ::warning file=dist/tools/generate_c11_atomics_cpp_compat_header/generate_c11_atomics_cpp_compat_header.sh,line=93::Remove surrounding $() to avoid executing output (or use eval if intentional). [SC2091]
 ::warning file=dist/tools/generate_c11_atomics_cpp_compat_header/generate_c11_atomics_cpp_compat_header.sh,line=98::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/generate_c11_atomics_cpp_compat_header/generate_c11_atomics_cpp_compat_header.sh,line=98::Remove surrounding $() to avoid executing output (or use eval if intentional). [SC2091]
-::warning file=dist/tools/headerguards/check.sh,line=105::This default assignment may cause DoS due to globbing. Quote it. [SC2223]
-::warning file=dist/tools/headerguards/check.sh,line=10::Double quote to prevent globbing and word splitting. [SC2086]
-::warning file=dist/tools/headerguards/check.sh,line=10::Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
-::warning file=dist/tools/headerguards/check.sh,line=13::Not following: ./ci/changed_files.sh was not specified as input (see shellcheck -x). [SC1091]
-::warning file=dist/tools/headerguards/check.sh,line=14::Not following: ./ci/github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
-::warning file=dist/tools/headerguards/check.sh,line=19::Double quote to prevent globbing and word splitting. [SC2086]
-::warning file=dist/tools/headerguards/check.sh,line=27::Prefer [ p ] && [ q ] as [ p -a q ] is not well defined. [SC2166]
-::warning file=dist/tools/headerguards/check.sh,line=33::Double quote to prevent globbing and word splitting. [SC2086]
-::warning file=dist/tools/headerguards/check.sh,line=97::This default assignment may cause DoS due to globbing. Quote it. [SC2223]
-::warning file=dist/tools/headerguards/check.sh,line=9::Double quote to prevent globbing and word splitting. [SC2086]
-::warning file=dist/tools/headerguards/check.sh,line=9::Quote this to prevent word splitting. [SC2046]
-::warning file=dist/tools/headerguards/check.sh,line=9::Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]
 ::warning file=dist/tools/jlink/jlink.sh,line=157::Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?. [SC2181]
 ::warning file=dist/tools/jlink/jlink.sh,line=164::Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?. [SC2181]
 ::warning file=dist/tools/jlink/jlink.sh,line=171::flash_common references arguments, but none are ever passed. [SC2120]
@@ -1021,8 +986,6 @@
 ::warning file=dist/tools/radvd/radvd.sh,line=8::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/radvd/radvd.sh,line=95::Prefer [ p ] || [ q ] as [ p -o q ] is not well defined. [SC2166]
 ::warning file=dist/tools/release-stats/release-stats.sh,line=38::In POSIX sh, echo flags are undefined. [SC3037]
-::warning file=dist/tools/shellcheck/check.sh,line=23::Not following: ./ci/changed_files.sh was not specified as input (see shellcheck -x). [SC1091]
-::warning file=dist/tools/shellcheck/check.sh,line=24::Not following: ./ci/github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
 ::warning file=dist/tools/sliptty/start_network.sh,line=100::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/sliptty/start_network.sh,line=113::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=dist/tools/sliptty/start_network.sh,line=132::Invalid flags are not handled. Add a *) case. [SC2220]
@@ -1103,10 +1066,6 @@
 ::warning file=dist/tools/vera++/check.sh,line=49::line was modified in a subshell. That change might be lost. [SC2031]
 ::warning file=dist/tools/vera++/check.sh,line=54::See if you can use ${variable//search/replace} instead. [SC2001]
 ::warning file=dist/tools/vera++/check.sh,line=58::See if you can use ${variable//search/replace} instead. [SC2001]
-::warning file=dist/tools/whitespacecheck/check.sh,line=39::Double quote to prevent globbing and word splitting. [SC2086]
-::warning file=dist/tools/whitespacecheck/check.sh,line=46::Double quote to prevent globbing and word splitting. [SC2086]
-::warning file=dist/tools/whitespacecheck/check.sh,line=55::Double quote to prevent globbing and word splitting. [SC2086]
-::warning file=dist/tools/whitespacecheck/check.sh,line=9::Not following: ./../ci/github_annotate.sh was not specified as input (see shellcheck -x). [SC1091]
 ::warning file=dist/tools/zep_dispatch/start_network.sh,line=65::Double quote to prevent globbing and word splitting. [SC2086]
 ::warning file=examples/advanced/suit_update/tests-with-config/check-config.sh,line=26::Expansions inside ${..} need to be quoted separately, otherwise they match as patterns. [SC2295]
 ::warning file=examples/advanced/suit_update/tests-with-config/check-config.sh,line=31::Expansions inside ${..} need to be quoted separately, otherwise they match as patterns. [SC2295]
```


### Issues/PRs references

Fixes the regressions introduced in #22597.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- Claude to ask questions about the errors and how to fix them

