### PR TITLE
examples/networking: use echowarn for `bplib_cla_udp` warnings

### DIFF
--- a/examples/networking/dtn/bplib_cla_udp/Makefile
+++ b/examples/networking/dtn/bplib_cla_udp/Makefile
@@ -6,6 +6,7 @@ BOARD ?= native
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../../..
+RIOTMAKE ?= $(RIOTBASE)/makefiles
 
 # Include bplib and the configuration modules
 USEPKG += bplib
@@ -28,20 +29,28 @@ CFLAGS += -DCONFIG_BPLIB_STOR_BASE=\"/nvm0/bp\"
 # ability of bplib can be disabled with the `bplib_no_vfs` module.
 CFLAGS += -DBPLIB_TIME_FILE_NAME=\"/nvm0/bp_time.dat\"
 
+include $(RIOTMAKE)/color.inc.mk
+
 # Example configuration
 ifeq (,$(REMOTE))
-  $(warning REMOTE IPv6 address not set, defaulting to [::1])
+  ifeq (,$(filter info-% generate-%,$(MAKECMDGOALS)))
+    $(call echowarn,("REMOTE IPv6 address not set, defaulting to [::1]"))
+  endif
   REMOTE := ::1
 endif
 CFLAGS += -DBPLIB_EXAMPLE_IP_REMOTE=\"$(REMOTE)\"
 ifeq (,$(REMOTE_EID_NODE))
-  $(warning REMOTE_EID_NODE destination node number not set, defaulting to 100)
+  ifeq (,$(filter info-% generate-%,$(MAKECMDGOALS)))
+    $(call echowarn,("REMOTE_EID_NODE destination node number not set, defaulting to 100"))
+  endif
   REMOTE_EID_NODE := 100
 endif
 # This sets the destination node number
 CFLAGS += -DBPLIB_EXAMPLE_REMOTE_NODE_NO=$(REMOTE_EID_NODE)
 ifeq (,$(LOCAL_EID_NODE))
-  $(warning LOCAL_EID_NODE destination node number not set, defaulting to 100)
+  ifeq (,$(filter info-% generate-%,$(MAKECMDGOALS)))
+    $(call echowarn,("LOCAL_EID_NODE destination node number not set, defaulting to 100"))
+  endif
   LOCAL_EID_NODE := 100
 endif
 # This sets the node number of the device that runs bplib.


### PR DESCRIPTION
### Contribution description

Running `make generate-Makefile.ci` for `examples/networking/dtn/bplib_cla_udp` creates a lot of noise, because the warnings are printed for `info` and `generate` targets as well.

And while we're at it, we might as well use `echowarn` and print some nice yellow warnings :)

### Testing procedure

Current `master`:
```
buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ make -C examples/networking/dtn/bplib_cla_udp/ generate-Makefile.ci
make: Entering directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/examples/networking/dtn/bplib_cla_udp'
Makefile:33: REMOTE IPv6 address not set, defaulting to [::1]
Makefile:38: REMOTE_EID_NODE destination node number not set, defaulting to 100
Makefile:44: LOCAL_EID_NODE destination node number not set, defaulting to 100
using BOARD="native64" as "native" on a 64-bit system
Makefile:33: REMOTE IPv6 address not set, defaulting to [::1]
Makefile:38: REMOTE_EID_NODE destination node number not set, defaulting to 100
Makefile:44: LOCAL_EID_NODE destination node number not set, defaulting to 100
using BOARD="native64" as "native" on a 64-bit system
Makefile:33: REMOTE IPv6 address not set, defaulting to [::1]
Makefile:38: REMOTE_EID_NODE destination node number not set, defaulting to 100
Makefile:44: LOCAL_EID_NODE destination node number not set, defaulting to 100
Makefile:33: REMOTE IPv6 address not set, defaulting to [::1]
Makefile:38: REMOTE_EID_NODE destination node number not set, defaulting to 100
Makefile:44: LOCAL_EID_NODE destination node number not set, defaulting to 100
Makefile:33: REMOTE IPv6 address not set, defaulting to [::1]
Makefile:38: REMOTE_EID_NODE destination node number not set, defaulting to 100
Makefile:44: LOCAL_EID_NODE destination node number not set, defaulting to 100
Makefile:33: REMOTE IPv6 address not set, defaulting to [::1]
...
```

With this PR:
```
buechse@skyleaf:~/RIOTstuff/riot-vanilla/RIOT$ make -C examples/networking/dtn/bplib_cla_udp/ generate-Makefile.ci -j
make: Entering directory '/home/buechse/RIOTstuff/riot-vanilla/RIOT/examples/networking/dtn/bplib_cla_udp'
using BOARD="native64" as "native" on a 64-bit system
using BOARD="native64" as "native" on a 64-bit system
acd52832                                ...
...
```

Also colors:
<img width="1086" height="403" alt="image" src="https://github.com/user-attachments/assets/bf262581-56fd-4065-83db-9a4a4196f357" />



### Issues/PRs references
None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none
