### PR TITLE
boards/common/silabs: make PB1 conditional

### DIFF
--- a/boards/common/silabs/board_common.c
+++ b/boards/common/silabs/board_common.c
@@ -41,7 +41,9 @@ void board_common_init(void)
 
     /* initialize the push buttons */
     gpio_init(PB0_PIN, GPIO_IN);
+#ifdef PB1_PIN
     gpio_init(PB1_PIN, GPIO_IN);
+#endif
 
     /* enable power and interrupt controller (for sensors) */
 #ifdef MODULE_SILABS_PIC

--- a/boards/common/silabs/include/arduino_iomap.h
+++ b/boards/common/silabs/include/arduino_iomap.h
@@ -28,9 +28,13 @@ extern "C" {
 #define ARDUINO_PIN_0       LED0_PIN
 #define ARDUINO_PIN_1       LED1_PIN
 #define ARDUINO_PIN_2       PB0_PIN
-#define ARDUINO_PIN_3       PB1_PIN
 
-#define ARDUINO_PIN_LAST    3
+#ifdef PB1_PIN
+#  define ARDUINO_PIN_3     PB1_PIN
+#  define ARDUINO_PIN_LAST  3
+#else
+#  define ARDUINO_PIN_LAST  2
+#endif
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

I am working on adding support for new Silicon Labs boards. The one I am working on does not have a secondary button (PB1).

In order to reduce the size of that PR, I contribute this separately.


### Testing procedure

It is only pre-processor logic. Existing Silicon Labs-based board should still compile.


### Issues/PRs references

None, yet.


### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- GitHub Copilot autocomplete in IDE.