### PR TITLE
cpu/efm32: add coretemp for series 2

### DIFF
--- a/boards/xg23-pk6068a/Makefile.dep
+++ b/boards/xg23-pk6068a/Makefile.dep
@@ -1,4 +1,5 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += efm32_coretemp
   USEMODULE += saul_gpio
 endif
 

--- a/boards/xg23-pk6068a/Makefile.features
+++ b/boards/xg23-pk6068a/Makefile.features
@@ -8,3 +8,6 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += efm32_coretemp

--- a/cpu/efm32/Makefile.dep
+++ b/cpu/efm32/Makefile.dep
@@ -2,7 +2,11 @@
 USEPKG += gecko_sdk
 
 ifneq (,$(filter efm32_coretemp,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_adc
+  # Series 0 and 1 have the internal temperature sensor wired to an ADC line,
+  # whereas Series 2 has a dedicated register to read the temperature.
+  ifneq (,$(filter 0 1,$(EFM32_SERIES)))
+    FEATURES_REQUIRED += periph_adc
+  endif
 endif
 
 # CMSIS-DSP is needed for arm_math.h on Cortex-M0+ architectures

--- a/cpu/efm32/drivers/coretemp/Makefile
+++ b/cpu/efm32/drivers/coretemp/Makefile
@@ -1,3 +1,14 @@
 MODULE = efm32_coretemp
 
+include $(RIOTCPU)/efm32/efm32-info.mk
+
+SRC = coretemp_saul.c
+
+# Select the correct implementation for the internal temperature sensor
+ifeq (2,$(EFM32_SERIES))
+  SRC += coretemp_series2.c
+else
+  SRC += coretemp_series01.c
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/cpu/efm32/drivers/coretemp/coretemp_series01.c
+++ b/cpu/efm32/drivers/coretemp/coretemp_series01.c
@@ -26,7 +26,7 @@
 
 int16_t coretemp_read(void)
 {
-    /* initialize factory calibration values */
+    /* read factory calibration values */
     int32_t cal_temp = ((DEVINFO->CAL & _DEVINFO_CAL_TEMP_MASK) >>
                          _DEVINFO_CAL_TEMP_SHIFT);
 #if defined(_SILICON_LABS_32B_SERIES_0)

--- a/cpu/efm32/drivers/coretemp/coretemp_series2.c
+++ b/cpu/efm32/drivers/coretemp/coretemp_series2.c
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     cpu_efm32_drivers_coretemp
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the EFM32 internal temperature sensor for
+ *              Series 2 devices
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include "coretemp.h"
+
+#include "em_device.h"
+#include "em_emu.h"
+
+int16_t coretemp_read(void)
+{
+    /* read factory calibration values */
+    int32_t cal_temp = ((DEVINFO->CALTEMP & _DEVINFO_CALTEMP_TEMP_MASK) >>
+                        _DEVINFO_CALTEMP_TEMP_SHIFT);
+    int32_t cal_value = ((DEVINFO->EMUTEMP & _DEVINFO_EMUTEMP_EMUTEMPROOM_MASK) >>
+                         _DEVINFO_EMUTEMP_EMUTEMPROOM_SHIFT);
+
+    /* no factory calibration values */
+    if ((cal_temp == 0xFF) || (cal_value == 0x1FF)) {
+        return -10000;
+    }
+
+    /* read the temperature sensor value in centi-Kelvin (the register has a
+     * resolution of 0.25 K) */
+    int32_t value = ((EMU->TEMP & (_EMU_TEMP_TEMP_MASK | _EMU_TEMP_TEMPLSB_MASK))
+                     >> _EMU_TEMP_TEMPLSB_SHIFT) * 25;
+
+    /* the raw sensor value has a mean error of a few degrees Celsius, which
+     * is corrected using the calibration value (value and cal_value are
+     * effectively in Kelvin, which cancels out the Kelvin offset of 273.15
+     * after subtracting them) */
+    return (int16_t)(value + ((cal_temp - cal_value) * 100));
+}
+
+int coretemp_init(void)
+{
+    /* the first temperature measurement is started automatically after reset,
+     * so wait for it to complete before the sensor can be read */
+    while (!EMU_TemperatureReady()) {}
+
+    return 0;
+}

--- a/cpu/efm32/include/drivers/coretemp.h
+++ b/cpu/efm32/include/drivers/coretemp.h
@@ -11,14 +11,21 @@
  * @ingroup     drivers_saul
  * @brief       Driver for the EFM32 internal temperature sensor
  *
- * All EFM32 chips have an internal ADC input channel that reads the internal
- * temperature sensor. This EFM32-specific driver provides an interface for
- * reading this value, compensated using factory-calibrated values.
+ * All EFM32 chips have an internal temperature sensor. This EFM32-specific
+ * driver provides an interface for reading this value, compensated using
+ * factory-calibrated values.
  *
- * The board must define `CORETEMP_ADC` to point to the ADC line that connects
- * to the right ADC input channel.
+ * On Series 0 and Series 1 devices, the sensor is read through an ADC input
+ * channel. The board must define `CORETEMP_ADC` to point to the ADC line
+ * that connects to the right ADC input channel.
+ *
+ * On Series 2 devices, the sensor is read directly through the EMU
+ * peripheral.
  *
  * This driver provides @ref drivers_saul capabilities.
+ *
+ * @note    The sensor measures the die temperature, which is higher than the
+ *          ambient temperature when the device is awake and dissipates power.
  *
  * @{
  *
@@ -38,21 +45,25 @@ extern "C" {
 /**
  * @brief   Initialize the sensor.
  *
- * @return                  0 on successful initialization
- * @return                  -EIO on ADC initialization error
+ * On Series 0 and Series 1 devices, this driver assumes that `CORETEMP_ADC`
+ * is defined and points to the ADC input channel that is connected to the
+ * internal temperature sensor. Series 2 devices require no configuration.
  *
- * This driver assumes that the `CORETEMP_ADC` is defined and points to the ADC
- * input channel that is connected to the internal temperature sensor.
+ * @retval      0       successful initialization
+ * @retval      -EIO    Initialization error (Series 0/1 only)
  */
 int coretemp_init(void);
 
 /**
  * @brief   Read the current temperature from the sensor.
  *
- * @return                  current temperature in centi-degrees Celsius
- *                          (times 100)
+ * The temperature readings are compensated using the factory-calibration
+ * values. On Series 0 and Series 1 devices, the sensor value is read via the
+ * ADC. On Series 2 devices, the sensor value is read from the EMU peripheral.
  *
- * Temperature readings are compensated using the factory-calibration values.
+ * @retval      -10000  Invalid reading (missing factory calibration data)
+ *
+ * @return      current temperature in centi-degrees Celsius (times 100)
  */
 int16_t coretemp_read(void);
 


### PR DESCRIPTION
### Contribution description

This PR adds support for Series 2 core temperature.

### Testing procedure

I added support for the xG23-PK6068A board (which is Series 2), but I don't own this one. Given that the temperature is directly read from a system register, I feel confident it will work the same (Series 0/1 used ADC).

I did test this on this on another Series 2 board that I will contribute soon. This helps the other PR to be smaller.

<img width="1962" height="1206" alt="Scherm­afbeelding 2026-08-22 om 15 50 50" src="https://github.com/user-attachments/assets/a314c605-4220-4f3c-a995-c6404a066d82" />

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- Claude Sonnet 5 to get me started with the implementation and documentation