### PR TITLE
byteorder.h: remove unused union members

### DIFF
--- a/sys/include/byteorder.h
+++ b/sys/include/byteorder.h
@@ -44,8 +44,6 @@ typedef union __attribute__((packed)) {
 typedef union __attribute__((packed)) {
     uint32_t u32;       /**< 32 bit representation */
     uint8_t u8[4];      /**< 8 bit representation */
-    uint16_t u16[2];    /**< 16 bit representation */
-    le_uint16_t l16[2]; /**< little endian 16 bit representation */
 } le_uint32_t;
 
 /**
@@ -56,10 +54,6 @@ typedef union __attribute__((packed)) {
 typedef union __attribute__((packed)) {
     uint64_t u64;       /**< 64 bit representation */
     uint8_t u8[8];      /**< 8 bit representation */
-    uint16_t u16[4];    /**< 16 bit representation */
-    uint32_t u32[2];    /**< 32 bit representation */
-    le_uint16_t l16[4]; /**< little endian 16 bit representation */
-    le_uint32_t l32[2]; /**< little endian 32 bit representation */
 } le_uint64_t;
 
 /**
@@ -80,8 +74,6 @@ typedef union __attribute__((packed)) {
 typedef union __attribute__((packed)) {
     uint32_t u32;       /**< 32 bit representation */
     uint8_t u8[4];      /**< 8 bit representation */
-    uint16_t u16[2];    /**< 16 bit representation */
-    be_uint16_t b16[2]; /**< big endian 16 bit representation */
 } be_uint32_t;
 
 /**
@@ -92,10 +84,6 @@ typedef union __attribute__((packed)) {
 typedef union __attribute__((packed)) {
     uint64_t u64;       /**< 64 bit representation */
     uint8_t u8[8];      /**< 8 bit representation */
-    uint16_t u16[4];    /**< 16 bit representation */
-    uint32_t u32[2];    /**< 32 bit representation */
-    be_uint16_t b16[4]; /**< big endian 16 bit representation */
-    be_uint32_t b32[2]; /**< big endian 32 bit representation */
 } be_uint64_t;
 
 /**

--- a/sys/include/net/ipv6/hdr.h
+++ b/sys/include/net/ipv6/hdr.h
@@ -244,7 +244,8 @@ static inline void ipv6_hdr_set_fl(ipv6_hdr_t *hdr, uint32_t fl)
 {
     hdr->v_tc_fl.u8[1] &= 0xf0;
     hdr->v_tc_fl.u8[1] |= (0x0f & (byteorder_htonl(fl).u8[1]));
-    hdr->v_tc_fl.u16[1] = byteorder_htonl(fl).u16[1];
+    hdr->v_tc_fl.u8[2] = byteorder_htonl(fl).u8[2];
+    hdr->v_tc_fl.u8[3] = byteorder_htonl(fl).u8[3];
 }
 
 /**


### PR DESCRIPTION
### Contribution description

As the title says. This makes the union much more readible, e.g. in the debugger.

### Testing procedure

CI should catch regressions.

### Related Issues/PRs

Spin out of https://github.com/RIOT-OS/RIOT/pull/22075#issuecomment-3954256223

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
