### PR TITLE
makefiles/tools/serial: fix socat for macOS

### DIFF
--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -68,7 +68,16 @@ ifeq ($(RIOT_TERMINAL),pyterm)
 else ifeq ($(RIOT_TERMINAL),socat)
   SOCAT_OUTPUT ?= -
   TERMPROG ?= $(RIOT_TERMINAL)
-  TERMFLAGS ?= $(SOCAT_OUTPUT) open:$(PORT),b$(BAUD),echo=0,raw,cs8,parenb=0,cstopb=0
+  ifeq ($(OS),Linux)
+    # RIOT's build image is based on Ubuntu 22.04, which ships a broken version
+    # of socat that does not support the "ispeed" and "ospeed" options. Once
+    # Ubuntu 22.04 is end-of-life (April 2027), the Linux-specific case can be
+    # removed. See https://bugs.launchpad.net/ubuntu/+source/socat/+bug/2165102
+    # for more information on the issue.
+    TERMFLAGS ?= $(SOCAT_OUTPUT) open:$(PORT),b$(BAUD),nonblock,clocal=1,cread=1,echo=0,raw,cs8,parenb=0,cstopb=0
+  else ifeq ($(OS),Darwin)
+    TERMFLAGS ?= $(SOCAT_OUTPUT) open:$(PORT),ispeed=$(BAUD),ospeed=$(BAUD),nonblock,clocal=1,cread=1,echo=0,raw,cs8,parenb=0,cstopb=0
+  endif
 else ifeq ($(RIOT_TERMINAL),picocom)
   TERMPROG  ?= picocom
   TERMFLAGS ?= --nolock --imap lfcrlf --baud "$(BAUD)" "$(PORT)"


### PR DESCRIPTION
### Contribution description

On macOS, the `b<baudrate>` option does not exist for `socat`. Instead, use `ispeed` and `ospeed`. These options are available under Linux on more recent versions of `socat`, but RIOT's Docker image still ships with a broken version. That's why that still uses the `b<baudrate>` alternative.

I also added `nonblock,clocal=1,cread=1`. These flags are of no harm for USB serial adapters, but more or less mimics what Pyserial does too.

macOS compatibility isn't a goal, but it makes it easier for me. The change seems to work for Linux too.

### Testing procedure

Run `make test` for a test application on macOS or Linux

<details>
<summary>With the fix:</summary>

```
basilfx:rtt_min/ (p-rtt-min-test-fail) $ BOARD=stk3600 make -j14 flash test
Building application "tests_rtt_min" for "stk3600" with CPU "efm32".

..

Script processing completed.

r
socat - open:/dev/tty.usbmodem0004400370091,ispeed=115200,ospeed=115200,nonblock,clocal=1,cread=1,echo=0,raw,cs8,parenb=0,cstopb=0
Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2026.10-devel-373-ge9aa7-p-rtt-min-test-fail)
Evaluate RTT_MIN_OFFSET over 1024 samples
Sample 0
Sample 1
...
Sample 1023

RTT_MIN_OFFSET for stk3600 over 1024 samples: 1
OK 1 <= 2
```
</details>

<details>
<summary>Without the fix:</summary>

```
basilfx:rtt_min/ (p-rtt-min-test-fail) $ BOARD=stk3600 make -j14 flash test
Building application "tests_rtt_min" for "stk3600" with CPU "efm32".

...

Script processing completed.

r
socat - open:/dev/tty.usbmodem0004400370091,b115200,echo=0,raw,cs8,parenb=0,cstopb=0
2026/08/25 00:16:59 socat[84911] E parseopts_table(): unknown option "b115200"
make[1]: *** [/Users/basilfx/Desktop/Projecten/RIOT/RIOT_pr/Makefile.include:889: cleanterm] Error 1
Traceback (most recent call last):
  File "/Users/basilfx/Desktop/Projecten/RIOT/RIOT_pr/tests/periph/rtt_min/tests/01-run.py", line 28, in <module>
    sys.exit(run(testfunc))
             ~~~^^^^^^^^^^
  File "/Users/basilfx/Desktop/Projecten/RIOT/RIOT_pr/dist/pythonlibs/testrunner/__init__.py", line 27, in run
    child = setup_child(timeout, env=os.environ,
                        logfile=sys.stdout if echo else None)
  File "/Users/basilfx/Desktop/Projecten/RIOT/RIOT_pr/dist/pythonlibs/testrunner/spawn.py", line 95, in setup_child
    sync_child(child, env)
    ~~~~~~~~~~^^^^^^^^^^^^
  File "/Users/basilfx/Desktop/Projecten/RIOT/RIOT_pr/dist/pythonlibs/testrunner/spawn.py", line 132, in sync_child
    utils.test_utils_interactive_sync(child,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
                                      TEST_INTERACTIVE_RETRIES,
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^
                                      TEST_INTERACTIVE_DELAY)
                                      ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/basilfx/Desktop/Projecten/RIOT/RIOT_pr/dist/pythonlibs/testrunner/utils.py", line 30, in test_utils_interactive_sync
    _test_utils_interactive_sync(child, retries, delay)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/basilfx/Desktop/Projecten/RIOT/RIOT_pr/dist/pythonlibs/testrunner/utils.py", line 17, in _test_utils_interactive_sync
    ret = child.expect_exact([ready_exp, pexpect.TIMEOUT], timeout=delay)
  File "/Users/basilfx/Desktop/Projecten/RIOT/env/lib/python3.14/site-packages/pexpect/spawnbase.py", line 432, in expect_exact
    return exp.expect_loop(timeout)
           ~~~~~~~~~~~~~~~^^^^^^^^^
  File "/Users/basilfx/Desktop/Projecten/RIOT/env/lib/python3.14/site-packages/pexpect/expect.py", line 179, in expect_loop
    return self.eof(e)
           ~~~~~~~~^^^
  File "/Users/basilfx/Desktop/Projecten/RIOT/env/lib/python3.14/site-packages/pexpect/expect.py", line 122, in eof
    raise exc
pexpect.exceptions.EOF: End Of File (EOF). Empty string style platform.
<pexpect.pty_spawn.spawn object at 0x10768acf0>
command: /opt/homebrew/opt/make/libexec/gnubin/make
args: [b'/opt/homebrew/opt/make/libexec/gnubin/make', b'cleanterm']
buffer (last 100 chars): ''
before (last 100 chars): 'ke[1]: *** [/Users/basilfx/Desktop/Projecten/RIOT/RIOT_pr/Makefile.include:889: cleanterm] Error 1\r\n'
after: <class 'pexpect.exceptions.EOF'>
match: None
match_index: None
exitstatus: 2
flag_eof: True
pid: 84827
child_fd: 5
closed: False
timeout: 10
delimiter: <class 'pexpect.exceptions.EOF'>
logfile: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
logfile_read: None
logfile_send: None
maxread: 2000
ignorecase: False
searchwindowsize: None
delaybeforesend: 0.05
delayafterclose: 0.1
delayafterterminate: 0.1
searcher: searcher_string:
    0: 'READY'
    1: TIMEOUT
make: *** [/Users/basilfx/Desktop/Projecten/RIOT/RIOT_pr/makefiles/tests/tests.inc.mk:32: test] Error 1
```
</details>

<details>
<summary>Using `socat` as terminal on macOS</summary>

```
basilfx:default/ (p-rtt-min-test-fail✗) $ RIOT_TERMINAL=socat BOARD=stk3600 make -j14 flash term
Building application "default" for "stk3600" with CPU "efm32".

..

Script processing completed.

socat - open:/dev/tty.usbmodem0004400370091,ispeed=115200,ospeed=115200,nonblock,clocal=1,cread=1,echo=0,raw,cs8,parenb=0,cstopb=0
main(): This is RIOT! (Version: 2026.10-devel-372-g03642f-p-rtt-min-test-fail)
Welcome to RIOT!
> help
help
Command              Description
---------------------------------------
pm                   interact with layered PM subsystem
ps                   Prints information about running threads.
rtc                  control RTC peripheral interface
saul                 interact with sensors and actuators using SAUL
version              Prints current RIOT_VERSION
rebo
```
</details>

<details>
<summary>Using `socat` as terminal on Linux</summary>

```
basilfx:irq/ (feature/socat_fix_macos) $ RIOT_TERMINAL=socat BOARD=stk3600 make term
socat - open:/dev/ttyACM0,ispeed=115200,ospeed=115200,nonblock,clocal=1,cread=1,echo=0,raw,cs8,parenb=0,cstopb=0
s


Help: Press s to start test, r to print it is ready
s
START
main(): This is RIOT! (Version: 2026.10-devel-377-g83fc7-feature/socat_fix_macos)
START
busy_thread created
xtimer_wait()
busy_thread starting
main: return
{ "threads": [{ "name": "main", "stack_size": 1536, "stack_used": 220 }]}
i: 392372
j: 392372
k: 392372
SUCCESS
{ "threads": [{ "name": "busy_thread", "stack_size": 1536, "stack_used": 416 }]}
```
</details>

### Issues/PRs references

Found this while testing #22618.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- Claude Sonnet 5 to find alternative arguments for socat.
