### PR TITLE
net/unicoap: Only import IP deps when in use

### DIFF
--- a/sys/net/application_layer/unicoap/Makefile.dep
+++ b/sys/net/application_layer/unicoap/Makefile.dep
@@ -20,10 +20,6 @@ ifneq (,$(filter unicoap,$(USEMODULE)))
   # Synchronous methods
   USEMODULE += sema
 
-  USEMODULE += netif
-  USEMODULE += ipv6_addr
-  USEMODULE += ipv4_addr
-
   DEFAULT_MODULE += auto_init_unicoap
 endif
 
@@ -76,6 +72,11 @@ ifneq (,$(filter unicoap_driver_udp,$(USEMODULE)))
   # We're using the sock API
   USEMODULE += unicoap_sock_support
   USEMODULE += sock_udp
+
+  # We're going over IP
+  USEMODULE += netif
+  USEMODULE += ipv6_addr
+  USEMODULE += ipv4_addr
 endif
 
 ifneq (,$(filter unicoap_driver_dtls,$(USEMODULE)))
@@ -85,6 +86,11 @@ ifneq (,$(filter unicoap_driver_dtls,$(USEMODULE)))
   # We're using the sock API
   USEMODULE += unicoap_sock_support
   USEMODULE += sock_dtls
+
+  # We're going over IP
+  USEMODULE += netif
+  USEMODULE += ipv6_addr
+  USEMODULE += ipv4_addr
 
   # DTLS stuff
   USEMODULE += tinydtls_sock_dtls


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hiiii 🐐

this change ensures that unicoap only pulls in IP related modules when those are actually needed.
It does not fix a bug. All binaries remain the same, as unused modules are garbage collected.
However, we get slightly faster build times when building unicoap without needing IP. (Up to 500ms faster on my machine)

### Testing procedure

Review, thinking a bit about implication, build test.

Obviously I tested stuff locally, including the unicoap_server example.


### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
