### PR TITLE
cpu/stm32: fix comments concerning C0 clock

### DIFF
--- a/cpu/stm32/include/clk/c0/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/c0/cfg_clock_default.h
@@ -49,13 +49,13 @@ extern "C" {
 
 #endif
 
-#define CLOCK_AHB                       CLOCK_CORECLOCK  /* max: 64MHz (G0), 170MHZ (G4) */
+#define CLOCK_AHB                       CLOCK_CORECLOCK  /* max: 48MHz (C0) */
 
 #ifndef CONFIG_CLOCK_APB1_DIV
 #define CONFIG_CLOCK_APB1_DIV           (1)
 #endif
 #define CLOCK_APB1                      (CLOCK_CORECLOCK / CONFIG_CLOCK_APB1_DIV)  \
-                                        /* max: 64MHz (G0), 170MHZ (G4) */
+                                        /* max: 48MHz (C0) */
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

During preparation of MCU table for `stm32c0116-dk` I found some copy-pasted comments,
concerning MCU clocks.

This PR fix them.

### Testing procedure

Look at changes and compare it with MCU datasheets for `nucleo-c031c6` or `nucleo-c071RB/stm32c0316-dk` (search AHB keyword).

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none