### PR TITLE
makefiles/docker: bump Docker image version after C2Rust update

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -5,7 +5,7 @@
 # When the docker image is updated, checks at
 # dist/tools/buildsystem_sanity_check/check.sh start complaining in CI, and
 # provide the latest values to verify and fill in.
-DOCKER_TESTED_IMAGE_REPO_DIGEST := 6cca585c8f1557754fd1a035f9507a9cd13b02f80a3d3031d097dbb2eadaccda
+DOCKER_TESTED_IMAGE_REPO_DIGEST := 3772a50fdfa716dd9429328b032bbc48560aee420f941472eacee360974465af
 
 DOCKER_PULL_IDENTIFIER := docker.io/riot/riotbuild@sha256:$(DOCKER_TESTED_IMAGE_REPO_DIGEST)
 export DOCKER_IMAGE ?= $(DOCKER_PULL_IDENTIFIER)


### PR DESCRIPTION
### Contribution description

Necessary after merging https://github.com/RIOT-OS/riotdocker/pull/283

The C2Rust update and LLVM updates are what I'm most afraid of that something might break, so they deserve their own updates I guess 👀 


### Testing procedure

Static test should be happy and CI builds.

### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none