### PR TITLE
makefiles/docker: bump riotdocker version

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -5,7 +5,7 @@
 # When the docker image is updated, checks at
 # dist/tools/buildsystem_sanity_check/check.sh start complaining in CI, and
 # provide the latest values to verify and fill in.
-DOCKER_TESTED_IMAGE_REPO_DIGEST := 61c1aa5371bd0e3a8764121671555c8b54907ad8e1eddc520f4e601bbcbcd702
+DOCKER_TESTED_IMAGE_REPO_DIGEST := ed4b463606fe0653432f7c516f6bd94876ac13cc8949e4ffff39106d7c82ed0e
 
 DOCKER_PULL_IDENTIFIER := docker.io/riot/riotbuild@sha256:$(DOCKER_TESTED_IMAGE_REPO_DIGEST)
 export DOCKER_IMAGE ?= $(DOCKER_PULL_IDENTIFIER)


### PR DESCRIPTION
### Contribution description
Just the usual image hash bump.

### Testing procedure
The buildsystem sanity check should pass again.

### Issues/PRs references
Necessary after merging https://github.com/RIOT-OS/riotdocker/pull/284, https://github.com/RIOT-OS/riotdocker/pull/287 and https://github.com/RIOT-OS/riotdocker/pull/280, https://github.com/RIOT-OS/riotdocker/pull/284, https://github.com/RIOT-OS/riotdocker/pull/285.

### Declaration of AI-Tools / LLMs usage:
AI-Tools / LLMs that were used are:
- none