### PR TITLE
boards: add BMP as programmer for EFM32 boards

### DIFF
--- a/boards/common/silabs/Makefile.include
+++ b/boards/common/silabs/Makefile.include
@@ -1,10 +1,13 @@
 INCLUDES += -I$(RIOTBOARD)/common/silabs/include
 INCLUDES += -I$(RIOTBOARD)/common/silabs/drivers/include
 
+# setup JLink for flashing
 PROGRAMMER ?= jlink
 
-# Silabs boards can use openocd programmer
-PROGRAMMERS_SUPPORTED += openocd
+# Series 2 is not supported by the BMP or OpenOCD programmer.
+ifneq (2,$(EFM32_SERIES))
+  PROGRAMMERS_SUPPORTED += bmp openocd
+endif
 
 JLINK_DEVICE ?= ${CPU_MODEL}
 OPENOCD_CONFIG ?= board/efm32.cfg

--- a/boards/e180-zg120b-tb/Makefile.include
+++ b/boards/e180-zg120b-tb/Makefile.include
@@ -3,12 +3,14 @@ JLINK_DEVICE = EFR32MG1BxxxF256
 JLINK_PRE_FLASH += r
 
 # setup OpenOCD for flashing
-PROGRAMMERS_SUPPORTED += openocd
 OPENOCD_DEBUG_ADAPTER ?= stlink
 
-# default to jlink as programmer, but only if JLinkExe is in $PATH
+# default to JLink as programmer, but only if JLinkExe is in $PATH
 ifneq (,$(shell which JLinkExe))
   PROGRAMMER ?= jlink
 else
   PROGRAMMER ?= openocd
 endif
+
+# board can also use BMP or OpenOCD as programmer
+PROGRAMMERS_SUPPORTED += bmp openocd

--- a/boards/ikea-tradfri/Makefile.include
+++ b/boards/ikea-tradfri/Makefile.include
@@ -1,4 +1,12 @@
 # setup JLink for flashing
-PROGRAMMER ?= jlink
 JLINK_DEVICE = EFR32MG1PxxxF256
 JLINK_PRE_FLASH += r
+
+# setup OpenOCD for flashing
+OPENOCD_CONFIG ?= board/efm32.cfg
+
+# configure JLink as default programmer
+PROGRAMMER ?= jlink
+
+# board can also use BMP or OpenOCD as programmer
+PROGRAMMERS_SUPPORTED += bmp openocd


### PR DESCRIPTION
### Contribution description

The Black Magic Probe supports Series 0 and Series 1 EFM32 microcontrollers.

OpenOCD has included support for Series 2, since [April 2026](https://review.openocd.org/c/openocd/+/9452), but there has not been an official release yet.

This PR adds them to the list of supported programmers.

### Testing procedure

The following Series 0 and Series 1 board should still default to JLink:

* `BOARD=stk3600 make -C examples/basic/hello-world flash`
* `BOARD=slstk3401a make -C examples/basic/hello-world flash`

Then retest with `PROGRAMMER=bmp` or `PROGRAMMER=openocd`. Before this PR, it would mention that the programmer is unsupported.

I did not test OpenOCD specifically, but given that it has been enabled before for some boards, the change makes sense. I own a BMP 2.3 (official) and have been using this on some boards.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- none