### PR TITLE
makefiles/docker: bump Docker image version after build workflow update

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -5,7 +5,7 @@
 # When the docker image is updated, checks at
 # dist/tools/buildsystem_sanity_check/check.sh start complaining in CI, and
 # provide the latest values to verify and fill in.
-DOCKER_TESTED_IMAGE_REPO_DIGEST := fddca5759642d63a99d728301b1a6abc01ed7547a5c66abc14a97aeb5a8cd0de
+DOCKER_TESTED_IMAGE_REPO_DIGEST := 6cca585c8f1557754fd1a035f9507a9cd13b02f80a3d3031d097dbb2eadaccda
 
 DOCKER_PULL_IDENTIFIER := docker.io/riot/riotbuild@sha256:$(DOCKER_TESTED_IMAGE_REPO_DIGEST)
 export DOCKER_IMAGE ?= $(DOCKER_PULL_IDENTIFIER)


### PR DESCRIPTION
### Contribution description

Necessary after merging https://github.com/RIOT-OS/riotdocker/pull/290

I know that this is the second image version bump in the last 24 hours, but I'd like to get the build test actually working before proceeding with the migration to Ubuntu 26.04 LTS Resolute Raccoon to catch major issues ahead of time and not cause bigger problems in this repo.

### Testing procedure

Static test should be happy and CI builds.

### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none