### PR TITLE
makefiles/docker: conditionally add BINDIR as docker volume

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -353,7 +353,6 @@ compile() {
 
     # set build directory. CI ensures only one build at a time in $(pwd).
     export BINDIR="$(pwd)/build"
-    export PKGDIRBASE="${BINDIR}/pkg"
 
     # Pre-build cleanup
     rm -rf ${BINDIR}

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -54,7 +54,6 @@ export DOCKER_ENV_VARS += \
   AR \
   AS \
   ASFLAGS \
-  BINDIR \
   BINDIRBASE \
   BOARD \
   BOARDS \
@@ -300,6 +299,13 @@ DOCKER_VOLUMES_AND_ENV += $(call docker_volume,$(HOME)/.cargo/git,$(DOCKER_BUILD
 DOCKER_VOLUMES_AND_ENV += -e 'TZ=$(HOST_TIMEZONE)'
 DOCKER_VOLUMES_AND_ENV += -e 'RIOTBASE=$(DOCKER_RIOTBASE)'
 DOCKER_VOLUMES_AND_ENV += -e 'CCACHE_BASEDIR=$(DOCKER_RIOTBASE)'
+
+# Only export the BINDIR path if it is not the standard path.
+# We have to check it this way since BINDIR is often overridden and we can not
+# reliably check it's origin.
+ifneq ($(BINDIR),$(BINDIRBASE)/$(BOARD))
+  DOCKER_VOLUMES_AND_ENV += $(call docker_volume_and_env,BINDIR,,bindir)
+endif
 
 DOCKER_VOLUMES_AND_ENV += $(call docker_volume_and_env,BUILD_DIR,,build)
 


### PR DESCRIPTION
### Contribution description

In https://github.com/RIOT-OS/riotdocker/pull/290 I discoverd that the build tests from the RIOT Docker workflow are not executed after https://github.com/RIOT-OS/riotdocker/pull/256 changed the build method from the then-removed Makefile procedure to `compile_like_murdock`.
The paths to the examples were incorrect, so the build was skipped.

Fixing the paths led to failed compile tests, which can be traced back to the Docker Makefile.

The `.murdock` script sets the `BINDIR` environment variable, where it later on expects the hash file:
https://github.com/RIOT-OS/RIOT/blob/2b8fadd02795497427d85f038d1704bae8a99260/.murdock#L354-L356
https://github.com/RIOT-OS/RIOT/blob/2b8fadd02795497427d85f038d1704bae8a99260/.murdock#L377-L378

The current mechanism in our `makefiles/docker.inc.mk` had `BINDIR` listed as variables that should be exported to Docker when it was set in the environment or in the command line.
HOWEVER this did not work because the `Makefile.include` overrides the `BINDIR` to make sure it is an absolute path, which changes the origin to `override`:
https://github.com/RIOT-OS/RIOT/blob/2b8fadd02795497427d85f038d1704bae8a99260/Makefile.include#L143-L144

This is a good thing though because it would've exported the outside path to Docker, which then would cause another error, since `/home/crasbe/...` does not exist inside of the Docker container.

It is bad for `.murdock` though, since the hash file generated by `test-input-hash` is not where the script would expect it to be.


Also, `PKGDIRBASE` should not be set explicitly and `.murdock` set it to the standard path nevertheless.
So instead of adding a mechanism for `PKGDIRBASE` to `makefiles/docker.inc.mk`, I opted for removing the line from `.murdock`.


### Testing procedure

I extracted the command that is effectively called by the GitHub workflow in RIOT-OS/riotdocker.
You don't have to set `DOCKER_IMAGE` explicitly, I just had an image locally that I wanted to use instead of downloading the upstream image.

Behavior on `master`:
```
buechse@skyleaf:~/RIOTstuff/riot-vanillaschote/RIOT$ BUILD_IN_DOCKER=1 DOCKER_IMAGE=docker.io/library/riotbuild:latest ./dist/tools/compile_test/compile_like_murdock.py -a examples/basic/hello-world -b arduino-uno -t gnu
examples/basic/hello-world     arduino-uno                    FAIL
This took 0:00:01.079526...
You could have 76399574.992608 digits of pi calculated

buechse@skyleaf:~/RIOTstuff/riot-vanillaschote/RIOT$ BUILD_IN_DOCKER=1 DOCKER_IMAGE=docker.io/library/riotbuild:latest ./dist/tools/compile_test/compile_like_murdock.py -a examples/basic/hello-world -b arduino
-uno -t gnu -vvv
make: Entering directory '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT/examples/basic/hello-world'
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT/examples/basic/hello-world'
make: Entering directory '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT/examples/basic/hello-world'
Launching build container using image "docker.io/library/riotbuild:latest".
docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/buechse/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'    -e 'BOARD=arduino-uno' -e 'CC_NOCOLOR=1' -e 'RIOT_CI_BUILD=1' -e 'TOOLCHAIN=gnu' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=' -e 'USEPKG='  -w '/data/riotbuild/riotbase/examples/basic/hello-world/' 'docker.io/library/riotbuild:latest' make    -j4 all
Building application "hello-world" for "arduino-uno" with CPU "atmega328p".

   text    data     bss     dec     hex filename
   4980     110     900    5990    1766 /data/riotbuild/riotbase/examples/basic/hello-world/bin/arduino-uno/hello-world.elf
make: *** No rule to make target '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT/build/hello-world.bin', needed by 'test-input-hash'.  Stop.
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT/examples/basic/hello-world'
cat: /home/buechse/RIOTstuff/riot-vanillaschote/RIOT/build/test-input-hash.sha1: No such file or directory

examples/basic/hello-world     arduino-uno                    FAIL
This took 0:00:00.913839...
You could have 2.81462412e-07 bitcoins mined
```

Behavior with this PR:
```
buechse@skyleaf:~/RIOTstuff/riot-vanillaschote/RIOT$ BUILD_IN_DOCKER=1 DOCKER_IMAGE=docker.io/library/riotbuild:latest ./dist/tools/compile_test/compile_like_murdock.py -a examples/basic/hello-world -b arduino-uno -t gnu
examples/basic/hello-world     arduino-uno                    PASS
This took 0:00:01.635343...
You could have 0.00026165488 liters of maple syrup refined

buechse@skyleaf:~/RIOTstuff/riot-vanillaschote/RIOT$ BUILD_IN_DOCKER=1 DOCKER_IMAGE=docker.io/library/riotbuild:latest ./dist/tools/compile_test/compile_like_murdock.py -a examples/basic/hello-world -b arduino-uno -t gnu -vvv
make: Entering directory '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT/examples/basic/hello-world'
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT/examples/basic/hello-world'
make: Entering directory '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT/examples/basic/hello-world'
Launching build container using image "docker.io/library/riotbuild:latest".
docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BINDIR=/data/riotbuild/riotbase/build' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/buechse/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'    -e 'BOARD=arduino-uno' -e 'CC_NOCOLOR=1' -e 'RIOT_CI_BUILD=1' -e 'TOOLCHAIN=gnu' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=' -e 'USEPKG='  -w '/data/riotbuild/riotbase/examples/basic/hello-world/' 'docker.io/library/riotbuild:latest' make    -j4 all
Building application "hello-world" for "arduino-uno" with CPU "atmega328p".

   text    data     bss     dec     hex filename
   4980     110     900    5990    1766 /data/riotbuild/riotbase/build/hello-world.elf
sha1sum /home/buechse/RIOTstuff/riot-vanillaschote/RIOT/build/hello-world.bin > /home/buechse/RIOTstuff/riot-vanillaschote/RIOT/build/test-input-hash.sha1
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT/examples/basic/hello-world'
{"build/": 6644}

examples/basic/hello-world     arduino-uno                    PASS
This took 0:00:01.594122...
You could have 0.00025505952 liters of maple syrup refined
```


### Issues/PRs references

Prerequisite for https://github.com/RIOT-OS/riotdocker/pull/290

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none