### PR TITLE
boards: unnecessary CPU definition for EFM32 boards

### DIFF
--- a/boards/slstk3400a/Makefile.features
+++ b/boards/slstk3400a/Makefile.features
@@ -1,4 +1,3 @@
-CPU = efm32
 CPU_FAM = efm32hg
 CPU_MODEL = efm32hg322f64
 

--- a/boards/slstk3701a/Makefile.features
+++ b/boards/slstk3701a/Makefile.features
@@ -1,4 +1,3 @@
-CPU = efm32
 CPU_FAM = efm32gg11b
 CPU_MODEL = efm32gg11b820f2048gl192
 

--- a/boards/sltb009a/Makefile.features
+++ b/boards/sltb009a/Makefile.features
@@ -1,4 +1,3 @@
-CPU = efm32
 CPU_FAM = efm32gg12b
 CPU_MODEL = efm32gg12b810f1024gm64
 


### PR DESCRIPTION
### Contribution description

These boards have `CPU = efm32` set in the common features in `common/silabs/Makefile.features`, so there is no need to redefine them in the board itself.


### Testing procedure

Build still passes.


### Issues/PRs references

None


### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- none
