### PR TITLE
pkg/bplib: Move Makefile out of patches

### DIFF
--- a/pkg/bplib/Makefile
+++ b/pkg/bplib/Makefile
@@ -12,7 +12,8 @@ IGNORE  += bplib_no_vfs
 
 SUBMODS := $(filter-out $(IGNORE),$(filter bplib_%,$(USEMODULE)))
 
-all: $(BINDIR)/libbplib.a $(SUBMODS)
+all: $(SUBMODS)
+	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(CURDIR)/Makefile.$(PKG_NAME)
 
 # ------------------------- General helper submodules --------------------------
 bplib_fwp:
@@ -40,10 +41,3 @@ bplib_cla_ble:
 
 bplib_cla_udp:
 	+"$(MAKE)" -C $(RIOTPKG)/bplib/cla/udp
-
-# ------------------------------- bplib library --------------------------------
-$(BINDIR)/libbplib.a: $(PKG_BUILD_DIR)/libbplib.a
-	@cp $< $@
-
-$(PKG_BUILD_DIR)/libbplib.a:
-	+"$(MAKE)" -C $(PKG_SOURCE_DIR) -f riot.mk BUILDDIR=$(PKG_BUILD_DIR)

--- a/pkg/bplib/Makefile.bplib
+++ b/pkg/bplib/Makefile.bplib
@@ -1,0 +1,33 @@
+MODULE=bplib
+
+BPLIB_FOLDERS := aa/arp aa/as aa/fwp aa/nc \
+    bpa/bi bpa/ct bpa/ebp bpa/pdb bpa/pi bpa/stor \
+    ci/cbor ci/crc ci/eid ci/em ci/mem ci/pl ci/qm ci/rbt ci/time \
+    cla version
+
+BPLIB_PRIVATE_INCLUDE_DIRS := $(foreach dir,$(BPLIB_FOLDERS),$(dir)/inc) inc
+
+# Note 1: We don't compile bpa/stor
+# Note 2: We use the ben_allocator and exlude the std_allocator (which would use
+#  malloc instead of a static allocation pool for the blocks). This could be
+#  swapped or a custom allocator could even be used here.
+BPLIB_SOURCES_INIT := $(foreach dir,$(BPLIB_FOLDERS),$(wildcard $(dir)/src/*.c))
+BPLIB_IGNORED_SOURCES := bpa/stor/src/% ci/mem/src/bplib_std_allocator.c
+
+INCLUDES += $(foreach dir,$(BPLIB_PRIVATE_INCLUDE_DIRS),-I$(dir))
+SRC += $(filter-out $(BPLIB_IGNORED_SOURCES),$(BPLIB_SOURCES_INIT))
+
+CFLAGS += -Wno-format
+CFLAGS += -Wno-int-to-pointer-cast
+CFLAGS += -Wno-old-style-definition
+CFLAGS += -Wno-unused-parameter
+CFLAGS += -Wno-cast-function-type
+CFLAGS += -Wno-sign-compare
+# LLVM specifics that GCC does not complain about
+ifeq (llvm,$(TOOLCHAIN))
+  CFLAGS += -Wno-strict-prototypes
+  CFLAGS += -Wno-format-nonliteral
+  CFLAGS += -Wno-unused-but-set-variable
+endif
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/bplib/Makefile.dep
+++ b/pkg/bplib/Makefile.dep
@@ -1,6 +1,8 @@
 USEPKG += qcbor
 # We need a newer version of QCBOR, >= 1.5.1 (as specified by NASA)
 
+USEMODULE += bplib
+
 USEMODULE += core_mutex
 USEMODULE += core_thread
 USEMODULE += ztimer

--- a/pkg/bplib/Makefile.include
+++ b/pkg/bplib/Makefile.include
@@ -52,5 +52,3 @@ PSEUDOMODULES += bplib_walltime_available
 PSEUDOMODULES += bplib_include_nc_telemetry
 PSEUDOMODULES += bplib_include_as
 PSEUDOMODULES += bplib_no_vfs
-
-ARCHIVES += $(BINDIR)/libbplib.a


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Before, I placed the makefile compiling the library itself as a patch inside the bplib folder. For multiple reasons this is bad.

Why this is better / Why was it bad before?
- #22561 did not consider this case (rightfully so), now it can be easily added to the .include file.
- This is much easier to change than to change a patch every time
- When defines changed the core library was not rebuilt (which is bad if these defines changes something in the core library, like the local EID)

The patch still remains and will be removed when I update the version of bplib.

Currently the Makefiles contain all the includes/dependencies for all submodules (e.g. CLAs). When more such submodules are added I would also change this to use sub-Makefiles and include them, but for now this should still be fine.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Since this is a buildsystem change it should be fine that it still compiles. It does and the `examples/networking/dtn/bplib_cla_udp` still works as expected on native.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

- none

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
