### PR TITLE
makefiles: rebuild after BUILD_DIR changes

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -117,6 +117,21 @@ ASSMOBJ     := $(ASSMSRC:%.S=$(BINDIR)/$(MODULE)/%.o)
 OBJ := $(OBJC) $(OBJCXX) $(ASMOBJ) $(ASSMOBJ) $(GENOBJC)
 DEP := $(OBJC:.o=.d) $(OBJCXX:.o=.d) $(ASSMOBJ:.o=.d)
 
+# Dependency files contain absolute paths. If BUILD_DIR changed since the
+# last successful link, the existing dependency files may refer to files in
+# the old build directory. Ignore them until they are regenerated.
+_BUILD_DIR_STAMP := $(BINDIR)/.build_dir
+_BUILD_DIR_STAMP_MATCH := $(shell \
+    test -f "$(_BUILD_DIR_STAMP)" && \
+    grep -Fqx "$(BUILD_DIR)" "$(_BUILD_DIR_STAMP)" && \
+    echo 1)
+ifneq (1,$(_BUILD_DIR_STAMP_MATCH))
+  DEP :=
+  .PHONY: _BUILD_DIR_CHANGED
+  _BUILD_DIR_CHANGED:
+  $(OBJ): _BUILD_DIR_CHANGED
+endif
+
 SRC_ALL := $(SRC) $(SRCXX) $(ASMSRC) $(ASSMSRC)
 SUBDIRS_IN_DIRS := $(filter $(DIRS), $(abspath $(sort $(dir $(SRC_ALL)))))
 ifneq (,$(SUBDIRS_IN_DIRS))

--- a/Makefile.include
+++ b/Makefile.include
@@ -740,6 +740,8 @@ endif # RIOTNOLINK
 
 $(ELFFILE): $(BASELIBS) $(ARCHIVES) $(LD_SCRIPTS)
 	$(Q)$(_LINK) -o $@
+	$(Q)mkdir -p "$(BINDIR)"
+	$(Q)printf '%s\n' "$(BUILD_DIR)" > "$(BINDIR)/.build_dir"
 
 .PHONY: $(APPLICATION_MODULE).module
 
@@ -774,6 +776,23 @@ print-size: $(ELFFILE)
 
 endif # BUILD_IN_DOCKER
 
+# Keep track of the BUILD_DIR used for the dependency files. This is done only
+# after all link prerequisites completed successfully. Invalidate the stamp
+# before a build only when it does not match the current BUILD_DIR, so an
+# unchanged BUILD_DIR can reuse valid dependency files incrementally.
+.PHONY: ..build-dir-prepare
+..build-dir-prepare:
+	$(Q)if ! test -f "$(BINDIR)/.build_dir" || \
+	    ! grep -Fqx "$(BUILD_DIR)" "$(BINDIR)/.build_dir"; then \
+	    rm -f "$(BINDIR)/.build_dir"; \
+	fi
+
+ifneq (1,$(BUILD_IN_DOCKER))
+link:
+	$(Q)mkdir -p "$(BINDIR)"
+	$(Q)printf '%s\n' "$(BUILD_DIR)" > "$(BINDIR)/.build_dir"
+endif # BUILD_IN_DOCKER
+
 # Check given command is available in the path
 #   check_cmd 'command' 'description'
 define check_cmd
@@ -802,8 +821,15 @@ endif
 	@$(call sh_echogreen,("Building application \"$(APPLICATION)\" for \"$(BOARD)\" with CPU \"$(CPU)\"."))
 	@$(call sh_echoinfo)
 
-# The `clean` needs to be serialized before everything else.
-all $(BASELIBS) $(ARCHIVES) $(BUILDDEPS) $(GENSRC) ..in-docker-container: | $(CLEAN)
+# The `clean` and build directory stamp preparation need to be serialized
+# before everything else.
+all link $(BUILD_FILES) $(BASELIBS) $(ARCHIVES) $(BUILDDEPS) $(GENSRC) \
+    ..in-docker-container pkg-build: | $(CLEAN)
+
+ifneq (1,$(BUILD_IN_DOCKER))
+all link $(BUILD_FILES) $(BASELIBS) $(ARCHIVES) $(BUILDDEPS) $(GENSRC) \
+    ..in-docker-container pkg-build: | ..build-dir-prepare
+endif # BUILD_IN_DOCKER
 
 .PHONY: pkg-prepare pkg-build
 pkg-prepare:


### PR DESCRIPTION
### Contribution description

When BUILD_DIR changes, generated .d files can retain absolute paths into the previous build directory. This change:

- records the BUILD_DIR used by the last successful link in the application build directory;
- ignores stale dependency files and forces object regeneration when the stamp does not match;
- invalidates the stamp before a changed build and only records it after a successful link;
- supports direct ELF targets and keeps Docker host-side paths from overwriting the container stamp.

### Testing procedure

- native64 tests/pkg/qcbor with custom BUILD_DIR, including switching between two build directories;
- a same-BUILD_DIR incremental rebuild;
- a forced compiler failure after partial .d generation, deleting the failed build directory, then switching back;
- direct make elffile;
- timeout 30 tests/pkg/qcbor/bin/native64/tests_qcbor.elf — OK (2 tests);
- examples/basic/hello-world with BOARD=native64 — build succeeds;
- ENABLE_DOCKER_PINNING_TEST=0 bash dist/tools/buildsystem_sanity_check/check.sh — succeeds;
- BUILD_IN_DOCKER=1 BOARD=native64 make -n -C tests/pkg/qcbor — succeeds; the outer Docker invocation does not prepare or overwrite the stamp.

Full Docker execution was not available in the local environment; CI should cover it.

### Issues/PRs references

Fixes #22531.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- ChatGPT (Codex) in agent mode for issue analysis, implementation, test execution, independent review, and PR preparation.
