### PR TITLE
cpu/stm32,boards/nucleo-h753zi: enable LPUART support

### DIFF
--- a/boards/nucleo-h753zi/Makefile.dep
+++ b/boards/nucleo-h753zi/Makefile.dep
@@ -1,1 +1,7 @@
+# The H7 has an LPUART present and it is configured, so we have to add the
+# `periph_lpuart` to the required features.
+ifneq (,$(filter periph_uart,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_lpuart
+endif
+
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-h753zi/Makefile.features
+++ b/boards/nucleo-h753zi/Makefile.features
@@ -9,7 +9,7 @@ FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_uart periph_lpuart
 FEATURES_PROVIDED += periph_vbat
 FEATURES_PROVIDED += periph_wdt
 

--- a/boards/nucleo-h753zi/include/periph_conf.h
+++ b/boards/nucleo-h753zi/include/periph_conf.h
@@ -38,9 +38,9 @@ extern "C" {
  * @{
  */
 static const dma_conf_t dma_config[] = {
-    { .stream = 4 },   /* DMA1 Stream 4 - USART3_TX */
-    { .stream = 14 },  /* DMA2 Stream 6 - USART6_TX */
-    { .stream = 6 },   /* DMA1 Stream 6 - USART2_TX */
+    { .stream = 4 },   /* DMA1 Stream 4  - USART3_TX */
+    { .stream = 14 },  /* DMA2 Stream 14 - USART6_TX */
+    { .stream = 6 },   /* DMA1 Stream 6  - USART2_TX */
 };
 
 #define DMA_0_ISR  isr_dma1_stream4
@@ -65,6 +65,8 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
         .irqn       = USART3_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
 #ifdef MODULE_PERIPH_DMA
         .dma        = 0,
         .dma_chan   = 46 /* DMAMUX_REQ_USART3_TX */
@@ -79,6 +81,8 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB2,
         .irqn       = USART6_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
 #ifdef MODULE_PERIPH_DMA
         .dma        = 1,
         .dma_chan   = 72 /* DMAMUX_REQ_USART6_TX */
@@ -93,16 +97,32 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
         .irqn       = USART2_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
 #ifdef MODULE_PERIPH_DMA
         .dma        = 2,
         .dma_chan   = 44 /* DMAMUX_REQ_USART2_TX */
 #endif
-    }
+    },
+    {
+        .dev        = LPUART1,
+        .rcc_mask   = RCC_APB4ENR_LPUART1EN,
+        .rx_pin     = GPIO_PIN(PORT_B, 7), /* connected to D0 */
+        .tx_pin     = GPIO_PIN(PORT_B, 6), /* connected to D1 */
+        .rx_af      = GPIO_AF8,
+        .tx_af      = GPIO_AF8,
+        .bus        = APB4,
+        .irqn       = LPUART1_IRQn,
+        .type       = STM32_LPUART,
+        .clk_src    = 0, /* Use APB clock */
+        /* the LPUART uses the BDMA controller rather than the normal DMA controller */
+    },
 };
 
 #define UART_0_ISR          (isr_usart3)
 #define UART_1_ISR          (isr_usart6)
 #define UART_2_ISR          (isr_usart2)
+#define UART_3_ISR          (isr_lpuart1)
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 

--- a/cpu/stm32/include/periph/cpu_uart.h
+++ b/cpu/stm32/include/periph/cpu_uart.h
@@ -39,7 +39,7 @@ typedef enum {
  * @brief   Size of the UART TX buffer for non-blocking mode.
  */
 #ifndef UART_TXBUF_SIZE
-#define UART_TXBUF_SIZE    (64)
+#  define UART_TXBUF_SIZE  (64)
 #endif
 
 #ifndef DOXYGEN
@@ -116,11 +116,11 @@ typedef struct {
     gpio_af_t rts_af;       /**< alternate function for RTS pin */
 #endif
 #endif
-#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L4) || \
-    defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32G4) || \
-    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U3) || \
-    defined(CPU_FAM_STM32MP1) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32WL)
+#if defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32H7)  || \
+    defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L4)  || \
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32MP1) || \
+    defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32U5)  || \
+    defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32WL)
     uart_type_t type;       /**< hardware module type (USART or LPUART) */
     uint32_t clk_src;       /**< clock source used for UART */
 #endif

--- a/cpu/stm32/periph/uart.c
+++ b/cpu/stm32/periph/uart.c
@@ -103,10 +103,11 @@ static inline USART_TypeDef *dev(uart_t uart)
 }
 
 static inline void uart_init_usart(uart_t uart, uint32_t baudrate);
-#if defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32L0) || \
-    defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32L5) || \
-    defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32WL)
+#if defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32H7) || \
+    defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L4) || \
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32WB) || \
+    defined(CPU_FAM_STM32WL)
 #  ifdef MODULE_PERIPH_LPUART
 static inline void uart_init_lpuart(uart_t uart, uint32_t baudrate);
 #  endif
@@ -198,10 +199,11 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     dev(uart)->CR2 = 0;
     dev(uart)->CR3 = 0;
 
-#if defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32L0) || \
-    defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32L5) || \
-    defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32WL)
+#if defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32H7) || \
+    defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L4) || \
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32WB) || \
+    defined(CPU_FAM_STM32WL)
     switch (uart_config[uart].type) {
     case STM32_USART:
         uart_init_usart(uart, baudrate);
@@ -329,19 +331,20 @@ static inline void uart_init_usart(uart_t uart, uint32_t baudrate)
     dev(uart)->BRR = ((mantissa & 0x0fff) << 4) | (fraction & 0x0f);
 }
 
-#if defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32L0) || \
-    defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32L5) || \
-    defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32U5) || \
-    defined(CPU_FAM_STM32WB) || defined(CPU_FAM_STM32WL)
-#  ifdef CPU_FAM_STM32L5
+#if defined(CPU_FAM_STM32G4) || defined(CPU_FAM_STM32H7) || \
+    defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L4) || \
+    defined(CPU_FAM_STM32L5) || defined(CPU_FAM_STM32U3) || \
+    defined(CPU_FAM_STM32U5) || defined(CPU_FAM_STM32WB) || \
+    defined(CPU_FAM_STM32WL)
+#  if defined(CPU_FAM_STM32H7)
+#    define RCC_CCIPR_LPUART1SEL_0  RCC_D3CCIPR_LPUART1SEL_0
+#    define RCC_CCIPR_LPUART1SEL_1  RCC_D3CCIPR_LPUART1SEL_1
+#    define CCIPR                   D3CCIPR
+#  elif defined(CPU_FAM_STM32L5)
 #    define RCC_CCIPR_LPUART1SEL_0  RCC_CCIPR1_LPUART1SEL_0
 #    define RCC_CCIPR_LPUART1SEL_1  RCC_CCIPR1_LPUART1SEL_1
 #    define CCIPR                   CCIPR1
-#  elif CPU_FAM_STM32U3
-#    define RCC_CCIPR_LPUART1SEL_0  RCC_CCIPR3_LPUART1SEL_0
-#    define RCC_CCIPR_LPUART1SEL_1  RCC_CCIPR3_LPUART1SEL_1
-#    define CCIPR                   CCIPR3
-# elif CPU_FAM_STM32U5
+#  elif defined(CPU_FAM_STM32U3) || defined(CPU_FAM_STM32U5)
 #    define RCC_CCIPR_LPUART1SEL_0  RCC_CCIPR3_LPUART1SEL_0
 #    define RCC_CCIPR_LPUART1SEL_1  RCC_CCIPR3_LPUART1SEL_1
 #    define CCIPR                   CCIPR3


### PR DESCRIPTION
### Contribution description

This enabled the LPUART support for the STM32H7 in the STM32 UART code and adds a default configuration for the `nucleo-h753zi`.

### Testing procedure

The `tests/periph/uart` test succeeds:
```
2026-08-24 14:05:29,231 # main(): This is RIOT! (Version: 2026.10-devel-277-g6e672-pr/stm32h7_lpuart)
2026-08-24 14:05:29,232 #
2026-08-24 14:05:29,234 # Manual UART driver test application
2026-08-24 14:05:29,237 # ===================================
2026-08-24 14:05:29,243 # This application is intended for testing additional UART
2026-08-24 14:05:29,246 # interfaces, that might be defined for a board. The 'primary' UART
2026-08-24 14:05:29,252 # interface is tested implicitly, as it is running the shell...
2026-08-24 14:05:29,253 #
2026-08-24 14:05:29,263 # When receiving data on one of the additional UART interfaces, this
2026-08-24 14:05:29,267 # data will be outputted via STDIO. So the easiest way to test an
2026-08-24 14:05:29,271 # UART interface, is to simply connect the RX with the TX pin. Then
2026-08-24 14:05:29,278 # you can send data on that interface and you should see the data
2026-08-24 14:05:29,280 # being printed to STDOUT.
2026-08-24 14:05:29,280 #
2026-08-24 14:05:29,283 # NOTE: all strings need to be '\n' terminated!
2026-08-24 14:05:29,284 #
2026-08-24 14:05:29,537 # UARD_DEV(0): test uart_poweron() and uart_poweroff()  ->  [OK]
2026-08-24 14:05:29,537 #
2026-08-24 14:05:29,538 # UART INFO:
2026-08-24 14:05:29,540 # Available devices:               4
2026-08-24 14:05:29,545 # UART used for STDIO (the shell): UART_DEV(0)
2026-08-24 14:05:29,546 #
> init 3 115200
2026-08-24 14:05:37,525 # init 3 115200
2026-08-24 14:05:37,526 # Success: Initialized UART_DEV(3) at BAUD 115200
2026-08-24 14:05:37,782 # UARD_DEV(3): test uart_poweron() and uart_poweroff()  ->  [OK]
> send 3 helloworld
2026-08-24 14:05:46,617 # send 3 helloworld
2026-08-24 14:05:46,619 # UART_DEV(3) TX: helloworld
2026-08-24 14:05:46,624 # Success: UART_DEV(3) RX: [helloworld\n]
> test 3
2026-08-24 14:05:49,790 # test 3
2026-08-24 14:05:49,791 # [START]
2026-08-24 14:05:49,825 # [SUCCESS]
>
```

The Baud Rate seems also correct (the logic analyzer is kinda crap, so it is probably correct. I guess.)
<img width="1869" height="589" alt="image" src="https://github.com/user-attachments/assets/55c4099f-5ce9-4a05-868f-bce8fe3ba675" />


### Issues/PRs references

Currently includes #22599, has to be rebased once that is merged.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none