### PR TITLE
boards: update documentation for EFM32 boards

### DIFF
--- a/boards/common/slwstk6000b/doc.md
+++ b/boards/common/slwstk6000b/doc.md
@@ -1,6 +1,6 @@
-@defgroup    boards_common_slwstk6000b Silicon Labs SLWSTK6000B starter kit
-@ingroup     boards
-@brief       Support for the Silicon Labs SLWSTK6000B starter kit
+@defgroup   boards_common_slwstk6000b Silicon Labs SLWSTK6000B starter kit
+@ingroup    boards
+@brief      Support for the Silicon Labs SLWSTK6000B starter kit
 
 ## Overview
 
@@ -47,6 +47,7 @@ The MCU depends on the module used.
 | Low-level driver | ADC                   | yes       |                                                                |
 |                  | Flash                 | yes       |                                                                |
 |                  | GPIO                  | yes       | Interrupts are shared across pins (see reference manual)       |
+|                  | HWRNG                 | yes       | Only on the EFR32MG12P, the EFR32MG1P has no TRNG              |
 |                  | I2C                   | yes       |                                                                |
 |                  | PWM                   | yes       |                                                                |
 |                  | RTCC                  | yes       | As RTT or RTC                                                  |
@@ -60,7 +61,7 @@ The MCU depends on the module used.
 ### Board controller
 
 The starter kit is equipped with a Board Controller. This controller provides a
-virtual serial port. The boardcontroller is enabled via a GPIO pin.
+virtual serial port. The board controller is enabled via a GPIO pin.
 
 By default, this pin is enabled. You can disable the board controller module by
 passing `DISABLE_MODULE=silabs_bc` to the `make` command.

--- a/boards/common/slwstk6000b/doc.md
+++ b/boards/common/slwstk6000b/doc.md
@@ -15,7 +15,8 @@ actively measure the power consumption of your hardware and code, in real-time.
 
 ### MCU
 
-The MCU depends on the module used.
+The MCU depends on the module used. All modules are based on an EFR32
+Series 1 MCU.
 
 | Module     | MCU                     |
 |------------|-------------------------|

--- a/boards/common/slwstk6000b/doc.md
+++ b/boards/common/slwstk6000b/doc.md
@@ -152,7 +152,7 @@ Configured at 1 Hz interval, the RTCC will overflow each 136 years.
 
 ### Usage of EMLIB
 
-This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
+This port makes use of EMLIB by Silicon Labs to abstract peripheral registers.
 While some overhead is to be expected, it ensures proper setup of devices,
 provides chip errata and simplifies development. The exact overhead depends on
 the application and peripheral usage, but the largest overhead is expected
@@ -161,7 +161,10 @@ inline methods or macros (which have no overhead).
 
 Another advantage of EMLIB are the included assertions. These assertions ensure
 that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
-compiler.
+compiler defines.
+
+EMLIB is licensed by Silicon Labs under the zlib-style license, which permits
+distribution of source.
 
 ### Pin locations
 
@@ -205,7 +208,3 @@ Some boards have (limited) support for emulation, which can be started with:
 ```shell
 BOARD=slwstk6000b make emulate
 ```
-
-## License information
-
-Silicon Labs' EMLIB: zlib-style license (permits distribution of source).

--- a/boards/common/slwstk6000b/doc.md
+++ b/boards/common/slwstk6000b/doc.md
@@ -50,7 +50,7 @@ The MCU depends on the module used.
 |                  | I2C                   | yes       |                                                                |
 |                  | PWM                   | yes       |                                                                |
 |                  | RTCC                  | yes       | As RTT or RTC                                                  |
-|                  | SPI                   | partially | Only master mode                                               |
+|                  | SPI                   | yes       | Only master mode                                               |
 |                  | Timer                 | yes       |                                                                |
 |                  | UART                  | yes       | USART is shared with SPI. LEUART baud rate limited (see below) |
 |                  | USB                   | no        |                                                                |

--- a/boards/common/slwstk6000b/doc.md
+++ b/boards/common/slwstk6000b/doc.md
@@ -47,7 +47,6 @@ The MCU depends on the module used.
 | Low-level driver | ADC                   | yes       |                                                                |
 |                  | Flash                 | yes       |                                                                |
 |                  | GPIO                  | yes       | Interrupts are shared across pins (see reference manual)       |
-|                  | HW Crypto             | yes       |                                                                |
 |                  | I2C                   | yes       |                                                                |
 |                  | PWM                   | yes       |                                                                |
 |                  | RTCC                  | yes       | As RTT or RTC                                                  |
@@ -150,14 +149,6 @@ Calendar*, which can be configured in ticker mode **or** calendar mode.
 Therefore, only one of both peripherals can be enabled at the same time.
 
 Configured at 1 Hz interval, the RTCC will overflow each 136 years.
-
-### Hardware crypto
-
-This MCU is equipped with a hardware accelerated crypto peripheral that can
-speed up AES128, AES256, SHA1, SHA256 and several other cryptographic
-computations.
-
-A peripheral driver interface for RIOT-OS is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 

--- a/boards/e180-zg120b-tb/doc.md
+++ b/boards/e180-zg120b-tb/doc.md
@@ -189,7 +189,7 @@ Configured at 1 Hz interval, the RTCC will overflow each 136 years.
 
 ### Usage of EMLIB
 
-This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
+This port makes use of EMLIB by Silicon Labs to abstract peripheral registers.
 While some overhead is to be expected, it ensures proper setup of devices,
 provides chip errata and simplifies development. The exact overhead depends on
 the application and peripheral usage, but the largest overhead is expected
@@ -198,7 +198,10 @@ inline methods or macros (which have no overhead).
 
 Another advantage of EMLIB are the included assertions. These assertions ensure
 that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
-compiler.
+compiler defines.
+
+EMLIB is licensed by Silicon Labs under the zlib-style license, which permits
+distribution of source.
 
 ### Pin locations
 
@@ -254,7 +257,3 @@ Some boards have (limited) support for emulation, which can be started with:
 ```shell
 BOARD=e180-zg120b-tb make emulate
 ```
-
-## License information
-
-Silicon Labs' EMLIB: zlib-style license (permits distribution of source).

--- a/boards/e180-zg120b-tb/doc.md
+++ b/boards/e180-zg120b-tb/doc.md
@@ -19,7 +19,7 @@ peripherals, different energy modes and short wake-up times.
 | Family        | ARM Cortex-M4F                                                                          |
 | Vendor        | Silicon Labs                                                                            |
 | Vendor Family | EFM32 Mighty Gecko 1B                                                                   |
-| RAM           | 32.0 KiB (1.0 KiB reserved by radio blob)                                               |
+| RAM           | 32.0 KiB (1.0 KiB reserved for the radio blob)                                          |
 | Flash         | 256.0 KiB                                                                               |
 | EEPROM        | no                                                                                      |
 | Frequency     | up to 38.4 MHz                                                                          |

--- a/boards/e180-zg120b-tb/doc.md
+++ b/boards/e180-zg120b-tb/doc.md
@@ -101,13 +101,13 @@ peripherals, different energy modes and short wake-up times.
 
 ### User interface
 
-| Peripheral | Mapped to | Pin  | Comments        |
-|------------|-----------|------|-----------------|
-| Button     | PB0_PIN   | PD15 | Mode Change     |
-|            | PB1_PIN   | PD13 | Touch Link      |
-|            | PB2_PIN   | PB11 | Baud Rate Reset |
-| LED        | LED0_PIN  | PF2  | GPIO2 LED       |
-|            | LED1_PIN  | PF3  | Link LED        |
+| Peripheral | Number | Mapped to | Pin  | Comments        |
+|------------|--------|-----------|------|-----------------|
+| Button     | 0      | PB0_PIN   | PD15 | Mode Change     |
+|            | 1      | PB1_PIN   | PD13 | Touch Link      |
+|            | 2      | PB2_PIN   | PB11 | Baud Rate Reset |
+| LED        | 0      | LED0_PIN  | PF2  | GPIO2 LED       |
+|            | 1      | LED1_PIN  | PF3  | Link LED        |
 
 The fourth button with the Chinese description is the reset button.
 

--- a/boards/e180-zg120b-tb/doc.md
+++ b/boards/e180-zg120b-tb/doc.md
@@ -17,7 +17,7 @@ peripherals, different energy modes and short wake-up times.
 | MCU           | EFR32MG1B232F256GM32                                                                    |
 |---------------|-----------------------------------------------------------------------------------------|
 | Family        | ARM Cortex-M4F                                                                          |
-| Vendor        | Ebyte                                                                                   |
+| Vendor        | Silicon Labs                                                                            |
 | Vendor Family | EFM32 Mighty Gecko 1B                                                                   |
 | RAM           | 32.0 KiB (1.0 KiB reserved by radio blob)                                               |
 | Flash         | 256.0 KiB                                                                               |
@@ -199,7 +199,7 @@ A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 
-This port makes uses of EMLIB by Ebyte to abstract peripheral registers.
+This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
 While some overhead is to be expected, it ensures proper setup of devices,
 provides chip errata and simplifies development. The exact overhead depends on
 the application and peripheral usage, but the largest overhead is expected
@@ -267,4 +267,4 @@ BOARD=e180-zg120b-tb make emulate
 
 ## License information
 
-Ebyte' EMLIB: zlib-style license (permits distribution of source).
+Silicon Labs' EMLIB: zlib-style license (permits distribution of source).

--- a/boards/e180-zg120b-tb/doc.md
+++ b/boards/e180-zg120b-tb/doc.md
@@ -132,7 +132,7 @@ The fourth button with the Chinese description is the reset button.
 ### Clock selection
 
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
+peripherals. You are advised to read [AN0004.1](https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed                            | Comments                           |

--- a/boards/e180-zg120b-tb/doc.md
+++ b/boards/e180-zg120b-tb/doc.md
@@ -17,6 +17,7 @@ peripherals, different energy modes and short wake-up times.
 | MCU           | EFR32MG1B232F256GM32                                                                    |
 |---------------|-----------------------------------------------------------------------------------------|
 | Family        | ARM Cortex-M4F                                                                          |
+| Series        | Series 1                                                                                |
 | Vendor        | Silicon Labs                                                                            |
 | Vendor Family | EFM32 Mighty Gecko 1B                                                                   |
 | RAM           | 32.0 KiB (1.0 KiB reserved for the radio blob)                                          |

--- a/boards/e180-zg120b-tb/doc.md
+++ b/boards/e180-zg120b-tb/doc.md
@@ -122,7 +122,7 @@ The fourth button with the Chinese description is the reset button.
 |                  | I2C       | yes       |                                                                |
 |                  | PWM       | yes       |                                                                |
 |                  | RTCC      | yes       | As RTT or RTC                                                  |
-|                  | SPI       | partially | Only master mode                                               |
+|                  | SPI       | yes       | Only master mode                                               |
 |                  | Timer     | yes       |                                                                |
 |                  | UART      | yes       | USART is shared with SPI. LEUART baud rate limited (see below) |
 |                  | USB       | no        |                                                                |

--- a/boards/e180-zg120b-tb/doc.md
+++ b/boards/e180-zg120b-tb/doc.md
@@ -90,14 +90,14 @@ peripherals, different energy modes and short wake-up times.
 
 ### Peripheral mapping
 
-| Peripheral | Number  | Hardware        | Pins                        | Comments                                            |
-|------------|---------|-----------------|-----------------------------|-----------------------------------------------------|
-| ADC        | 0       | ADC0            | CHAN0: internal temperature | Ports are fixed, 14/16-bit resolution not supported |
-| RTT        | &mdash; | RTCC            |                             | 1 Hz interval. Either RTT or RTC (see below)        |
-| RTC        | &mdash; | RTCC            |                             | 1 Hz interval. Either RTC or RTT (see below)        |
-| Timer      | 0       | TIMER0 + TIMER1 |                             | TIMER0 is used as prescaler (must be adjacent)      |
-|            | 1       | LETIMER0        |                             |                                                     |
-| UART       | 0       | USART0          | RX: PA1, TX: PA0            | Default STDIO output                                |
+| Peripheral | Number | Hardware        | Pins                        | Comments                                            |
+|------------|--------|-----------------|-----------------------------|-----------------------------------------------------|
+| ADC        | 0      | ADC0            | CHAN0: internal temperature | Ports are fixed, 14/16-bit resolution not supported |
+| RTT        | -      | RTCC            |                             | 1 Hz interval. Either RTT or RTC (see below)        |
+| RTC        | -      | RTCC            |                             | 1 Hz interval. Either RTC or RTT (see below)        |
+| Timer      | 0      | TIMER0 + TIMER1 |                             | TIMER0 is used as prescaler (must be adjacent)      |
+|            | 1      | LETIMER0        |                             |                                                     |
+| UART       | 0      | USART0          | RX: PA1, TX: PA0            | Default STDIO output                                |
 
 ### User interface
 

--- a/boards/e180-zg120b-tb/doc.md
+++ b/boards/e180-zg120b-tb/doc.md
@@ -93,7 +93,6 @@ peripherals, different energy modes and short wake-up times.
 | Peripheral | Number  | Hardware        | Pins                        | Comments                                            |
 |------------|---------|-----------------|-----------------------------|-----------------------------------------------------|
 | ADC        | 0       | ADC0            | CHAN0: internal temperature | Ports are fixed, 14/16-bit resolution not supported |
-| HWCRYPTO   | &mdash; | &mdash;         |                             | AES128/AES256, SHA1, SHA256                         |
 | RTT        | &mdash; | RTCC            |                             | 1 Hz interval. Either RTT or RTC (see below)        |
 | RTC        | &mdash; | RTCC            |                             | 1 Hz interval. Either RTC or RTT (see below)        |
 | Timer      | 0       | TIMER0 + TIMER1 |                             | TIMER0 is used as prescaler (must be adjacent)      |
@@ -120,7 +119,6 @@ The fourth button with the Chinese description is the reset button.
 | Low-level driver | ADC       | yes       |                                                                |
 |                  | Flash     | yes       |                                                                |
 |                  | GPIO      | yes       | Interrupts are shared across pins (see reference manual)       |
-|                  | HW Crypto | yes       |                                                                |
 |                  | I2C       | yes       |                                                                |
 |                  | PWM       | yes       |                                                                |
 |                  | RTCC      | yes       | As RTT or RTC                                                  |
@@ -188,14 +186,6 @@ Calendar*, which can be configured in ticker mode **or** calendar mode.
 Therefore, only one of both peripherals can be enabled at the same time.
 
 Configured at 1 Hz interval, the RTCC will overflow each 136 years.
-
-### Hardware crypto
-
-This MCU is equipped with a hardware-accelerated crypto peripheral that can
-speed up AES128, AES256, SHA1, SHA256 and several other cryptographic
-computations.
-
-A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 

--- a/boards/ikea-tradfri/doc.md
+++ b/boards/ikea-tradfri/doc.md
@@ -91,7 +91,7 @@ Pin 1 is on the top-left side with only 6 contacts.
 |                  | I2C        | yes       |                                                                |
 |                  | PWM        | yes       |                                                                |
 |                  | RTCC       | yes       | As RTT or RTC                                                  |
-|                  | SPI        | partially | Only master mode                                               |
+|                  | SPI        | yes       | Only master mode                                               |
 |                  | Timer      | yes       |                                                                |
 |                  | UART       | yes       | USART is shared with SPI. LEUART baud rate limited (see below) |
 | SPI NOR Flash    | IS25LQ020B | yes       | 2MBit flash. Can be used with the MTD API.                     |

--- a/boards/ikea-tradfri/doc.md
+++ b/boards/ikea-tradfri/doc.md
@@ -75,10 +75,10 @@ Pin 1 is on the top-left side with only 6 contacts.
 
 ### User interface
 
-| Peripheral | Mapped to | Pin  | Comments |
-|------------|-----------|------|----------|
-| LED        | LED0      | PB13 |          |
-|            | LED1      | PA1  |          |
+| Peripheral | Number | Mapped to | Pin  | Comments |
+|------------|--------|-----------|------|----------|
+| LED        | 0      | LED0_PIN  | PA1  |          |
+|            | 1      | LED1_PIN  | PB13 |          |
 
 ## Implementation Status
 

--- a/boards/ikea-tradfri/doc.md
+++ b/boards/ikea-tradfri/doc.md
@@ -12,20 +12,20 @@ More information about the module can be found on this
 
 ## Hardware
 
-##
+### MCU
 
 | MCU             | EFR32MG1P132F256GM32                                                                    |
 |-----------------|-----------------------------------------------------------------------------------------|
 | Family          | ARM Cortex-M4F                                                                          |
 | Vendor          | Silicon Labs                                                                            |
 | Vendor Family   | EFR32 Mighty Gecko 1P                                                                   |
-| RAM             | 32.0 KiB (1.0 KiB reserved)                                                             |
+| RAM             | 32.0 KiB (1.0 KiB reserved for the radio blob)                                          |
 | Flash           | 256.0 KiB                                                                               |
 | EEPROM          | no                                                                                      |
 | Frequency       | up to 38.4 MHz                                                                          |
 | FPU             | yes                                                                                     |
 | MPU             | yes                                                                                     |
-| DMA             | 12 channels                                                                             |
+| DMA             | 8 channels                                                                              |
 | Timers          | 2x 16-bit + 1x 16-bit (low power)                                                       |
 | ADCs            | 12-bit ADC                                                                              |
 | UARTs           | 2x USART, 1x LEUART                                                                     |

--- a/boards/ikea-tradfri/doc.md
+++ b/boards/ikea-tradfri/doc.md
@@ -17,6 +17,7 @@ More information about the module can be found on this
 | MCU             | EFR32MG1P132F256GM32                                                                    |
 |-----------------|-----------------------------------------------------------------------------------------|
 | Family          | ARM Cortex-M4F                                                                          |
+| Series          | Series 1                                                                                |
 | Vendor          | Silicon Labs                                                                            |
 | Vendor Family   | EFR32 Mighty Gecko 1P                                                                   |
 | RAM             | 32.0 KiB (1.0 KiB reserved for the radio blob)                                          |

--- a/boards/ikea-tradfri/doc.md
+++ b/boards/ikea-tradfri/doc.md
@@ -62,16 +62,16 @@ Pin 1 is on the top-left side with only 6 contacts.
 
 ### Peripheral mapping
 
-| Peripheral | Number  | Hardware        | Pins                              | Comments                                            |
-|------------|---------|-----------------|-----------------------------------|-----------------------------------------------------|
-| ADC        | 0       | ADC0            | CHAN0: internal temperature       | Ports are fixed, 14/16-bit resolution not supported |
-| RTT        | &mdash; | RTCC            |                                   | 1 Hz interval. Either RTT or RTC (see below)        |
-| RTC        | &mdash; | RTCC            |                                   | 1 Hz interval. Either RTC or RTT (see below)        |
-| SPI        | 0       | USART1          | MOSI: PD15, MISO: PD14, CLK: PD13 |                                                     |
-| Timer      | 0       | TIMER0 + TIMER1 |                                   | TIMER0 is used as prescaler (must be adjacent)      |
-|            | 1       | LETIMER0        |                                   |                                                     |
-| UART       | 0       | USART0          | RX: PB15, TX: PB14                | Default STDIO output                                |
-|            | 1       | LEUART0         | RX: PB15, TX: PB14                | Baud rate limited (see below)                       |
+| Peripheral | Number | Hardware        | Pins                              | Comments                                            |
+|------------|--------|-----------------|-----------------------------------|-----------------------------------------------------|
+| ADC        | 0      | ADC0            | CHAN0: internal temperature       | Ports are fixed, 14/16-bit resolution not supported |
+| RTT        | -      | RTCC            |                                   | 1 Hz interval. Either RTT or RTC (see below)        |
+| RTC        | -      | RTCC            |                                   | 1 Hz interval. Either RTC or RTT (see below)        |
+| SPI        | 0      | USART1          | MOSI: PD15, MISO: PD14, CLK: PD13 |                                                     |
+| Timer      | 0      | TIMER0 + TIMER1 |                                   | TIMER0 is used as prescaler (must be adjacent)      |
+|            | 1      | LETIMER0        |                                   |                                                     |
+| UART       | 0      | USART0          | RX: PB15, TX: PB14                | Default STDIO output                                |
+|            | 1      | LEUART0         | RX: PB15, TX: PB14                | Baud rate limited (see below)                       |
 
 ### User interface
 

--- a/boards/ikea-tradfri/doc.md
+++ b/boards/ikea-tradfri/doc.md
@@ -166,7 +166,7 @@ Configured at 1 Hz interval, the RTCC will overflow each 136 years.
 
 ### Usage of EMLIB
 
-This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
+This port makes use of EMLIB by Silicon Labs to abstract peripheral registers.
 While some overhead is to be expected, it ensures proper setup of devices,
 provides chip errata and simplifies development. The exact overhead depends on
 the application and peripheral usage, but the largest overhead is expected
@@ -175,7 +175,10 @@ inline methods or macros (which have no overhead).
 
 Another advantage of EMLIB are the included assertions. These assertions ensure
 that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
-compiler.
+compiler defines.
+
+EMLIB is licensed by Silicon Labs under the zlib-style license, which permits
+distribution of source.
 
 ### Pin locations
 
@@ -219,7 +222,3 @@ Some boards have (limited) support for emulation, which can be started with:
 ```shell
 BOARD=ikea-tradfri make emulate
 ```
-
-## License information
-
-Silicon Labs' EMLIB: zlib-style license (permits distribution of source).

--- a/boards/ikea-tradfri/doc.md
+++ b/boards/ikea-tradfri/doc.md
@@ -65,7 +65,6 @@ Pin 1 is on the top-left side with only 6 contacts.
 | Peripheral | Number  | Hardware        | Pins                              | Comments                                            |
 |------------|---------|-----------------|-----------------------------------|-----------------------------------------------------|
 | ADC        | 0       | ADC0            | CHAN0: internal temperature       | Ports are fixed, 14/16-bit resolution not supported |
-| HWCRYPTO   | &mdash; | &mdash;         |                                   | AES128/AES256, SHA1, SHA256                         |
 | RTT        | &mdash; | RTCC            |                                   | 1 Hz interval. Either RTT or RTC (see below)        |
 | RTC        | &mdash; | RTCC            |                                   | 1 Hz interval. Either RTC or RTT (see below)        |
 | SPI        | 0       | USART1          | MOSI: PD15, MISO: PD14, CLK: PD13 |                                                     |
@@ -89,7 +88,6 @@ Pin 1 is on the top-left side with only 6 contacts.
 | Low-level driver | ADC        | yes       |                                                                |
 |                  | Flash      | yes       |                                                                |
 |                  | GPIO       | yes       | Interrupts are shared across pins (see reference manual)       |
-|                  | HW Crypto  | yes       |                                                                |
 |                  | I2C        | yes       |                                                                |
 |                  | PWM        | yes       |                                                                |
 |                  | RTCC       | yes       | As RTT or RTC                                                  |
@@ -165,14 +163,6 @@ Calendar*, which can be configured in ticker mode **or** calendar mode.
 Therefore, only one of both peripherals can be enabled at the same time.
 
 Configured at 1 Hz interval, the RTCC will overflow each 136 years.
-
-### Hardware crypto
-
-This MCU is equipped with a hardware-accelerated crypto peripheral that can
-speed up AES128, AES256, SHA1, SHA256 and several other cryptographic
-computations.
-
-A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 

--- a/boards/slstk3301a/doc.md
+++ b/boards/slstk3301a/doc.md
@@ -94,7 +94,7 @@ PIN 1 is the bottom-left contact when the header faces you horizontally.
 |                               | I2C        | yes       |                                                                |
 |                               | PWM        | yes       |                                                                |
 |                               | RTCC       | yes       | As RTT or RTC                                                  |
-|                               | SPI        | partially | Only master mode                                               |
+|                               | SPI        | yes       | Only master mode                                               |
 |                               | Timer      | yes       |                                                                |
 |                               | UART       | yes       | USART is shared with SPI. LEUART baud rate limited (see below) |
 | Temperature + humidity sensor | Si7021     | yes       | Silicon Labs Temperature + Humidity sensor                     |

--- a/boards/slstk3301a/doc.md
+++ b/boards/slstk3301a/doc.md
@@ -18,6 +18,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 | MCU             | EFM32TG11B520F128GM80                                                                              |
 |-----------------|----------------------------------------------------------------------------------------------------|
 | Family          | ARM Cortex-M0PLUS                                                                                  |
+| Series          | Series 1                                                                                           |
 | Vendor          | Silicon Labs                                                                                       |
 | Vendor Family   | EFM32 Tiny Gecko 11B                                                                               |
 | RAM             | 32.0 KiB                                                                                           |

--- a/boards/slstk3301a/doc.md
+++ b/boards/slstk3301a/doc.md
@@ -123,7 +123,7 @@ expects data from the MCU with the same settings.
 ### Clock selection
 
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
+peripherals. You are advised to read [AN0004.1](https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |

--- a/boards/slstk3301a/doc.md
+++ b/boards/slstk3301a/doc.md
@@ -1,6 +1,6 @@
-@defgroup    boards_slstk3301a Silicon Labs SLSTK3301A starter kit
-@ingroup     boards
-@brief       Support for Silicon Labs SLSTK3301A starter kit
+@defgroup   boards_slstk3301a Silicon Labs SLSTK3301A starter kit
+@ingroup    boards
+@brief      Support for Silicon Labs SLSTK3301A starter kit
 
 ## Overview
 
@@ -66,6 +66,7 @@ PIN 1 is the bottom-left contact when the header faces you horizontally.
 |------------|--------|-----------------|-----------------------------------|----------------------------------------------------------|
 | ADC        | 0      | ADC0            | CHAN0: internal temperature       | Ports are fixed, 14/16-bit resolution not supported      |
 | I2C        | 0      | I2C0            | SDA: PD6, CLK: PD7                | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
+| HWRNG      | -      | TRNG0           |                                   | Hardware-based true random number generator              |
 | RTT        | -      | RTCC            |                                   | 1 Hz interval. Either RTT or RTC (see below)             |
 | RTC        | -      | RTCC            |                                   | 1 Hz interval. Either RTC or RTT (see below)             |
 | SPI        | 0      | USART1          | MOSI: PC11, MISO: PC10, CLK: PA12 |                                                          |
@@ -91,6 +92,7 @@ PIN 1 is the bottom-left contact when the header faces you horizontally.
 | Low-level driver              | ADC        | yes       |                                                                |
 |                               | Flash      | yes       |                                                                |
 |                               | GPIO       | yes       | Interrupts are shared across pins (see reference manual)       |
+|                               | HWRNG      | yes       |                                                                |
 |                               | I2C        | yes       |                                                                |
 |                               | PWM        | yes       |                                                                |
 |                               | RTCC       | yes       | As RTT or RTC                                                  |

--- a/boards/slstk3301a/doc.md
+++ b/boards/slstk3301a/doc.md
@@ -76,12 +76,12 @@ PIN 1 is the bottom-left contact when the header faces you horizontally.
 
 ### User interface
 
-| Peripheral | Mapped to | Pin  | Comments   |
-|------------|-----------|------|------------|
-| Button     | PB0_PIN   | PD5  |            |
-|            | PB1_PIN   | PC9  |            |
-| LED        | LED0_PIN  | PD2  |            |
-|            | LED1_PIN  | PC2  |            |
+| Peripheral | Number | Mapped to | Pin | Comments |
+|------------|--------|-----------|-----|----------|
+| Button     | 0      | PB0_PIN   | PD5 |          |
+|            | 1      | PB1_PIN   | PC9 |          |
+| LED        | 0      | LED0_PIN  | PD2 |          |
+|            | 1      | LED1_PIN  | PC2 |          |
 
 ## Implementation Status
 

--- a/boards/slstk3301a/doc.md
+++ b/boards/slstk3301a/doc.md
@@ -62,17 +62,17 @@ PIN 1 is the bottom-left contact when the header faces you horizontally.
 
 ### Peripheral mapping
 
-| Peripheral | Number  | Hardware        | Pins                              | Comments                                                 |
-|------------|---------|-----------------|-----------------------------------|----------------------------------------------------------|
-| ADC        | 0       | ADC0            | CHAN0: internal temperature       | Ports are fixed, 14/16-bit resolution not supported      |
-| I2C        | 0       | I2C0            | SDA: PD6, CLK: PD7                | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-| RTT        | &mdash; | RTCC            |                                   | 1 Hz interval. Either RTT or RTC (see below)             |
-| RTC        | &mdash; | RTCC            |                                   | 1 Hz interval. Either RTC or RTT (see below)             |
-| SPI        | 0       | USART1          | MOSI: PC11, MISO: PC10, CLK: PA12 |                                                          |
-| Timer      | 0       | TIMER0 + TIMER1 |                                   | TIMER0 is used as prescaler (must be adjacent)           |
-|            | 1       | LETIMER0        |                                   |                                                          |
-| UART       | 0       | USART1          | RX: PD1, TX: PD0                  | Default STDIO output                                     |
-|            | 1       | LEUART0         | RX: PC15, TX: PC14                | Baud rate limited (see below)                            |
+| Peripheral | Number | Hardware        | Pins                              | Comments                                                 |
+|------------|--------|-----------------|-----------------------------------|----------------------------------------------------------|
+| ADC        | 0      | ADC0            | CHAN0: internal temperature       | Ports are fixed, 14/16-bit resolution not supported      |
+| I2C        | 0      | I2C0            | SDA: PD6, CLK: PD7                | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
+| RTT        | -      | RTCC            |                                   | 1 Hz interval. Either RTT or RTC (see below)             |
+| RTC        | -      | RTCC            |                                   | 1 Hz interval. Either RTC or RTT (see below)             |
+| SPI        | 0      | USART1          | MOSI: PC11, MISO: PC10, CLK: PA12 |                                                          |
+| Timer      | 0      | TIMER0 + TIMER1 |                                   | TIMER0 is used as prescaler (must be adjacent)           |
+|            | 1      | LETIMER0        |                                   |                                                          |
+| UART       | 0      | USART1          | RX: PD1, TX: PD0                  | Default STDIO output                                     |
+|            | 1      | LEUART0         | RX: PC15, TX: PC14                | Baud rate limited (see below)                            |
 
 ### User interface
 

--- a/boards/slstk3301a/doc.md
+++ b/boards/slstk3301a/doc.md
@@ -66,7 +66,6 @@ PIN 1 is the bottom-left contact when the header faces you horizontally.
 |------------|---------|-----------------|-----------------------------------|----------------------------------------------------------|
 | ADC        | 0       | ADC0            | CHAN0: internal temperature       | Ports are fixed, 14/16-bit resolution not supported      |
 | I2C        | 0       | I2C0            | SDA: PD6, CLK: PD7                | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-| HWCRYPTO   | &mdash; | &mdash;         |                                   | AES128/AES256, SHA1, SHA256                              |
 | RTT        | &mdash; | RTCC            |                                   | 1 Hz interval. Either RTT or RTC (see below)             |
 | RTC        | &mdash; | RTCC            |                                   | 1 Hz interval. Either RTC or RTT (see below)             |
 | SPI        | 0       | USART1          | MOSI: PC11, MISO: PC10, CLK: PA12 |                                                          |
@@ -92,7 +91,6 @@ PIN 1 is the bottom-left contact when the header faces you horizontally.
 | Low-level driver              | ADC        | yes       |                                                                |
 |                               | Flash      | yes       |                                                                |
 |                               | GPIO       | yes       | Interrupts are shared across pins (see reference manual)       |
-|                               | HW Crypto  | yes       |                                                                |
 |                               | I2C        | yes       |                                                                |
 |                               | PWM        | yes       |                                                                |
 |                               | RTCC       | yes       | As RTT or RTC                                                  |
@@ -180,14 +178,6 @@ Calendar* (RTCC), which can be configured in ticker mode **or** calendar mode.
 Therefore, only one of both peripherals can be enabled at the same time.
 
 Configured at 1 Hz interval, the RTCC will overflow each 136 years.
-
-### Hardware crypto
-
-This MCU is equipped with a hardware-accelerated crypto peripheral that can
-speed up AES128, AES256, SHA1, SHA256 and several other cryptographic
-computations.
-
-A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 

--- a/boards/slstk3301a/doc.md
+++ b/boards/slstk3301a/doc.md
@@ -190,7 +190,7 @@ inline methods or macros (which have no overhead).
 
 Another advantage of EMLIB are the included assertions. These assertions ensure
 that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
-compiler.
+compiler defines.
 
 EMLIB is licensed by Silicon Labs under the zlib-style license, which permits
 distribution of source.

--- a/boards/slstk3400a/doc.md
+++ b/boards/slstk3400a/doc.md
@@ -93,7 +93,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |                               | I2C         | yes       |                                                                |
 |                               | PWM         | yes       |                                                                |
 |                               | RTC         | yes       | As RTT or RTC                                                  |
-|                               | SPI         | partially | Only master mode                                               |
+|                               | SPI         | yes       | Only master mode                                               |
 |                               | Timer       | yes       |                                                                |
 |                               | UART        | yes       | USART is shared with SPI. LEUART baud rate limited (see below) |
 |                               | USB         | no        |                                                                |

--- a/boards/slstk3400a/doc.md
+++ b/boards/slstk3400a/doc.md
@@ -41,7 +41,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 ### Pinout
 
 This is the pinout of the expansion header on the right side of the board.
-PIN 1 is the bottom-left contact when the header faces  you horizontally.
+PIN 1 is the bottom-left contact when the header faces you horizontally.
 
 |      | PIN | PIN |      |
 |------|-----|-----|------|

--- a/boards/slstk3400a/doc.md
+++ b/boards/slstk3400a/doc.md
@@ -18,6 +18,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 | MCU             | EFM32HG322F64                                                                                    |
 |-----------------|--------------------------------------------------------------------------------------------------|
 | Family          | ARM Cortex-M0PLUS                                                                                |
+| Series          | Series 0                                                                                         |
 | Vendor          | Silicon Labs                                                                                     |
 | Vendor Family   | EFM32 Happy Gecko                                                                                |
 | RAM             | 8.0 KiB                                                                                          |

--- a/boards/slstk3400a/doc.md
+++ b/boards/slstk3400a/doc.md
@@ -178,7 +178,7 @@ the ticker-to-calendar mode, this interval is extended artificially.
 
 ### Usage of EMLIB
 
-This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
+This port makes use of EMLIB by Silicon Labs to abstract peripheral registers.
 While some overhead is to be expected, it ensures proper setup of devices,
 provides chip errata and simplifies development. The exact overhead depends on
 the application and peripheral usage, but the largest overhead is expected
@@ -187,7 +187,10 @@ inline methods or macros (which have no overhead).
 
 Another advantage of EMLIB are the included assertions. These assertions ensure
 that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
-compiler.
+compiler defines.
+
+EMLIB is licensed by Silicon Labs under the zlib-style license, which permits
+distribution of source.
 
 ### Pin locations
 
@@ -228,7 +231,3 @@ Some boards have (limited) support for emulation, which can be started with:
 ```shell
 BOARD=slstk3400a make emulate
 ```
-
-## License information
-
-Silicon Labs' EMLIB: zlib-style license (permits distribution of source).

--- a/boards/slstk3400a/doc.md
+++ b/boards/slstk3400a/doc.md
@@ -66,7 +66,6 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |------------|---------|-----------------|-----------------------------------|----------------------------------------------------------|
 | ADC        | 0       | ADC0            | CHAN0: internal temperature       | Ports are fixed, 14/16-bit resolution not supported      |
 | I2C        | 0       | I2C0            | SDA: PD6,  CLK: PD7               | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-| HWCRYPTO   | &mdash; | &mdash;         |                                   | AES128                                                   |
 | RTT        | &mdash; | RTCC            |                                   | 1 Hz interval. Either RTT or RTC (see below)             |
 | RTC        | &mdash; | RTCC            |                                   | 1 Hz interval. Either RTC or RTT (see below)             |
 | SPI        | 0       | USART0          | MOSI: PE10, MISO: PE11, CLK: PE12 |                                                          |
@@ -91,7 +90,6 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | Low-level driver              | ADC         | yes       |                                                                |
 |                               | Flash       | yes       |                                                                |
 |                               | GPIO        | yes       | Interrupts are shared across pins (see reference manual)       |
-|                               | HW Crypto   | yes       |                                                                |
 |                               | I2C         | yes       |                                                                |
 |                               | PWM         | yes       |                                                                |
 |                               | RTC         | yes       | As RTT or RTC                                                  |
@@ -177,12 +175,6 @@ structures and visa versa.
 
 Configured at 1 Hz interval, the RTC will overflow each 194 days. When using
 the ticker-to-calendar mode, this interval is extended artificially.
-
-### Hardware crypto
-
-This MCUs has support for hardware-accelerated AES128.
-
-A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 

--- a/boards/slstk3400a/doc.md
+++ b/boards/slstk3400a/doc.md
@@ -75,12 +75,12 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ### User interface
 
-| Peripheral | Mapped to | Pin  | Comments   |
-|------------|-----------|------|------------|
-| Button     | PB0       | PC9  |            |
-|            | PB1       | PC10 |            |
-| LED        | LED0      | PF4  | Yellow LED |
-|            | LED1      | PF5  | Yellow LED |
+| Peripheral | Number | Mapped to | Pin  | Comments   |
+|------------|--------|-----------|------|------------|
+| Button     | 0      | PB0_PIN   | PC9  |            |
+|            | 1      | PB1_PIN   | PC10 |            |
+| LED        | 0      | LED0_PIN  | PF4  | Yellow LED |
+|            | 1      | LED1_PIN  | PF5  | Yellow LED |
 
 ## Implementation Status
 

--- a/boards/slstk3400a/doc.md
+++ b/boards/slstk3400a/doc.md
@@ -62,16 +62,16 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ### Peripheral mapping
 
-| Peripheral | Number  | Hardware        | Pins                              | Comments                                                 |
-|------------|---------|-----------------|-----------------------------------|----------------------------------------------------------|
-| ADC        | 0       | ADC0            | CHAN0: internal temperature       | Ports are fixed, 14/16-bit resolution not supported      |
-| I2C        | 0       | I2C0            | SDA: PD6,  CLK: PD7               | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-| RTT        | &mdash; | RTCC            |                                   | 1 Hz interval. Either RTT or RTC (see below)             |
-| RTC        | &mdash; | RTCC            |                                   | 1 Hz interval. Either RTC or RTT (see below)             |
-| SPI        | 0       | USART0          | MOSI: PE10, MISO: PE11, CLK: PE12 |                                                          |
-| Timer      | 0       | TIMER0 + TIMER1 |                                   | TIMER0 is used as prescaler (must be adjacent)           |
-| UART       | 0       | USART1          | RX: PA0, TX: PF2                  | Default STDIO output                                     |
-|            | 1       | LEUART0         | RX: PD5, TX: PD4                  | Baud rate limited (see below)                            |
+| Peripheral | Number | Hardware        | Pins                              | Comments                                                 |
+|------------|--------|-----------------|-----------------------------------|----------------------------------------------------------|
+| ADC        | 0      | ADC0            | CHAN0: internal temperature       | Ports are fixed, 14/16-bit resolution not supported      |
+| I2C        | 0      | I2C0            | SDA: PD6,  CLK: PD7               | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
+| RTT        | -      | RTCC            |                                   | 1 Hz interval. Either RTT or RTC (see below)             |
+| RTC        | -      | RTCC            |                                   | 1 Hz interval. Either RTC or RTT (see below)             |
+| SPI        | 0      | USART0          | MOSI: PE10, MISO: PE11, CLK: PE12 |                                                          |
+| Timer      | 0      | TIMER0 + TIMER1 |                                   | TIMER0 is used as prescaler (must be adjacent)           |
+| UART       | 0      | USART1          | RX: PA0, TX: PF2                  | Default STDIO output                                     |
+|            | 1      | LEUART0         | RX: PD5, TX: PD4                  | Baud rate limited (see below)                            |
 
 ### User interface
 

--- a/boards/slstk3401a/doc.md
+++ b/boards/slstk3401a/doc.md
@@ -18,6 +18,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 | MCU             | EFM32PG1B200F256GM48                                                                             |
 |-----------------|--------------------------------------------------------------------------------------------------|
 | Family          | ARM Cortex-M4F                                                                                   |
+| Series          | Series 1                                                                                         |
 | Vendor          | Silicon Labs                                                                                     |
 | Vendor Family   | EFM32 Pearl Gecko 1B                                                                             |
 | RAM             | 32.0 KiB                                                                                         |

--- a/boards/slstk3401a/doc.md
+++ b/boards/slstk3401a/doc.md
@@ -62,17 +62,17 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ### Peripheral mapping
 
-| Peripheral | Number  | Hardware        | Pins                           | Comments                                                 |
-|------------|---------|-----------------|--------------------------------|----------------------------------------------------------|
-| ADC        | 0       | ADC0            | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
-| I2C        | 0       | I2C0            | SDA: PC10, CLK: PC11           | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-| RTT        | &mdash; | RTCC            |                                | 1 Hz interval. Either RTT or RTC (see below)             |
-| RTC        | &mdash; | RTCC            |                                | 1 Hz interval. Either RTC or RTT (see below)             |
-| SPI        | 0       | USART1          | MOSI: PC6, MISO: PC7, CLK: PC8 |                                                          |
-| Timer      | 0       | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjacent)           |
-|            | 1       | LETIMER0        |                                |                                                          |
-| UART       | 0       | USART0          | RX: PA1, TX: PA0               | Default STDIO output                                     |
-|            | 1       | LEUART0         | RX: PD11, TX: PD10             | Baud rate limited (see below)                            |
+| Peripheral | Number | Hardware        | Pins                           | Comments                                                 |
+|------------|--------|-----------------|--------------------------------|----------------------------------------------------------|
+| ADC        | 0      | ADC0            | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
+| I2C        | 0      | I2C0            | SDA: PC10, CLK: PC11           | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
+| RTT        | -      | RTCC            |                                | 1 Hz interval. Either RTT or RTC (see below)             |
+| RTC        | -      | RTCC            |                                | 1 Hz interval. Either RTC or RTT (see below)             |
+| SPI        | 0      | USART1          | MOSI: PC6, MISO: PC7, CLK: PC8 |                                                          |
+| Timer      | 0      | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjacent)           |
+|            | 1      | LETIMER0        |                                |                                                          |
+| UART       | 0      | USART0          | RX: PA1, TX: PA0               | Default STDIO output                                     |
+|            | 1      | LEUART0         | RX: PD11, TX: PD10             | Baud rate limited (see below)                            |
 
 ### User interface
 

--- a/boards/slstk3401a/doc.md
+++ b/boards/slstk3401a/doc.md
@@ -202,7 +202,7 @@ Configured at 1 Hz interval, the RTCC will overflow each 136 years.
 
 ### Usage of EMLIB
 
-This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
+This port makes use of EMLIB by Silicon Labs to abstract peripheral registers.
 While some overhead is to be expected, it ensures proper setup of devices,
 provides chip errata and simplifies development. The exact overhead depends on
 the application and peripheral usage, but the largest overhead is expected
@@ -211,7 +211,10 @@ inline methods or macros (which have no overhead).
 
 Another advantage of EMLIB are the included assertions. These assertions ensure
 that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
-compiler.
+compiler defines.
+
+EMLIB is licensed by Silicon Labs under the zlib-style license, which permits
+distribution of source.
 
 ### Pin locations
 
@@ -255,7 +258,3 @@ Some boards have (limited) support for emulation, which can be started with:
 ```shell
 BOARD=slstk3401a make emulate
 ```
-
-## License information
-
-Silicon Labs' EMLIB: zlib-style license (permits distribution of source).

--- a/boards/slstk3401a/doc.md
+++ b/boards/slstk3401a/doc.md
@@ -41,7 +41,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 ### Pinout
 
 This is the pinout of the expansion header on the right side of the board.
-PIN 1 is the bottom-left contact when the header faces  you horizontally.
+PIN 1 is the bottom-left contact when the header faces you horizontally.
 
 |      | PIN | PIN |      |
 |------|-----|-----|------|

--- a/boards/slstk3401a/doc.md
+++ b/boards/slstk3401a/doc.md
@@ -76,12 +76,12 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ### User interface
 
-| Peripheral | Mapped to | Pin | Comments   |
-|------------|-----------|-----|------------|
-| Button     | PB0       | PF6 |            |
-|            | PB1       | PF7 |            |
-| LED        | LED0      | PF4 | Yellow LED |
-|            | LED1      | PF5 | Yellow LED |
+| Peripheral | Number | Mapped to | Pin | Comments   |
+|------------|--------|-----------|-----|------------|
+| Button     | 0      | PB0_PIN   | PF6 |            |
+|            | 1      | PB1_PIN   | PF7 |            |
+| LED        | 0      | LED0_PIN  | PF4 | Yellow LED |
+|            | 1      | LED1_PIN  | PF5 | Yellow LED |
 
 ## Implementation Status
 

--- a/boards/slstk3401a/doc.md
+++ b/boards/slstk3401a/doc.md
@@ -94,7 +94,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |                               | I2C        | yes       |                                                                |
 |                               | PWM        | yes       |                                                                |
 |                               | RTCC       | yes       | As RTT or RTC                                                  |
-|                               | SPI        | partially | Only master mode                                               |
+|                               | SPI        | yes       | Only master mode                                               |
 |                               | Timer      | yes       |                                                                |
 |                               | UART       | yes       | USART is shared with SPI. LEUART baud rate limited (see below) |
 |                               | USB        | no        |                                                                |

--- a/boards/slstk3401a/doc.md
+++ b/boards/slstk3401a/doc.md
@@ -66,7 +66,6 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |------------|---------|-----------------|--------------------------------|----------------------------------------------------------|
 | ADC        | 0       | ADC0            | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
 | I2C        | 0       | I2C0            | SDA: PC10, CLK: PC11           | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-| HWCRYPTO   | &mdash; | &mdash;         |                                | AES128/AES256, SHA1, SHA256                              |
 | RTT        | &mdash; | RTCC            |                                | 1 Hz interval. Either RTT or RTC (see below)             |
 | RTC        | &mdash; | RTCC            |                                | 1 Hz interval. Either RTC or RTT (see below)             |
 | SPI        | 0       | USART1          | MOSI: PC6, MISO: PC7, CLK: PC8 |                                                          |
@@ -92,7 +91,6 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | Low-level driver              | ADC        | yes       |                                                                |
 |                               | Flash      | yes       |                                                                |
 |                               | GPIO       | yes       | Interrupts are shared across pins (see reference manual)       |
-|                               | HW Crypto  | yes       |                                                                |
 |                               | I2C        | yes       |                                                                |
 |                               | PWM        | yes       |                                                                |
 |                               | RTCC       | yes       | As RTT or RTC                                                  |
@@ -201,14 +199,6 @@ Calendar*, which can be configured in ticker mode **or** calendar mode.
 Therefore, only one of both peripherals can be enabled at the same time.
 
 Configured at 1 Hz interval, the RTCC will overflow each 136 years.
-
-### Hardware crypto
-
-This MCU is equipped with a hardware-accelerated crypto peripheral that can
-speed up AES128, AES256, SHA1, SHA256 and several other cryptographic
-computations.
-
-A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 

--- a/boards/slstk3401a/doc.md
+++ b/boards/slstk3401a/doc.md
@@ -145,7 +145,7 @@ symbols (`-gdwarf-2` for GCC).
 ### Clock selection
 
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
+peripherals. You are advised to read [AN0004.1](https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |

--- a/boards/slstk3402a/doc.md
+++ b/boards/slstk3402a/doc.md
@@ -41,7 +41,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 ### Pinout
 
 This is the pinout of the expansion header on the right side of the board.
-PIN 1 is the bottom-left contact when the header faces  you horizontally.
+PIN 1 is the bottom-left contact when the header faces you horizontally.
 
 |      | PIN | PIN |      |
 |------|-----|-----|------|
@@ -66,7 +66,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |------------|--------|-------------------|--------------------------------|----------------------------------------------------------|
 | ADC        | 0      | ADC0              | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
 | I2C        | 0      | I2C0              | SDA: PC10, CLK: PC11           | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-| HWRNG      | -      | TNRG0             |                                | Hardware-based true random number generator              |
+| HWRNG      | -      | TRNG0             |                                | Hardware-based true random number generator              |
 | RTT        | -      | RTCC              |                                | 1 Hz interval. Either RTT or RTC (see below)             |
 | RTC        | -      | RTCC              |                                | 1 Hz interval. Either RTC or RTT (see below)             |
 | SPI        | 0      | USART2            | MOSI: PA6, MISO: PA7, CLK: PA8 |                                                          |
@@ -94,7 +94,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | Low-level driver              | ADC         | yes       |                                                                |
 |                               | Flash       | yes       |                                                                |
 |                               | GPIO        | yes       | Interrupts are shared across pins (see reference manual)       |
-|                               | HW RNG      | yes       |                                                                |
+|                               | HWRNG       | yes       |                                                                |
 |                               | I2C         | yes       |                                                                |
 |                               | PWM         | yes       |                                                                |
 |                               | RTCC        | yes       | As RTT or RTC                                                  |

--- a/boards/slstk3402a/doc.md
+++ b/boards/slstk3402a/doc.md
@@ -149,7 +149,7 @@ symbols (`-gdwarf-2` for GCC).
 ### Clock selection
 
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
+peripherals. You are advised to read [AN0004.1](https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |

--- a/boards/slstk3402a/doc.md
+++ b/boards/slstk3402a/doc.md
@@ -62,20 +62,20 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ### Peripheral mapping
 
-| Peripheral | Number  | Hardware          | Pins                           | Comments                                                 |
-|------------|---------|-------------------|--------------------------------|----------------------------------------------------------|
-| ADC        | 0       | ADC0              | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
-| I2C        | 0       | I2C0              | SDA: PC10, CLK: PC11           | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-| HWRNG      | &mdash; | TNRG0             |                                | Hardware-based true random number generator              |
-| RTT        | &mdash; | RTCC              |                                | 1 Hz interval. Either RTT or RTC (see below)             |
-| RTC        | &mdash; | RTCC              |                                | 1 Hz interval. Either RTC or RTT (see below)             |
-| SPI        | 0       | USART2            | MOSI: PA6, MISO: PA7, CLK: PA8 |                                                          |
-|            | 1       | USART1            | MOSI: PC6, MISO: PC7, CLK: PC8 | On-board LCD                                             |
-| Timer      | 0       | WTIMER0 + WTIMER1 |                                | WTIMER0 is used as prescaler (must be adjacent)          |
-| Timer      | 1       | TIMER0 + TIMER1   |                                | TIMER0 is used as prescaler (must be adjacent)           |
-|            | 2       | LETIMER0          |                                |                                                          |
-| UART       | 0       | USART0            | RX: PA1, TX: PA0               | Default STDIO output                                     |
-|            | 1       | LEUART0           | RX: PD11, TX: PD10             | Baud rate limited (see below)                            |
+| Peripheral | Number | Hardware          | Pins                           | Comments                                                 |
+|------------|--------|-------------------|--------------------------------|----------------------------------------------------------|
+| ADC        | 0      | ADC0              | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
+| I2C        | 0      | I2C0              | SDA: PC10, CLK: PC11           | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
+| HWRNG      | -      | TNRG0             |                                | Hardware-based true random number generator              |
+| RTT        | -      | RTCC              |                                | 1 Hz interval. Either RTT or RTC (see below)             |
+| RTC        | -      | RTCC              |                                | 1 Hz interval. Either RTC or RTT (see below)             |
+| SPI        | 0      | USART2            | MOSI: PA6, MISO: PA7, CLK: PA8 |                                                          |
+|            | 1      | USART1            | MOSI: PC6, MISO: PC7, CLK: PC8 | On-board LCD                                             |
+| Timer      | 0      | WTIMER0 + WTIMER1 |                                | WTIMER0 is used as prescaler (must be adjacent)          |
+| Timer      | 1      | TIMER0 + TIMER1   |                                | TIMER0 is used as prescaler (must be adjacent)           |
+|            | 2      | LETIMER0          |                                |                                                          |
+| UART       | 0      | USART0            | RX: PA1, TX: PA0               | Default STDIO output                                     |
+|            | 1      | LEUART0           | RX: PD11, TX: PD10             | Baud rate limited (see below)                            |
 
 ### User interface
 

--- a/boards/slstk3402a/doc.md
+++ b/boards/slstk3402a/doc.md
@@ -98,7 +98,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |                               | I2C         | yes       |                                                                |
 |                               | PWM         | yes       |                                                                |
 |                               | RTCC        | yes       | As RTT or RTC                                                  |
-|                               | SPI         | partially | Only master mode                                               |
+|                               | SPI         | yes       | Only master mode                                               |
 |                               | Timer       | yes       |                                                                |
 |                               | UART        | yes       | USART is shared with SPI. LEUART baud rate limited (see below) |
 |                               | USB         | no        |                                                                |

--- a/boards/slstk3402a/doc.md
+++ b/boards/slstk3402a/doc.md
@@ -18,6 +18,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 | MCU             | EFM32PG12B500F1024GL125                                                                          |
 |-----------------|--------------------------------------------------------------------------------------------------|
 | Family          | ARM Cortex-M4F                                                                                   |
+| Series          | Series 1                                                                                         |
 | Vendor          | Silicon Labs                                                                                     |
 | Vendor Family   | EFM32 Pearl Gecko 12B                                                                            |
 | RAM             | 256.0 KiB                                                                                        |

--- a/boards/slstk3402a/doc.md
+++ b/boards/slstk3402a/doc.md
@@ -79,12 +79,12 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ### User interface
 
-| Peripheral | Mapped to | Pin | Comments   |
-|------------|-----------|-----|------------|
-| Button     | PB0       | PF6 |            |
-|            | PB1       | PF7 |            |
-| LED        | LED0      | PF4 | Yellow LED |
-|            | LED1      | PF5 | Yellow LED |
+| Peripheral | Number | Mapped to | Pin | Comments   |
+|------------|--------|-----------|-----|------------|
+| Button     | 0      | PB0_PIN   | PF6 |            |
+|            | 1      | PB1_PIN   | PF7 |            |
+| LED        | 0      | LED0_PIN  | PF4 | Yellow LED |
+|            | 1      | LED1_PIN  | PF5 | Yellow LED |
 
 ## Implementation Status
 

--- a/boards/slstk3402a/doc.md
+++ b/boards/slstk3402a/doc.md
@@ -206,7 +206,7 @@ Configured at 1 Hz interval, the RTCC will overflow each 136 years.
 
 ### Usage of EMLIB
 
-This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
+This port makes use of EMLIB by Silicon Labs to abstract peripheral registers.
 While some overhead is to be expected, it ensures proper setup of devices,
 provides chip errata and simplifies development. The exact overhead depends on
 the application and peripheral usage, but the largest overhead is expected
@@ -215,7 +215,10 @@ inline methods or macros (which have no overhead).
 
 Another advantage of EMLIB are the included assertions. These assertions ensure
 that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
-compiler.
+compiler defines.
+
+EMLIB is licensed by Silicon Labs under the zlib-style license, which permits
+distribution of source.
 
 ### Pin locations
 
@@ -259,7 +262,3 @@ Some boards have (limited) support for emulation, which can be started with:
 ```shell
 BOARD=slstk3402a make emulate
 ```
-
-## License information
-
-Silicon Labs' EMLIB: zlib-style license (permits distribution of source).

--- a/boards/slstk3402a/doc.md
+++ b/boards/slstk3402a/doc.md
@@ -66,7 +66,6 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |------------|---------|-------------------|--------------------------------|----------------------------------------------------------|
 | ADC        | 0       | ADC0              | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
 | I2C        | 0       | I2C0              | SDA: PC10, CLK: PC11           | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-| HWCRYPTO   | &mdash; | &mdash;           |                                | AES128/AES256, SHA1, SHA256                              |
 | HWRNG      | &mdash; | TNRG0             |                                | Hardware-based true random number generator              |
 | RTT        | &mdash; | RTCC              |                                | 1 Hz interval. Either RTT or RTC (see below)             |
 | RTC        | &mdash; | RTCC              |                                | 1 Hz interval. Either RTC or RTT (see below)             |
@@ -95,7 +94,6 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | Low-level driver              | ADC         | yes       |                                                                |
 |                               | Flash       | yes       |                                                                |
 |                               | GPIO        | yes       | Interrupts are shared across pins (see reference manual)       |
-|                               | HW Crypto   | yes       |                                                                |
 |                               | HW RNG      | yes       |                                                                |
 |                               | I2C         | yes       |                                                                |
 |                               | PWM         | yes       |                                                                |
@@ -205,14 +203,6 @@ Calendar*, which can be configured in ticker mode **or** calendar mode.
 Therefore, only one of both peripherals can be enabled at the same time.
 
 Configured at 1 Hz interval, the RTCC will overflow each 136 years.
-
-### Hardware crypto
-
-This MCU is equipped with a hardware-accelerated crypto peripheral that can
-speed up AES128, AES256, SHA1, SHA256 and several other cryptographic
-computations.
-
-A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 

--- a/boards/slstk3701a/doc.md
+++ b/boards/slstk3701a/doc.md
@@ -218,7 +218,7 @@ Configured at 1 Hz interval, the RTCC will overflow each 136 years.
 
 ### Usage of EMLIB
 
-This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
+This port makes use of EMLIB by Silicon Labs to abstract peripheral registers.
 While some overhead is to be expected, it ensures proper setup of devices,
 provides chip errata and simplifies development. The exact overhead depends on
 the application and peripheral usage, but the largest overhead is expected
@@ -227,7 +227,10 @@ inline methods or macros (which have no overhead).
 
 Another advantage of EMLIB are the included assertions. These assertions ensure
 that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
-compiler.
+compiler defines.
+
+EMLIB is licensed by Silicon Labs under the zlib-style license, which permits
+distribution of source.
 
 ### Pin locations
 
@@ -271,7 +274,3 @@ Some boards have (limited) support for emulation, which can be started with:
 ```shell
 BOARD=slstk3701a make emulate
 ```
-
-## License information
-
-Silicon Labs' EMLIB: zlib-style license (permits distribution of source).

--- a/boards/slstk3701a/doc.md
+++ b/boards/slstk3701a/doc.md
@@ -86,18 +86,18 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ### User interface
 
-| Peripheral | Mapped to | Pin       | Comments   |
-|------------|-----------|-----------|------------|
-| Button     | PB0_PIN   | PC8       |            |
-|            | PB1_PIN   | PC9       |            |
-| LED        | LED0R_PIN | PH10      | Active low |
-|            | LED0G_PIN | PH11      | Active low |
-|            | LED0B_PIN | PH12      | Active low |
-|            | LED1R_PIN | PH13      | Active low |
-|            | LED1G_PIN | PH14      | Active low |
-|            | LED1B_PIN | PH15      | Active low |
-|            | LED0_PIN  | LED0R_PIN | Active low |
-|            | LED1_PIN  | LED1R_PIN | Active low |
+| Peripheral | Number | Mapped to | Pin       | Comments   |
+|------------|--------|-----------|-----------|------------|
+| Button     | 0      | PB0_PIN   | PC8       |            |
+|            | 1      | PB1_PIN   | PC9       |            |
+| LED        | 0      | LED0R_PIN | PH10      | Active low |
+|            |        | LED0G_PIN | PH11      | Active low |
+|            |        | LED0B_PIN | PH12      | Active low |
+|            |        | LED0_PIN  | LED0R_PIN | Active low |
+|            | 1      | LED1R_PIN | PH13      | Active low |
+|            |        | LED1G_PIN | PH14      | Active low |
+|            |        | LED1B_PIN | PH15      | Active low |
+|            |        | LED1_PIN  | LED1R_PIN | Active low |
 
 ## Implementation Status
 

--- a/boards/slstk3701a/doc.md
+++ b/boards/slstk3701a/doc.md
@@ -44,7 +44,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 ### Pinout
 
 This is the pinout of the expansion header on the right side of the board.
-PIN 1 is the bottom-left contact when the header faces  you horizontally.
+PIN 1 is the bottom-left contact when the header faces you horizontally.
 
 | RIOT Peripheral | Name | PIN | PIN | Name   | RIOT Peripheral |
 |-----------------|------|-----|-----|--------|-----------------|
@@ -73,7 +73,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | I2C         | 0       | I2C0       | SDA:PC0, SCL:PC1 | Normal speed                        |
 | I2C         | 1       | I2C1       | SDA:PC4, SCL:PC5 | Normal speed                        |
 | I2C         | 2       | I2C2       | SDA:PI4, SCL:PI5 | Normal speed, Sensor I2C bus        |
-| HWRNG       | -       | TNRG0      |                  | True Random Number Generator (TRNG) |
+| HWRNG       | -       | TRNG0      |                  | True Random Number Generator (TRNG) |
 | RTT         | -       | RTCC       |                  | 1 Hz interval, either RTT or RTC    |
 | RTC         | -       | RTCC       |                  | 1 Hz interval, either RTT or RTC    |
 | SPI         | 0       | USART0     | MOSI:PE10, MISO:PE11, CLK:PE12 |                       |
@@ -109,12 +109,12 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |                               | Ethernet    | no        |                                                       |
 |                               | Flash       | yes       |                                                       |
 |                               | GPIO        | yes       | Interrupts are shared across pins (see ref manual)    |
+|                               | HWRNG       | yes       | True Random Number Generator                          |
 |                               | I2C         | yes       |                                                       |
 |                               | PWM         | yes       |                                                       |
 |                               | RTCC        | yes       | As RTT or RTC                                         |
 |                               | SPI         | yes       | Only master mode                                      |
 |                               | Timer       | yes       |                                                       |
-|                               | TRNG        | yes       | True Random Number Generator                          |
 |                               | UART        | yes       | USART is shared with SPI. LEUART baud rate limited    |
 |                               | USB         | yes       | Device mode                                           |
 | LCD driver                    | LS013B7DH06 | no        | Sharp Low Power Memory color LCD (Rev. A0 - A5 board) |

--- a/boards/slstk3701a/doc.md
+++ b/boards/slstk3701a/doc.md
@@ -161,7 +161,7 @@ symbols (`-gdwarf-2` for GCC).
 
 There are several clock sources that are available for the different
 peripherals. You are advised to read
-[AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
+[AN0004.1](https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |

--- a/boards/slstk3701a/doc.md
+++ b/boards/slstk3701a/doc.md
@@ -73,7 +73,6 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | I2C         | 0       | I2C0       | SDA:PC0, SCL:PC1 | Normal speed                        |
 | I2C         | 1       | I2C1       | SDA:PC4, SCL:PC5 | Normal speed                        |
 | I2C         | 2       | I2C2       | SDA:PI4, SCL:PI5 | Normal speed, Sensor I2C bus        |
-| HWCRYPTO    | -       | -          |                  | AES128/AES256, SHA1, SHA224/SHA256  |
 | HWRNG       | -       | TNRG0      |                  | True Random Number Generator (TRNG) |
 | RTT         | -       | RTCC       |                  | 1 Hz interval, either RTT or RTC    |
 | RTC         | -       | RTCC       |                  | 1 Hz interval, either RTT or RTC    |
@@ -110,7 +109,6 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |                               | Ethernet    | no        |                                                       |
 |                               | Flash       | yes       |                                                       |
 |                               | GPIO        | yes       | Interrupts are shared across pins (see ref manual)    |
-|                               | HW Crypto   | yes       |                                                       |
 |                               | I2C         | yes       |                                                       |
 |                               | PWM         | yes       |                                                       |
 |                               | RTCC        | yes       | As RTT or RTC                                         |
@@ -217,14 +215,6 @@ Calendar*, which can be configured in ticker mode **or** calendar mode.
 Therefore, only one of both peripherals can be enabled at the same time.
 
 Configured at 1 Hz interval, the RTCC will overflow each 136 years.
-
-### Hardware crypto
-
-This MCU is equipped with a hardware-accelerated crypto peripheral that can
-speed up AES128, AES256, SHA1, SHA256 and several other cryptographic
-computations.
-
-A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 

--- a/boards/slstk3701a/doc.md
+++ b/boards/slstk3701a/doc.md
@@ -18,6 +18,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 | MCU             | EFM32GG11B820F2048GL192                              |
 |-----------------|------------------------------------------------------|
 | Family          | ARM Cortex-M4F                                       |
+| Series          | Series 1                                             |
 | Vendor          | Silicon Labs                                         |
 | Vendor Family   | EFM32 Giant Gecko 11B                                |
 | RAM             | 512.0 KiB                                            |

--- a/boards/sltb001a/doc.md
+++ b/boards/sltb001a/doc.md
@@ -74,12 +74,12 @@ is the top-left contact, marked on the silkscreen.
 
 ### User interface
 
-| Peripheral | Mapped to | Pin  | Comments  |
-|------------|-----------|------|-----------|
-| Button     | PB0       | PD14 |           |
-|            | PB1       | PD15 |           |
-| LED        | LED0      | PD11 | Red LED   |
-|            | LED1      | PD12 | Green LED |
+| Peripheral | Number | Mapped to | Pin  | Comments  |
+|------------|--------|-----------|------|-----------|
+| Button     | 0      | PB0_PIN   | PD14 |           |
+|            | 1      | PB1_PIN   | PD15 |           |
+| LED        | 0      | LED0_PIN  | PD12 | Green LED |
+|            | 1      | LED1_PIN  | PD11 | Red LED   |
 
 ## Implementation Status
 

--- a/boards/sltb001a/doc.md
+++ b/boards/sltb001a/doc.md
@@ -18,6 +18,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 | MCU             | EFR32MG1P132F256GM48                                                                           |
 |-----------------|------------------------------------------------------------------------------------------------|
 | Family          | ARM Cortex-M4F                                                                                 |
+| Series          | Series 1                                                                                       |
 | Vendor          | Silicon Labs                                                                                   |
 | Vendor Family   | EFR32 Mighty Gecko 1P                                                                          |
 | RAM             | 32.0 KiB (1.0 KiB reserved for the radio blob)                                                 |

--- a/boards/sltb001a/doc.md
+++ b/boards/sltb001a/doc.md
@@ -64,7 +64,6 @@ is the top-left contact, marked on the silkscreen.
 |------------|---------|-----------------|--------------------------------|----------------------------------------------------------|
 | ADC        | 0       | ADC0            | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
 | I2C        | 0       | I2C0            | SDA: PC10, CLK: PC11           | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-| HWCRYPTO   | &mdash; | &mdash;         |                                | AES128/AES256, SHA1, SHA256                              |
 | RTT        | &mdash; | RTCC            |                                | 1 Hz interval. Either RTT or RTC (see below)             |
 | RTC        | &mdash; | RTCC            |                                | 1 Hz interval. Either RTC or RTT (see below)             |
 | SPI        | 0       | USART1          | MOSI: PC6, MISO: PC7, CLK: PC8 |                                                          |
@@ -90,7 +89,6 @@ is the top-left contact, marked on the silkscreen.
 | Low-level driver              | ADC       | yes       |                                                                |
 |                               | Flash     | yes       |                                                                |
 |                               | GPIO      | yes       | Interrupts are shared across pins (see reference manual)       |
-|                               | HW Crypto | yes       |                                                                |
 |                               | I2C       | yes       |                                                                |
 |                               | PWM       | yes       |                                                                |
 |                               | RTCC      | yes       | As RTT or RTC                                                  |
@@ -178,14 +176,6 @@ Calendar*, which can be configured in ticker mode **or** calendar mode.
 Therefore, only one of both peripherals can be enabled at the same time.
 
 Configured at 1 Hz interval, the RTCC will overflow each 136 years.
-
-### Hardware crypto
-
-This MCU is equipped with a hardware-accelerated crypto peripheral that can
-speed up AES128, AES256, SHA1, SHA256 and several other cryptographic
-computations.
-
-A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 

--- a/boards/sltb001a/doc.md
+++ b/boards/sltb001a/doc.md
@@ -60,17 +60,17 @@ is the top-left contact, marked on the silkscreen.
 
 ### Peripheral mapping
 
-| Peripheral | Number  | Hardware        | Pins                           | Comments                                                 |
-|------------|---------|-----------------|--------------------------------|----------------------------------------------------------|
-| ADC        | 0       | ADC0            | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
-| I2C        | 0       | I2C0            | SDA: PC10, CLK: PC11           | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-| RTT        | &mdash; | RTCC            |                                | 1 Hz interval. Either RTT or RTC (see below)             |
-| RTC        | &mdash; | RTCC            |                                | 1 Hz interval. Either RTC or RTT (see below)             |
-| SPI        | 0       | USART1          | MOSI: PC6, MISO: PC7, CLK: PC8 |                                                          |
-| Timer      | 0       | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjacent)           |
-|            | 1       | LETIMER0        |                                |                                                          |
-| UART       | 0       | USART0          | RX: PA1, TX: PA0               | Default STDIO output                                     |
-|            | 1       | LEUART0         | RX: PD11, TX: PD10             | Baud rate limited (see below)                            |
+| Peripheral | Number | Hardware        | Pins                           | Comments                                                 |
+|------------|--------|-----------------|--------------------------------|----------------------------------------------------------|
+| ADC        | 0      | ADC0            | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
+| I2C        | 0      | I2C0            | SDA: PC10, CLK: PC11           | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
+| RTT        | -      | RTCC            |                                | 1 Hz interval. Either RTT or RTC (see below)             |
+| RTC        | -      | RTCC            |                                | 1 Hz interval. Either RTC or RTT (see below)             |
+| SPI        | 0      | USART1          | MOSI: PC6, MISO: PC7, CLK: PC8 |                                                          |
+| Timer      | 0      | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjacent)           |
+|            | 1      | LETIMER0        |                                |                                                          |
+| UART       | 0      | USART0          | RX: PA1, TX: PA0               | Default STDIO output                                     |
+|            | 1      | LEUART0         | RX: PD11, TX: PD10             | Baud rate limited (see below)                            |
 
 ### User interface
 

--- a/boards/sltb001a/doc.md
+++ b/boards/sltb001a/doc.md
@@ -179,7 +179,7 @@ Configured at 1 Hz interval, the RTCC will overflow each 136 years.
 
 ### Usage of EMLIB
 
-This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
+This port makes use of EMLIB by Silicon Labs to abstract peripheral registers.
 While some overhead is to be expected, it ensures proper setup of devices,
 provides chip errata and simplifies development. The exact overhead depends on
 the application and peripheral usage, but the largest overhead is expected
@@ -188,7 +188,10 @@ inline methods or macros (which have no overhead).
 
 Another advantage of EMLIB are the included assertions. These assertions ensure
 that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
-compiler.
+compiler defines.
+
+EMLIB is licensed by Silicon Labs under the zlib-style license, which permits
+distribution of source.
 
 ### Pin locations
 
@@ -232,7 +235,3 @@ Some boards have (limited) support for emulation, which can be started with:
 ```shell
 BOARD=sltb001a make emulate
 ```
-
-## License information
-
-Silicon Labs' EMLIB: zlib-style license (permits distribution of source).

--- a/boards/sltb001a/doc.md
+++ b/boards/sltb001a/doc.md
@@ -122,7 +122,7 @@ expects data from the MCU with the same settings.
 ### Clock selection
 
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
+peripherals. You are advised to read [AN0004.1](https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |

--- a/boards/sltb001a/doc.md
+++ b/boards/sltb001a/doc.md
@@ -92,7 +92,7 @@ is the top-left contact, marked on the silkscreen.
 |                               | I2C       | yes       |                                                                |
 |                               | PWM       | yes       |                                                                |
 |                               | RTCC      | yes       | As RTT or RTC                                                  |
-|                               | SPI       | partially | Only master mode                                               |
+|                               | SPI       | yes       | Only master mode                                               |
 |                               | Timer     | yes       |                                                                |
 |                               | UART      | yes       | USART is shared with SPI. LEUART baud rate limited (see below) |
 |                               | USB       | no        |                                                                |

--- a/boards/sltb001a/doc.md
+++ b/boards/sltb001a/doc.md
@@ -20,16 +20,16 @@ actively measure the power consumption of your hardware and code, in real-time.
 | Family          | ARM Cortex-M4F                                                                                 |
 | Vendor          | Silicon Labs                                                                                   |
 | Vendor Family   | EFR32 Mighty Gecko 1P                                                                          |
-| RAM             | 31.0 KiB                                                                                       |
+| RAM             | 32.0 KiB (1.0 KiB reserved for the radio blob)                                                 |
 | Flash           | 256.0 KiB                                                                                      |
 | EEPROM          | no                                                                                             |
 | Frequency       | up to 38.4 MHz                                                                                 |
 | FPU             | yes                                                                                            |
 | MPU             | yes                                                                                            |
-| DMA             | 12 channels                                                                                    |
+| DMA             | 8 channels                                                                                     |
 | Timers          | 2x 16-bit + 1x 16-bit (low power)                                                              |
 | ADCs            | 12-bit ADC                                                                                     |
-| UARTs           | 3x UART, 2x USART, 1x LEUART                                                                   |
+| UARTs           | 2x USART, 1x LEUART                                                                            |
 | SPIs            | 2x USART                                                                                       |
 | I2Cs            | 1x                                                                                             |
 | Vcc             | 1.85 V - 3.8 V                                                                                 |

--- a/boards/sltb009a/doc.md
+++ b/boards/sltb009a/doc.md
@@ -84,18 +84,18 @@ PIN 1 is the top-left contact.
 
 ### User interface
 
-| Peripheral | Mapped to | Pin       | Comments   |
-|------------|-----------|-----------|------------|
-| Button     | PB0_PIN   | PD5       |            |
-|            | PB1_PIN   | PD8       |            |
-| LED        | LED0R_PIN | PA12      |            |
-|            | LED0G_PIN | PA13      |            |
-|            | LED0B_PIN | PA14      |            |
-|            | LED1R_PIN | PD6       |            |
-|            | LED1G_PIN | PF12      |            |
-|            | LED1B_PIN | PE12      |            |
-|            | LED0_PIN  | LED0R_PIN |            |
-|            | LED1_PIN  | LED1R_PIN |            |
+| Peripheral | Number | Mapped to | Pin       | Comments |
+|------------|--------|-----------|-----------|----------|
+| Button     | 0      | PB0_PIN   | PD5       |          |
+|            | 1      | PB1_PIN   | PD8       |          |
+| LED        | 0      | LED0R_PIN | PA12      |          |
+|            |        | LED0G_PIN | PA13      |          |
+|            |        | LED0B_PIN | PA14      |          |
+|            |        | LED0_PIN  | LED0R_PIN |          |
+|            | 1      | LED1R_PIN | PD6       |          |
+|            |        | LED1G_PIN | PF12      |          |
+|            |        | LED1B_PIN | PE12      |          |
+|            |        | LED1_PIN  | LED1R_PIN |          |
 
 ## Implementation Status
 

--- a/boards/sltb009a/doc.md
+++ b/boards/sltb009a/doc.md
@@ -186,7 +186,7 @@ Configured at 1 Hz interval, the RTCC will overflow each 136 years.
 
 ### Usage of EMLIB
 
-This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
+This port makes use of EMLIB by Silicon Labs to abstract peripheral registers.
 While some overhead is to be expected, it ensures proper setup of devices,
 provides chip errata and simplifies development. The exact overhead depends on
 the application and peripheral usage, but the largest overhead is expected
@@ -195,7 +195,10 @@ inline methods or macros (which have no overhead).
 
 Another advantage of EMLIB are the included assertions. These assertions ensure
 that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
-compiler.
+compiler defines.
+
+EMLIB is licensed by Silicon Labs under the zlib-style license, which permits
+distribution of source.
 
 ### Pin locations
 
@@ -239,7 +242,3 @@ Some boards have (limited) support for emulation, which can be started with:
 ```shell
 BOARD=sltb009a make emulate
 ```
-
-## License information
-
-Silicon Labs' EMLIB: zlib-style license (permits distribution of source).

--- a/boards/sltb009a/doc.md
+++ b/boards/sltb009a/doc.md
@@ -129,7 +129,7 @@ expects data from the MCU with the same settings.
 
 There are several clock sources that are available for the different
 peripherals. You are advised to read
-[AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
+[AN0004.1](https://www.silabs.com/documents/public/application-notes/an0004.1-efm32-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |

--- a/boards/sltb009a/doc.md
+++ b/boards/sltb009a/doc.md
@@ -18,6 +18,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 | MCU             | EFM32GG12B810F1024GM64                               |
 |-----------------|------------------------------------------------------|
 | Family          | ARM Cortex-M4F                                       |
+| Series          | Series 1                                             |
 | Vendor          | Silicon Labs                                         |
 | Vendor Family   | EFM32 Giant Gecko 12B                                |
 | RAM             | 192.0 KiB                                            |

--- a/boards/sltb009a/doc.md
+++ b/boards/sltb009a/doc.md
@@ -72,7 +72,7 @@ PIN 1 is the top-left contact.
 | ADC         | 0       | ADC0:CH0   |                  | Internal temperature                |
 | ADC         | 1       | ADC0:CH1   |                  | AVDD                                |
 | I2C         | 0       | I2C0       | SDA:PE4, SCL:PE5 | Normal speed                        |
-| HWRNG       | -       | TNRG0      |                  | True Random Number Generator (TRNG) |
+| HWRNG       | -       | TRNG0      |                  | True Random Number Generator (TRNG) |
 | RTT         | -       | RTCC       |                  | 1 Hz interval, either RTT or RTC    |
 | RTC         | -       | RTCC       |                  | 1 Hz interval, either RTT or RTC    |
 | SPI         | 0       | USART3     | MOSI:PA0, MISO:PA1, CLK:PA2 |                          |
@@ -106,6 +106,7 @@ PIN 1 is the top-left contact.
 |                  | DAC        | yes       | VDAC, IDAC is not supported                        |
 |                  | Flash      | yes       |                                                    |
 |                  | GPIO       | yes       | Interrupts are shared across pins (see ref manual) |
+|                  | HWRNG      | yes       |                                                    |
 |                  | I2C        | yes       |                                                    |
 |                  | PWM        | yes       |                                                    |
 |                  | RTCC       | yes       | As RTT or RTC                                      |

--- a/boards/sltb009a/doc.md
+++ b/boards/sltb009a/doc.md
@@ -72,7 +72,6 @@ PIN 1 is the top-left contact.
 | ADC         | 0       | ADC0:CH0   |                  | Internal temperature                |
 | ADC         | 1       | ADC0:CH1   |                  | AVDD                                |
 | I2C         | 0       | I2C0       | SDA:PE4, SCL:PE5 | Normal speed                        |
-| HWCRYPTO    | -       | -          |                  | AES128/AES256, SHA1, SHA224/SHA256  |
 | HWRNG       | -       | TNRG0      |                  | True Random Number Generator (TRNG) |
 | RTT         | -       | RTCC       |                  | 1 Hz interval, either RTT or RTC    |
 | RTC         | -       | RTCC       |                  | 1 Hz interval, either RTT or RTC    |
@@ -107,7 +106,6 @@ PIN 1 is the top-left contact.
 |                  | DAC        | yes       | VDAC, IDAC is not supported                        |
 |                  | Flash      | yes       |                                                    |
 |                  | GPIO       | yes       | Interrupts are shared across pins (see ref manual) |
-|                  | HW Crypto  | yes       |                                                    |
 |                  | I2C        | yes       |                                                    |
 |                  | PWM        | yes       |                                                    |
 |                  | RTCC       | yes       | As RTT or RTC                                      |
@@ -185,14 +183,6 @@ Calendar*, which can be configured in ticker mode **or** calendar mode.
 Therefore, only one of both peripherals can be enabled at the same time.
 
 Configured at 1 Hz interval, the RTCC will overflow each 136 years.
-
-### Hardware crypto
-
-This MCU is equipped with a hardware-accelerated crypto peripheral that can
-speed up AES128, AES256, SHA1, SHA256 and several other cryptographic
-computations.
-
-A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 

--- a/boards/slwstk6000b-slwrb4150a/doc.md
+++ b/boards/slwstk6000b-slwrb4150a/doc.md
@@ -1,9 +1,9 @@
-@defgroup    boards_slwstk6000b-slwrb4150a Silicon Labs SLWSTK6000B with SLWRB4150A
-@ingroup     boards
-@brief       Support for the Silicon Labs SLWSTK6000B Starter Kit with SLWRB4150A
+@defgroup   boards_slwstk6000b-slwrb4150a Silicon Labs SLWSTK6000B with SLWRB4150A
+@ingroup    boards
+@brief      Support for the Silicon Labs SLWSTK6000B Starter Kit with SLWRB4150A
 
 ## Overview
 
-The SLWSTK6000B combined with the SLWRB4150A radio board provides
-a Wireless Gecko starter kit based on EFR32MG series MCUs.
-It is intended for developing 2.4 GHz wireless applications and other IoT use cases.
+The SLWSTK6000B combined with the SLWRB4150A radio board provides a
+Wireless Gecko starter kit based on EFR32MG series MCUs. It is intended for
+developing 2.4 GHz wireless applications and other IoT use cases.

--- a/boards/slwstk6000b-slwrb4162a/doc.md
+++ b/boards/slwstk6000b-slwrb4162a/doc.md
@@ -1,9 +1,9 @@
-@defgroup    boards_slwstk6000b-slwrb4162a Silicon Labs SLWSTK6000B with SLWRB4162A
-@ingroup     boards
-@brief       Support for the Silicon Labs SLWSTK6000B Starter Kit with SLWRB4162A
+@defgroup   boards_slwstk6000b-slwrb4162a Silicon Labs SLWSTK6000B with SLWRB4162A
+@ingroup    boards
+@brief      Support for the Silicon Labs SLWSTK6000B Starter Kit with SLWRB4162A
 
 ## Overview
 
-The SLWSTK6000B paired with SLWRB4162A offers a Wireless Gecko platform based on
-EFR32MG family MCUs with extended memory and radio features.
-It is suitable for advanced 2.4 GHz and multi-protocol wireless development.
+The SLWSTK6000B paired with SLWRB4162A offers a Wireless Gecko platform based
+on EFR32MG family MCUs with extended memory and radio features. It is suitable
+for advanced 2.4 GHz and multi-protocol wireless development.

--- a/boards/slwstk6220a/doc.md
+++ b/boards/slwstk6220a/doc.md
@@ -66,7 +66,6 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |------------|---------|-----------------|--------------------------------|----------------------------------------------------------|
 | ADC        | 0       | ADC0            | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
 | DAC        | 0       | DAC0            | CHAN0: PB11                    | Ports are fixed, shared with I2C                         |
-| HWCRYPTO   | &mdash; | &mdash;         |                                | AES128/AES256 only                                       |
 | I2C        | 0       | I2C0            | SDA: PE0, SCL: PE1             | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
 | PWM        | 0       | TIMER0          | CHAN0: PF6, CHAN1: PF7         | Mapped to LED0 and LED1                                  |
 | RTT        | &mdash; | RTC             |                                | Either RTT or RTC (see below)                            |
@@ -95,7 +94,6 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |                               | DAC         | yes       |                                                                |
 |                               | Flash       | yes       |                                                                |
 |                               | GPIO        | yes       | Interrupts are shared across pins (see reference manual)       |
-|                               | HW Crypto   | yes       |                                                                |
 |                               | I2C         | yes       |                                                                |
 |                               | PWM         | yes       |                                                                |
 |                               | RTC         | yes       | As RTT or RTC                                                  |
@@ -205,12 +203,6 @@ structures and visa versa.
 
 Configured at 1 Hz interval, the RTC will overflow each 194 days. When using
 the ticker-to-calendar mode, this interval is extended artificially.
-
-### Hardware crypto
-
-This MCUs has support for hardware-accelerated AES128 and AES256.
-
-A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 

--- a/boards/slwstk6220a/doc.md
+++ b/boards/slwstk6220a/doc.md
@@ -206,7 +206,7 @@ the ticker-to-calendar mode, this interval is extended artificially.
 
 ### Usage of EMLIB
 
-This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
+This port makes use of EMLIB by Silicon Labs to abstract peripheral registers.
 While some overhead is to be expected, it ensures proper setup of devices,
 provides chip errata and simplifies development. The exact overhead depends on
 the application and peripheral usage, but the largest overhead is expected
@@ -215,7 +215,10 @@ inline methods or macros (which have no overhead).
 
 Another advantage of EMLIB are the included assertions. These assertions ensure
 that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
-compiler.
+compiler defines.
+
+EMLIB is licensed by Silicon Labs under the zlib-style license, which permits
+distribution of source.
 
 ### Pin locations
 
@@ -256,7 +259,3 @@ Some boards have (limited) support for emulation, which can be started with:
 ```shell
 BOARD=slwstk6220a make emulate
 ```
-
-## License information
-
-Silicon Labs' EMLIB: zlib-style license (permits distribution of source).

--- a/boards/slwstk6220a/doc.md
+++ b/boards/slwstk6220a/doc.md
@@ -78,12 +78,12 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ### User interface
 
-| Peripheral | Mapped to | Pin | Comments   |
-|------------|-----------|-----|------------|
-| Button     | PB0       | PE3 |            |
-|            | PB1       | PE2 |            |
-| LED        | LED0      | PF6 | Yellow LED |
-|            | LED1      | PF7 | Yellow LED |
+| Peripheral | Number | Mapped to | Pin | Comments   |
+|------------|--------|-----------|-----|------------|
+| Button     | 0      | PB0_PIN   | PE3 |            |
+|            | 1      | PB1_PIN   | PE2 |            |
+| LED        | 0      | LED0_PIN  | PF6 | Yellow LED |
+|            | 1      | LED1_PIN  | PF7 | Yellow LED |
 
 ## Implementation Status
 

--- a/boards/slwstk6220a/doc.md
+++ b/boards/slwstk6220a/doc.md
@@ -41,7 +41,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 ### Pinout
 
 This is the pinout of the expansion header on the right side of the board.
-PIN 1 is the bottom-left contact when the header faces  you horizontally.
+PIN 1 is the bottom-left contact when the header faces you horizontally.
 
 |      | PIN | PIN |      |
 |------|-----|-----|------|

--- a/boards/slwstk6220a/doc.md
+++ b/boards/slwstk6220a/doc.md
@@ -97,7 +97,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |                               | I2C         | yes       |                                                                |
 |                               | PWM         | yes       |                                                                |
 |                               | RTC         | yes       | As RTT or RTC                                                  |
-|                               | SPI         | partially | Only master mode                                               |
+|                               | SPI         | yes       | Only master mode                                               |
 |                               | Timer       | yes       |                                                                |
 |                               | UART        | yes       | USART is shared with SPI. LEUART baud rate limited (see below) |
 |                               | USB         | no        |                                                                |

--- a/boards/slwstk6220a/doc.md
+++ b/boards/slwstk6220a/doc.md
@@ -18,6 +18,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 | MCU             | EZR32WG330F256R60                                                                                 |
 |-----------------|---------------------------------------------------------------------------------------------------|
 | Family          | ARM Cortex-M4F                                                                                    |
+| Series          | Series 0                                                                                          |
 | Vendor          | Silicon Labs                                                                                      |
 | Vendor Family   | EZR32 Wonder Gecko                                                                                |
 | RAM             | 32.0 KiB                                                                                          |

--- a/boards/slwstk6220a/doc.md
+++ b/boards/slwstk6220a/doc.md
@@ -62,19 +62,19 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ### Peripheral mapping
 
-| Peripheral | Number  | Hardware        | Pins                           | Comments                                                 |
-|------------|---------|-----------------|--------------------------------|----------------------------------------------------------|
-| ADC        | 0       | ADC0            | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
-| DAC        | 0       | DAC0            | CHAN0: PB11                    | Ports are fixed, shared with I2C                         |
-| I2C        | 0       | I2C0            | SDA: PE0, SCL: PE1             | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-| PWM        | 0       | TIMER0          | CHAN0: PF6, CHAN1: PF7         | Mapped to LED0 and LED1                                  |
-| RTT        | &mdash; | RTC             |                                | Either RTT or RTC (see below)                            |
-| RTC        | &mdash; | RTC             |                                | Either RTC or RTT (see below)                            |
-| SPI        | 0       | USART1          | MOSI: PD0, MISO: PD1, CLK: PD2 |                                                          |
-| Timer      | 0       | TIMER1 + TIMER2 |                                | TIMER1 is used as prescaler (must be adjacent)           |
-|            | 1       | LETIMER0        |                                |                                                          |
-| UART       | 0       | UART0           | RX: PE1, TX: PE0               | STDIO output                                             |
-|            | 1       | LEUART0         | RX: PD5, TX: PD4               | Baud rate limited (see below)                            |
+| Peripheral | Number | Hardware        | Pins                           | Comments                                                 |
+|------------|--------|-----------------|--------------------------------|----------------------------------------------------------|
+| ADC        | 0      | ADC0            | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
+| DAC        | 0      | DAC0            | CHAN0: PB11                    | Ports are fixed, shared with I2C                         |
+| I2C        | 0      | I2C0            | SDA: PE0, SCL: PE1             | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
+| PWM        | 0      | TIMER0          | CHAN0: PF6, CHAN1: PF7         | Mapped to LED0 and LED1                                  |
+| RTT        | -      | RTC             |                                | Either RTT or RTC (see below)                            |
+| RTC        | -      | RTC             |                                | Either RTC or RTT (see below)                            |
+| SPI        | 0      | USART1          | MOSI: PD0, MISO: PD1, CLK: PD2 |                                                          |
+| Timer      | 0      | TIMER1 + TIMER2 |                                | TIMER1 is used as prescaler (must be adjacent)           |
+|            | 1      | LETIMER0        |                                |                                                          |
+| UART       | 0      | UART0           | RX: PE1, TX: PE0               | STDIO output                                             |
+|            | 1      | LEUART0         | RX: PD5, TX: PD4               | Baud rate limited (see below)                            |
 
 ### User interface
 

--- a/boards/stk3200/doc.md
+++ b/boards/stk3200/doc.md
@@ -92,7 +92,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |                  | I2C         | yes       |                                                                |
 |                  | PWM         | yes       |                                                                |
 |                  | RTC         | yes       | As RTT or RTC                                                  |
-|                  | SPI         | partially | Only master mode                                               |
+|                  | SPI         | yes       | Only master mode                                               |
 |                  | Timer       | yes       |                                                                |
 |                  | UART        | yes       | USART is shared with SPI. LEUART baud rate limited (see below) |
 |                  | USB         | no        |                                                                |

--- a/boards/stk3200/doc.md
+++ b/boards/stk3200/doc.md
@@ -26,7 +26,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 | Frequency       | up to 24 MHz                                                                               |
 | FPU             | no                                                                                         |
 | MPU             | no                                                                                         |
-| DMA             | 12 channels                                                                                |
+| DMA             | 4 channels                                                                                 |
 | Timers          | 2x 16-bit                                                                                  |
 | ADCs            | 12-bit ADC                                                                                 |
 | UARTs           | 2x USART, 1x LEUART                                                                        |
@@ -41,7 +41,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 ### Pinout
 
 This is the pinout of the expansion header on the right side of the board.
-PIN 1 is the bottom-left contact when the header faces  you horizontally.
+PIN 1 is the bottom-left contact when the header faces you horizontally.
 
 |      | PIN | PIN |      |
 |------|-----|-----|------|

--- a/boards/stk3200/doc.md
+++ b/boards/stk3200/doc.md
@@ -66,7 +66,6 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |------------|---------|-----------------|---------------------------------|----------------------------------------------------------|
 | ADC        | 0       | ADC0            | CHAN0: internal temperature     | Ports are fixed, 14/16-bit resolution not supported      |
 | I2C        | 0       | I2C0            | SDA: PE12, SCL: PE13            | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-| HWCRYPTO   | &mdash; | &mdash;         |                                 | AES128/AES256 only                                       |
 | RTT        | &mdash; | RTC             |                                 | Either RTT or RTC (see below)                            |
 | RTC        | &mdash; | RTC             |                                 | Either RTC or RTT (see below)                            |
 | SPI        | 0       | USART1          | MOSI: PD7, MISO: PD6, CLK: PC15 |                                                          |
@@ -90,7 +89,6 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | Low-level driver | ADC         | yes       |                                                                |
 |                  | Flash       | yes       |                                                                |
 |                  | GPIO        | yes       | Interrupts are shared across pins (see reference manual)       |
-|                  | HW Crypto   | yes       |                                                                |
 |                  | I2C         | yes       |                                                                |
 |                  | PWM         | yes       |                                                                |
 |                  | RTC         | yes       | As RTT or RTC                                                  |
@@ -180,12 +178,6 @@ structures and visa versa.
 
 Configured at 1 Hz interval, the RTC will overflow each 194 days. When using
 the ticker-to-calendar mode, this interval is extended artificially.
-
-### Hardware crypto
-
-This MCUs has support for hardware-accelerated AES128.
-
-A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 

--- a/boards/stk3200/doc.md
+++ b/boards/stk3200/doc.md
@@ -62,15 +62,15 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ### Peripheral mapping
 
-| Peripheral | Number  | Hardware        | Pins                            | Comments                                                 |
-|------------|---------|-----------------|---------------------------------|----------------------------------------------------------|
-| ADC        | 0       | ADC0            | CHAN0: internal temperature     | Ports are fixed, 14/16-bit resolution not supported      |
-| I2C        | 0       | I2C0            | SDA: PE12, SCL: PE13            | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-| RTT        | &mdash; | RTC             |                                 | Either RTT or RTC (see below)                            |
-| RTC        | &mdash; | RTC             |                                 | Either RTC or RTT (see below)                            |
-| SPI        | 0       | USART1          | MOSI: PD7, MISO: PD6, CLK: PC15 |                                                          |
-| Timer      | 0       | TIMER0 + TIMER1 |                                 | TIMER0 is used as prescaler (must be adjacent)           |
-| UART       | 0       | LEUART0         | RX: PD5, TX: PD4                | STDIO Output, Baud rate limited (see below)              |
+| Peripheral | Number | Hardware        | Pins                            | Comments                                                 |
+|------------|--------|-----------------|---------------------------------|----------------------------------------------------------|
+| ADC        | 0      | ADC0            | CHAN0: internal temperature     | Ports are fixed, 14/16-bit resolution not supported      |
+| I2C        | 0      | I2C0            | SDA: PE12, SCL: PE13            | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
+| RTT        | -      | RTC             |                                 | Either RTT or RTC (see below)                            |
+| RTC        | -      | RTC             |                                 | Either RTC or RTT (see below)                            |
+| SPI        | 0      | USART1          | MOSI: PD7, MISO: PD6, CLK: PC15 |                                                          |
+| Timer      | 0      | TIMER0 + TIMER1 |                                 | TIMER0 is used as prescaler (must be adjacent)           |
+| UART       | 0      | LEUART0         | RX: PD5, TX: PD4                | STDIO Output, Baud rate limited (see below)              |
 
 ### User interface
 

--- a/boards/stk3200/doc.md
+++ b/boards/stk3200/doc.md
@@ -74,12 +74,12 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ### User interface
 
-| Peripheral | Mapped to | Pin  | Comments   |
-|------------|-----------|------|------------|
-| Button     | PB0_PIN   | PC8  |            |
-|            | PB1_PIN   | PC9  |            |
-| LED        | LED0_PIN  | PC10 | Yellow LED |
-|            | LED1_PIN  | PC11 | Yellow LED |
+| Peripheral | Number | Mapped to | Pin  | Comments   |
+|------------|--------|-----------|------|------------|
+| Button     | 0      | PB0_PIN   | PC8  |            |
+|            | 1      | PB1_PIN   | PC9  |            |
+| LED        | 0      | LED0_PIN  | PC10 | Yellow LED |
+|            | 1      | LED1_PIN  | PC11 | Yellow LED |
 
 ## Implementation Status
 

--- a/boards/stk3200/doc.md
+++ b/boards/stk3200/doc.md
@@ -18,6 +18,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 | MCU             | EFM32ZG222F32                                                                              |
 |-----------------|--------------------------------------------------------------------------------------------|
 | Family          | ARM Cortex-M0PLUS                                                                          |
+| Series          | Series 0                                                                                   |
 | Vendor          | Silicon Labs                                                                               |
 | Vendor Family   | EFM32 Zero Gecko                                                                           |
 | RAM             | 4.0 KiB                                                                                    |

--- a/boards/stk3200/doc.md
+++ b/boards/stk3200/doc.md
@@ -181,7 +181,7 @@ the ticker-to-calendar mode, this interval is extended artificially.
 
 ### Usage of EMLIB
 
-This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
+This port makes use of EMLIB by Silicon Labs to abstract peripheral registers.
 While some overhead is to be expected, it ensures proper setup of devices,
 provides chip errata and simplifies development. The exact overhead depends on
 the application and peripheral usage, but the largest overhead is expected
@@ -190,7 +190,10 @@ inline methods or macros (which have no overhead).
 
 Another advantage of EMLIB are the included assertions. These assertions ensure
 that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
-compiler.
+compiler defines.
+
+EMLIB is licensed by Silicon Labs under the zlib-style license, which permits
+distribution of source.
 
 ### Pin locations
 
@@ -231,7 +234,3 @@ Some boards have (limited) support for emulation, which can be started with:
 ```shell
 BOARD=stk3200 make emulate
 ```
-
-## License information
-
-Silicon Labs' EMLIB: zlib-style license (permits distribution of source).

--- a/boards/stk3600/doc.md
+++ b/boards/stk3600/doc.md
@@ -80,12 +80,12 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ### User interface
 
-| Peripheral | Mapped to | Pin  | Comments   |
-|------------|-----------|------|------------|
-| Button     | PB0       | PB9  |            |
-|            | PB1       | PB10 |            |
-| LED        | LED0      | PE2  | Yellow LED |
-|            | LED1      | PE3  | Yellow LED |
+| Peripheral | Number | Mapped to | Pin  | Comments   |
+|------------|--------|-----------|------|------------|
+| Button     | 0      | PB0_PIN   | PB9  |            |
+|            | 1      | PB1_PIN   | PB10 |            |
+| LED        | 0      | LED0_PIN  | PE2  | Yellow LED |
+|            | 1      | LED1_PIN  | PE3  | Yellow LED |
 
 ## Implementation Status
 

--- a/boards/stk3600/doc.md
+++ b/boards/stk3600/doc.md
@@ -66,7 +66,6 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |------------|---------|-----------------|--------------------------------|----------------------------------------------------------|
 | ADC        | 0       | ADC0            | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
 | DAC        | 0       | DAC0            | CHAN0: PB11                    | Ports are fixed, shared with I2C                         |
-| HWCRYPTO   | &mdash; | &mdash;         |                                | AES128/AES256 only                                       |
 | I2C        | 0       | I2C0            | SDA: PD6, SCL: PD7             | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
 |            | 1       | I2C1            | SDA: PC4, SCL: PC5             | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
 | PWM        | 0       | TIMER3          | CHAN0: PE2                     | Mapped to LED0                                           |
@@ -97,7 +96,6 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |                  | DAC       | yes       |                                                                |
 |                  | Flash     | yes       |                                                                |
 |                  | GPIO      | yes       | Interrupts are shared across pins (see reference manual)       |
-|                  | HW Crypto | yes       |                                                                |
 |                  | I2C       | yes       |                                                                |
 |                  | PWM       | yes       |                                                                |
 |                  | RTC       | yes       | As RTT or RTC                                                  |
@@ -200,12 +198,6 @@ structures and visa versa.
 
 Configured at 1 Hz interval, the RTC will overflow each 194 days. When using
 the ticker-to-calendar mode, this interval is extended artificially.
-
-### Hardware crypto
-
-This MCUs has support for hardware-accelerated AES128 and AES256.
-
-A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 

--- a/boards/stk3600/doc.md
+++ b/boards/stk3600/doc.md
@@ -18,6 +18,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 | MCU             | EFM32LG990F256                                                                             |
 |-----------------|--------------------------------------------------------------------------------------------|
 | Family          | ARM Cortex-M3                                                                              |
+| Series          | Series 0                                                                                   |
 | Vendor          | Silicon Labs                                                                               |
 | Vendor Family   | EFM32 Leopard Gecko                                                                       |
 | RAM             | 32.0 KiB                                                                                   |

--- a/boards/stk3600/doc.md
+++ b/boards/stk3600/doc.md
@@ -201,7 +201,7 @@ the ticker-to-calendar mode, this interval is extended artificially.
 
 ### Usage of EMLIB
 
-This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
+This port makes use of EMLIB by Silicon Labs to abstract peripheral registers.
 While some overhead is to be expected, it ensures proper setup of devices,
 provides chip errata and simplifies development. The exact overhead depends on
 the application and peripheral usage, but the largest overhead is expected
@@ -210,7 +210,10 @@ inline methods or macros (which have no overhead).
 
 Another advantage of EMLIB are the included assertions. These assertions ensure
 that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
-compiler.
+compiler defines.
+
+EMLIB is licensed by Silicon Labs under the zlib-style license, which permits
+distribution of source.
 
 ### Pin locations
 
@@ -251,7 +254,3 @@ Some boards have (limited) support for emulation, which can be started with:
 ```shell
 BOARD=stk3600 make emulate
 ```
-
-## License information
-
-Silicon Labs' EMLIB: zlib-style license (permits distribution of source).

--- a/boards/stk3600/doc.md
+++ b/boards/stk3600/doc.md
@@ -1,6 +1,6 @@
-@defgroup    boards_stk3600 Silicon Labs STK3600 starter kit
-@ingroup     boards
-@brief       Support for Silicon Labs STK3600 starter kit
+@defgroup   boards_stk3600 Silicon Labs STK3600 starter kit
+@ingroup    boards
+@brief      Support for Silicon Labs STK3600 starter kit
 
 ## Overview
 
@@ -19,7 +19,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 |-----------------|--------------------------------------------------------------------------------------------|
 | Family          | ARM Cortex-M3                                                                              |
 | Vendor          | Silicon Labs                                                                               |
-| Vendor Family   | EFM32 Leoppard Gecko                                                                       |
+| Vendor Family   | EFM32 Leopard Gecko                                                                       |
 | RAM             | 32.0 KiB                                                                                   |
 | Flash           | 256.0 KiB                                                                                  |
 | EEPROM          | no                                                                                         |
@@ -41,7 +41,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 ### Pinout
 
 This is the pinout of the expansion header on the right side of the board.
-PIN 1 is the bottom-left contact when the header faces  you horizontally.
+PIN 1 is the bottom-left contact when the header faces you horizontally.
 
 |      | PIN | PIN |      |
 |------|-----|-----|------|

--- a/boards/stk3600/doc.md
+++ b/boards/stk3600/doc.md
@@ -99,7 +99,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |                  | I2C       | yes       |                                                                |
 |                  | PWM       | yes       |                                                                |
 |                  | RTC       | yes       | As RTT or RTC                                                  |
-|                  | SPI       | partially | Only master mode                                               |
+|                  | SPI       | yes       | Only master mode                                               |
 |                  | Timer     | yes       |                                                                |
 |                  | UART      | yes       | USART is shared with SPI. LEUART baud rate limited (see below) |
 |                  | USB       | no        |                                                                |

--- a/boards/stk3600/doc.md
+++ b/boards/stk3600/doc.md
@@ -62,21 +62,21 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ### Peripheral mapping
 
-| Peripheral | Number  | Hardware        | Pins                           | Comments                                                 |
-|------------|---------|-----------------|--------------------------------|----------------------------------------------------------|
-| ADC        | 0       | ADC0            | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
-| DAC        | 0       | DAC0            | CHAN0: PB11                    | Ports are fixed, shared with I2C                         |
-| I2C        | 0       | I2C0            | SDA: PD6, SCL: PD7             | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-|            | 1       | I2C1            | SDA: PC4, SCL: PC5             | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-| PWM        | 0       | TIMER3          | CHAN0: PE2                     | Mapped to LED0                                           |
-| RTT        | &mdash; | RTC             |                                | Either RTT or RTC (see below)                            |
-| RTC        | &mdash; | RTC             |                                | Either RTC or RTT (see below)                            |
-| SPI        | 0       | USART1          | MOSI: PD0, MISO: PD1, CLK: PD2 |                                                          |
-|            | 1       | USART2          | MOSI: NC, MISO: PC3, CLK: PC4  |                                                          |
-| Timer      | 0       | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjacent)           |
-|            | 1       | LETIMER0        |                                |                                                          |
-| UART       | 0       | UART0           | RX: PE1, TX: PE0               | STDIO output                                             |
-|            | 1       | LEUART0         | RX: PD5, TX: PD4               | Baud rate limited (see below)                            |
+| Peripheral | Number | Hardware        | Pins                           | Comments                                                 |
+|------------|--------|-----------------|--------------------------------|----------------------------------------------------------|
+| ADC        | 0      | ADC0            | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
+| DAC        | 0      | DAC0            | CHAN0: PB11                    | Ports are fixed, shared with I2C                         |
+| I2C        | 0      | I2C0            | SDA: PD6, SCL: PD7             | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
+|            | 1      | I2C1            | SDA: PC4, SCL: PC5             | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
+| PWM        | 0      | TIMER3          | CHAN0: PE2                     | Mapped to LED0                                           |
+| RTT        | -      | RTC             |                                | Either RTT or RTC (see below)                            |
+| RTC        | -      | RTC             |                                | Either RTC or RTT (see below)                            |
+| SPI        | 0      | USART1          | MOSI: PD0, MISO: PD1, CLK: PD2 |                                                          |
+|            | 1      | USART2          | MOSI: NC, MISO: PC3, CLK: PC4  |                                                          |
+| Timer      | 0      | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjacent)           |
+|            | 1      | LETIMER0        |                                |                                                          |
+| UART       | 0      | UART0           | RX: PE1, TX: PE0               | STDIO output                                             |
+|            | 1      | LEUART0         | RX: PD5, TX: PD4               | Baud rate limited (see below)                            |
 
 ### User interface
 

--- a/boards/stk3700/doc.md
+++ b/boards/stk3700/doc.md
@@ -80,12 +80,12 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ### User interface
 
-| Peripheral | Mapped to | Pin  | Comments   |
-|------------|-----------|------|------------|
-| Button     | PB0       | PB9  |            |
-|            | PB1       | PB10 |            |
-| LED        | LED0      | PE2  | Yellow LED |
-|            | LED1      | PE3  | Yellow LED |
+| Peripheral | Number | Mapped to | Pin  | Comments   |
+|------------|--------|-----------|------|------------|
+| Button     | 0      | PB0_PIN   | PB9  |            |
+|            | 1      | PB1_PIN   | PB10 |            |
+| LED        | 0      | LED0_PIN  | PE2  | Yellow LED |
+|            | 1      | LED1_PIN  | PE3  | Yellow LED |
 
 ## Implementation Status
 

--- a/boards/stk3700/doc.md
+++ b/boards/stk3700/doc.md
@@ -66,7 +66,6 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |------------|---------|-----------------|--------------------------------|----------------------------------------------------------|
 | ADC        | 0       | ADC0            | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
 | DAC        | 0       | DAC0            | CHAN0: PB11                    | Ports are fixed, shared with I2C                         |
-| HWCRYPTO   | &mdash; | &mdash;         |                                | AES128/AES256 only                                       |
 | I2C        | 0       | I2C0            | SDA: PD6, SCL: PD7             | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
 |            | 1       | I2C1            | SDA: PC4, SCL: PC5             | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
 | PWM        | 0       | TIMER3          | CHAN0: PE2                     | Mapped to LED0                                           |
@@ -97,7 +96,6 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |                  | DAC       | yes       |                                                                |
 |                  | Flash     | yes       |                                                                |
 |                  | GPIO      | yes       | Interrupts are shared across pins (see reference manual)       |
-|                  | HW Crypto | yes       |                                                                |
 |                  | I2C       | yes       |                                                                |
 |                  | PWM       | yes       |                                                                |
 |                  | RTC       | yes       | As RTT or RTC                                                  |
@@ -200,12 +198,6 @@ structures and visa versa.
 
 Configured at 1 Hz interval, the RTC will overflow each 194 days. When using
 the ticker-to-calendar mode, this interval is extended artificially.
-
-### Hardware crypto
-
-This MCUs has support for hardware-accelerated AES128 and AES256.
-
-A peripheral driver interface is proposed, but not yet implemented.
 
 ### Usage of EMLIB
 

--- a/boards/stk3700/doc.md
+++ b/boards/stk3700/doc.md
@@ -18,6 +18,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 | MCU             | EFM32GG990F1024                                                                            |
 |-----------------|--------------------------------------------------------------------------------------------|
 | Family          | ARM Cortex-M3                                                                              |
+| Series          | Series 0                                                                                   |
 | Vendor          | Silicon Labs                                                                               |
 | Vendor Family   | EFM32 Giant Gecko                                                                          |
 | RAM             | 128.0 KiB                                                                                  |

--- a/boards/stk3700/doc.md
+++ b/boards/stk3700/doc.md
@@ -41,7 +41,7 @@ actively measure the power consumption of your hardware and code, in real-time.
 ### Pinout
 
 This is the pinout of the expansion header on the right side of the board.
-PIN 1 is the bottom-left contact when the header faces  you horizontally.
+PIN 1 is the bottom-left contact when the header faces you horizontally.
 
 |      | PIN | PIN |      |
 |------|-----|-----|------|

--- a/boards/stk3700/doc.md
+++ b/boards/stk3700/doc.md
@@ -201,7 +201,7 @@ the ticker-to-calendar mode, this interval is extended artificially.
 
 ### Usage of EMLIB
 
-This port makes uses of EMLIB by Silicon Labs to abstract peripheral registers.
+This port makes use of EMLIB by Silicon Labs to abstract peripheral registers.
 While some overhead is to be expected, it ensures proper setup of devices,
 provides chip errata and simplifies development. The exact overhead depends on
 the application and peripheral usage, but the largest overhead is expected
@@ -210,7 +210,10 @@ inline methods or macros (which have no overhead).
 
 Another advantage of EMLIB are the included assertions. These assertions ensure
 that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
-compiler.
+compiler defines.
+
+EMLIB is licensed by Silicon Labs under the zlib-style license, which permits
+distribution of source.
 
 ### Pin locations
 
@@ -251,7 +254,3 @@ Some boards have (limited) support for emulation, which can be started with:
 ```shell
 BOARD=stk3700 make emulate
 ```
-
-## License information
-
-Silicon Labs' EMLIB: zlib-style license (permits distribution of source).

--- a/boards/stk3700/doc.md
+++ b/boards/stk3700/doc.md
@@ -99,7 +99,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |                  | I2C       | yes       |                                                                |
 |                  | PWM       | yes       |                                                                |
 |                  | RTC       | yes       | As RTT or RTC                                                  |
-|                  | SPI       | partially | Only master mode                                               |
+|                  | SPI       | yes       | Only master mode                                               |
 |                  | Timer     | yes       |                                                                |
 |                  | UART      | yes       | USART is shared with SPI. LEUART baud rate limited (see below) |
 |                  | USB       | no        |                                                                |

--- a/boards/stk3700/doc.md
+++ b/boards/stk3700/doc.md
@@ -62,21 +62,21 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ### Peripheral mapping
 
-| Peripheral | Number  | Hardware        | Pins                           | Comments                                                 |
-|------------|---------|-----------------|--------------------------------|----------------------------------------------------------|
-| ADC        | 0       | ADC0            | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
-| DAC        | 0       | DAC0            | CHAN0: PB11                    | Ports are fixed, shared with I2C                         |
-| I2C        | 0       | I2C0            | SDA: PD6, SCL: PD7             | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-|            | 1       | I2C1            | SDA: PC4, SCL: PC5             | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
-| PWM        | 0       | TIMER3          | CHAN0: PE2                     | Mapped to LED0                                           |
-| RTT        | &mdash; | RTC             |                                | Either RTT or RTC (see below)                            |
-| RTC        | &mdash; | RTC             |                                | Either RTC or RTT (see below)                            |
-| SPI        | 0       | USART1          | MOSI: PD0, MISO: PD1, CLK: PD2 |                                                          |
-|            | 1       | USART2          | MOSI: NC, MISO: PC3, CLK: PC4  |                                                          |
-| Timer      | 0       | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjacent)           |
-|            | 1       | LETIMER0        |                                |                                                          |
-| UART       | 0       | UART0           | RX: PE1, TX: PE0               | STDIO output                                             |
-|            | 1       | LEUART0         | RX: PD5, TX: PD4               | Baud rate limited (see below)                            |
+| Peripheral | Number | Hardware        | Pins                           | Comments                                                 |
+|------------|--------|-----------------|--------------------------------|----------------------------------------------------------|
+| ADC        | 0      | ADC0            | CHAN0: internal temperature    | Ports are fixed, 14/16-bit resolution not supported      |
+| DAC        | 0      | DAC0            | CHAN0: PB11                    | Ports are fixed, shared with I2C                         |
+| I2C        | 0      | I2C0            | SDA: PD6, SCL: PD7             | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
+|            | 1      | I2C1            | SDA: PC4, SCL: PC5             | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate |
+| PWM        | 0      | TIMER3          | CHAN0: PE2                     | Mapped to LED0                                           |
+| RTT        | -      | RTC             |                                | Either RTT or RTC (see below)                            |
+| RTC        | -      | RTC             |                                | Either RTC or RTT (see below)                            |
+| SPI        | 0      | USART1          | MOSI: PD0, MISO: PD1, CLK: PD2 |                                                          |
+|            | 1      | USART2          | MOSI: NC, MISO: PC3, CLK: PC4  |                                                          |
+| Timer      | 0      | TIMER0 + TIMER1 |                                | TIMER0 is used as prescaler (must be adjacent)           |
+|            | 1      | LETIMER0        |                                |                                                          |
+| UART       | 0      | UART0           | RX: PE1, TX: PE0               | STDIO output                                             |
+|            | 1      | LEUART0         | RX: PD5, TX: PD4               | Baud rate limited (see below)                            |
 
 ### User interface
 

--- a/boards/xg23-pk6068a/doc.md
+++ b/boards/xg23-pk6068a/doc.md
@@ -88,7 +88,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 | Low-level driver              | ADC         | no        |                                                                |
 |                               | Flash       | yes       |                                                                |
 |                               | GPIO        | yes       | Interrupts are shared across pins (see reference manual)       |
-|                               | HW Crypto   | partially | Only hwrng                                                     |
+|                               | HW Crypto   | partially | Only HW RNG                                                    |
 |                               | I2C         | yes       |                                                                |
 |                               | PWM         | no        |                                                                |
 |                               | RTC         | no        | As RTT or RTC                                                  |

--- a/boards/xg23-pk6068a/doc.md
+++ b/boards/xg23-pk6068a/doc.md
@@ -103,7 +103,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 ### Clock selection
 
 There are several clock sources that are available for the different
-peripherals. You are advised to read [AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
+peripherals. You are advised to read [AN0004.2](https://www.silabs.com/documents/public/application-notes/an0004.2-efr32-series2-cmu.pdf)
 to get familiar with the different clocks.
 
 | Source | Internal | Speed      | Comments                           |

--- a/boards/xg23-pk6068a/doc.md
+++ b/boards/xg23-pk6068a/doc.md
@@ -21,6 +21,7 @@ expansion header.
 | MCU             | EFR32ZG23                                                                                        |
 |-----------------|--------------------------------------------------------------------------------------------------|
 | Family          | ARM Cortex-M33                                                                                   |
+| Series          | Series 2                                                                                         |
 | Vendor          | Silicon Labs                                                                                     |
 | Vendor Family   | EFM32 Wireless Gecko                                                                             |
 | RAM             | 64.0 KiB                                                                                         |

--- a/boards/xg23-pk6068a/doc.md
+++ b/boards/xg23-pk6068a/doc.md
@@ -101,6 +101,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 ## Board configuration
 
 ### Clock selection
+
 There are several clock sources that are available for the different
 peripherals. You are advised to read [AN0004.0](https://www.silabs.com/documents/public/application-notes/an0004.0-efm32-cmu.pdf)
 to get familiar with the different clocks.
@@ -114,6 +115,22 @@ It is important that the clock speeds are known to the code, for proper
 calculations of speeds and baud rates. If the HFXO or LFXO are different from
 the speeds above, ensure to pass `HFXO_FREQ=freq_in_hz` and
 `LFXO_FREQ=freq_in_hz` to your compiler defines.
+
+### Usage of EMLIB
+
+This port makes use of EMLIB by Silicon Labs to abstract peripheral registers.
+While some overhead is to be expected, it ensures proper setup of devices,
+provides chip errata and simplifies development. The exact overhead depends on
+the application and peripheral usage, but the largest overhead is expected
+during peripheral setup. A lot of read/write/get/set methods are implemented as
+inline methods or macros (which have no overhead).
+
+Another advantage of EMLIB are the included assertions. These assertions ensure
+that peripherals are used properly. To enable this, pass `DEBUG_EFM` to your
+compiler defines.
+
+EMLIB is licensed by Silicon Labs under the zlib-style license, which permits
+distribution of source.
 
 ## Flashing the device
 
@@ -137,7 +154,3 @@ Or, to connect with your own debugger:
 ```shell
 BOARD=xg23-pk6068a make debug-server
 ```
-
-## License information
-
-Silicon Labs' EMLIB: zlib-style license (permits distribution of source).

--- a/boards/xg23-pk6068a/doc.md
+++ b/boards/xg23-pk6068a/doc.md
@@ -92,7 +92,7 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 |                               | I2C         | yes       |                                                                |
 |                               | PWM         | no        |                                                                |
 |                               | RTC         | no        | As RTT or RTC                                                  |
-|                               | SPI         | partially | Only master mode                                               |
+|                               | SPI         | yes       | Only master mode                                               |
 |                               | Timer       | yes       |                                                                |
 |                               | UART        | yes       |                                                                |
 | LCD driver                    | LS013B7DH03 | yes       | Sharp Low Power Memory LCD via the U8g2 package                |

--- a/boards/xg23-pk6068a/doc.md
+++ b/boards/xg23-pk6068a/doc.md
@@ -44,7 +44,7 @@ expansion header.
 ### Pinout
 
 This is the pinout of the expansion header on the right side of the board.
-PIN 1 is the bottom-left contact when the header faces  you horizontally.
+PIN 1 is the bottom-left contact when the header faces you horizontally.
 
 |      | PIN | PIN |      |
 |------|-----|-----|------|

--- a/boards/xg23-pk6068a/doc.md
+++ b/boards/xg23-pk6068a/doc.md
@@ -73,12 +73,12 @@ PIN 1 is the bottom-left contact when the header faces  you horizontally.
 
 ### User interface
 
-| Peripheral | Mapped to | Pin  | Comments   |
-|------------|-----------|------|------------|
-| Button     | PB0       | PB1  |            |
-|            | PB1       | PB3  |            |
-| LED        | LED0      | PB2  | Yellow LED |
-|            | LED1      | PD3  | Yellow LED |
+| Peripheral | Number | Mapped to | Pin | Comments   |
+|------------|--------|-----------|-----|------------|
+| Button     | 0      | PB0_PIN   | PB1 |            |
+|            | 1      | PB1_PIN   | PB3 |            |
+| LED        | 0      | LED0_PIN  | PB2 | Yellow LED |
+|            | 1      | LED1_PIN  | PD3 | Yellow LED |
 
 ## Implementation Status
 


### PR DESCRIPTION
### Contribution description

The documentation of EFM32-based boards have deviated a bit over time. This PR addresses several inconsistencies, including several improvements to make the documentation more useful.


### Testing procedure

This is a doc-only change. The generated documentation should (still) look good.


### Issues/PRs references

None


### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- Claude Sonnet 5 was used to find inconsistencies. I have made all changes myself.
