### PR TITLE
cpu/samd5x,samd21: define RTT_MIN_OFFSET

### DIFF
--- a/boards/common/arduino-zero/include/periph_conf.h
+++ b/boards/common/arduino-zero/include/periph_conf.h
@@ -282,7 +282,6 @@ static const i2c_conf_t i2c_config[] = {
 #ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
 #endif
-#define RTT_MIN_OFFSET      (10U)
 /** @} */
 
 /**

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -295,7 +295,6 @@ static const i2c_conf_t i2c_config[] = {
 #ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
 #endif
-#define RTT_MIN_OFFSET      (10U)
 /** @} */
 
 /**

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -158,7 +158,7 @@ static const gpio_t sam0_adc_pins[1][20] = {
  * @{
  */
 #define RTT_RUNSTDBY        (1)         /* Keep RTT running in sleep states */
-
+#define RTT_MIN_OFFSET      (10U)
 #define RTT_MAX_VALUE       (0xffffffff)
 #define RTT_CLOCK_FREQUENCY (32768U)                      /* in Hz */
 #define RTT_MIN_FREQUENCY   (RTT_CLOCK_FREQUENCY / 1024U) /* in Hz */

--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -186,6 +186,7 @@ static const gpio_t sam0_adc_pins[2][16] = {
  * @name    Real time counter configuration
  * @{
  */
+#define RTT_MIN_OFFSET      (8U)
 #define RTT_MAX_VALUE       (0xffffffff)
 #define RTT_CLOCK_FREQUENCY (32768U)                      /* in Hz */
 #define RTT_MIN_FREQUENCY   (RTT_CLOCK_FREQUENCY / 1024U) /* in Hz */


### PR DESCRIPTION

<!--
-->

### Contribution description

had something fail, did some digging 
ran a test it showed that there should be a value for same5 
added that value :) 

for samd5 `RIOT/tests/periph/rtt_min> BOARD=same54-xpro make flash test` was run and showed the result
`RTT_MIN_OFFSET for same54-xpro over 1024 samples: 8`

for samd21 the value was taken from arduino-zero since its probably more cpu than board specific 

### Testing procedure

read or run the test by yourself


### Issues/PRs references

#14146
#14276
#14259
#22618
#22617 

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
