### PR TITLE
tests/periph/rtt_min: fail if RTT_MIN_OFFSET is not high enough

### DIFF
--- a/tests/periph/rtt_min/main.c
+++ b/tests/periph/rtt_min/main.c
@@ -73,5 +73,14 @@ int main(void)
     printf("RTT_MIN_OFFSET for %s over %" PRIu32 " samples: %" PRIu32 "\n",
            RIOT_BOARD, samples, value);
 
+    if (value <= RTT_MIN_OFFSET) {
+        printf("OK %" PRIu32 " <= %u\n", value, RTT_MIN_OFFSET);
+    }
+    else {
+        printf("BAD %" PRIu32 " > %u\n", value, RTT_MIN_OFFSET);
+        printf("Please define RTT_MIN_OFFSET as (%" PRIu32"U) in your CPU's " \
+               "periph_cpu.h file!\n", value);
+    }
+
     return 0;
 }

--- a/tests/periph/rtt_min/tests/01-run.py
+++ b/tests/periph/rtt_min/tests/01-run.py
@@ -20,6 +20,8 @@ def testfunc(child):
     test_ongoing = r'Sample \d+'
     while child.expect([test_end, test_ongoing]):
         pass
+    test_result_ok = r'OK \d+ <= \d+'
+    child.expect(test_result_ok)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- -->

### Contribution description

Make rtt_min_test fail if RTT_MIN_OFFSET isn't high enough.

Higher values are accepted since this test tries to find a lower bound with just 1024 samples.

### Testing procedure

Run test on your hardware  and see if you should define RTT_MIN_OFFSET.
or for comfort
Something with a same5x will probably fail without #22600 and succeed with #22600.

### Issues/PRs references

introduced with #14259 still does not see much use even though 
required at least by sam: #22600 
#14146

#22617

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
