### PR TITLE
sys/net/sock: start transition to type-safe ipvX_addr_t

### DIFF
--- a/doc/guides/networking/coap.mdx
+++ b/doc/guides/networking/coap.mdx
@@ -247,7 +247,7 @@ static int _send_coap_request(void)
     remote.netif = SOCK_ADDR_ANY_NETIF;
     remote.port = CONFIG_GCOAP_PORT;
 
-    if (ipv6_addr_from_str((ipv6_addr_t *)&remote.addr.ipv6, SERVER_ADDRESS) ==
+    if (ipv6_addr_from_str(&remote.ip.addr.v6, SERVER_ADDRESS) ==
         NULL) {
         puts("Error: unable to parse destination address");
         return -1;

--- a/examples/guides/coap/client/main.c
+++ b/examples/guides/coap/client/main.c
@@ -54,7 +54,7 @@ static int _send_coap_request(void)
     remote.netif = SOCK_ADDR_ANY_NETIF;
     remote.port = CONFIG_GCOAP_PORT;
 
-    if (ipv6_addr_from_str((ipv6_addr_t *)&remote.addr.ipv6, SERVER_ADDRESS) ==
+    if (ipv6_addr_from_str(&remote.ip.addr.v6, SERVER_ADDRESS) ==
         NULL) {
         puts("Error: unable to parse destination address");
         return -1;

--- a/examples/networking/coap/libcoap_server/server_coap.c
+++ b/examples/networking/coap/libcoap_server/server_coap.c
@@ -130,9 +130,8 @@ static int init_coap_context_endpoints(const char *use_psk)
     }
 
     coap_address_init(&listenaddress);
-    listenaddress.riot.family = AF_INET6;
-    memcpy(&listenaddress.riot.addr.ipv6, &addr,
-           sizeof(listenaddress.riot.addr.ipv6));
+    listenaddress.riot.ip.family = AF_INET6;
+    listenaddress.riot.ip.addr.v6 = addr;
     coap_print_ip_addr(&listenaddress, addr_str, sizeof(addr_str));
     coap_log_info("Server IP [%s]\n", addr_str);
 

--- a/examples/networking/cord/cord_epsim/main.c
+++ b/examples/networking/cord/cord_epsim/main.c
@@ -87,7 +87,7 @@ int main(void)
 
     /* if netif is not specified in addr and it's link local */
     if ((rd_ep.netif == SOCK_ADDR_ANY_NETIF) &&
-         ipv6_addr_is_link_local((ipv6_addr_t *) &rd_ep.addr.ipv6)) {
+         ipv6_addr_is_link_local(&rd_ep.ip.addr.v6)) {
         /* if there is only one interface we use that */
         if (gnrc_netif_numof() == 1) {
             rd_ep.netif = (uint16_t)gnrc_netif_iter(NULL)->pid;

--- a/examples/networking/dtls/dtls-echo/dtls-client.c
+++ b/examples/networking/dtls/dtls-echo/dtls-client.c
@@ -120,14 +120,14 @@ static int dtls_handle_read(dtls_context_t *ctx)
     dtls_session_init(&session);
     session.addr.port = remote.port;
     session.addr.family = AF_INET6;
-    if (remote.netif == SOCK_ADDR_ANY_NETIF) {
+    if (remote.ip.netif == SOCK_ADDR_ANY_NETIF) {
         session.ifindex = SOCK_ADDR_ANY_NETIF;
     }
     else {
-        session.ifindex = remote.netif;
+        session.ifindex = remote.ip.netif;
     }
 
-    memcpy(&session.addr.ipv6, &remote.addr.ipv6, sizeof(session.addr.ipv6));
+    session.addr.ipv6 = remote.ip.addr.v6;
 
     if (IS_ACTIVE(ENABLE_DEBUG)) {
         DEBUG("DBG-Client: Msg received from \n\t Addr Src: [");
@@ -353,7 +353,7 @@ dtls_context_t *_init_dtls(sock_udp_t *sock, sock_udp_ep_t *local,
         remote->netif = (uint16_t)netif->pid;
     }
 
-    if (ipv6_addr_from_str(remote->ip.addr.v6, addr_str) == NULL) {
+    if (ipv6_addr_from_str(&remote->ip.addr.v6, addr_str) == NULL) {
         puts("ERROR: unable to parse destination address");
         return new_context;
     }

--- a/examples/networking/dtls/dtls-echo/dtls-client.c
+++ b/examples/networking/dtls/dtls-echo/dtls-client.c
@@ -353,7 +353,7 @@ dtls_context_t *_init_dtls(sock_udp_t *sock, sock_udp_ep_t *local,
         remote->netif = (uint16_t)netif->pid;
     }
 
-    if (ipv6_addr_from_str((ipv6_addr_t *)remote->addr.ipv6, addr_str) == NULL) {
+    if (ipv6_addr_from_str(remote->ip.addr.v6, addr_str) == NULL) {
         puts("ERROR: unable to parse destination address");
         return new_context;
     }

--- a/examples/networking/dtls/dtls-echo/dtls-server.c
+++ b/examples/networking/dtls/dtls-echo/dtls-server.c
@@ -115,14 +115,14 @@ static int dtls_handle_read(dtls_context_t *ctx)
     dtls_session_init(&session);
     session.addr.port = remote_peer->remote->port;
     session.addr.family = AF_INET6;
-    if (remote_peer->remote->netif ==  SOCK_ADDR_ANY_NETIF) {
+    if (remote_peer->remote->ip.netif == SOCK_ADDR_ANY_NETIF) {
         session.ifindex = SOCK_ADDR_ANY_NETIF;
     }
     else {
-        session.ifindex = remote_peer->remote->netif;
+        session.ifindex = remote_peer->remote->ip.netif;
     }
 
-    memcpy(&session.addr.ipv6, &remote_peer->remote->addr.ipv6, sizeof(session.addr.ipv6));
+    session.addr.ipv6 = remote_peer->remote->ip.addr.v6;
     return dtls_handle_message(ctx, &session, packet_rcvd, res);
 }
 

--- a/examples/networking/dtls/dtls-wolfssl/dtls-client.c
+++ b/examples/networking/dtls/dtls-wolfssl/dtls-client.c
@@ -117,7 +117,7 @@ static int _client_cmd(int argc, char **argv)
         }
         remote.netif = (uint16_t)netif->pid;
     }
-    if (ipv6_addr_from_str(remote.addr.v6, addr_str) == NULL) {
+    if (ipv6_addr_from_str(&remote.ip.addr.v6, addr_str) == NULL) {
         LOG(LOG_ERROR, "ERROR: unable to parse destination address\n");
         usage(argv[0]);
         return -1;

--- a/examples/networking/dtls/dtls-wolfssl/dtls-client.c
+++ b/examples/networking/dtls/dtls-wolfssl/dtls-client.c
@@ -117,7 +117,7 @@ static int _client_cmd(int argc, char **argv)
         }
         remote.netif = (uint16_t)netif->pid;
     }
-    if (ipv6_addr_from_str((ipv6_addr_t *)remote.addr.ipv6, addr_str) == NULL) {
+    if (ipv6_addr_from_str(remote.addr.v6, addr_str) == NULL) {
         LOG(LOG_ERROR, "ERROR: unable to parse destination address\n");
         usage(argv[0]);
         return -1;

--- a/examples/networking/misc/telnet_server/main.c
+++ b/examples/networking/misc/telnet_server/main.c
@@ -42,7 +42,7 @@ void telnet_cb_pre_connected(sock_tcp_t *sock)
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
     sock_tcp_get_local(sock, &ep);
-    ipv6_addr_to_str(addr_str, ep.ip.addr.v6, sizeof(addr_str));
+    ipv6_addr_to_str(addr_str, &ep.ip.addr.v6, sizeof(addr_str));
 
     printf("%s connected\n", addr_str);
 }

--- a/examples/networking/misc/telnet_server/main.c
+++ b/examples/networking/misc/telnet_server/main.c
@@ -42,7 +42,7 @@ void telnet_cb_pre_connected(sock_tcp_t *sock)
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
     sock_tcp_get_local(sock, &ep);
-    ipv6_addr_to_str(addr_str, (ipv6_addr_t *)ep.addr.ipv6, sizeof(addr_str));
+    ipv6_addr_to_str(addr_str, ep.ip.addr.v6, sizeof(addr_str));
 
     printf("%s connected\n", addr_str);
 }

--- a/examples/networking/mqtt/emcute_mqttsn/main.c
+++ b/examples/networking/mqtt/emcute_mqttsn/main.c
@@ -83,7 +83,7 @@ static int cmd_con(int argc, char **argv)
     }
 
     /* parse address */
-    if (ipv6_addr_from_str((ipv6_addr_t *)&gw.addr.ipv6, argv[1]) == NULL) {
+    if (ipv6_addr_from_str(&gw.ip.addr.v6, argv[1]) == NULL) {
         printf("error parsing IPv6 address\n");
         return 1;
     }

--- a/pkg/bplib/cla/udp/bplib_cla_udp.c
+++ b/pkg/bplib/cla/udp/bplib_cla_udp.c
@@ -84,7 +84,7 @@ int bplib_cla_udp_start(bplib_cla_udp_t* cla, uint32_t contact_id)
     sock_udp_ep_t local_ep = SOCK_IPV6_EP_ANY;
     sock_udp_ep_t remote_ep = SOCK_IPV6_EP_ANY;
 
-    if (ipv6_addr_from_str((ipv6_addr_t*) &remote_ep.addr.ipv6, bplib_instance_data.ConfigPtrs.
+    if (ipv6_addr_from_str(&remote_ep.ip.addr.v6, bplib_instance_data.ConfigPtrs.
                            ContactsConfigPtr->ContactSet[contact_id].ClaOutAddr) == NULL) {
         DEBUG("Failed to convert IP address [%s]\n",
             bplib_instance_data.ConfigPtrs.ContactsConfigPtr->ContactSet[contact_id].ClaOutAddr);
@@ -94,7 +94,7 @@ int bplib_cla_udp_start(bplib_cla_udp_t* cla, uint32_t contact_id)
     remote_ep.port = bplib_instance_data.ConfigPtrs.
                         ContactsConfigPtr->ContactSet[contact_id].ClaOutPort;
 
-    if (ipv6_addr_from_str((ipv6_addr_t*) &local_ep.addr.ipv6, bplib_instance_data.ConfigPtrs.
+    if (ipv6_addr_from_str(&local_ep.ip.addr.v6, bplib_instance_data.ConfigPtrs.
                            ContactsConfigPtr->ContactSet[contact_id].ClaInAddr) == NULL) {
         DEBUG("Failed to convert IP address [%s]\n",
             bplib_instance_data.ConfigPtrs.ContactsConfigPtr->ContactSet[contact_id].ClaInAddr);

--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -946,7 +946,7 @@ void sock_dtls_init(void)
 static void _ep_to_session(const sock_udp_ep_t *ep, session_t *session)
 {
     dtls_session_init(session);
-    session->addr.family = ep->family;
+    session->addr.family = ep->ip.family;
     session->addr.port = ep->port;
 
     switch (ep->family) {
@@ -958,7 +958,7 @@ static void _ep_to_session(const sock_udp_ep_t *ep, session_t *session)
 #endif
 #ifdef SOCK_HAS_IPV6
     case AF_INET6:
-        if (ipv6_addr_is_link_local(ep->ip.addr.v6)) {
+        if (ipv6_addr_is_link_local(&ep->ip.addr.v6)) {
             /* set ifindex for link-local addresses */
             session->ifindex = ep->netif;
         }
@@ -977,8 +977,8 @@ static void _ep_to_session(const sock_udp_ep_t *ep, session_t *session)
 static void _session_to_ep(const session_t *session, sock_udp_ep_t *ep)
 {
     ep->port = session->addr.port;
-    ep->netif = session->ifindex;
-    ep->family = session->addr.family;
+    ep->ip.netif = session->ifindex;
+    ep->ip.family = session->addr.family;
 
     switch (session->addr.family) {
 #ifdef SOCK_HAS_IPV4

--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -958,7 +958,7 @@ static void _ep_to_session(const sock_udp_ep_t *ep, session_t *session)
 #endif
 #ifdef SOCK_HAS_IPV6
     case AF_INET6:
-        if (ipv6_addr_is_link_local((ipv6_addr_t *)ep->addr.ipv6)) {
+        if (ipv6_addr_is_link_local(ep->ip.addr.v6)) {
             /* set ifindex for link-local addresses */
             session->ifindex = ep->netif;
         }

--- a/pkg/wakaama/contrib/lwm2m_client_connection.c
+++ b/pkg/wakaama/contrib/lwm2m_client_connection.c
@@ -154,8 +154,8 @@ bool lwm2m_session_is_equal(void *session1, void *session2, void *user_data)
     lwm2m_client_connection_t *conn_2 = (lwm2m_client_connection_t *)session2;
 
     return ((conn_1->remote.port == conn_2->remote.port) &&
-            ipv6_addr_equal((ipv6_addr_t *)&(conn_1->remote.addr.ipv6),
-                            (ipv6_addr_t *)&(conn_2->remote.addr.ipv6)));
+            ipv6_addr_equal(&conn_1->remote.ip.addr.v6,
+                            &conn_2->remote.ip.addr.v6));
 }
 
 uint8_t lwm2m_buffer_send(void *sessionH, uint8_t *buffer, size_t length,
@@ -186,7 +186,7 @@ lwm2m_client_connection_t *lwm2m_client_connection_find(lwm2m_client_connection_
     char ip[128];
     uint8_t ip_len = 128;
 
-    ipv6_addr_to_str(ip, (ipv6_addr_t *)&remote->addr.ipv6, ip_len);
+    ipv6_addr_to_str(ip, &remote->ip.addr.v6, ip_len);
     DEBUG("Looking for connection from [%s]:%" PRIu16 "\n", ip, remote->port);
 
     if (conn_list == NULL) {
@@ -194,11 +194,11 @@ lwm2m_client_connection_t *lwm2m_client_connection_find(lwm2m_client_connection_
     }
 
     while (conn != NULL) {
-        ipv6_addr_to_str(ip, (ipv6_addr_t *)&conn->remote.addr.ipv6, ip_len);
+        ipv6_addr_to_str(ip, &conn->remote.ip.addr.v6, ip_len);
         DEBUG("Comparing to [%s]:%" PRIu16 "\n", ip, conn->remote.port);
         if ((conn->remote.port == remote->port) && conn->type == type &&
-            ipv6_addr_equal((ipv6_addr_t *)&(conn->remote.addr.ipv6),
-                            (ipv6_addr_t *)&(remote->addr.ipv6))) {
+            ipv6_addr_equal(&conn->remote.ip.addr.v6,
+                            &remote->ip.addr.v6)) {
             break;
         }
         conn = conn->next;
@@ -336,13 +336,13 @@ static lwm2m_client_connection_t *_connection_create(uint16_t sec_obj_inst_id,
     conn->remote.netif = SOCK_ADDR_ANY_NETIF;
     conn->remote.port = port;
 
-    if (!ipv6_addr_from_buf((ipv6_addr_t *)&conn->remote.addr.ipv6, parsed_uri.ipv6addr,
+    if (!ipv6_addr_from_buf(&conn->remote.ip.addr.v6, parsed_uri.ipv6addr,
                             parsed_uri.ipv6addr_len)) {
         DEBUG("[_connection_create] IPv6 address malformed\n");
         goto free_out;
     }
 
-    if (ipv6_addr_is_unspecified((const ipv6_addr_t *)&conn->remote.addr.ipv6)) {
+    if (ipv6_addr_is_unspecified(&conn->remote.ip.addr.v6)) {
         DEBUG("[_connection_create] Invalid server address ([::])\n");
         goto free_out;
     }
@@ -350,7 +350,7 @@ static lwm2m_client_connection_t *_connection_create(uint16_t sec_obj_inst_id,
     /* If the address is a link-local one first check if interface is specified,
      * if not, check the number of interfaces and default to the first if there
      * is only one defined. */
-    if (ipv6_addr_is_link_local((ipv6_addr_t *)&conn->remote.addr.ipv6)) {
+    if (ipv6_addr_is_link_local(&conn->remote.ip.addr.v6)) {
         netif_t *netif = _get_interface(parsed_uri.zoneid, parsed_uri.zoneid_len);
 
         if (netif == NULL) {

--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -102,6 +102,9 @@
 #include <stddef.h>
 #include "iolist.h"
 
+#include "net/ipv4/addr.h"
+#include "net/ipv6/addr.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -185,11 +188,29 @@ typedef struct {
          * @brief IPv6 address mode
          *
          * @note only available if @ref SOCK_HAS_IPV6 is defined.
+         * @deprecated use @ref sock_ip_ep_t::addr::v6 instead. will be removed after release 2027.04
          */
         uint8_t ipv6[16];
+        /**
+         * @brief IPv6 address mode
+         *
+         * @note only available if @ref SOCK_HAS_IPV6 is defined.
+         */
+        ipv6_addr_t v6;
 #endif
-        uint8_t ipv4[4];        /**< IPv4 address mode */
-        uint32_t ipv4_u32;      /**< IPv4 address *in network byte order* */
+        /**
+         * @brief IPv4 address mode
+         *
+         * @deprecated use @ref sock_ip_ep_t::addr::v4 instead. will be removed after release 2027.04
+         */
+        uint8_t ipv4[4];
+        ipv4_addr_t v4;      /**< IPv4 address mode */
+        /**
+         * @brief IPv4 address *in network byte order*
+         *
+         * @deprecated use @ref sock_ip_ep_t::addr::v4::u32 instead. will be removed after release 2027.04
+         */
+        uint32_t ipv4_u32;
     } addr;                 /**< address */
 
     /**
@@ -205,41 +226,64 @@ typedef struct {
     uint16_t netif;
 } sock_ip_ep_t;
 
+/// some usages could be replaced automatically with
+/// search (regex): \(ipv[46]_addr_t \*\)(.*)addr\.ipv([46])
+/// replace: $1ip.addr.v$2
+/// others worthwhile to replace are memcmp/memcpy etc.__builtin_bswap16
+
 /**
  * @brief   Common IP-based transport layer end point
  */
 struct _sock_tl_ep {
-    /**
-     * @brief family of sock_ip_ep_t::addr
-     *
-     * @see @ref net_af
-     */
-    int family;
-
     union {
-#ifdef SOCK_HAS_IPV6
-        /**
-         * @brief IPv6 address mode
-         *
-         * @note only available if @ref SOCK_HAS_IPV6 is defined.
-         */
-        uint8_t ipv6[16];
-#endif
-        uint8_t ipv4[4];        /**< IPv4 address mode */
-        uint32_t ipv4_u32;      /**< IPv4 address *in network byte order* */
-    } addr;                 /**< address */
+        struct {
+            /**
+             * @brief family of _sock_tl_ep::addr
+             *
+             * @see @ref net_af
+             * @deprecated use @ref _sock_tl_ep::ip::family instead. will be removed after release 2027.04
+             */
+            int family;
 
-    /**
-     * @brief   stack-specific network interface ID
-     *
-     * @todo    port to common network interface identifiers in PR #5511.
-     *
-     * Use @ref SOCK_ADDR_ANY_NETIF for any interface.
-     * For reception this is the local interface the message came over,
-     * for transmission, this is the local interface the message should be send
-     * over
-     */
-    uint16_t netif;
+            union {
+        #ifdef SOCK_HAS_IPV6
+                /**
+                 * @brief IPv6 address mode
+                 *
+                 * @note only available if @ref SOCK_HAS_IPV6 is defined.
+                 * @deprecated use @ref _sock_tl_ep::ip::addr::v6 instead. will be removed after release 2027.04
+                 */
+                uint8_t ipv6[16];
+        #endif
+                /**
+                 * @brief IPv4 address mode
+                 *
+                 * @deprecated use @ref _sock_tl_ep::ip::addr::v4 instead. will be removed after release 2027.04
+                 */
+                uint8_t ipv4[4];
+                /**
+                 * @brief IPv4 address *in network byte order*
+                 *
+                 * @deprecated use @ref _sock_tl_ep::ip::addr::v4::u32 instead. will be removed after release 2027.04
+                 */
+                uint32_t ipv4_u32;
+            } addr;                 /**< address */
+
+            /**
+             * @brief   stack-specific network interface ID
+             *
+             * @todo    port to common network interface identifiers in PR #5511.
+             * @deprecated use @ref _sock_tl_ep::ip::netif instead. will be removed after release 2027.04
+             *
+             * Use @ref SOCK_ADDR_ANY_NETIF for any interface.
+             * For reception this is the local interface the message came over,
+             * for transmission, this is the local interface the message should be send
+             * over
+             */
+            uint16_t netif;
+        };
+        sock_ip_ep_t ip;
+    };
     uint16_t port;          /**< transport layer port (in host byte order) */
 };
 

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -335,7 +335,7 @@
  *     sock_dtls_t dtls_sock;
  *     sock_dtls_session_t session;
  *
- *     if (!ipv6_addr_from_str(remote.ip.addr.v6, SERVER_ADDR)) {
+ *     if (!ipv6_addr_from_str(&remote.ip.addr.v6, SERVER_ADDR)) {
  *         puts("Error parsing destination address");
  *         return -1;
  *     }
@@ -407,7 +407,7 @@
  * remote.port = DTLS_DEFAULT_PORT;
  * remote.netif = gnrc_netif_iter(NULL)->pid;   // only if gnrc_netif_highlander() returns true
  *
- * if (!ipv6_addr_from_str(remote.ip.addr.v6, SERVER_ADDR)) {
+ * if (!ipv6_addr_from_str(&remote.ip.addr.v6, SERVER_ADDR)) {
  *     puts("Error parsing destination address");
  *     return -1;
  * }

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -335,7 +335,7 @@
  *     sock_dtls_t dtls_sock;
  *     sock_dtls_session_t session;
  *
- *     if (!ipv6_addr_from_str((ipv6_addr_t *)remote.addr.ipv6, SERVER_ADDR)) {
+ *     if (!ipv6_addr_from_str(remote.ip.addr.v6, SERVER_ADDR)) {
  *         puts("Error parsing destination address");
  *         return -1;
  *     }
@@ -407,7 +407,7 @@
  * remote.port = DTLS_DEFAULT_PORT;
  * remote.netif = gnrc_netif_iter(NULL)->pid;   // only if gnrc_netif_highlander() returns true
  *
- * if (!ipv6_addr_from_str((ipv6_addr_t *)remote.addr.ipv6, SERVER_ADDR)) {
+ * if (!ipv6_addr_from_str(remote.ip.addr.v6, SERVER_ADDR)) {
  *     puts("Error parsing destination address");
  *     return -1;
  * }

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -162,7 +162,7 @@
  *         sock_ip_ep_t remote = { .family = AF_INET6 };
  *         ssize_t res;
  *
- *         ipv6_addr_set_all_nodes_multicast((ipv6_addr_t *)&remote.addr.ipv6,
+ *         ipv6_addr_set_all_nodes_multicast(&remote.addr.v6,
  *                                           IPV6_ADDR_MCAST_SCP_LINK_LOCAL);
  *
  *         if (sock_ip_send(&sock, "Hello!", sizeof("Hello!"), 0, &remote) < 0) {
@@ -219,7 +219,7 @@
  *         sock_ip_ep_t remote = { .family = AF_INET6 };
  *         ssize_t res;
  *
- *         ipv6_addr_set_all_nodes_multicast((ipv6_addr_t *)&remote.addr.ipv6,
+ *         ipv6_addr_set_all_nodes_multicast(&remote.addr.v6,
  *                                           IPV6_ADDR_MCAST_SCP_LINK_LOCAL);
  *
  *         if (sock_ip_send(&sock, "Hello!", sizeof("Hello!"), 0, &remote) < 0) {

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -160,7 +160,7 @@
  *         ssize_t res;
  *
  *         remote.port = 12345;
- *         ipv6_addr_set_all_nodes_multicast((ipv6_addr_t *)&remote.addr.ipv6,
+ *         ipv6_addr_set_all_nodes_multicast(&remote.ip.addr.v6,
  *                                           IPV6_ADDR_MCAST_SCP_LINK_LOCAL);
  *         if (sock_udp_send(&sock, "Hello!", sizeof("Hello!"), &remote) < 0) {
  *             puts("Error sending message");
@@ -219,7 +219,7 @@
  *         ssize_t res;
  *
  *         remote.port = 12345;
- *         ipv6_addr_set_all_nodes_multicast((ipv6_addr_t *)&remote.addr.ipv6,
+ *         ipv6_addr_set_all_nodes_multicast(&remote.ip.addr.v6,
  *                                           IPV6_ADDR_MCAST_SCP_LINK_LOCAL);
  *         if (sock_udp_send(&sock, "Hello!", sizeof("Hello!"), &remote) < 0) {
  *             puts("Error sending message");
@@ -808,11 +808,11 @@ static inline bool sock_udp_ep_is_multicast(const sock_udp_ep_t *ep)
     switch (ep->family) {
 #ifdef SOCK_HAS_IPV6
     case AF_INET6:
-        return ipv6_addr_is_multicast((const ipv6_addr_t *)&ep->addr.ipv6);
+        return ipv6_addr_is_multicast(&ep->ip.addr.v6);
 #endif
 #ifdef SOCK_HAS_IPV4
     case AF_INET:
-        return ipv4_addr_is_multicast((const ipv4_addr_t *)&ep->addr.ipv4);
+        return ipv4_addr_is_multicast(&ep->ip.addr.v4);
 #endif
     default:
         assert(0);

--- a/sys/net/application_layer/dhcpv6/client_dns.c
+++ b/sys/net/application_layer/dhcpv6/client_dns.c
@@ -35,10 +35,9 @@ void dhcpv6_client_dns_rns_conf(const dhcpv6_opt_dns_rns_t *opt, uint16_t netif)
     DEBUG("Overriding sock_dns_server with %s\n",
           ipv6_addr_to_str(addr_str, opt->dns_rns, sizeof(addr_str)));
     sock_dns_server.port = SOCK_DNS_PORT;
-    sock_dns_server.family = AF_INET6;
-    sock_dns_server.netif = netif;
-    memcpy(sock_dns_server.addr.ipv6, opt->dns_rns,
-           sizeof(sock_dns_server.addr.ipv6));
+    sock_dns_server.ip.family = AF_INET6;
+    sock_dns_server.ip.netif = netif;
+    sock_dns_server.ip.addr.v6 = opt->dns_rns;
     return;
 #endif
 }

--- a/sys/net/application_layer/dhcpv6/relay.c
+++ b/sys/net/application_layer/dhcpv6/relay.c
@@ -290,9 +290,7 @@ static void _forward_msg(const sock_udp_ep_t *remote, const uint8_t *in_msg,
     /* set link-address to unspecified address, we will provide an Interface-ID
      * option instead */
     memset(&out_fwd->link_address, 0, sizeof(out_fwd->link_address));
-    assert(sizeof(out_fwd->peer_address) == sizeof(remote->addr.ipv6));
-    memcpy(&out_fwd->peer_address, &remote->addr.ipv6,
-           sizeof(out_fwd->peer_address));
+    out_fwd->peer_address = remote->ip.addr.v6;
 
     /* set mandatory options */
     out_fwd_len += _compose_iid_opt(
@@ -393,9 +391,7 @@ static void _forward_reply(const uint8_t *in_msg, size_t in_msg_size)
         /* out message is heading for the client it is destined to */
         target.port = DHCPV6_CLIENT_PORT;
     }
-    assert(sizeof(in_reply->peer_address) == sizeof(target.addr.ipv6));
-
-    memcpy(&target.addr.ipv6, &in_reply->peer_address, sizeof(target.addr.ipv6));
+    target.ip.addr.v6 = in_reply->peer_address;
     if (IS_USED(MODULE_SOCK_UTIL) && ENABLE_DEBUG) {
         static char addr_str[IPV6_ADDR_MAX_STR_LEN];
         uint16_t port;

--- a/sys/net/application_layer/gcoap/dns.c
+++ b/sys/net/application_layer/gcoap/dns.c
@@ -407,7 +407,7 @@ static int _set_remote(const uri_parser_result_t *uri_comp,
     memset(remote, 0, sizeof(*remote));
 
     if (uri_comp->ipv6addr != NULL) {
-        if (ipv6_addr_from_buf((ipv6_addr_t *)remote->addr.ipv6,
+        if (ipv6_addr_from_buf(remote->ip.addr.v6,
                                uri_comp->ipv6addr,
                                uri_comp->ipv6addr_len) == NULL) {
             DEBUG("gcoap_dns: unable to parse IPv6 address %*.s\n",
@@ -429,7 +429,7 @@ static int _set_remote(const uri_parser_result_t *uri_comp,
             remote->netif = SOCK_ADDR_ANY_NETIF;
         }
     }
-    else if (ipv4_addr_from_buf((ipv4_addr_t *)remote->addr.ipv4,
+    else if (ipv4_addr_from_buf(remote->ip.addr.v4,
                                 uri_comp->host, uri_comp->host_len) != NULL) {
         remote->family = AF_INET;
     }
@@ -655,7 +655,7 @@ static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t *pdu,
 
     if ((remote->port != _remote.port) ||
         (remote->family != _remote.family) ||
-        (!ipv6_addr_is_unspecified((ipv6_addr_t *)_remote.addr.ipv6) &&
+        (!ipv6_addr_is_unspecified(_remote.ip.addr.v6) &&
          (memcmp(remote->addr.ipv6, _remote.addr.ipv6,
                  sizeof(_remote.addr.ipv6)) != 0))) {
         DEBUG("gcoap_dns: unexpected remote for reply\n");

--- a/sys/net/application_layer/gcoap/dns.c
+++ b/sys/net/application_layer/gcoap/dns.c
@@ -407,7 +407,7 @@ static int _set_remote(const uri_parser_result_t *uri_comp,
     memset(remote, 0, sizeof(*remote));
 
     if (uri_comp->ipv6addr != NULL) {
-        if (ipv6_addr_from_buf(remote->ip.addr.v6,
+        if (ipv6_addr_from_buf(&remote->ip.addr.v6,
                                uri_comp->ipv6addr,
                                uri_comp->ipv6addr_len) == NULL) {
             DEBUG("gcoap_dns: unable to parse IPv6 address %*.s\n",
@@ -429,7 +429,7 @@ static int _set_remote(const uri_parser_result_t *uri_comp,
             remote->netif = SOCK_ADDR_ANY_NETIF;
         }
     }
-    else if (ipv4_addr_from_buf(remote->ip.addr.v4,
+    else if (ipv4_addr_from_buf(&remote->ip.addr.v4,
                                 uri_comp->host, uri_comp->host_len) != NULL) {
         remote->family = AF_INET;
     }
@@ -655,9 +655,8 @@ static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t *pdu,
 
     if ((remote->port != _remote.port) ||
         (remote->family != _remote.family) ||
-        (!ipv6_addr_is_unspecified(_remote.ip.addr.v6) &&
-         (memcmp(remote->addr.ipv6, _remote.addr.ipv6,
-                 sizeof(_remote.addr.ipv6)) != 0))) {
+        (!ipv6_addr_is_unspecified(&_remote.ip.addr.v6) &&
+         !ipv6_addr_equal(&remote->ip.addr.v6, &_remote.ip.addr.v6))) {
         DEBUG("gcoap_dns: unexpected remote for reply\n");
         context->res = -EDESTADDRREQ;
         goto unlock;

--- a/sys/net/application_layer/gcoap/forward_proxy.c
+++ b/sys/net/application_layer/gcoap/forward_proxy.c
@@ -213,7 +213,7 @@ static bool _parse_endpoint(sock_udp_ep_t *remote,
         ipv6_addr_is_link_local(&addr)) {
         return false;
     }
-    memcpy(&remote->addr.ipv6[0], &addr.u8[0], sizeof(addr.u8));
+    remote->ip.addr.v6 = addr;
 
     if (urip->port != 0) {
         remote->port = urip->port;

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -951,13 +951,13 @@ static gcoap_request_memo_t* _find_req_memo_by_token(const sock_udp_ep_t *remote
         /* verbose debug to catch bugs with request/response matching */
 #if SOCK_HAS_IPV4
         DEBUG("Seeking memo for remote=%s, tkn=0x%02x%02x%02x%02x%02x%02x%02x%02x, tkl=%"PRIuSIZE"\n",
-              ipv4_addr_to_str(_ipv6_addr_str, (ipv4_addr_t *)&remote->addr.ipv4,
+              ipv4_addr_to_str(_ipv6_addr_str, &remote->ip.addr.v4,
                                IPV6_ADDR_MAX_STR_LEN),
               token[0], token[1], token[2], token[3], token[4], token[5], token[6], token[7],
               tkl);
 #else
         DEBUG("Seeking memo for remote=%s, tkn=0x%02x%02x%02x%02x%02x%02x%02x%02x, tkl=%"PRIuSIZE"\n",
-              ipv6_addr_to_str(_ipv6_addr_str, (ipv6_addr_t *)&remote->addr.ipv6,
+              ipv6_addr_to_str(_ipv6_addr_str, &remote->ip.addr.v6,
                                IPV6_ADDR_MAX_STR_LEN),
               token[0], token[1], token[2], token[3], token[4], token[5], token[6], token[7],
               tkl);
@@ -982,11 +982,11 @@ static gcoap_request_memo_t* _find_req_memo_by_token(const sock_udp_ep_t *remote
             else {
 #if SOCK_HAS_IPV4
                 DEBUG("Remote address mismatch %s\n",
-                      ipv4_addr_to_str(_ipv6_addr_str, (ipv4_addr_t *)&memo->remote_ep.addr.ipv4,
+                      ipv4_addr_to_str(_ipv6_addr_str, &memo->remote_ep.ip.addr.v4,
                                        IPV6_ADDR_MAX_STR_LEN));
 #else
                 DEBUG("Remote address mismatch %s\n",
-                      ipv6_addr_to_str(_ipv6_addr_str, (ipv6_addr_t *)&memo->remote_ep.addr.ipv6,
+                      ipv6_addr_to_str(_ipv6_addr_str, &memo->remote_ep.ip.addr.v6,
                                        IPV6_ADDR_MAX_STR_LEN));
 #endif
                 continue;

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -1100,7 +1100,7 @@ int nanocoap_sock_url_connect(const char *url, nanocoap_sock_t *sock)
 #if SOCK_HAS_IPV6
         /* tinydtls wants the interface to match */
         if (!remote.netif && sock_udp_ep_is_v6(&remote) &&
-            ipv6_addr_is_link_local(remote.ip.addr.v6)) {
+            ipv6_addr_is_link_local(&remote.ip.addr.v6)) {
             netif_t *iface = netif_iter(NULL);
             if (iface == NULL) {
                 return -ENODEV;

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -1100,7 +1100,7 @@ int nanocoap_sock_url_connect(const char *url, nanocoap_sock_t *sock)
 #if SOCK_HAS_IPV6
         /* tinydtls wants the interface to match */
         if (!remote.netif && sock_udp_ep_is_v6(&remote) &&
-            ipv6_addr_is_link_local((ipv6_addr_t *)remote.addr.ipv6)) {
+            ipv6_addr_is_link_local(remote.ip.addr.v6)) {
             netif_t *iface = netif_iter(NULL);
             if (iface == NULL) {
                 return -ENODEV;

--- a/sys/net/application_layer/unicoap/endpoint.c
+++ b/sys/net/application_layer/unicoap/endpoint.c
@@ -41,7 +41,7 @@ void unicoap_print_sock_tl_ep(const struct _sock_tl_ep* ep) {
     case AF_INET6:
         printf("ipv6=");
 #  if SOCK_HAS_IPV6 && IS_USED(MODULE_IPV6_ADDR)
-        ipv6_addr_print((ipv6_addr_t*)ep->addr.ipv6);
+        ipv6_addr_print(ep->ip.addr.v6);
 #  else
         UNICOAP_DEBUG("SOCK_HAS_IPV6: v6 support missing, cannot print\n");
         printf("?");
@@ -50,7 +50,7 @@ void unicoap_print_sock_tl_ep(const struct _sock_tl_ep* ep) {
     case AF_INET:
         printf("ipv4=");
 #  if SOCK_HAS_IPV4 && IS_USED(MODULE_IPV4_ADDR)
-        ipv4_addr_print((ipv4_addr_t*)ep->addr.ipv4);
+        ipv4_addr_print(ep->ip.addr.v4);
 #  else
         UNICOAP_DEBUG("SOCK_HAS_IPV4: v4 support missing, cannot print\n");
         printf("?");

--- a/sys/net/application_layer/unicoap/endpoint.c
+++ b/sys/net/application_layer/unicoap/endpoint.c
@@ -41,7 +41,7 @@ void unicoap_print_sock_tl_ep(const struct _sock_tl_ep* ep) {
     case AF_INET6:
         printf("ipv6=");
 #  if SOCK_HAS_IPV6 && IS_USED(MODULE_IPV6_ADDR)
-        ipv6_addr_print(ep->ip.addr.v6);
+        ipv6_addr_print(&ep->ip.addr.v6);
 #  else
         UNICOAP_DEBUG("SOCK_HAS_IPV6: v6 support missing, cannot print\n");
         printf("?");

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
@@ -237,7 +237,7 @@ static gnrc_pktsnip_t *_build_ext_opts(gnrc_netif_t *netif,
 
     /* with auto_init_sock_dns we always have a valid (static) DNS server */
     if (((rdnss_ltime < UINT32_MAX) || IS_USED(MODULE_AUTO_INIT_SOCK_DNS)) &&
-        (!ipv6_addr_is_link_local((ipv6_addr_t *)sock_dns_server.addr.ipv6))) {
+        (!ipv6_addr_is_link_local(sock_dns_server.ip.addr.v6))) {
         gnrc_pktsnip_t *rdnsso = gnrc_ndp_opt_rdnss_build(
                 rdnss_ltime * MS_PER_SEC,
                 (ipv6_addr_t *)&sock_dns_server.addr,

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
@@ -237,7 +237,7 @@ static gnrc_pktsnip_t *_build_ext_opts(gnrc_netif_t *netif,
 
     /* with auto_init_sock_dns we always have a valid (static) DNS server */
     if (((rdnss_ltime < UINT32_MAX) || IS_USED(MODULE_AUTO_INIT_SOCK_DNS)) &&
-        (!ipv6_addr_is_link_local(sock_dns_server.ip.addr.v6))) {
+        (!ipv6_addr_is_link_local(&sock_dns_server.ip.addr.v6))) {
         gnrc_pktsnip_t *rdnsso = gnrc_ndp_opt_rdnss_build(
                 rdnss_ltime * MS_PER_SEC,
                 (ipv6_addr_t *)&sock_dns_server.addr,

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1668,9 +1668,7 @@ static uint32_t _handle_rdnsso(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
     if (addr == NULL) {
         unsigned addrs_num = (rdnsso->len - 1) / 2;
         for (unsigned i = 0; i < addrs_num; i++) {
-            if (memcmp(sock_dns_server.addr.ipv6,
-                       &rdnsso->addrs[i],
-                       sizeof(rdnsso->addrs[i])) == 0) {
+            if (ipv6_addr_equal(&sock_dns_server.ip.addr.v6, &rdnsso->addrs[i])) {
                 addr = &rdnsso->addrs[i];
                 break;
             }
@@ -1683,8 +1681,7 @@ static uint32_t _handle_rdnsso(gnrc_netif_t *netif, const icmpv6_hdr_t *icmpv6,
             sock_dns_server.port = SOCK_DNS_PORT;
             sock_dns_server.family = AF_INET6;
             sock_dns_server.netif = netif->pid;
-            memcpy(sock_dns_server.addr.ipv6, rdnsso->addrs,
-                   sizeof(sock_dns_server.addr.ipv6));
+            sock_dns_server.ip.addr.v6 = rdnsso->addrs[0];
 
             if (ltime < UINT32_MAX) {
                 /* the valid lifetime is given in seconds, but our timers work

--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -227,8 +227,8 @@ ssize_t gnrc_sock_send(gnrc_pktsnip_t *payload, sock_ip_ep_t *local,
 #ifdef SOCK_HAS_IPV6
         case AF_INET6: {
             ipv6_hdr_t *hdr;
-            pkt = gnrc_ipv6_hdr_build(payload, (ipv6_addr_t *)&local->addr.ipv6,
-                                      (ipv6_addr_t *)&remote->addr.ipv6);
+            pkt = gnrc_ipv6_hdr_build(payload, &local->addr.v6,
+                                      &remote->addr.v6);
             if (pkt == NULL) {
                 return -ENOMEM;
             }

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
@@ -144,7 +144,7 @@ int gnrc_tcp_ep_init(gnrc_tcp_ep_t *ep, int family, const uint8_t *addr, size_t 
     }
 
     if (addr == NULL && addr_size == 0) {
-        ipv6_addr_set_unspecified(ep->ip.addr.v6);
+        ipv6_addr_set_unspecified((ipv6_addr_t *)ep->addr.ipv6);
     }
     else if (addr_size == sizeof(ipv6_addr_t)) {
         memcpy(ep->addr.ipv6, addr, sizeof(ipv6_addr_t));
@@ -268,7 +268,7 @@ int gnrc_tcp_ep_from_str(gnrc_tcp_ep_t *ep, const char *str)
     }
 
     /* 5.2) Try to read address into endpoint. */
-    if (ipv6_addr_from_str(ep->ip.addr.v6, tmp) == NULL) {
+    if (ipv6_addr_from_str((ipv6_addr_t *)&ep->addr.ipv6, tmp) == NULL) {
         TCP_DEBUG_ERROR("-EINVAL: Invalid address string.");
         TCP_DEBUG_LEAVE;
         return -EINVAL;
@@ -1071,7 +1071,7 @@ int gnrc_tcp_queue_get_local(gnrc_tcp_tcb_queue_t *queue, gnrc_tcp_ep_t *ep)
 #ifdef MODULE_GNRC_IPV6
         if (ep->family == AF_INET6) {
             if (tcb->status & STATUS_ALLOW_ANY_ADDR) {
-                ipv6_addr_set_unspecified( ep->ip.addr.v6);
+                ipv6_addr_set_unspecified((ipv6_addr_t *)&ep->addr.ipv6);
             } else {
                 memcpy(ep->addr.ipv6, tcb->local_addr, sizeof(ep->addr.ipv6));
             }

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
@@ -144,7 +144,7 @@ int gnrc_tcp_ep_init(gnrc_tcp_ep_t *ep, int family, const uint8_t *addr, size_t 
     }
 
     if (addr == NULL && addr_size == 0) {
-        ipv6_addr_set_unspecified((ipv6_addr_t *) ep->addr.ipv6);
+        ipv6_addr_set_unspecified(ep->ip.addr.v6);
     }
     else if (addr_size == sizeof(ipv6_addr_t)) {
         memcpy(ep->addr.ipv6, addr, sizeof(ipv6_addr_t));
@@ -268,7 +268,7 @@ int gnrc_tcp_ep_from_str(gnrc_tcp_ep_t *ep, const char *str)
     }
 
     /* 5.2) Try to read address into endpoint. */
-    if (ipv6_addr_from_str((ipv6_addr_t *) ep->addr.ipv6, tmp) == NULL) {
+    if (ipv6_addr_from_str(ep->ip.addr.v6, tmp) == NULL) {
         TCP_DEBUG_ERROR("-EINVAL: Invalid address string.");
         TCP_DEBUG_LEAVE;
         return -EINVAL;
@@ -1071,7 +1071,7 @@ int gnrc_tcp_queue_get_local(gnrc_tcp_tcb_queue_t *queue, gnrc_tcp_ep_t *ep)
 #ifdef MODULE_GNRC_IPV6
         if (ep->family == AF_INET6) {
             if (tcb->status & STATUS_ALLOW_ANY_ADDR) {
-                ipv6_addr_set_unspecified((ipv6_addr_t *) ep->addr.ipv6);
+                ipv6_addr_set_unspecified( ep->ip.addr.v6);
             } else {
                 memcpy(ep->addr.ipv6, tcb->local_addr, sizeof(ep->addr.ipv6));
             }

--- a/sys/net/sock/sock_util.c
+++ b/sys/net/sock/sock_util.c
@@ -336,7 +336,7 @@ bool sock_tl_ep_equal(const struct _sock_tl_ep *a,
     assert(a && b);
 
     /* compare family and port */
-    if ((a->family != b->family) || (a->port != b->port)) {
+    if ((a->ip.family != b->ip.family) || (a->port != b->port)) {
         return false;
     }
 
@@ -344,11 +344,11 @@ bool sock_tl_ep_equal(const struct _sock_tl_ep *a,
     switch (a->family) {
 #  ifdef SOCK_HAS_IPV4
     case AF_INET:
-        return memcmp(a->addr.ipv4, b->addr.ipv4, 4) == 0;
+        return ipv4_addr_equal(&a->ip.addr.v4, &b->ip.addr.v4);
 #  endif
 #  ifdef SOCK_HAS_IPV6
     case AF_INET6:
-        return memcmp(a->addr.ipv6, b->addr.ipv6, 16) == 0;
+        return ipv6_addr_equal(&a->ip.addr.v6, &b->ip.addr.v6);
 #  endif
     default:
         return false;

--- a/sys/shell/cmds/cord_ep.c
+++ b/sys/shell/cmds/cord_ep.c
@@ -85,7 +85,7 @@ static int _cord_ep_handler(int argc, char **argv)
             return 1;
         }
 
-        if (!ipv6_addr_from_buf((ipv6_addr_t *)&remote.addr.ipv6, uri_result.ipv6addr,
+        if (!ipv6_addr_from_buf(&remote.ip.addr.v6, uri_result.ipv6addr,
                                 uri_result.ipv6addr_len)) {
             puts("error: IPv6 address malformed");
             return 1;

--- a/sys/test_utils/benchmark_udp/benchmark_udp.c
+++ b/sys/test_utils/benchmark_udp/benchmark_udp.c
@@ -155,7 +155,7 @@ int benchmark_udp_start(const char *server, uint16_t port)
         return 1;
     }
 
-    if (netutils_get_ipv6((ipv6_addr_t *)&remote.addr.ipv6, &netif, server) < 0) {
+    if (netutils_get_ipv6(&remote.ip.addr.v6, &netif, server) < 0) {
         puts("can't resolve remote address");
         return 1;
     }

--- a/tests/net/emcute/main.c
+++ b/tests/net/emcute/main.c
@@ -332,7 +332,7 @@ static int _info(int argc, char **argv)
     (void)argv;
     if (_gw.port > 0) {
         printf("Broker: '[%s]:%u'\n",
-               ipv6_addr_to_str(_addr_str, (ipv6_addr_t *)_gw.addr.ipv6,
+               ipv6_addr_to_str(_addr_str, _gw.ip.addr.v6,
                                 sizeof(_addr_str)), _gw.port);
         puts("- Topics:");
         for (unsigned i = 0; i < NUMOFTOPS; i++) {

--- a/tests/net/emcute/main.c
+++ b/tests/net/emcute/main.c
@@ -332,7 +332,7 @@ static int _info(int argc, char **argv)
     (void)argv;
     if (_gw.port > 0) {
         printf("Broker: '[%s]:%u'\n",
-               ipv6_addr_to_str(_addr_str, _gw.ip.addr.v6,
+               ipv6_addr_to_str(_addr_str, &_gw.ip.addr.v6,
                                 sizeof(_addr_str)), _gw.port);
         puts("- Topics:");
         for (unsigned i = 0; i < NUMOFTOPS; i++) {

--- a/tests/net/gnrc_sock_async_event/main.c
+++ b/tests/net/gnrc_sock_async_event/main.c
@@ -78,7 +78,7 @@ static void _recv_udp(sock_udp_t *sock, sock_async_flags_t flags, void *arg)
         if ((res = sock_udp_recv(sock, _buffer, sizeof(_buffer), 0,
                                  &remote)) >= 0) {
             printf("Received UDP packet from [%s]:%u:\n",
-                   ipv6_addr_to_str(_addr_str, (ipv6_addr_t *)remote.addr.ipv6,
+                   ipv6_addr_to_str(_addr_str, remote.ip.addr.v6,
                                     sizeof(_addr_str)),
                    remote.port);
             od_hex_dump(_buffer, res, OD_WIDTH_DEFAULT);
@@ -100,7 +100,7 @@ static void _recv_ip(sock_ip_t *sock, sock_async_flags_t flags, void *arg)
         if ((res = sock_ip_recv(sock, _buffer, sizeof(_buffer), 0,
                                 &remote)) >= 0) {
             printf("Received IP packet from [%s]:\n",
-                   ipv6_addr_to_str(_addr_str, (ipv6_addr_t *)remote.addr.ipv6,
+                   ipv6_addr_to_str(_addr_str, remote.ip.addr.v6,
                                     sizeof(_addr_str)));
             od_hex_dump(_buffer, res, OD_WIDTH_DEFAULT);
         }

--- a/tests/net/gnrc_sock_async_event/main.c
+++ b/tests/net/gnrc_sock_async_event/main.c
@@ -78,7 +78,7 @@ static void _recv_udp(sock_udp_t *sock, sock_async_flags_t flags, void *arg)
         if ((res = sock_udp_recv(sock, _buffer, sizeof(_buffer), 0,
                                  &remote)) >= 0) {
             printf("Received UDP packet from [%s]:%u:\n",
-                   ipv6_addr_to_str(_addr_str, remote.ip.addr.v6,
+                   ipv6_addr_to_str(_addr_str, &remote.ip.addr.v6,
                                     sizeof(_addr_str)),
                    remote.port);
             od_hex_dump(_buffer, res, OD_WIDTH_DEFAULT);
@@ -100,7 +100,7 @@ static void _recv_ip(sock_ip_t *sock, sock_async_flags_t flags, void *arg)
         if ((res = sock_ip_recv(sock, _buffer, sizeof(_buffer), 0,
                                 &remote)) >= 0) {
             printf("Received IP packet from [%s]:\n",
-                   ipv6_addr_to_str(_addr_str, remote.ip.addr.v6,
+                   ipv6_addr_to_str(_addr_str, &remote.addr.v6,
                                     sizeof(_addr_str)));
             od_hex_dump(_buffer, res, OD_WIDTH_DEFAULT);
         }

--- a/tests/net/gnrc_sock_ip/main.c
+++ b/tests/net/gnrc_sock_ip/main.c
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include "net/ipv6/addr.h"
 #include "net/sock/ip.h"
 #include "test_utils/expect.h"
 #include "xtimer.h"
@@ -91,8 +92,7 @@ static void test_sock_ip_create__only_local(void)
                                SOCK_FLAGS_REUSE_EP));
     expect(0 == sock_ip_get_local(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
 }
@@ -109,13 +109,11 @@ static void test_sock_ip_create__only_local_reuse_ep(void)
     expect(0 == sock_ip_get_local(&_sock, &ep));
     expect(0 == sock_ip_get_local(&_sock2, &ep2));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
     expect(AF_INET6 == ep2.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep2.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep2.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep2.netif);
     expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep2));
     sock_ip_close(&_sock2);
@@ -133,7 +131,7 @@ static void test_sock_ip_create__only_remote(void)
     expect(-EADDRNOTAVAIL == sock_ip_get_local(&_sock, &ep));
     expect(0 == sock_ip_get_remote(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&remote_addr, &ep.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
 }
 
@@ -149,12 +147,11 @@ static void test_sock_ip_create__full(void)
                                SOCK_FLAGS_REUSE_EP));
     expect(0 == sock_ip_get_local(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.addr.v6));
     expect(_TEST_NETIF == ep.netif);
     expect(0 == sock_ip_get_remote(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&remote_addr, &ep.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
 }
 

--- a/tests/net/gnrc_sock_tcp/main.c
+++ b/tests/net/gnrc_sock_tcp/main.c
@@ -153,7 +153,7 @@ int sock_tcp_get_local_cmd(int argc, char **argv)
     print_result(argv[0], err);
     if (err == 0) {
         printf("Endpoint: addr.ipv6=");
-        ipv6_addr_print(ep.ip.addr.v6);
+        ipv6_addr_print(&ep.ip.addr.v6);
         printf(" netif=%u port=%u\n", ep.netif, ep.port);
     }
     return 0;
@@ -168,7 +168,7 @@ int sock_tcp_queue_get_local_cmd(int argc, char **argv)
     print_result(argv[0], err);
     if (err == 0) {
         printf("Endpoint: addr.ipv6=");
-        ipv6_addr_print(ep.ip.addr.v6);
+        ipv6_addr_print(&ep.ip.addr.v6);
         printf(" netif=%u port=%u\n", ep.netif, ep.port);
     }
     return 0;
@@ -183,7 +183,7 @@ int sock_tcp_get_remote_cmd(int argc, char **argv)
     print_result(argv[0], err);
     if (err == 0) {
         printf("Endpoint: addr.ipv6=");
-        ipv6_addr_print(ep.ip.addr.v6);
+        ipv6_addr_print(&ep.ip.addr.v6);
         printf(" netif=%u port=%u\n", ep.netif, ep.port);
     }
     return 0;

--- a/tests/net/gnrc_sock_tcp/main.c
+++ b/tests/net/gnrc_sock_tcp/main.c
@@ -153,7 +153,7 @@ int sock_tcp_get_local_cmd(int argc, char **argv)
     print_result(argv[0], err);
     if (err == 0) {
         printf("Endpoint: addr.ipv6=");
-        ipv6_addr_print((ipv6_addr_t *) ep.addr.ipv6);
+        ipv6_addr_print(ep.ip.addr.v6);
         printf(" netif=%u port=%u\n", ep.netif, ep.port);
     }
     return 0;
@@ -168,7 +168,7 @@ int sock_tcp_queue_get_local_cmd(int argc, char **argv)
     print_result(argv[0], err);
     if (err == 0) {
         printf("Endpoint: addr.ipv6=");
-        ipv6_addr_print((ipv6_addr_t *) ep.addr.ipv6);
+        ipv6_addr_print(ep.ip.addr.v6);
         printf(" netif=%u port=%u\n", ep.netif, ep.port);
     }
     return 0;
@@ -183,7 +183,7 @@ int sock_tcp_get_remote_cmd(int argc, char **argv)
     print_result(argv[0], err);
     if (err == 0) {
         printf("Endpoint: addr.ipv6=");
-        ipv6_addr_print((ipv6_addr_t *) ep.addr.ipv6);
+        ipv6_addr_print(ep.ip.addr.v6);
         printf(" netif=%u port=%u\n", ep.netif, ep.port);
     }
     return 0;

--- a/tests/net/gnrc_sock_udp/main.c
+++ b/tests/net/gnrc_sock_udp/main.c
@@ -109,8 +109,7 @@ static void test_sock_udp_create__only_local(void)
     expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
     expect(0 == sock_udp_get_local(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(_TEST_PORT_LOCAL == ep.port);
     expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
@@ -125,8 +124,7 @@ static void test_sock_udp_create__only_local_port0(void)
     expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
     expect(0 == sock_udp_get_local(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(0U != ep.port);
     expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
@@ -143,14 +141,12 @@ static void test_sock_udp_create__only_local_reuse_ep(void)
     expect(0 == sock_udp_get_local(&_sock, &ep));
     expect(0 == sock_udp_get_local(&_sock2, &ep2));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(_TEST_PORT_LOCAL == ep.port);
     expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
     expect(AF_INET6 == ep2.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep2.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep2.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep2.netif);
     expect(_TEST_PORT_LOCAL == ep2.port);
     expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep2));
@@ -169,7 +165,7 @@ static void test_sock_udp_create__only_remote(void)
     expect(-EADDRNOTAVAIL == sock_udp_get_local(&_sock, &ep));
     expect(0 == sock_udp_get_remote(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&remote_addr, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(_TEST_PORT_REMOTE == ep.port);
 }
@@ -187,13 +183,12 @@ static void test_sock_udp_create__full(void)
     expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
     expect(0 == sock_udp_get_local(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.ip.addr.v6));
     expect(_TEST_NETIF == ep.netif);
     expect(_TEST_PORT_LOCAL == ep.port);
     expect(0 == sock_udp_get_remote(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&remote_addr, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(_TEST_PORT_REMOTE == ep.port);
 }

--- a/tests/net/gnrc_tcp/main.c
+++ b/tests/net/gnrc_tcp/main.c
@@ -100,7 +100,7 @@ int gnrc_tcp_ep_from_str_cmd(int argc, char **argv)
         switch (ep.family) {
             case AF_INET6:
                 printf("Family: AF_INET6\n");
-                ipv6_addr_to_str(addr_as_str, (ipv6_addr_t *) ep.addr.ipv6,
+                ipv6_addr_to_str(addr_as_str, ep.ip.addr.v6,
                                  sizeof(addr_as_str));
                 printf("Addr: %s\n", addr_as_str);
                 break;
@@ -356,7 +356,7 @@ int gnrc_tcp_get_local_cmd(int argc, char **argv)
         case 0:
             printf("%s: returns 0\n", argv[0]);
             printf("Endpoint: addr.ipv6=");
-            ipv6_addr_print((ipv6_addr_t *) ep.addr.ipv6);
+            ipv6_addr_print(ep.ip.addr.v6);
             printf(" netif=%u port=%u\n", ep.netif, ep.port);
             break;
 
@@ -380,7 +380,7 @@ int gnrc_tcp_get_remote_cmd(int argc, char **argv)
         case 0:
             printf("%s: returns 0\n", argv[0]);
             printf("Endpoint: addr.ipv6=");
-            ipv6_addr_print((ipv6_addr_t *) ep.addr.ipv6);
+            ipv6_addr_print(ep.ip.addr.v6);
             printf(" netif=%u port=%u\n", ep.netif, ep.port);
             break;
 
@@ -404,7 +404,7 @@ int gnrc_tcp_queue_get_local_cmd(int argc, char **argv)
         case 0:
             printf("%s: returns 0\n", argv[0]);
             printf("Endpoint: addr.ipv6=");
-            ipv6_addr_print((ipv6_addr_t *) ep.addr.ipv6);
+            ipv6_addr_print(ep.ip.addr.v6);
             printf(" netif=%u port=%u\n", ep.netif, ep.port);
             break;
 

--- a/tests/net/gnrc_tcp/main.c
+++ b/tests/net/gnrc_tcp/main.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "net/ipv6/addr.h"
 #include "shell.h"
 #include "msg.h"
 #include "net/af.h"
@@ -100,7 +101,7 @@ int gnrc_tcp_ep_from_str_cmd(int argc, char **argv)
         switch (ep.family) {
             case AF_INET6:
                 printf("Family: AF_INET6\n");
-                ipv6_addr_to_str(addr_as_str, ep.ip.addr.v6,
+                ipv6_addr_to_str(addr_as_str, (ipv6_addr_t *)&ep.addr.ipv6,
                                  sizeof(addr_as_str));
                 printf("Addr: %s\n", addr_as_str);
                 break;
@@ -356,7 +357,7 @@ int gnrc_tcp_get_local_cmd(int argc, char **argv)
         case 0:
             printf("%s: returns 0\n", argv[0]);
             printf("Endpoint: addr.ipv6=");
-            ipv6_addr_print(ep.ip.addr.v6);
+            ipv6_addr_print((ipv6_addr_t *)&ep.addr.ipv6);
             printf(" netif=%u port=%u\n", ep.netif, ep.port);
             break;
 
@@ -380,7 +381,7 @@ int gnrc_tcp_get_remote_cmd(int argc, char **argv)
         case 0:
             printf("%s: returns 0\n", argv[0]);
             printf("Endpoint: addr.ipv6=");
-            ipv6_addr_print(ep.ip.addr.v6);
+            ipv6_addr_print((ipv6_addr_t *)&ep.addr.ipv6);
             printf(" netif=%u port=%u\n", ep.netif, ep.port);
             break;
 
@@ -404,7 +405,7 @@ int gnrc_tcp_queue_get_local_cmd(int argc, char **argv)
         case 0:
             printf("%s: returns 0\n", argv[0]);
             printf("Endpoint: addr.ipv6=");
-            ipv6_addr_print(ep.ip.addr.v6);
+            ipv6_addr_print((ipv6_addr_t *)&ep.addr.ipv6);
             printf(" netif=%u port=%u\n", ep.netif, ep.port);
             break;
 

--- a/tests/net/gnrc_tx_sync/main.c
+++ b/tests/net/gnrc_tx_sync/main.c
@@ -215,7 +215,7 @@ int main(void)
     sock_udp_ep_t local = SOCK_IPV6_EP_ANY;
     sock_udp_ep_t remote = { .family = AF_INET6 };
     remote.port = 12345;
-    ipv6_addr_set_all_nodes_multicast((ipv6_addr_t *)&remote.addr.ipv6,
+    ipv6_addr_set_all_nodes_multicast(&remote.ip.addr.v6,
                                       IPV6_ADDR_MCAST_SCP_LINK_LOCAL);
     expect(sock_udp_create(&sock, &local, NULL, 0) == 0);
     /* with gnrc_tx_sync, we expect sock_udp_send() to block until transmission is done */

--- a/tests/net/netutils/main.c
+++ b/tests/net/netutils/main.c
@@ -197,7 +197,7 @@ static void test_sock_tl_name2ep__ip_if_port(void)
     TEST_ASSERT_EQUAL_INT(AF_INET6, ep.family);
     TEST_ASSERT_EQUAL_INT(1234, ep.port);
     TEST_ASSERT_EQUAL_INT(1, ep.netif);
-    TEST_ASSERT(ipv6_addr_equal(&a, (ipv6_addr_t *)&ep.addr.ipv6));
+    TEST_ASSERT(ipv6_addr_equal(&a, &ep.ip.addr.v6));
 }
 
 static void test_sock_tl_name2ep__name_port(void)
@@ -213,7 +213,7 @@ static void test_sock_tl_name2ep__name_port(void)
     TEST_ASSERT_EQUAL_INT(0, res);
     TEST_ASSERT_EQUAL_INT(AF_INET6, ep.family);
     TEST_ASSERT_EQUAL_INT(1234, ep.port);
-    TEST_ASSERT(ipv6_addr_equal(&a, (ipv6_addr_t *)&ep.addr.ipv6));
+    TEST_ASSERT(ipv6_addr_equal(&a, &ep.ip.addr.v6));
 }
 
 static void test_sock_tl_name2ep__name_only(void)
@@ -229,7 +229,7 @@ static void test_sock_tl_name2ep__name_only(void)
     TEST_ASSERT_EQUAL_INT(0, res);
     TEST_ASSERT_EQUAL_INT(AF_INET6, ep.family);
     TEST_ASSERT_EQUAL_INT(0, ep.port);
-    TEST_ASSERT(ipv6_addr_equal(&a, (ipv6_addr_t *)&ep.addr.ipv6));
+    TEST_ASSERT(ipv6_addr_equal(&a, &ep.ip.addr.v6));
 }
 
 Test *tests_netutils_ipv6_tests(void)

--- a/tests/net/sock_udp_aux/main.c
+++ b/tests/net/sock_udp_aux/main.c
@@ -61,7 +61,7 @@ static void *server_thread(void *arg)
             print_str("Received a message via: [");
             if (!(rx_aux.flags & SOCK_AUX_GET_LOCAL)) {
                 char tmp[IPV6_ADDR_MAX_STR_LEN + 1];
-                ipv6_addr_to_str(tmp, (ipv6_addr_t *)rx_aux.local.addr.ipv6,
+                ipv6_addr_to_str(tmp, rx_aux.local.ip.addr.v6,
                                  sizeof(tmp));
                 print_str(tmp);
                 print_str("]:");

--- a/tests/net/sock_udp_aux/main.c
+++ b/tests/net/sock_udp_aux/main.c
@@ -61,7 +61,7 @@ static void *server_thread(void *arg)
             print_str("Received a message via: [");
             if (!(rx_aux.flags & SOCK_AUX_GET_LOCAL)) {
                 char tmp[IPV6_ADDR_MAX_STR_LEN + 1];
-                ipv6_addr_to_str(tmp, rx_aux.local.ip.addr.v6,
+                ipv6_addr_to_str(tmp, &rx_aux.local.ip.addr.v6,
                                  sizeof(tmp));
                 print_str(tmp);
                 print_str("]:");

--- a/tests/pkg/lwip/ip.c
+++ b/tests/pkg/lwip/ip.c
@@ -59,7 +59,7 @@ static void _ip_recv(sock_ip_t *sock, sock_async_flags_t flags, void *arg)
 #if IS_USED(MODULE_LWIP_IPV4)
                     printf("[%s]:\n",
                            ipv4_addr_to_str(addrstr,
-                                            (ipv4_addr_t *)&src.addr.ipv4,
+                                            &src.ip.addr.v4,
                                             sizeof(addrstr)));
                     break;
 #else
@@ -70,7 +70,7 @@ static void _ip_recv(sock_ip_t *sock, sock_async_flags_t flags, void *arg)
 #if IS_USED(MODULE_LWIP_IPV6)
                     printf("[%s]:\n",
                            ipv6_addr_to_str(addrstr,
-                                            (ipv6_addr_t *)&src.addr.ipv6,
+                                            &src.ip.addr.v6,
                                             sizeof(addrstr)));
                     break;
 #else
@@ -117,7 +117,7 @@ static int ip_send(char *addr_str, char *port_str, char *data, unsigned int num,
     /* parse destination address */
 #if IS_USED(MODULE_LWIP_IPV6)
     if (strchr(addr_str, ':')) {
-        if (ipv6_addr_from_str((ipv6_addr_t *)&dst.addr.ipv6,
+        if (ipv6_addr_from_str(&dst.ip.addr.v6,
                                addr_str) == NULL) {
             puts("Error: unable to parse destination address");
             return 1;
@@ -131,7 +131,7 @@ static int ip_send(char *addr_str, char *port_str, char *data, unsigned int num,
 #endif
 #endif
 #if IS_USED(MODULE_LWIP_IPV4)
-    if (ipv4_addr_from_str((ipv4_addr_t *)&dst.addr.ipv4,
+    if (ipv4_addr_from_str(&dst.ip.addr.v4,
                            addr_str) == NULL) {
         puts("Error: unable to parse destination address");
         return 1;

--- a/tests/pkg/lwip/ip.c
+++ b/tests/pkg/lwip/ip.c
@@ -59,7 +59,7 @@ static void _ip_recv(sock_ip_t *sock, sock_async_flags_t flags, void *arg)
 #if IS_USED(MODULE_LWIP_IPV4)
                     printf("[%s]:\n",
                            ipv4_addr_to_str(addrstr,
-                                            &src.ip.addr.v4,
+                                            &src.addr.v4,
                                             sizeof(addrstr)));
                     break;
 #else
@@ -70,7 +70,7 @@ static void _ip_recv(sock_ip_t *sock, sock_async_flags_t flags, void *arg)
 #if IS_USED(MODULE_LWIP_IPV6)
                     printf("[%s]:\n",
                            ipv6_addr_to_str(addrstr,
-                                            &src.ip.addr.v6,
+                                            &src.addr.v6,
                                             sizeof(addrstr)));
                     break;
 #else
@@ -117,7 +117,7 @@ static int ip_send(char *addr_str, char *port_str, char *data, unsigned int num,
     /* parse destination address */
 #if IS_USED(MODULE_LWIP_IPV6)
     if (strchr(addr_str, ':')) {
-        if (ipv6_addr_from_str(&dst.ip.addr.v6,
+        if (ipv6_addr_from_str(&dst.addr.v6,
                                addr_str) == NULL) {
             puts("Error: unable to parse destination address");
             return 1;
@@ -131,7 +131,7 @@ static int ip_send(char *addr_str, char *port_str, char *data, unsigned int num,
 #endif
 #endif
 #if IS_USED(MODULE_LWIP_IPV4)
-    if (ipv4_addr_from_str(&dst.ip.addr.v4,
+    if (ipv4_addr_from_str(&dst.addr.v4,
                            addr_str) == NULL) {
         puts("Error: unable to parse destination address");
         return 1;

--- a/tests/pkg/lwip_sock_ip/main.c
+++ b/tests/pkg/lwip_sock_ip/main.c
@@ -639,8 +639,7 @@ static void test_sock_ip_create6__only_local(void)
                                SOCK_FLAGS_REUSE_EP));
     expect(0 == sock_ip_get_local(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
 }
@@ -657,13 +656,11 @@ static void test_sock_ip_create6__only_local_reuse_ep(void)
     expect(0 == sock_ip_get_local(&_sock, &ep));
     expect(0 == sock_ip_get_local(&_sock2, &ep2));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep));
     expect(AF_INET6 == ep2.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep2.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep2.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep2.netif);
     expect(-ENOTCONN == sock_ip_get_remote(&_sock, &ep2));
     sock_ip_close(&_sock2);
@@ -682,7 +679,7 @@ static void test_sock_ip_create6__only_remote(void)
     expect(0 == sock_ip_get_local(&_sock, &ep));
     expect(0 == sock_ip_get_remote(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&remote_addr, &ep.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
 }
 
@@ -699,12 +696,11 @@ static void test_sock_ip_create6__full(void)
     expect(0 == sock_ip_get_local(&_sock, &ep));
     expect(AF_INET6 == ep.family);
     /* this can't be guaranteed with lwIP */
-    /* expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6, */
-    /*               sizeof(ipv6_addr_t)) == 0); */
+    /* expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.addr.v6)); */
     expect(_TEST_NETIF == ep.netif);
     expect(0 == sock_ip_get_remote(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&remote_addr, &ep.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
 }
 

--- a/tests/pkg/lwip_sock_tcp/main.c
+++ b/tests/pkg/lwip_sock_tcp/main.c
@@ -592,7 +592,7 @@ static void test_tcp_connect6__success_without_port(void)
     expect(0 == sock_tcp_connect(&_sock, &remote, 0, SOCK_FLAGS_REUSE_EP));
     expect(0 == sock_tcp_get_remote(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&remote_addr, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(_TEST_PORT_REMOTE == ep.port);
 }
@@ -619,7 +619,7 @@ static void test_tcp_connect6__success_local_port(void)
     expect(_TEST_PORT_LOCAL == ep.port);
     expect(0 == sock_tcp_get_remote(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&remote_addr, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(_TEST_PORT_REMOTE == ep.port);
 }
@@ -673,7 +673,7 @@ static void test_tcp_listen6__success_any_netif(void)
                                 _QUEUE_SIZE, 0));
     expect(0 == sock_tcp_queue_get_local(&_queue, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&local_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&local_addr, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(_TEST_PORT_LOCAL == ep.port);
 }
@@ -751,7 +751,7 @@ static void test_tcp_accept6__success(void)
     expect(_TEST_PORT_LOCAL == ep.port);
     expect(0 == sock_tcp_get_remote(sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&remote_addr, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(_TEST_PORT_REMOTE == ep.port);
 }

--- a/tests/pkg/lwip_sock_udp/main.c
+++ b/tests/pkg/lwip_sock_udp/main.c
@@ -779,8 +779,7 @@ static void test_sock_udp_create6__only_local(void)
     expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
     expect(0 == sock_udp_get_local(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(_TEST_PORT_LOCAL == ep.port);
     expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
@@ -795,8 +794,7 @@ static void test_sock_udp_create6__only_local_port0(void)
     expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
     expect(0 == sock_udp_get_local(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(0U != ep.port);
     expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
@@ -813,14 +811,12 @@ static void test_sock_udp_create6__only_local_reuse_ep(void)
     expect(0 == sock_udp_get_local(&_sock, &ep));
     expect(0 == sock_udp_get_local(&_sock2, &ep2));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(_TEST_PORT_LOCAL == ep.port);
     expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
     expect(AF_INET6 == ep2.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep2.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep2.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep2.netif);
     expect(_TEST_PORT_LOCAL == ep2.port);
     expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep2));
@@ -840,7 +836,7 @@ static void test_sock_udp_create6__only_remote(void)
     expect(0 == sock_udp_get_local(&_sock, &ep));
     expect(0 == sock_udp_get_remote(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&remote_addr, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(_TEST_PORT_REMOTE == ep.port);
 }
@@ -859,13 +855,12 @@ static void test_sock_udp_create6__full(void)
     expect(0 == sock_udp_get_local(&_sock, &ep));
     expect(AF_INET6 == ep.family);
     /* this can't be guaranteed with lwIP */
-    /* expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6, */
-    /*               sizeof(ipv6_addr_t)) == 0); */
+    /* expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.ip.addr.v6)); */
     expect(_TEST_NETIF == ep.netif);
     expect(_TEST_PORT_LOCAL == ep.port);
     expect(0 == sock_udp_get_remote(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&remote_addr, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(_TEST_PORT_REMOTE == ep.port);
 }

--- a/tests/pkg/openwsn_sock_udp/main.c
+++ b/tests/pkg/openwsn_sock_udp/main.c
@@ -122,8 +122,7 @@ static void test_sock_udp_create__only_local(void)
     expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
     expect(0 == sock_udp_get_local(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(_TEST_PORT_LOCAL == ep.port);
     expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
@@ -138,8 +137,7 @@ static void test_sock_udp_create__only_local_port0(void)
     expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
     expect(0 == sock_udp_get_local(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(0U != ep.port);
     expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
@@ -156,14 +154,12 @@ static void test_sock_udp_create__only_local_reuse_ep(void)
     expect(0 == sock_udp_get_local(&_sock, &ep));
     expect(0 == sock_udp_get_local(&_sock2, &ep2));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(_TEST_PORT_LOCAL == ep.port);
     expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep));
     expect(AF_INET6 == ep2.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep2.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep2.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep2.netif);
     expect(_TEST_PORT_LOCAL == ep2.port);
     expect(-ENOTCONN == sock_udp_get_remote(&_sock, &ep2));
@@ -183,7 +179,7 @@ static void test_sock_udp_create__only_remote(void)
     expect(-EADDRNOTAVAIL == sock_udp_get_local(&_sock, &ep));
     expect(0 == sock_udp_get_remote(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&remote_addr, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(_TEST_PORT_REMOTE == ep.port);
 }
@@ -203,13 +199,12 @@ static void test_sock_udp_create__full(void)
     expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
     expect(0 == sock_udp_get_local(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&ipv6_addr_unspecified, &ep.addr.ipv6,
-                  sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&ipv6_addr_unspecified, &ep.ip.addr.v6));
     expect(_TEST_NETIF == ep.netif);
     expect(_TEST_PORT_LOCAL == ep.port);
     expect(0 == sock_udp_get_remote(&_sock, &ep));
     expect(AF_INET6 == ep.family);
-    expect(memcmp(&remote_addr, &ep.addr.ipv6, sizeof(ipv6_addr_t)) == 0);
+    expect(ipv6_addr_equal(&remote_addr, &ep.ip.addr.v6));
     expect(SOCK_ADDR_ANY_NETIF == ep.netif);
     expect(_TEST_PORT_REMOTE == ep.port);
 }

--- a/tests/pkg/tinydtls_sock_async/dtls-client.c
+++ b/tests/pkg/tinydtls_sock_async/dtls-client.c
@@ -204,7 +204,7 @@ static int client_send(char *addr_str, char *data)
         remote.netif = SOCK_ADDR_ANY_NETIF;
     }
 
-    if (!ipv6_addr_from_str((ipv6_addr_t *)remote.addr.ipv6, addr_str)) {
+    if (!ipv6_addr_from_str(remote.ip.addr.v6, addr_str)) {
         puts("Error parsing destination address");
         return -1;
     }

--- a/tests/pkg/tinydtls_sock_async/dtls-client.c
+++ b/tests/pkg/tinydtls_sock_async/dtls-client.c
@@ -204,7 +204,7 @@ static int client_send(char *addr_str, char *data)
         remote.netif = SOCK_ADDR_ANY_NETIF;
     }
 
-    if (!ipv6_addr_from_str(remote.ip.addr.v6, addr_str)) {
+    if (!ipv6_addr_from_str(&remote.ip.addr.v6, addr_str)) {
         puts("Error parsing destination address");
         return -1;
     }


### PR DESCRIPTION
### Contribution description

Currently, `sock_{ip,udp,tcp}_ep_t` contain IPv{4,6} addresses as bare arrays. We do have the `ipv{4,6}_addr_t` types in RIOT which are used, e.g., for address comparison. Right now, a lot of places just cast the byte arrays to `ipv{4,6}_addr_t` to call other functions. In order to reduce the number of wild typecasts, I propose to transition the sock_ep types to use the ip_addr types. Transport layer sock_ep types now include a sock_ip_ep instead to reduce code duplication (and avoid potential need to cast between those two).

Since this is a breaking change, the first commit is completely backwards-compatible and just deprecates the old struct members.

The second commit is a start to migrate in-tree users to the new interface, I will continue this path once we agree that this is the right way to go.


### Testing procedure

Look at the first commit. CI should catch regressions from the second commit.


### Issues/PRs references

Encountered in https://github.com/RIOT-OS/RIOT/pull/22075#issuecomment-3907251489

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none