### PR TITLE
sys/jelly: Add basic support for the Jelly tool

### DIFF
--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -110,4 +110,7 @@ else ifeq (${RIOT_TERMINAL},bootterm)
   TERMDEPS += $(TERMPROG)
 else ifeq (${RIOT_TERMINAL},native)
   TERMPROG ?= $(ELFFILE)
+else ifeq (${RIOT_TERMINAL},jelly)
+  TERMPROG = Jelly
+  TERMFLAGS += $(PORT)
 endif

--- a/sys/jelly/Makefile
+++ b/sys/jelly/Makefile
@@ -1,0 +1,5 @@
+MODULE = jelly
+
+SRC = jelly.c
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/jelly/Makefile.dep
+++ b/sys/jelly/Makefile.dep
@@ -1,0 +1,31 @@
+# Jelly speaks slipmux so we can do stdio/coap/network over serial.
+
+# Networking is a big dependency from which this module has no direct benefit.
+# Therefore we don't enable network by default.
+# Add the following line to your Makefile if you want or need networking through Jelly:
+# USEMODULE += slipdev_net
+
+# Enable stdio via slipmux.
+# This allows us to use Jelly with printf-debugging or to access the classic RIOT shell.
+USEMODULE += stdio_slipdev
+
+# Enable coap via slipmux (called configuration messages).
+USEMODULE += slipdev_config
+
+# We are using unicoap, because that is the coap implementation used by the slipmux driver.
+USEMODULE += unicoap
+
+# We are using the macro based resource declartions.
+USEMODULE += unicoap_server_resource_declarations
+
+# We want to reply to incoming requests => we are the server.
+USEMODULE += unicoap_server
+
+# Already imported by the slipmux driver when using slipdev_config but sometimes
+# the dependency resolution is slower than the unicoap warning on missing drivers.
+# This silences it.
+USEMODULE += unicoap_driver_slipmux
+
+# If we are preparing for Jelly, we should use Jelly.
+# This sets up "make term" to use Jelly.
+RIOT_TERMINAL = jelly

--- a/sys/jelly/doc.md
+++ b/sys/jelly/doc.md
@@ -1,0 +1,40 @@
+@defgroup       sys_jelly Jelly
+@ingroup        sys
+
+@brief          Use the Jelly tool to speak Slipmux with RIOT
+@author         Bennet Hattesen <bennet.hattesen@haw-hamburg.de>
+
+## About
+
+The [slipmux](https://datatracker.ietf.org/doc/html/draft-bormann-t2trg-slipmux-03)
+protocol allows to speak stdio, CoAP and IP over a single UART.
+RIOT implements it in the `slipmux` driver with the modules `stdio_slipdev`,
+`slipdev_config` and `slipdev_net`.
+On the host side, the [Jelly](https://github.com/Teufelchen1/jelly) tool
+can be used to interface with a slipmux speaking device.
+
+### Usage
+
+Install Jelly on your computer by either grabbing it from
+[crates.io](https://crates.io/crates/Jelly) via `cargo install Jelly` or
+build if from the [source](https://github.com/Teufelchen1/jelly).
+
+Add `USEMODULE += jelly` to your RIOT app makefile. Among other things,
+this will enable `stdio` and CoAP through `slipmux`. The backend for CoAP is `unicoap`.
+If you also want networking, you need to add `USEMODULE += slipdev_net` as well.
+
+We can now build, flash and open the Jelly shell:
+```shell
+USEMODULE=jelly BOARD=nrf52840dk make flash term
+```
+
+If you want to use networking through Jelly, add the `slipdev_net` module
+and tell Jelly which TUN interface to use:
+```shell
+TERMFLAGS=--network=slip0 USEMODULE="jelly slipdev_net" BOARD=nrf52840dk make flash term
+```
+
+Of course you can also manually run Jelly:
+```shell
+Jelly --help
+```

--- a/sys/jelly/jelly.c
+++ b/sys/jelly/jelly.c
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2026 HAW Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Bennet Hattesen <bennet.hattesen@haw-hamburg.de>
+ */
+
+#include "net/unicoap.h"
+
+static int _riot_version_handler(
+    unicoap_message_t *message, const unicoap_aux_t *aux,
+    unicoap_request_context_t *ctx, void *arg)
+{
+    (void)aux;
+    (void)arg;
+    unicoap_response_init_string(message, UNICOAP_STATUS_CONTENT, RIOT_VERSION);
+    return unicoap_send_response(message, ctx);
+}
+
+static int _riot_board_handler(
+    unicoap_message_t *message, const unicoap_aux_t *aux,
+    unicoap_request_context_t *ctx, void *arg)
+{
+    (void)aux;
+    (void)arg;
+    unicoap_response_init_string(message, UNICOAP_STATUS_CONTENT, RIOT_BOARD);
+    return unicoap_send_response(message, ctx);
+}
+
+UNICOAP_RESOURCE(riot_version)
+{
+    .path = UNICOAP_PATH("jelly", "ver"),
+    .methods = UNICOAP_METHODS(UNICOAP_METHOD_GET),
+    .handler = _riot_version_handler,
+    .protocols = UNICOAP_PROTOCOLS(UNICOAP_PROTO_SLIPMUX),
+};
+
+UNICOAP_RESOURCE(riot_board)
+{
+    .path = UNICOAP_PATH("jelly", "board"),
+    .methods = UNICOAP_METHODS(UNICOAP_METHOD_GET),
+    .handler = _riot_board_handler,
+    .protocols = UNICOAP_PROTOCOLS(UNICOAP_PROTO_SLIPMUX),
+};
+
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Moin 🪼

this adds a convenient way of getting started with my Jelly tool.

I am not super sure if it is already ready for sitting in master but eh, rather remove it again in a year than not trying at all.

### Testing procedure

If the doc.md doesn't tell you how to test, we shouldn't merge it :p 

Note: If you are using especially fast boards (e.g. nrf52), you might hit a race condition shortly after flashing that I currently believe to be in the linux usb subsystem but further research is needed. That bug scrambles the order of the first few bytes and might cause Jelly or RIOT to mistake a coap request/response for diagnostic text. Just re-run `make term` in that case. So far I have not encountered that bug when using third party USB-TTYs or any board that is not nrf52/4. (or you know, running make flash and make term separately)

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
