### PR TITLE
boards/nucleo: Select lpuart when using stdio_slipdev

### DIFF
--- a/boards/i-nucleo-lrwan1/Makefile.dep
+++ b/boards/i-nucleo-lrwan1/Makefile.dep
@@ -1,5 +1,9 @@
-ifneq (,$(filter stdio_uart,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_lpuart
+# The ST-Link is connected to the LPUART, so we require periph_lpuart too
+# when using the UART
+ifneq (,$(filter periph_uart,$(USEMODULE)))
+  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
+    FEATURES_REQUIRED += periph_lpuart
+  endif
 endif
 ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += sx1272

--- a/boards/i-nucleo-lrwan1/Makefile.dep
+++ b/boards/i-nucleo-lrwan1/Makefile.dep
@@ -1,9 +1,7 @@
 # The ST-Link is connected to the LPUART, so we require periph_lpuart too
 # when using the UART
 ifneq (,$(filter periph_uart,$(USEMODULE)))
-  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_lpuart
-  endif
+  FEATURES_REQUIRED += periph_lpuart
 endif
 ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += sx1272

--- a/boards/nucleo-g431rb/Makefile.dep
+++ b/boards/nucleo-g431rb/Makefile.dep
@@ -1,9 +1,7 @@
 # The ST-Link is connected to the LPUART, so we require periph_lpuart too
 # when using the UART
 ifneq (,$(filter periph_uart,$(USEMODULE)))
-  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_lpuart
-  endif
+  FEATURES_REQUIRED += periph_lpuart
 endif
 
 include $(RIOTBOARD)/common/nucleo64/Makefile.dep

--- a/boards/nucleo-g431rb/Makefile.dep
+++ b/boards/nucleo-g431rb/Makefile.dep
@@ -1,5 +1,9 @@
-ifneq (,$(filter stdio_uart,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_lpuart
+# The ST-Link is connected to the LPUART, so we require periph_lpuart too
+# when using the UART
+ifneq (,$(filter periph_uart,$(USEMODULE)))
+  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
+    FEATURES_REQUIRED += periph_lpuart
+  endif
 endif
 
 include $(RIOTBOARD)/common/nucleo64/Makefile.dep

--- a/boards/nucleo-g474re/Makefile.dep
+++ b/boards/nucleo-g474re/Makefile.dep
@@ -1,9 +1,7 @@
 # The ST-Link is connected to the LPUART, so we require periph_lpuart too
 # when using the UART
 ifneq (,$(filter periph_uart,$(USEMODULE)))
-  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_lpuart
-  endif
+  FEATURES_REQUIRED += periph_lpuart
 endif
 
 include $(RIOTBOARD)/common/nucleo64/Makefile.dep

--- a/boards/nucleo-g474re/Makefile.dep
+++ b/boards/nucleo-g474re/Makefile.dep
@@ -1,5 +1,9 @@
-ifneq (,$(filter stdio_uart,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_lpuart
+# The ST-Link is connected to the LPUART, so we require periph_lpuart too
+# when using the UART
+ifneq (,$(filter periph_uart,$(USEMODULE)))
+  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
+    FEATURES_REQUIRED += periph_lpuart
+  endif
 endif
 
 include $(RIOTBOARD)/common/nucleo64/Makefile.dep

--- a/boards/nucleo-g491re/Makefile.dep
+++ b/boards/nucleo-g491re/Makefile.dep
@@ -1,9 +1,7 @@
 # The ST-Link is connected to the LPUART, so we require periph_lpuart too
 # when using the UART
 ifneq (,$(filter periph_uart,$(USEMODULE)))
-  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_lpuart
-  endif
+  FEATURES_REQUIRED += periph_lpuart
 endif
 
 include $(RIOTBOARD)/common/nucleo64/Makefile.dep

--- a/boards/nucleo-g491re/Makefile.dep
+++ b/boards/nucleo-g491re/Makefile.dep
@@ -1,5 +1,9 @@
-ifneq (,$(filter stdio_uart,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_lpuart
+# The ST-Link is connected to the LPUART, so we require periph_lpuart too
+# when using the UART
+ifneq (,$(filter periph_uart,$(USEMODULE)))
+  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
+    FEATURES_REQUIRED += periph_lpuart
+  endif
 endif
 
 include $(RIOTBOARD)/common/nucleo64/Makefile.dep

--- a/boards/nucleo-l433rc/Makefile.dep
+++ b/boards/nucleo-l433rc/Makefile.dep
@@ -1,9 +1,7 @@
 # The ST-Link is connected to the LPUART, so we require periph_lpuart too
 # when using the UART
 ifneq (,$(filter periph_uart,$(USEMODULE)))
-  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_lpuart
-  endif
+  FEATURES_REQUIRED += periph_lpuart
 endif
 
 include $(RIOTBOARD)/common/nucleo64/Makefile.dep

--- a/boards/nucleo-l433rc/Makefile.dep
+++ b/boards/nucleo-l433rc/Makefile.dep
@@ -1,5 +1,9 @@
-ifneq (,$(filter stdio_uart,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_lpuart
+# The ST-Link is connected to the LPUART, so we require periph_lpuart too
+# when using the UART
+ifneq (,$(filter periph_uart,$(USEMODULE)))
+  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
+    FEATURES_REQUIRED += periph_lpuart
+  endif
 endif
 
 include $(RIOTBOARD)/common/nucleo64/Makefile.dep

--- a/boards/nucleo-l496zg/Makefile.dep
+++ b/boards/nucleo-l496zg/Makefile.dep
@@ -1,8 +1,6 @@
 # The ST-Link is connected to the LPUART, so we require periph_lpuart too
 # when using the UART
 ifneq (,$(filter periph_uart,$(USEMODULE)))
-  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_lpuart
-  endif
+  FEATURES_REQUIRED += periph_lpuart
 endif
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-l496zg/Makefile.dep
+++ b/boards/nucleo-l496zg/Makefile.dep
@@ -1,4 +1,8 @@
-ifneq (,$(filter stdio_uart,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_lpuart
+# The ST-Link is connected to the LPUART, so we require periph_lpuart too
+# when using the UART
+ifneq (,$(filter periph_uart,$(USEMODULE)))
+  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
+    FEATURES_REQUIRED += periph_lpuart
+  endif
 endif
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-l4r5zi/Makefile.dep
+++ b/boards/nucleo-l4r5zi/Makefile.dep
@@ -1,8 +1,6 @@
 # The ST-Link is connected to the LPUART, so we require periph_lpuart too
 # when using the UART
 ifneq (,$(filter periph_uart,$(USEMODULE)))
-  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_lpuart
-  endif
+  FEATURES_REQUIRED += periph_lpuart
 endif
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-l4r5zi/Makefile.dep
+++ b/boards/nucleo-l4r5zi/Makefile.dep
@@ -1,4 +1,8 @@
-ifneq (,$(filter stdio_uart,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_lpuart
+# The ST-Link is connected to the LPUART, so we require periph_lpuart too
+# when using the UART
+ifneq (,$(filter periph_uart,$(USEMODULE)))
+  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
+    FEATURES_REQUIRED += periph_lpuart
+  endif
 endif
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-l552ze-q/Makefile.dep
+++ b/boards/nucleo-l552ze-q/Makefile.dep
@@ -1,8 +1,6 @@
 # The ST-Link is connected to the LPUART, so we require periph_lpuart too
 # when using the UART
 ifneq (,$(filter periph_uart,$(USEMODULE)))
-  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_lpuart
-  endif
+  FEATURES_REQUIRED += periph_lpuart
 endif
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-l552ze-q/Makefile.dep
+++ b/boards/nucleo-l552ze-q/Makefile.dep
@@ -1,4 +1,8 @@
-ifneq (,$(filter stdio_uart,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_lpuart
+# The ST-Link is connected to the LPUART, so we require periph_lpuart too
+# when using the UART
+ifneq (,$(filter periph_uart,$(USEMODULE)))
+  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
+    FEATURES_REQUIRED += periph_lpuart
+  endif
 endif
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-wl55jc/Makefile.dep
+++ b/boards/nucleo-wl55jc/Makefile.dep
@@ -1,9 +1,7 @@
 # The ST-Link is connected to the LPUART, so we require periph_lpuart too
 # when using the UART
 ifneq (,$(filter periph_uart,$(USEMODULE)))
-  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_lpuart
-  endif
+  FEATURES_REQUIRED += periph_lpuart
 endif
 ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += sx126x_stm32wl

--- a/boards/nucleo-wl55jc/Makefile.dep
+++ b/boards/nucleo-wl55jc/Makefile.dep
@@ -1,5 +1,9 @@
-ifneq (,$(filter stdio_uart,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_lpuart
+# The ST-Link is connected to the LPUART, so we require periph_lpuart too
+# when using the UART
+ifneq (,$(filter periph_uart,$(USEMODULE)))
+  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
+    FEATURES_REQUIRED += periph_lpuart
+  endif
 endif
 ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += sx126x_stm32wl

--- a/boards/p-nucleo-wb55/Makefile.dep
+++ b/boards/p-nucleo-wb55/Makefile.dep
@@ -1,8 +1,6 @@
 # The ST-Link is connected to the LPUART, so we require periph_lpuart too
 # when using the UART
 ifneq (,$(filter periph_uart,$(USEMODULE)))
-  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_lpuart
-  endif
+  FEATURES_REQUIRED += periph_lpuart
 endif
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/p-nucleo-wb55/Makefile.dep
+++ b/boards/p-nucleo-wb55/Makefile.dep
@@ -1,4 +1,8 @@
-ifneq (,$(filter stdio_uart,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_lpuart
+# The ST-Link is connected to the LPUART, so we require periph_lpuart too
+# when using the UART
+ifneq (,$(filter periph_uart,$(USEMODULE)))
+  ifeq (,$(filter periph_lpuart,$(USEMODULE)))
+    FEATURES_REQUIRED += periph_lpuart
+  endif
 endif
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/cpu/stm32/stm32_riotboot.mk
+++ b/cpu/stm32/stm32_riotboot.mk
@@ -48,3 +48,8 @@ else ifeq (wb,$(CPU_FAM))
     RIOTBOOT_LEN ?= 0x2000
   endif
 endif
+
+# Set it to at least 2KB if lpuart is used
+ifneq (,$(filter periph_lpuart,$(USEMODULE)))
+  RIOTBOOT_LEN ?= 0x2000
+endif

--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -77,7 +77,7 @@ ifneq (,$(filter stdio_uart_rx,$(USEMODULE)))
   USEMODULE += stdio_available
 endif
 
-ifneq (,$(filter stdio_uart,$(USEMODULE)))
+ifneq (,$(filter stdio_uart stdio_slipdev,$(USEMODULE)))
   FEATURES_REQUIRED_ANY += periph_uart|periph_lpuart
 endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hello 🦫

this fixes an issue where STDOUT wouldn't work on certain nucleos.

### Testing procedure

Running this on master shows that `periph_init_lpuart` and `periph_lpuart` are missing. They are included on this PR.
`USEMODULE=stdio_slipdev BOARD=nucleo-wl55jc make info-modules`


### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
