### PR TITLE
sys/[o-z]*: replace license headers with SPDX

### DIFF
--- a/sys/od/od.c
+++ b/sys/od/od.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Martine Lenders <mlenders@inf.fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Martine Lenders <mlenders@inf.fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/oneway-malloc/include/malloc.h
+++ b/sys/oneway-malloc/include/malloc.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/oneway-malloc/oneway-malloc.c
+++ b/sys/oneway-malloc/oneway-malloc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/phydat/phydat.c
+++ b/sys/phydat/phydat.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Eistec AB
- *               2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Eistec AB
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/phydat/phydat_json.c
+++ b/sys/phydat/phydat_json.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/phydat/phydat_str.c
+++ b/sys/phydat/phydat_str.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/phydat/phydat_unix.c
+++ b/sys/phydat/phydat_unix.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Silke Hofstra
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Silke Hofstra
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include <stdint.h>

--- a/sys/picolibc_syscalls_default/syscalls.c
+++ b/sys/picolibc_syscalls_default/syscalls.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/pipe/pipe.c
+++ b/sys/pipe/pipe.c
@@ -1,19 +1,6 @@
 /*
- * Copyright (C) 2014  René Kijewski  <rene.kijewski@fu-berlin.de>
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * SPDX-FileCopyrightText: 2014 René Kijewski  <rene.kijewski@fu-berlin.de>
+ * SPDX-License-Identifier: NONE
  */
 
 /**

--- a/sys/pipe/pipe_dynamic.c
+++ b/sys/pipe/pipe_dynamic.c
@@ -1,19 +1,6 @@
 /*
- * Copyright (C) 2014  René Kijewski  <rene.kijewski@fu-berlin.de>
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * SPDX-FileCopyrightText: 2014 René Kijewski  <rene.kijewski@fu-berlin.de>
+ * SPDX-License-Identifier: NONE
  */
 
 /**

--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/posix/include/arpa/inet.h
+++ b/sys/posix/include/arpa/inet.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013-15 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 -15 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/include/fcntl.h
+++ b/sys/posix/include/fcntl.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/include/netinet/in.h
+++ b/sys/posix/include/netinet/in.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013-15 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 -15 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/include/semaphore.h
+++ b/sys/posix/include/semaphore.h
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 TriaGnoSys GmbH
- *               2013 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 TriaGnoSys GmbH
+ * SPDX-FileCopyrightText: 2013 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/include/sys/bytes.h
+++ b/sys/posix/include/sys/bytes.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/include/sys/select.h
+++ b/sys/posix/include/sys/select.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/include/sys/socket.h
+++ b/sys/posix/include/sys/socket.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013-15 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 -15 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/include/sys/statvfs.h
+++ b/sys/posix/include/sys/statvfs.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/inet/inet.c
+++ b/sys/posix/inet/inet.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013-15 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 -15 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include <arpa/inet.h>

--- a/sys/posix/pthread/include/pthread.h
+++ b/sys/posix/pthread/include/pthread.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/pthread/include/pthread_barrier.h
+++ b/sys/posix/pthread/include/pthread_barrier.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/pthread/include/pthread_cancellation.h
+++ b/sys/posix/pthread/include/pthread_cancellation.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 René Kijewski <rene.kijewski@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 René Kijewski <rene.kijewski@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/pthread/include/pthread_cleanup.h
+++ b/sys/posix/pthread/include/pthread_cleanup.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 René Kijewski <rene.kijewski@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 René Kijewski <rene.kijewski@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/pthread/include/pthread_cond.h
+++ b/sys/posix/pthread/include/pthread_cond.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Hamburg University of Applied Sciences (HAW)
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Hamburg University of Applied Sciences (HAW)
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/pthread/include/pthread_mutex.h
+++ b/sys/posix/pthread/include/pthread_mutex.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/pthread/include/pthread_mutex_attr.h
+++ b/sys/posix/pthread/include/pthread_mutex_attr.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/pthread/include/pthread_once.h
+++ b/sys/posix/pthread/include/pthread_once.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 René Kijewski <rene.kijewski@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 René Kijewski <rene.kijewski@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/pthread/include/pthread_rwlock.h
+++ b/sys/posix/pthread/include/pthread_rwlock.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 René Kijewski <rene.kijewski@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 René Kijewski <rene.kijewski@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/pthread/include/pthread_rwlock_attr.h
+++ b/sys/posix/pthread/include/pthread_rwlock_attr.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/pthread/include/pthread_scheduling.h
+++ b/sys/posix/pthread/include/pthread_scheduling.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 René Kijewski <rene.kijewski@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 René Kijewski <rene.kijewski@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/pthread/include/pthread_spin.h
+++ b/sys/posix/pthread/include/pthread_spin.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/pthread/include/pthread_threading.h
+++ b/sys/posix/pthread/include/pthread_threading.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 René Kijewski <rene.kijewski@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 René Kijewski <rene.kijewski@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/pthread/include/pthread_threading_attr.h
+++ b/sys/posix/pthread/include/pthread_threading_attr.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 René Kijewski <rene.kijewski@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 René Kijewski <rene.kijewski@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/pthread/include/pthread_tls.h
+++ b/sys/posix/pthread/include/pthread_tls.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Hamburg University of Applied Sciences (HAW)
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Hamburg University of Applied Sciences (HAW)
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/posix/pthread/pthread.c
+++ b/sys/posix/pthread/pthread.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/posix/pthread/pthread_attr.c
+++ b/sys/posix/pthread/pthread_attr.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/posix/pthread/pthread_barrier.c
+++ b/sys/posix/pthread/pthread_barrier.c
@@ -1,11 +1,6 @@
 /*
- * POSIX compatible implementation of barriers.
- *
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/posix/pthread/pthread_barrierattr.c
+++ b/sys/posix/pthread/pthread_barrierattr.c
@@ -1,11 +1,6 @@
 /*
- * POSIX compatible implementation of barriers.
- *
- * Copyright (C) 2014 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/posix/pthread/pthread_cond.c
+++ b/sys/posix/pthread/pthread_cond.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Hamburg University of Applied Sciences (HAW)
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Hamburg University of Applied Sciences (HAW)
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/posix/pthread/pthread_mutex.c
+++ b/sys/posix/pthread/pthread_mutex.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/posix/pthread/pthread_mutex_attr.c
+++ b/sys/posix/pthread/pthread_mutex_attr.c
@@ -1,19 +1,6 @@
 /*
- * Copyright (C) 2014 René Kijewski <rene.kijewski@fu-berlin.de>
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * SPDX-FileCopyrightText: 2014 René Kijewski <rene.kijewski@fu-berlin.de>
+ * SPDX-License-Identifier: NONE
  */
 
 /**

--- a/sys/posix/pthread/pthread_once.c
+++ b/sys/posix/pthread/pthread_once.c
@@ -1,11 +1,6 @@
 /*
- * POSIX implementation of threading.
- *
- * Copyright (C) 2013 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/posix/pthread/pthread_rwlock.c
+++ b/sys/posix/pthread/pthread_rwlock.c
@@ -1,19 +1,6 @@
 /*
- * Copyright (C) 2014  René Kijewski  <rene.kijewski@fu-berlin.de>
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * SPDX-FileCopyrightText: 2014 René Kijewski  <rene.kijewski@fu-berlin.de>
+ * SPDX-License-Identifier: NONE
  */
 
 /**

--- a/sys/posix/pthread/pthread_rwlock_attr.c
+++ b/sys/posix/pthread/pthread_rwlock_attr.c
@@ -1,19 +1,6 @@
 /*
- * Copyright (C) 2014  René Kijewski  <rene.kijewski@fu-berlin.de>
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * SPDX-FileCopyrightText: 2014 René Kijewski  <rene.kijewski@fu-berlin.de>
+ * SPDX-License-Identifier: NONE
  */
 
 /**

--- a/sys/posix/pthread/pthread_spin.c
+++ b/sys/posix/pthread/pthread_spin.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/posix/pthread/pthread_tls.c
+++ b/sys/posix/pthread/pthread_tls.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014 Hamburg University of Applied Sciences (HAW)
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Hamburg University of Applied Sciences (HAW)
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/posix/select/posix_select.c
+++ b/sys/posix/select/posix_select.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/posix/semaphore/posix_semaphore.c
+++ b/sys/posix/semaphore/posix_semaphore.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2017 TriaGnoSys GmbH
- *               2013 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 TriaGnoSys GmbH
+ * SPDX-FileCopyrightText: 2013 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/posix/sleep/posix_sleep.c
+++ b/sys/posix/sleep/posix_sleep.c
@@ -1,9 +1,6 @@
-/**
- * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+/*
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/posix/sockets/posix_sockets.c
+++ b/sys/posix/sockets/posix_sockets.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- * Copyright (C) 2015 INRIA
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 INRIA
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/progress_bar/Kconfig
+++ b/sys/progress_bar/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "progress bar module"
     depends on USEMODULE_PROGRESS_BAR

--- a/sys/progress_bar/progress_bar.c
+++ b/sys/progress_bar/progress_bar.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -1,21 +1,6 @@
-/**
- * Print thread information.
- *
- * Copyright (C) 2013, INRIA.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
- * @ingroup sys_ps
- * @{
- * @file
- * @brief   UNIX like ps command
- * @author  Kaspar Schleiser <kaspar@schleiser.de>
- *
- * @note    The entry 'runtime_usec' in 'MODULE_SCHEDSTATISTICS' is limited
- *          to 2**32 microseconds. So the entry gets reset after ~1.2 hours.
- * @}
+/*
+ * SPDX-FileCopyrightText: 2013 , INRIA.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include <stdio.h>

--- a/sys/psa_crypto/Kconfig
+++ b/sys/psa_crypto/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_PSA_CRYPTO
 

--- a/sys/psa_crypto/Kconfig.keys
+++ b/sys/psa_crypto/Kconfig.keys
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "PSA Key Management Configuration"
 

--- a/sys/psa_crypto/include/psa_aead.h
+++ b/sys/psa_crypto/include/psa_aead.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2025 TU Dresden
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2025 TU Dresden
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/psa_crypto/include/psa_ciphers.h
+++ b/sys/psa_crypto/include/psa_ciphers.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/psa_crypto/include/psa_crypto_algorithm_dispatch.h
+++ b/sys/psa_crypto/include/psa_crypto_algorithm_dispatch.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/psa_crypto/include/psa_crypto_cbor_encoder.h
+++ b/sys/psa_crypto/include/psa_crypto_cbor_encoder.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/psa_crypto/include/psa_crypto_location_dispatch.h
+++ b/sys/psa_crypto/include/psa_crypto_location_dispatch.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/psa_crypto/include/psa_crypto_operation_encoder.h
+++ b/sys/psa_crypto/include/psa_crypto_operation_encoder.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/psa_crypto/include/psa_crypto_persistent_storage.h
+++ b/sys/psa_crypto/include/psa_crypto_persistent_storage.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/psa_crypto/include/psa_crypto_se_management.h
+++ b/sys/psa_crypto/include/psa_crypto_se_management.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/psa_crypto/include/psa_crypto_slot_management.h
+++ b/sys/psa_crypto/include/psa_crypto_slot_management.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/psa_crypto/include/psa_ecc.h
+++ b/sys/psa_crypto/include/psa_ecc.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/psa_crypto/include/psa_hashes.h
+++ b/sys/psa_crypto/include/psa_hashes.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/psa_crypto/include/psa_mac.h
+++ b/sys/psa_crypto/include/psa_mac.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/psa_crypto/psa_crypto.c
+++ b/sys/psa_crypto/psa_crypto.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/psa_crypto/psa_crypto_algorithm_dispatch.c
+++ b/sys/psa_crypto/psa_crypto_algorithm_dispatch.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/psa_crypto/psa_crypto_location_dispatch.c
+++ b/sys/psa_crypto/psa_crypto_location_dispatch.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/psa_crypto/psa_key_slot_mgmt/psa_crypto_slot_management.c
+++ b/sys/psa_crypto/psa_key_slot_mgmt/psa_crypto_slot_management.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/psa_crypto/psa_persistent_storage/psa_crypto_cbor_encoder.c
+++ b/sys/psa_crypto/psa_persistent_storage/psa_crypto_cbor_encoder.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/psa_crypto/psa_persistent_storage/psa_crypto_persistent_storage.c
+++ b/sys/psa_crypto/psa_persistent_storage/psa_crypto_persistent_storage.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/psa_crypto/psa_se_mgmt/Kconfig
+++ b/sys/psa_crypto/psa_se_mgmt/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2022 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2022 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_PSA_SECURE_ELEMENT
 

--- a/sys/psa_crypto/psa_se_mgmt/psa_crypto_se_management.c
+++ b/sys/psa_crypto/psa_se_mgmt/psa_crypto_se_management.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/puf_sram/puf_sram.c
+++ b/sys/puf_sram/puf_sram.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/random/fortuna.c
+++ b/sys/random/fortuna.c
@@ -1,9 +1,6 @@
-/**
- * Copyright (C) 2016-2018 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+/*
+ * SPDX-FileCopyrightText: 2016-2018 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/random/hwrng.c
+++ b/sys/random/hwrng.c
@@ -1,12 +1,9 @@
-/**
- * Copyright (C) 2020 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+/*
+ * SPDX-FileCopyrightText: 2020 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
- /**
+/**
  * @ingroup sys_random
  * @{
  * @file

--- a/sys/random/minstd.c
+++ b/sys/random/minstd.c
@@ -1,14 +1,9 @@
-/**
- * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
- * Code taken from C FAQ (http://c-faq.com/lib/rand.html).
+/*
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
- /**
+/**
  * @ingroup sys_random
  * @{
  * @file

--- a/sys/random/random.c
+++ b/sys/random/random.c
@@ -1,13 +1,10 @@
-/**
- * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
- *               2019 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+/*
+ * SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
- /**
+/**
  * @ingroup     sys_random
  * @{
  * @file

--- a/sys/random/tinymt32.c
+++ b/sys/random/tinymt32.c
@@ -1,9 +1,6 @@
-/**
- * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+/*
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/random/tinymt32/tinymt32.c
+++ b/sys/random/tinymt32/tinymt32.c
@@ -1,18 +1,8 @@
-/**
- * @file tinymt32.c
- *
- * @brief Tiny Mersenne Twister only 127 bit internal state
- *
- * @author Mutsuo Saito (Hiroshima University)
- * @author Makoto Matsumoto (The University of Tokyo)
- *
- * Copyright (C) 2011 Mutsuo Saito, Makoto Matsumoto,
- * Hiroshima University and The University of Tokyo.
- * All rights reserved.
- *
- * The 3-clause BSD License is applied to this software, see
- * LICENSE.txt
+/*
+ * SPDX-FileCopyrightText: 2011 Mutsuo Saito, Makoto Matsumoto,
+ * SPDX-License-Identifier: BSD-2-Clause
  */
+
 #include "tinymt32.h"
 #define MIN_LOOP 8
 #define PRE_LOOP 8

--- a/sys/random/xorshift.c
+++ b/sys/random/xorshift.c
@@ -1,16 +1,11 @@
-/**
- * Copyright (C) 2017 Inria
- *               2017 Freie Universität Berlin
- *               2017 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
- * Code taken from Wikipedia (https://en.wikipedia.org/wiki/Xorshift)
+/*
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
- /**
+/**
  * @ingroup sys_random
  * @{
  * @file

--- a/sys/riotboot/flashwrite.c
+++ b/sys/riotboot/flashwrite.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2019 Inria
- *               2019 Freie Universität Berlin
- *               2019 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/riotboot/flashwrite_verify_sha256.c
+++ b/sys/riotboot/flashwrite_verify_sha256.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2019 Inria
- *               2019 Freie Universität Berlin
- *               2019 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/riotboot/hdr.c
+++ b/sys/riotboot/hdr.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
- *               2017 Inria
- *               2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/riotboot/reset.c
+++ b/sys/riotboot/reset.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/riotboot/serial.c
+++ b/sys/riotboot/serial.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/riotboot/slot.c
+++ b/sys/riotboot/slot.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
- *               2017 Inria
- *               2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2017 Inria
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/riotboot/tinyusb_dfu.c
+++ b/sys/riotboot/tinyusb_dfu.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/riotboot/usb_dfu.c
+++ b/sys/riotboot/usb_dfu.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/rtc_utils/rtc_utils.c
+++ b/sys/rtc_utils/rtc_utils.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2019 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/saul_reg/saul_reg.c
+++ b/sys/saul_reg/saul_reg.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/sched_round_robin/sched_round_robin.c
+++ b/sys/sched_round_robin/sched_round_robin.c
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2021 TUBA Freiberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 TUBA Freiberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup     sys
  * @{

--- a/sys/schedstatistics/schedstatistics.c
+++ b/sys/schedstatistics/schedstatistics.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2014 Freie Universität Berlin
- *               2019 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/sema/sema.c
+++ b/sys/sema/sema.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2016 TriaGnoSys GmbH
- *               2013-15 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 TriaGnoSys GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/sema_inv/sema_inv.c
+++ b/sys/sema_inv/sema_inv.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/senml/cbor.c
+++ b/sys/senml/cbor.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Silke Hofstra
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Silke Hofstra
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include "senml.h"

--- a/sys/senml/phydat.c
+++ b/sys/senml/phydat.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Silke Hofstra
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Silke Hofstra
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include <stdint.h>

--- a/sys/senml/saul.c
+++ b/sys/senml/saul.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Silke Hofstra
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Silke Hofstra
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include "nanocbor/nanocbor.h"

--- a/sys/senml/senml.c
+++ b/sys/senml/senml.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Silke Hofstra
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Silke Hofstra
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include "senml.h"

--- a/sys/seq/seq.c
+++ b/sys/seq/seq.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Cenk Gündoğan <cnkgndgn@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Cenk Gündoğan <cnkgndgn@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/Kconfig
+++ b/sys/shell/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "Shell interpreter"
     depends on USEMODULE_SHELL

--- a/sys/shell/Kconfig.config
+++ b/sys/shell/Kconfig.config
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 Freie Universität
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 Freie Universität
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config SHELL_SHUTDOWN_ON_EXIT
     bool "Shutdown RIOT on shell exit"

--- a/sys/shell/cmds/app_metadata.c
+++ b/sys/shell/cmds/app_metadata.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/at30tse75x.c
+++ b/sys/shell/cmds/at30tse75x.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Daniel Krebs
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Daniel Krebs
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/benchmark_udp.c
+++ b/sys/shell/cmds/benchmark_udp.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/conn_can.c
+++ b/sys/shell/cmds/conn_can.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2017 OTA keys S.A.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 OTA keys S.A.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/cord_ep.c
+++ b/sys/shell/cmds/cord_ep.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017-2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017-2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/coreclk.c
+++ b/sys/shell/cmds/coreclk.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 Otto-von-Guericke Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 Otto-von-Guericke Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/cryptoauthlib.c
+++ b/sys/shell/cmds/cryptoauthlib.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/dfplayer.c
+++ b/sys/shell/cmds/dfplayer.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2019 Marian Buschsieweke
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Marian Buschsieweke
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/fib.c
+++ b/sys/shell/cmds/fib.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/gnrc_icmpv6_echo.c
+++ b/sys/shell/cmds/gnrc_icmpv6_echo.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/gnrc_ipv6_frag_stats.c
+++ b/sys/shell/cmds/gnrc_ipv6_frag_stats.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/gnrc_ipv6_nib.c
+++ b/sys/shell/cmds/gnrc_ipv6_nib.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/gnrc_netif.c
+++ b/sys/shell/cmds/gnrc_netif.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/gnrc_pktbuf.c
+++ b/sys/shell/cmds/gnrc_pktbuf.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/gnrc_sixlowpan_ctx.c
+++ b/sys/shell/cmds/gnrc_sixlowpan_ctx.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/gnrc_sixlowpan_frag_stats.c
+++ b/sys/shell/cmds/gnrc_sixlowpan_frag_stats.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/gnrc_txtsnd.c
+++ b/sys/shell/cmds/gnrc_txtsnd.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/gnrc_udp.c
+++ b/sys/shell/cmds/gnrc_udp.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015-17 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 -17 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/heap.c
+++ b/sys/shell/cmds/heap.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013 Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Zakaria Kasmi <zkasmi@inf.fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/i2c_scan.c
+++ b/sys/shell/cmds/i2c_scan.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/iw.c
+++ b/sys/shell/cmds/iw.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 ML!PA Consulting Gmbh
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 ML!PA Consulting Gmbh
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/lwip_netif.c
+++ b/sys/shell/cmds/lwip_netif.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2021 Google LLC
- *               2024 Krzysztof Cabaj <kcabaj@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-FileCopyrightText: 2024 Krzysztof Cabaj <kcabaj@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/mci.c
+++ b/sys/shell/cmds/mci.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013  INRIA.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 INRIA.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/nanocoap_vfs.c
+++ b/sys/shell/cmds/nanocoap_vfs.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/nice.c
+++ b/sys/shell/cmds/nice.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/nimble_netif.c
+++ b/sys/shell/cmds/nimble_netif.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/nimble_statconn.c
+++ b/sys/shell/cmds/nimble_statconn.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/opendsme.c
+++ b/sys/shell/cmds/opendsme.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/openwsn.c
+++ b/sys/shell/cmds/openwsn.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/pm.c
+++ b/sys/shell/cmds/pm.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Thomas Stilwell <stilwellt@openlabs.co>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Thomas Stilwell <stilwellt@openlabs.co>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/ps.c
+++ b/sys/shell/cmds/ps.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2013  INRIA.
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 INRIA.
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/random.c
+++ b/sys/shell/cmds/random.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin
- *               2015 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/rtc.c
+++ b/sys/shell/cmds/rtc.c
@@ -1,10 +1,7 @@
 /*
- * Copyright 2013 INRIA.
- * Copyright 2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 INRIA.
+ * SPDX-FileCopyrightText: 2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/rtt.c
+++ b/sys/shell/cmds/rtt.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Gunar Schorcht
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Gunar Schorcht
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/saul_reg.c
+++ b/sys/shell/cmds/saul_reg.c
@@ -1,10 +1,6 @@
 /*
- * Copyright (C) 2015 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
+ * SPDX-FileCopyrightText: 2015 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/semtech-loramac.c
+++ b/sys/shell/cmds/semtech-loramac.c
@@ -1,9 +1,6 @@
 /*
- * Copyright 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/sht1x.c
+++ b/sys/shell/cmds/sht1x.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2013 INRIA
- *               2018 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 INRIA
+ * SPDX-FileCopyrightText: 2018 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/sntp.c
+++ b/sys/shell/cmds/sntp.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Luminița Lăzărescu <cluminita.lazarescu@gmail.com>
- *               2017 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Luminița Lăzărescu <cluminita.lazarescu@gmail.com>
+ * SPDX-FileCopyrightText: 2017 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/suit.c
+++ b/sys/shell/cmds/suit.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Alexandre Abadie <alexandre.abadie@inria.fr>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Alexandre Abadie <alexandre.abadie@inria.fr>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/sys.c
+++ b/sys/shell/cmds/sys.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2014  Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2014 Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/udptty.c
+++ b/sys/shell/cmds/udptty.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2023 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell/cmds/vfs.c
+++ b/sys/shell/cmds/vfs.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/shell_lock/Kconfig
+++ b/sys/shell_lock/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2023 Inria
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2023 Inria
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_SHELL_LOCK
 

--- a/sys/shell_lock/shell_lock.c
+++ b/sys/shell_lock/shell_lock.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ssp/ssp.c
+++ b/sys/ssp/ssp.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/stdio/stdio.c
+++ b/sys/stdio/stdio.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/stdio_nimble/stdio_nimble.c
+++ b/sys/stdio_nimble/stdio_nimble.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/stdio_null/stdio_null.c
+++ b/sys/stdio_null/stdio_null.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Bas Stottelaar <basstottelaar@gmail.com>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/stdio_semihosting/stdio_semihosting.c
+++ b/sys/stdio_semihosting/stdio_semihosting.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/stdio_uart/stdio_uart.c
+++ b/sys/stdio_uart/stdio_uart.c
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2013 INRIA
- *               2015 Kaspar Schleiser <kaspar@schleiser.de>
- *               2016 Eistec AB
- *               2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2013 INRIA
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/stdio_udp/stdio_udp.c
+++ b/sys/stdio_udp/stdio_udp.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2023 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2023 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/suit/conditions.c
+++ b/sys/suit/conditions.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *               2019 Inria
- *               2019 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-FileCopyrightText: 2019 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/suit/handlers.c
+++ b/sys/suit/handlers.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/suit/handlers_command_seq.c
+++ b/sys/suit/handlers_command_seq.c
@@ -1,11 +1,9 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup     sys_suit
  * @{

--- a/sys/suit/handlers_common.c
+++ b/sys/suit/handlers_common.c
@@ -1,11 +1,9 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup     sys_suit
  * @{

--- a/sys/suit/handlers_envelope.c
+++ b/sys/suit/handlers_envelope.c
@@ -1,11 +1,9 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup     sys_suit
  * @{

--- a/sys/suit/handlers_global.c
+++ b/sys/suit/handlers_global.c
@@ -1,11 +1,9 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup     sys_suit
  * @{

--- a/sys/suit/policy.c
+++ b/sys/suit/policy.c
@@ -1,12 +1,10 @@
 /*
- * Copyright (C) 2019 Kaspar Schleiser <kaspar@schleiser.de>
- *               2019 Inria
- *               2019 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup     sys_suit
  * @{

--- a/sys/suit/storage/flashwrite.c
+++ b/sys/suit/storage/flashwrite.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2020 Koen Zandberg
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/suit/storage/ram.c
+++ b/sys/suit/storage/ram.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2020 Koen Zandberg
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/suit/storage/storage.c
+++ b/sys/suit/storage/storage.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2020 Koen Zandberg
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Koen Zandberg
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/suit/storage/vfs.c
+++ b/sys/suit/storage/vfs.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/suit/suit.c
+++ b/sys/suit/suit.c
@@ -1,12 +1,10 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- * Copyright (C) 2019 Kaspar Schleiser <kaspar@schleiser.de>
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup     sys_suit
  * @{

--- a/sys/suit/transport/mock.c
+++ b/sys/suit/transport/mock.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include <assert.h>

--- a/sys/suit/transport/vfs.c
+++ b/sys/suit/transport/vfs.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/suit/transport/worker.c
+++ b/sys/suit/transport/worker.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2019 Freie Universität Berlin
- *               2019 Inria
- *               2019 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2019 Inria
+ * SPDX-FileCopyrightText: 2019 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/test_utils/benchmark_udp/benchmark_udp.c
+++ b/sys/test_utils/benchmark_udp/benchmark_udp.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/test_utils/dummy_thread/dummy_thread.c
+++ b/sys/test_utils/dummy_thread/dummy_thread.c
@@ -1,11 +1,6 @@
 /*
- * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
- *                    Freie Universität Berlin
- *                    Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/test_utils/interactive_sync/interactive_sync.c
+++ b/sys/test_utils/interactive_sync/interactive_sync.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/test_utils/netdev_eth_minimal/netdev_eth_minimal.c
+++ b/sys/test_utils/netdev_eth_minimal/netdev_eth_minimal.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/test_utils/netdev_eth_minimal/netdev_eth_minimal_internal.h
+++ b/sys/test_utils/netdev_eth_minimal/netdev_eth_minimal_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/test_utils/netdev_eth_minimal/shell_commands.c
+++ b/sys/test_utils/netdev_eth_minimal/shell_commands.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/test_utils/netdev_ieee802154_minimal/netdev_ieee802154_minimal.c
+++ b/sys/test_utils/netdev_ieee802154_minimal/netdev_ieee802154_minimal.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/test_utils/netdev_ieee802154_minimal/netdev_ieee802154_minimal_internal.h
+++ b/sys/test_utils/netdev_ieee802154_minimal/netdev_ieee802154_minimal_internal.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/test_utils/netdev_ieee802154_minimal/shell_commands.c
+++ b/sys/test_utils/netdev_ieee802154_minimal/shell_commands.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2022 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for
- * more details.
+ * SPDX-FileCopyrightText: 2022 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/test_utils/print_stack_usage/print_stack_usage.c
+++ b/sys/test_utils/print_stack_usage/print_stack_usage.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/test_utils/result_output/check/result_output_check.c
+++ b/sys/test_utils/result_output/check/result_output_check.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include <stdint.h>

--- a/sys/test_utils/result_output/check/result_output_types.h
+++ b/sys/test_utils/result_output/check/result_output_types.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/test_utils/result_output/json/result_output_json.c
+++ b/sys/test_utils/result_output/json/result_output_json.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include <stdint.h>

--- a/sys/test_utils/result_output/json/result_output_types.h
+++ b/sys/test_utils/result_output/json/result_output_types.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #pragma once

--- a/sys/test_utils/result_output/result_output.c
+++ b/sys/test_utils/result_output/result_output.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/test_utils/result_output/txt/result_output_txt.c
+++ b/sys/test_utils/result_output/txt/result_output_txt.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include <stdint.h>

--- a/sys/test_utils/result_output/txt/result_output_types.h
+++ b/sys/test_utils/result_output/txt/result_output_types.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #ifndef RESULT_OUTPUT_TYPES_H

--- a/sys/timex/timex_to_str.c
+++ b/sys/timex/timex_to_str.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/timex/tm.c
+++ b/sys/timex/tm.c
@@ -1,19 +1,6 @@
 /*
- * Copyright (C) 2014  René Kijewski  <rene.kijewski@fu-berlin.de>
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * SPDX-FileCopyrightText: 2014 René Kijewski  <rene.kijewski@fu-berlin.de>
+ * SPDX-License-Identifier: NONE
  */
 
 /**

--- a/sys/tiny_strerror/tiny_strerror.c
+++ b/sys/tiny_strerror/tiny_strerror.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2021 ML!PA Consulting GmbH
- *               2022 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 ML!PA Consulting GmbH
+ * SPDX-FileCopyrightText: 2022 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/trace/trace.c
+++ b/sys/trace/trace.c
@@ -1,11 +1,6 @@
 /*
- * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
- *                    Freie Universität Berlin
- *                    Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/tsrb/tsrb.c
+++ b/sys/tsrb/tsrb.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/universal_address/universal_address.c
+++ b/sys/universal_address/universal_address.c
@@ -1,18 +1,6 @@
-/**
- * universal address container implementation
- *
- * Copyright (C) 2014 Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
- *
- * @ingroup sys_universal_address
- * @{
- * @file
- * @brief   Functions to manage universal address container
- * @author  Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
- * @}
+/*
+ * SPDX-FileCopyrightText: 2014 Martin Landsmann <Martin.Landsmann@HAW-Hamburg.de>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 #include <stdio.h>

--- a/sys/uri_parser/uri_parser.c
+++ b/sys/uri_parser/uri_parser.c
@@ -1,10 +1,8 @@
 /*
- * Copyright (C) 2020 HAW Hamburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup     sys_uri_parser
  * @{

--- a/sys/usb/Kconfig
+++ b/sys/usb/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2019 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2019 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 if USEMODULE_PERIPH_USBDEV || USEMODULE_TINYUSB_DEVICE || USEMODULE_USBDEV_MOCK
 

--- a/sys/usb/usbus/Kconfig
+++ b/sys/usb/usbus/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "Configure USB Unified Stack (USBUS)"
     depends on USEMODULE_USBUS

--- a/sys/usb/usbus/cdc/acm/Kconfig
+++ b/sys/usb/usbus/cdc/acm/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "USBUS CDC ACM"
     depends on USEMODULE_USBUS_CDC_ACM

--- a/sys/usb/usbus/cdc/acm/cdc_acm.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Dylan Laduranty
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Dylan Laduranty
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/usb/usbus/cdc/ecm/Kconfig
+++ b/sys/usb/usbus/cdc/ecm/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2020 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "USBUS CDC ECM"
     depends on USEMODULE_USBUS_CDC_ECM

--- a/sys/usb/usbus/cdc/ecm/cdc_ecm.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/usb/usbus/dfu/Kconfig
+++ b/sys/usb/usbus/dfu/Kconfig
@@ -1,10 +1,5 @@
-
-# Copyright (c) 2020 Mesotic SAS
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2020 Mesotic SAS
+# SPDX-License-Identifier: LGPL-2.1-only
 
 menu "USBUS DFU"
     depends on USEMODULE_USBUS_DFU

--- a/sys/usb/usbus/dfu/dfu.c
+++ b/sys/usb/usbus/dfu/dfu.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/usb/usbus/hid/Kconfig
+++ b/sys/usb/usbus/hid/Kconfig
@@ -1,9 +1,5 @@
-# Copyright (c) 2021 HAW Hamburg
-#
-# This file is subject to the terms and conditions of the GNU Lesser
-# General Public License v2.1. See the file LICENSE in the top level
-# directory for more details.
-#
+# SPDX-FileCopyrightText: 2021 HAW Hamburg
+# SPDX-License-Identifier: LGPL-2.1-only
 
 config USBUS_HID_INTERRUPT_EP_SIZE
     int "Interrupt endpoint size in bytes"

--- a/sys/usb/usbus/hid/hid.c
+++ b/sys/usb/usbus/hid/hid.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Nils Ollrogge
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Nils Ollrogge
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/usb/usbus/hid/hid_io.c
+++ b/sys/usb/usbus/hid/hid_io.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021-2022 Nils Ollrogge
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021-2022 Nils Ollrogge
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/usb/usbus/msc/msc.c
+++ b/sys/usb/usbus/msc/msc.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019-2021 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019-2021 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/usb/usbus/msc/scsi.c
+++ b/sys/usb/usbus/msc/scsi.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2019-2022 Mesotic SAS
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2019-2022 Mesotic SAS
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/usb/usbus/usbus.c
+++ b/sys/usb/usbus/usbus.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/usb/usbus/usbus_control.c
+++ b/sys/usb/usbus/usbus_control.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/usb/usbus/usbus_control_slicer.c
+++ b/sys/usb/usbus/usbus_control_slicer.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/usb/usbus/usbus_fmt.c
+++ b/sys/usb/usbus/usbus_fmt.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2018 Koen Zandberg
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Koen Zandberg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/usb_board_reset/usb_board_reset.c
+++ b/sys/usb_board_reset/usb_board_reset.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ut_process/ut_process.c
+++ b/sys/ut_process/ut_process.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/uuid/uuid.c
+++ b/sys/uuid/uuid.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2018 Freie Universität Berlin
- * Copyright (C) 2018 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2018 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/vfs/vfs.c
+++ b/sys/vfs/vfs.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/vfs/vfs_stdio.c
+++ b/sys/vfs/vfs_stdio.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2016 Eistec AB
- *               2018 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-FileCopyrightText: 2018 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/vfs_util/vfs_util.c
+++ b/sys/vfs_util/vfs_util.c
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2021 Benjamin Valentin
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2021 Benjamin Valentin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- * Copyright (C) 2016 Eistec AB
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -1,12 +1,9 @@
-/**
- * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- *               2016 Eistec AB
- *               2018 Josua Arndt
- *               2018 UC Berkeley
- *
- * This file is subject to the terms and conditions of the GNU Lesser
- * General Public License v2.1. See the file LICENSE in the top level
- * directory for more details.
+/*
+ * SPDX-FileCopyrightText: 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2016 Eistec AB
+ * SPDX-FileCopyrightText: 2018 Josua Arndt
+ * SPDX-FileCopyrightText: 2018 UC Berkeley
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ztimer/convert.c
+++ b/sys/ztimer/convert.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
- *               2020 Freie Universität Berlin
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ztimer/convert_frac.c
+++ b/sys/ztimer/convert_frac.c
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
- *               2020 Freie Universität Berlin
- *               2020 Inria
- *               2018 Joakim Nohlgård <joakim.nohlgard@eistec.se>
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-FileCopyrightText: 2018 Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ztimer/convert_muldiv64.c
+++ b/sys/ztimer/convert_muldiv64.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
- *               2020 Freie Universität Berlin
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ztimer/convert_shift.c
+++ b/sys/ztimer/convert_shift.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
- *               2020 Freie Universität Berlin
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ztimer/core.c
+++ b/sys/ztimer/core.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
- *               2020 Freie Universität Berlin
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ztimer/init.c
+++ b/sys/ztimer/init.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
- *               2020 Freie Universität Berlin
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ztimer/mock.c
+++ b/sys/ztimer/mock.c
@@ -1,12 +1,9 @@
 /*
- * Copyright (C) 2018 Eistec AB
- *               2020 Kaspar Schleiser <kaspar@schleiser.de>
- *               2020 Freie Universität Berlin
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2018 Eistec AB
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ztimer/overhead.c
+++ b/sys/ztimer/overhead.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
- *               2020 Freie Universität Berlin
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ztimer/periodic.c
+++ b/sys/ztimer/periodic.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
- *               2020 Inria
- *               2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ztimer/periph_ptp.c
+++ b/sys/ztimer/periph_ptp.c
@@ -1,10 +1,7 @@
 /*
- * Copyright (C)    2018 Kaspar Schleiser <kaspar@schleiser.de>
-                    2021 Otto-von-Guericke-Universität Magdeburg
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2018 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2021 Otto-von-Guericke-Universität Magdeburg
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ztimer/periph_rtc.c
+++ b/sys/ztimer/periph_rtc.c
@@ -1,12 +1,10 @@
 /*
- * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
- *               2020 Freie Universität Berlin
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 /**
  * @ingroup     sys_ztimer_periph_rtc
  * @{

--- a/sys/ztimer/periph_rtt.c
+++ b/sys/ztimer/periph_rtt.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
- *               2020 Freie Universität Berlin
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ztimer/periph_timer.c
+++ b/sys/ztimer/periph_timer.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
- *               2020 Freie Universität Berlin
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ztimer/util.c
+++ b/sys/ztimer/util.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
- *               2020 Inria
- *               2020 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ztimer64/overhead.c
+++ b/sys/ztimer64/overhead.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
- *               2020 Freie Universität Berlin
- *               2020 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2020 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2020 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ztimer64/util.c
+++ b/sys/ztimer64/util.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2021 Kaspar Schleiser <kaspar@schleiser.de>
- *               2021 Inria
- *               2021 Freie Universität Berlin
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2021 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**

--- a/sys/ztimer64/ztimer64.c
+++ b/sys/ztimer64/ztimer64.c
@@ -1,11 +1,8 @@
 /*
- * Copyright (C) 2021 Kaspar Schleiser <kaspar@schleiser.de>
- *               2021 Freie Universität Berlin
- *               2021 Inria
- *
- * This file is subject to the terms and conditions of the GNU Lesser General
- * Public License v2.1. See the file LICENSE in the top level directory for more
- * details.
+ * SPDX-FileCopyrightText: 2021 Kaspar Schleiser <kaspar@schleiser.de>
+ * SPDX-FileCopyrightText: 2021 Freie Universität Berlin
+ * SPDX-FileCopyrightText: 2021 Inria
+ * SPDX-License-Identifier: LGPL-2.1-only
  */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR attempts to convert all license headers for all folders inside the `sys/` directory starting with the letters O to Z. Vendor specific files are left untouched as well as some files missing some copyright or license information.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
To check for correct license/copyright information in all files that are not vendor provided, use this command:

`reuse lint -l | grep "^sys/" | grep -v "/vendor/"`

### Declaration of AI-Tools / LLMs usage

AI-Tools / LLMs that were used are:
- VS Code Copilot for the python script

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Tracking #21515 
