### PR TITLE
treewide: change serial port for macOS and other improvements

### DIFF
--- a/boards/airfy-beacon/Makefile.include
+++ b/boards/airfy-beacon/Makefile.include
@@ -1,6 +1,6 @@
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # this board uses an ST-Link v2 debug adapter
 OPENOCD_DEBUG_ADAPTER ?= stlink

--- a/boards/airfy-beacon/Makefile.include
+++ b/boards/airfy-beacon/Makefile.include
@@ -1,6 +1,6 @@
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # this board uses an ST-Link v2 debug adapter
 OPENOCD_DEBUG_ADAPTER ?= stlink

--- a/boards/arduino-duemilanove/Makefile.include
+++ b/boards/arduino-duemilanove/Makefile.include
@@ -1,6 +1,5 @@
 # configure the terminal program
 PORT_LINUX  ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD        ?= 9600
 
 ARDUINO_DUEMILANOVE_BOOTLOADER ?= atmegaboot

--- a/boards/arduino-leonardo/Makefile.include
+++ b/boards/arduino-leonardo/Makefile.include
@@ -1,6 +1,5 @@
 PORT_LINUX      ?= /dev/ttyUSB0
 PROG_DEV        ?= /dev/ttyACM0
-PORT_DARWIN     ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD            ?= 9600
 
 # PROGRAMMER defaults to avr109 which is the internal flasher via USB. Can be

--- a/boards/arduino-mega2560/doc.md
+++ b/boards/arduino-mega2560/doc.md
@@ -164,7 +164,7 @@ BOARD=arduino-mega2560 PROGRAMMER=dragon_isp make clean all flash debug
             connected via USB, you also need to export `AVR_DEBUGINTERFACE` to
             the correct value.
 
-## Mac OSX El Capitan users
+## macOS users
 
 Mac users can flash this Arduino board by installing `avr-gcc` and `avrdude`
 from `brew`.
@@ -196,14 +196,3 @@ brew install avrdude --with-usb
 
 With this you should be allowed to compile and to flash code to the Arduino
 Mega.
-
-## Troubleshooting for serial connection
-
-In OSX El Capitan, there is no native driver working for the serial
-connection.
-
-In order to install it, you must download and install a CDC-ACM driver from
-[here](https://www.aten.com/global/en/products/usb-&-thunderbolt/usb-converters/uc232a/)
-(Go to Support and Downloads/Software & Driver/Mac Software).
-
-A reboot should be enough to find your Arduino on `/dev/tty.usbmodem*`

--- a/boards/arduino-nano-33-iot/Makefile.include
+++ b/boards/arduino-nano-33-iot/Makefile.include
@@ -1,6 +1,3 @@
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # Include all definitions for flashing with bossa over USB
 include $(RIOTBOARD)/common/samdx1-arduino-bootloader/Makefile.include
 

--- a/boards/arduino-nano/Makefile.include
+++ b/boards/arduino-nano/Makefile.include
@@ -1,6 +1,5 @@
 # configure the terminal program
 PORT_LINUX  ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD        ?= 9600
 
 ARDUINO_NANO_BOOTLOADER ?= atmegaboot

--- a/boards/atmega1284p/Makefile.include
+++ b/boards/atmega1284p/Makefile.include
@@ -1,6 +1,5 @@
 # configure the terminal program
 PORT_LINUX          ?= /dev/ttyUSB0
-PORT_DARWIN         ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD                ?= 9600
 ATMEGA1284P_CLOCK   ?=
 

--- a/boards/atmega328p/Makefile.include
+++ b/boards/atmega328p/Makefile.include
@@ -1,6 +1,5 @@
 # configure the terminal program
 PORT_LINUX          ?= /dev/ttyUSB0
-PORT_DARWIN         ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD                ?= 9600
 ATMEGA328P_CLOCK    ?=
 

--- a/boards/atmega8/Makefile.include
+++ b/boards/atmega8/Makefile.include
@@ -1,6 +1,5 @@
 # configure the terminal program
 PORT_LINUX          ?= /dev/ttyUSB0
-PORT_DARWIN         ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD                ?= 9600
 ATMEGA8_CLOCK    	?=
 

--- a/boards/avr-rss2/Makefile.include
+++ b/boards/avr-rss2/Makefile.include
@@ -1,6 +1,6 @@
 # configure the terminal program
 PORT_LINUX  ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
 # refine serial port information for pyterm
 BAUD        ?= 115200
 AVR_RSS2_BOOTLOADER ?= stk500v2

--- a/boards/bitcraze-crazyflie21-main/Makefile.include
+++ b/boards/bitcraze-crazyflie21-main/Makefile.include
@@ -1,8 +1,6 @@
 # include shared STM32 headers
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-PORT_LINUX ?= /dev/ttyACM0
-
 ROM_OFFSET ?= 0x4000
 TERM_DELAY ?= 2
 

--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -4,6 +4,6 @@ PROGRAMMER_SERIAL ?= 06EB
 # setup serial terminal
 # the debug UART is always the second tty with the matching serial number:
 PORT_LINUX ?= $(word 2,$(shell $(RIOTTOOLS)/usb-serial/find-tty.sh '^$(PROGRAMMER_SERIAL)'))
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 include $(RIOTBOARD)/common/cc2538/Makefile.include

--- a/boards/common/esp32x/Makefile.include
+++ b/boards/common/esp32x/Makefile.include
@@ -2,4 +2,4 @@ INCLUDES += -I$(RIOTBOARD)/common/esp32x/include
 
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))

--- a/boards/common/esp32x/Makefile.include
+++ b/boards/common/esp32x/Makefile.include
@@ -2,4 +2,4 @@ INCLUDES += -I$(RIOTBOARD)/common/esp32x/include
 
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))

--- a/boards/common/esp8266/Makefile.include
+++ b/boards/common/esp8266/Makefile.include
@@ -1,6 +1,6 @@
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # Set RTS and DTR to 0 to release reset when RTS is connected to the reset pin
 # and DTR to GPIO0.

--- a/boards/common/esp8266/Makefile.include
+++ b/boards/common/esp8266/Makefile.include
@@ -1,6 +1,6 @@
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # Set RTS and DTR to 0 to release reset when RTS is connected to the reset pin
 # and DTR to GPIO0.

--- a/boards/common/gd32v/Makefile.include
+++ b/boards/common/gd32v/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/gd32v/include
 
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # configure the flasher
 PROGRAMMER ?= openocd

--- a/boards/common/gd32v/Makefile.include
+++ b/boards/common/gd32v/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/gd32v/include
 
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # configure the flasher
 PROGRAMMER ?= openocd

--- a/boards/common/iotlab/Makefile.include
+++ b/boards/common/iotlab/Makefile.include
@@ -1,6 +1,6 @@
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB1
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*B)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*B)))
 
 # setup serial terminal
 BAUD ?= 500000

--- a/boards/common/msba2/Makefile.include
+++ b/boards/common/msba2/Makefile.include
@@ -1,7 +1,7 @@
 # configure serial interface
 PORT_LINUX ?= /dev/ttyUSB0
 # This does not make a lot of sense, but it has the same value as the previous code
-PORT_DARWIN ?= /dev/tty.usbserial-ARM
+PORT_DARWIN ?= /dev/cu.usbserial-ARM
 
 # Use lpc2k_pgm programmer
 PROGRAMMER ?= lpc2k_pgm

--- a/boards/common/msp430/Makefile.include
+++ b/boards/common/msp430/Makefile.include
@@ -2,7 +2,7 @@ INCLUDES += -I$(RIOTBOARD)/common/msp430/include
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # setup flash tool
 PROGRAMMER ?= mspdebug

--- a/boards/common/msp430/Makefile.include
+++ b/boards/common/msp430/Makefile.include
@@ -2,7 +2,7 @@ INCLUDES += -I$(RIOTBOARD)/common/msp430/include
 
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # setup flash tool
 PROGRAMMER ?= mspdebug

--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -5,7 +5,7 @@ ifeq (bmp,$(PROGRAMMER))
   # On Blackmagic Probe, the first ACM is used to connect to the gdb server,
   # the second is the BMP's UART interface
   PORT_LINUX ?= /dev/ttyACM1
-  PORT_DARWIN ?= $(wordlist 2, 2, $(sort $(wildcard /dev/tty.usbmodem*)))
+  PORT_DARWIN ?= $(wordlist 2, 2, $(sort $(wildcard /dev/cu.usbmodem*)))
 endif
 
 # set list of supported programmers

--- a/boards/derfmega128/Makefile.include
+++ b/boards/derfmega128/Makefile.include
@@ -2,7 +2,6 @@ FLASHFILE=$(BINFILE)
 
 # configure the terminal program
 PORT_LINUX  ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # refine serial port information for pyterm
 BAUD        ?= 115200
 DERFMEGA128_BOOTLOADER  ?= derfmega

--- a/boards/derfmega256/Makefile.include
+++ b/boards/derfmega256/Makefile.include
@@ -2,7 +2,7 @@ FLASHFILE=$(BINFILE)
 
 # configure the terminal program
 PORT_LINUX  ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
 # refine serial port information for pyterm
 BAUD        ?= 115200
 DERFMEGA256_BOOTLOADER  ?= derfmega

--- a/boards/f4vi1/Makefile.include
+++ b/boards/f4vi1/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # st-flash
 FLASHER = st-flash

--- a/boards/f4vi1/Makefile.include
+++ b/boards/f4vi1/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # st-flash
 FLASHER = st-flash

--- a/boards/firefly/Makefile.include
+++ b/boards/firefly/Makefile.include
@@ -1,5 +1,5 @@
 # define the default port depending on the host OS
 PORT_LINUX  ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 include $(RIOTBOARD)/common/remote/Makefile.include

--- a/boards/firefly/Makefile.include
+++ b/boards/firefly/Makefile.include
@@ -1,5 +1,5 @@
 # define the default port depending on the host OS
 PORT_LINUX  ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 include $(RIOTBOARD)/common/remote/Makefile.include

--- a/boards/firefly/doc.md
+++ b/boards/firefly/doc.md
@@ -95,7 +95,7 @@ On windows, devices will appear as a virtual `COM` port.
 
 On Linux, devices will appear under `/dev/`.
 
-On macOS, `/dev/tty.usbserial*`.
+On macOS, `/dev/cu.usbserial*`.
 
 On Linux:
 

--- a/boards/firefly/doc.md
+++ b/boards/firefly/doc.md
@@ -95,7 +95,7 @@ On windows, devices will appear as a virtual `COM` port.
 
 On Linux, devices will appear under `/dev/`.
 
-On macOS, `/dev/tty.SLAB_USBtoUARTx`.
+On macOS, `/dev/tty.usbserial*`.
 
 On Linux:
 

--- a/boards/hifive1/Makefile.include
+++ b/boards/hifive1/Makefile.include
@@ -1,6 +1,5 @@
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB1
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
 # this board uses openocd with a custom reset command
 PROGRAMMER ?= openocd

--- a/boards/limifrog-v1/Makefile.include
+++ b/boards/limifrog-v1/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd

--- a/boards/limifrog-v1/Makefile.include
+++ b/boards/limifrog-v1/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd

--- a/boards/lobaro-lorabox/Makefile.include
+++ b/boards/lobaro-lorabox/Makefile.include
@@ -3,7 +3,6 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # configure the serial terminal
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
 # Configure programmer
 PROGRAMMER ?= stm32loader

--- a/boards/lora-e5-dev/Makefile.include
+++ b/boards/lora-e5-dev/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # Setup of programmer and serial is shared between STM32 based boards
 include $(RIOTMAKE)/boards/stm32.inc.mk

--- a/boards/mbed_lpc1768/Makefile.include
+++ b/boards/mbed_lpc1768/Makefile.include
@@ -7,4 +7,4 @@ FFLAGS = $(FLASHFILE)
 DEBUGGER_FLAGS =
 
 # define the default port depending on the host OS
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))

--- a/boards/mbed_lpc1768/Makefile.include
+++ b/boards/mbed_lpc1768/Makefile.include
@@ -5,6 +5,3 @@ DEBUGSERVER =
 FLASHFILE ?= $(BINFILE)
 FFLAGS = $(FLASHFILE)
 DEBUGGER_FLAGS =
-
-# define the default port depending on the host OS
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))

--- a/boards/mega-xplained/Makefile.include
+++ b/boards/mega-xplained/Makefile.include
@@ -4,11 +4,12 @@ ATMEGA_BOOTLOADER_SIZE ?= 4K
 
 # Avrdude programmer defaults to the external flasher Bus Pirate ISP.
 AVRDUDE_PROGRAMMER  ?= buspirate
+
 # set serial port for avrdude with buspirate
 ifeq ($(OS),Linux)
   PROG_DEV ?= /dev/ttyUSB0
 else ifeq ($(OS),Darwin)
-  PROG_DEV ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+  PROG_DEV ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 endif
 
 # configure the terminal program

--- a/boards/microbit/Makefile.include
+++ b/boards/microbit/Makefile.include
@@ -1,5 +1,5 @@
 # define the default port depending on the host OS
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # for this board we support flashing via openocd or pyocd
 PROGRAMMER ?= openocd

--- a/boards/microbit/Makefile.include
+++ b/boards/microbit/Makefile.include
@@ -1,5 +1,5 @@
 # define the default port depending on the host OS
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # for this board we support flashing via openocd or pyocd
 PROGRAMMER ?= openocd

--- a/boards/microduino-corerf/Makefile.include
+++ b/boards/microduino-corerf/Makefile.include
@@ -1,6 +1,5 @@
 # configure the terminal program
 PORT_LINUX  ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD        ?= 115200
 
 # Avrdude programmer defaults to UM232H which is a FT232H breakout board

--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -27,5 +27,5 @@ DEBUG_ADAPTER_ID ?= $(PROGRAMMER_SERIAL)
 
 # Define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 TTY_BOARD_FILTER := --model 'Mulle Programmer' --iface-num 0

--- a/boards/nrf51dk/Makefile.include
+++ b/boards/nrf51dk/Makefile.include
@@ -1,5 +1,5 @@
 # define the default port depending on the host OS
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # use openocd by default to program this board
 PROGRAMMER ?= openocd

--- a/boards/nrf51dk/Makefile.include
+++ b/boards/nrf51dk/Makefile.include
@@ -1,5 +1,5 @@
 # define the default port depending on the host OS
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # use openocd by default to program this board
 PROGRAMMER ?= openocd

--- a/boards/nrf51dongle/Makefile.include
+++ b/boards/nrf51dongle/Makefile.include
@@ -1,5 +1,5 @@
 # define the default port depending on the host OS
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # use jlink to program this board
 PROGRAMMER ?= jlink

--- a/boards/nrf51dongle/Makefile.include
+++ b/boards/nrf51dongle/Makefile.include
@@ -1,5 +1,5 @@
 # define the default port depending on the host OS
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # use jlink to program this board
 PROGRAMMER ?= jlink

--- a/boards/nz32-sc151/Makefile.include
+++ b/boards/nz32-sc151/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # this board is flashed using DFU
 PROGRAMMER ?= dfu-util

--- a/boards/nz32-sc151/Makefile.include
+++ b/boards/nz32-sc151/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # this board is flashed using DFU
 PROGRAMMER ?= dfu-util

--- a/boards/omote/Makefile.include
+++ b/boards/omote/Makefile.include
@@ -1,5 +1,5 @@
 # define the default port depending on the host OS
 PORT_LINUX  ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 include $(RIOTBOARD)/common/cc2538/Makefile.include

--- a/boards/omote/Makefile.include
+++ b/boards/omote/Makefile.include
@@ -1,5 +1,5 @@
 # define the default port depending on the host OS
 PORT_LINUX  ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 include $(RIOTBOARD)/common/cc2538/Makefile.include

--- a/boards/omote/doc.md
+++ b/boards/omote/doc.md
@@ -42,7 +42,7 @@ On Windows, devices will appear as a virtual `COM` port.
 
 On Linux, devices will appear under `/dev/`.
 
-On macOS, `/dev/tty.SLAB_USBtoUARTx`.
+On macOS, `/dev/tty.usbserial*`.
 
 On Linux:
 

--- a/boards/omote/doc.md
+++ b/boards/omote/doc.md
@@ -42,7 +42,7 @@ On Windows, devices will appear as a virtual `COM` port.
 
 On Linux, devices will appear under `/dev/`.
 
-On macOS, `/dev/tty.usbserial*`.
+On macOS, `/dev/cu.usbserial*`.
 
 On Linux:
 

--- a/boards/openmote-b/Makefile.include
+++ b/boards/openmote-b/Makefile.include
@@ -1,6 +1,6 @@
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB1
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 PROGRAMMER ?= cc2538-bsl
 

--- a/boards/openmote-cc2538/Makefile.include
+++ b/boards/openmote-cc2538/Makefile.include
@@ -1,6 +1,6 @@
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 PROGRAMMER ?= cc2538-bsl
 CC2538_BSL_FLASHFILE ?= $(HEXFILE)

--- a/boards/pyboard/Makefile.include
+++ b/boards/pyboard/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # this board is flashed using DFU
 PROGRAMMER ?= dfu-util

--- a/boards/pyboard/Makefile.include
+++ b/boards/pyboard/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # this board is flashed using DFU
 PROGRAMMER ?= dfu-util

--- a/boards/remote-pa/Makefile.include
+++ b/boards/remote-pa/Makefile.include
@@ -1,5 +1,5 @@
 # define the default port depending on the host OS
 PORT_LINUX  ?= /dev/ttyUSB1
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 include $(RIOTBOARD)/common/remote/Makefile.include

--- a/boards/remote-pa/README.md
+++ b/boards/remote-pa/README.md
@@ -100,8 +100,8 @@ On Linux and macOS, devices will appear under `/dev/`.
 
 On macOS:
 
-* XDS backchannel: `tty.usbserial-<serial number>`
-* EM in CDC-ACM: `tty.usbmodemf<X><ABC>` (X a letter, ABC a number e.g. `tty.usbmodemfd121`)
+* XDS backchannel: `cu.usbserial-<serial number>`
+* EM in CDC-ACM: `cu.usbmodemf<X><ABC>` (X a letter, ABC a number e.g. `cu.usbmodemfd121`)
 
 On Linux:
 

--- a/boards/remote-reva/Makefile.include
+++ b/boards/remote-reva/Makefile.include
@@ -1,5 +1,5 @@
 # define the default port depending on the host OS
 PORT_LINUX  ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 include $(RIOTBOARD)/common/remote/Makefile.include

--- a/boards/remote-reva/Makefile.include
+++ b/boards/remote-reva/Makefile.include
@@ -1,5 +1,5 @@
 # define the default port depending on the host OS
 PORT_LINUX  ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 include $(RIOTBOARD)/common/remote/Makefile.include

--- a/boards/remote-reva/README.md
+++ b/boards/remote-reva/README.md
@@ -91,7 +91,7 @@ On windows, devices will appear as a virtual `COM` port.
 
 On Linux, devices will appear under `/dev/`.
 
-On macOS, `/dev/tty.usbserial*`.
+On macOS, `/dev/cu.usbserial*`.
 
 On Linux:
 

--- a/boards/remote-reva/README.md
+++ b/boards/remote-reva/README.md
@@ -91,7 +91,7 @@ On windows, devices will appear as a virtual `COM` port.
 
 On Linux, devices will appear under `/dev/`.
 
-On macOS, `/dev/tty.SLAB_USBtoUARTx`.
+On macOS, `/dev/tty.usbserial*`.
 
 On Linux:
 

--- a/boards/remote-revb/Makefile.include
+++ b/boards/remote-revb/Makefile.include
@@ -1,5 +1,5 @@
 # define the default port depending on the host OS
 PORT_LINUX  ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 include $(RIOTBOARD)/common/remote/Makefile.include

--- a/boards/remote-revb/Makefile.include
+++ b/boards/remote-revb/Makefile.include
@@ -1,5 +1,5 @@
 # define the default port depending on the host OS
 PORT_LINUX  ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 include $(RIOTBOARD)/common/remote/Makefile.include

--- a/boards/remote-revb/README.md
+++ b/boards/remote-revb/README.md
@@ -97,7 +97,7 @@ On windows, devices will appear as a virtual `COM` port.
 
 On Linux, devices will appear under `/dev/`.
 
-On macOS, `/dev/tty.SLAB_USBtoUARTx`.
+On macOS, `/dev/tty.usbserial*`.
 
 On Linux:
 

--- a/boards/remote-revb/README.md
+++ b/boards/remote-revb/README.md
@@ -97,7 +97,7 @@ On windows, devices will appear as a virtual `COM` port.
 
 On Linux, devices will appear under `/dev/`.
 
-On macOS, `/dev/tty.usbserial*`.
+On macOS, `/dev/cu.usbserial*`.
 
 On Linux:
 

--- a/boards/rpi-pico-2-arm/Makefile.include
+++ b/boards/rpi-pico-2-arm/Makefile.include
@@ -1,5 +1,4 @@
 CPU_MODEL       := RP2350_ARM
-PORT_LINUX      ?= /dev/ttyACM0
 
 # JLink has unresolved bugs regarding the RP2350 (as of 23.02.2026)
 # https://forum.segger.com/thread/10038-j-link-edu-not-connecting-to-rp2350

--- a/boards/rpi-pico-2-riscv/Makefile.include
+++ b/boards/rpi-pico-2-riscv/Makefile.include
@@ -1,5 +1,3 @@
-PORT_LINUX      ?= /dev/ttyACM0
-
 # JLink has unresolved bugs regarding the RP2350 (as of 23.02.2026)
 # https://forum.segger.com/thread/10038-j-link-edu-not-connecting-to-rp2350
 # https://forum.segger.com/thread/9977-rp2350-extremely-poor-performance-after-flashing

--- a/boards/seeeduino_arch-pro/Makefile.include
+++ b/boards/seeeduino_arch-pro/Makefile.include
@@ -1,7 +1,3 @@
-# define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
-
 # this board uses openocd with an HEXFILE
 PROGRAMMER ?= openocd
 PROGRAMMERS_SUPPORTED += openocd

--- a/boards/seeeduino_arch-pro/Makefile.include
+++ b/boards/seeeduino_arch-pro/Makefile.include
@@ -1,6 +1,6 @@
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # this board uses openocd with an HEXFILE
 PROGRAMMER ?= openocd

--- a/boards/slstk3701a/Makefile.include
+++ b/boards/slstk3701a/Makefile.include
@@ -2,9 +2,6 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # setup JLink for flashing
 JLINK_PRE_FLASH += r
 

--- a/boards/slstk3701a/Makefile.include
+++ b/boards/slstk3701a/Makefile.include
@@ -1,7 +1,3 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup JLink for flashing
 JLINK_PRE_FLASH += r
 

--- a/boards/sltb009a/Makefile.include
+++ b/boards/sltb009a/Makefile.include
@@ -2,9 +2,6 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 # setup JLink for flashing
 JLINK_PRE_FLASH += r
 

--- a/boards/sltb009a/Makefile.include
+++ b/boards/sltb009a/Makefile.include
@@ -1,7 +1,3 @@
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # setup JLink for flashing
 JLINK_PRE_FLASH += r
 

--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # Skip the space needed by the embedded bootloader
 ROM_OFFSET ?= 0x5000

--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # Skip the space needed by the embedded bootloader
 ROM_OFFSET ?= 0x5000

--- a/boards/stm32c0116-dk/Makefile.include
+++ b/boards/stm32c0116-dk/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBASE)/boards/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 PROGRAMMER ?= openocd
 OPENOCD_DEBUG_ADAPTER ?= stlink

--- a/boards/stm32c0116-dk/Makefile.include
+++ b/boards/stm32c0116-dk/Makefile.include
@@ -2,8 +2,7 @@
 INCLUDES += -I$(RIOTBASE)/boards/common/stm32/include
 
 # define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 PROGRAMMER ?= openocd
 OPENOCD_DEBUG_ADAPTER ?= stlink

--- a/boards/stm32c0116-dk/Makefile.include
+++ b/boards/stm32c0116-dk/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBASE)/boards/common/stm32/include
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 PROGRAMMER ?= openocd
 OPENOCD_DEBUG_ADAPTER ?= stlink
 

--- a/boards/stm32c0316-dk/Makefile.include
+++ b/boards/stm32c0316-dk/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBASE)/boards/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 PROGRAMMER ?= openocd
 OPENOCD_DEBUG_ADAPTER ?= stlink

--- a/boards/stm32c0316-dk/Makefile.include
+++ b/boards/stm32c0316-dk/Makefile.include
@@ -2,8 +2,7 @@
 INCLUDES += -I$(RIOTBASE)/boards/common/stm32/include
 
 # define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 PROGRAMMER ?= openocd
 OPENOCD_DEBUG_ADAPTER ?= stlink

--- a/boards/stm32c0316-dk/Makefile.include
+++ b/boards/stm32c0316-dk/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBASE)/boards/common/stm32/include
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 PROGRAMMER ?= openocd
 OPENOCD_DEBUG_ADAPTER ?= stlink
 

--- a/boards/stm32f0discovery/Makefile.include
+++ b/boards/stm32f0discovery/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBASE)/boards/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # this board uses openocd
 PROGRAMMER ?= openocd

--- a/boards/stm32f0discovery/Makefile.include
+++ b/boards/stm32f0discovery/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBASE)/boards/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # this board uses openocd
 PROGRAMMER ?= openocd

--- a/boards/stm32f3discovery/Makefile.include
+++ b/boards/stm32f3discovery/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # this board uses openocd
 PROGRAMMER ?= openocd

--- a/boards/stm32f3discovery/Makefile.include
+++ b/boards/stm32f3discovery/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # this board uses openocd
 PROGRAMMER ?= openocd

--- a/boards/stm32g0316-disco/Makefile.include
+++ b/boards/stm32g0316-disco/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBASE)/boards/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 PROGRAMMER ?= openocd
 OPENOCD_DEBUG_ADAPTER ?= stlink

--- a/boards/stm32g0316-disco/Makefile.include
+++ b/boards/stm32g0316-disco/Makefile.include
@@ -2,8 +2,7 @@
 INCLUDES += -I$(RIOTBASE)/boards/common/stm32/include
 
 # define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 PROGRAMMER ?= openocd
 OPENOCD_DEBUG_ADAPTER ?= stlink

--- a/boards/stm32g0316-disco/Makefile.include
+++ b/boards/stm32g0316-disco/Makefile.include
@@ -5,9 +5,6 @@ INCLUDES += -I$(RIOTBASE)/boards/common/stm32/include
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
-
 PROGRAMMER ?= openocd
 OPENOCD_DEBUG_ADAPTER ?= stlink
 

--- a/boards/stm32l0538-disco/Makefile.include
+++ b/boards/stm32l0538-disco/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd

--- a/boards/stm32l0538-disco/Makefile.include
+++ b/boards/stm32l0538-disco/Makefile.include
@@ -3,7 +3,7 @@ INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # this board uses openocd with st-link
 PROGRAMMER ?= openocd

--- a/boards/teensy31/Makefile.include
+++ b/boards/teensy31/Makefile.include
@@ -10,7 +10,7 @@ ifeq ($(TEENSY_LOADER),$(FLASHER))
 endif
 
 # define the default port depending on the host OS
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial-*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 $(TEENSY_LOADER):
 	@echo "[INFO] teensy_loader binary not found - building it from source now"

--- a/boards/weact-g030f6/Makefile.include
+++ b/boards/weact-g030f6/Makefile.include
@@ -9,4 +9,4 @@ include $(RIOTMAKE)/tools/openocd.inc.mk
 
 # setup serial terminal
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))

--- a/boards/weact-g030f6/Makefile.include
+++ b/boards/weact-g030f6/Makefile.include
@@ -8,5 +8,4 @@ OPENOCD_DEBUG_ADAPTER ?= stlink
 include $(RIOTMAKE)/tools/openocd.inc.mk
 
 # setup serial terminal
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))

--- a/boards/weact-g030f6/Makefile.include
+++ b/boards/weact-g030f6/Makefile.include
@@ -10,4 +10,3 @@ include $(RIOTMAKE)/tools/openocd.inc.mk
 # setup serial terminal
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/yunjia-nrf51822/Makefile.include
+++ b/boards/yunjia-nrf51822/Makefile.include
@@ -1,6 +1,6 @@
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
 
 # This board uses an ST-Link v2 debug adapter
 OPENOCD_DEBUG_ADAPTER ?= stlink

--- a/boards/yunjia-nrf51822/Makefile.include
+++ b/boards/yunjia-nrf51822/Makefile.include
@@ -1,6 +1,6 @@
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # This board uses an ST-Link v2 debug adapter
 OPENOCD_DEBUG_ADAPTER ?= stlink

--- a/boards/yunjia-nrf51822/doc.md
+++ b/boards/yunjia-nrf51822/doc.md
@@ -130,10 +130,10 @@ The default values are PIN 1: `UART_RX` and Pin 2: `UART_TX` _(also compare
 schematic above)_.
 
 The BLE400 development board contains a CP2102 accessible through
-/dev/tty.SLAB_USBtoUART. You have to edit periph_conf.h to use it with UART_RX
-pin 11 and UART_TX pin 9.
+`/dev/tty.usbserial`. You have to edit `periph_conf.h` to use it with `UART_RX`
+pin 11 and `UART_TX` pin 9.
 
-The default Baud rate is `115200`.
+The default baud rate is `115200`.
 
 ### Troubleshooting
 

--- a/boards/yunjia-nrf51822/doc.md
+++ b/boards/yunjia-nrf51822/doc.md
@@ -130,8 +130,8 @@ The default values are PIN 1: `UART_RX` and Pin 2: `UART_TX` _(also compare
 schematic above)_.
 
 The BLE400 development board contains a CP2102 accessible through
-`/dev/tty.usbserial`. You have to edit `periph_conf.h` to use it with `UART_RX`
-pin 11 and `UART_TX` pin 9.
+`/dev/ttyUSB0` on Linux and `/dev/cu.usbserial` on macOS. You have to edit
+`periph_conf.h` to use it with `UART_RX` pin 11 and `UART_TX` pin 9.
 
 The default baud rate is `115200`.
 

--- a/boards/zigduino/Makefile.include
+++ b/boards/zigduino/Makefile.include
@@ -1,6 +1,5 @@
 # configure the terminal program
 PORT_LINUX  ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD        ?= 57600
 
 ZIGDUINO_BOOTLOADER ?= atmegaboot

--- a/dist/tools/goodfet/goodfet.bsl
+++ b/dist/tools/goodfet/goodfet.bsl
@@ -1504,7 +1504,7 @@ def main(itest=1):
         if len(glob_list) > 0:
             comPort = glob_list[0];
     if comPort is None:
-        glob_list = glob.glob("/dev/tty.usbserial*");
+        glob_list = glob.glob("/dev/cu.usbserial*");
         if len(glob_list) > 0:
             comPort = glob_list[0];
     if comPort is None:

--- a/dist/tools/stm32loader/stm32loader.py
+++ b/dist/tools/stm32loader/stm32loader.py
@@ -64,7 +64,7 @@ class CmdException(Exception):
     pass
 
 class CommandInterface(object):
-    def open(self, aport='/dev/tty.usbserial-FTD3TMCH', abaudrate=115200) :
+    def open(self, aport='/dev/cu.usbserial-FTD3TMCH', abaudrate=115200) :
         self.sp = serial.Serial(
             port=aport,
             baudrate=abaudrate,     # baudrate
@@ -582,7 +582,7 @@ if __name__ == "__main__":
         ports = []
 
         # Get a list of all USB-like names in /dev
-        for name in ['tty.usbserial', 'ttyUSB']:
+        for name in ['cu.usbserial', 'ttyUSB']:
             ports.extend(glob.glob('/dev/%s*' % name))
 
         ports = sorted(ports)

--- a/doc/guides/advanced_tutorials/porting_boards.mdx
+++ b/doc/guides/advanced_tutorials/porting_boards.mdx
@@ -176,7 +176,7 @@ port (depending on the host OS):
 
 ```makefile
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbmodem*)))
 ```
 
 So if the board is also using this, there's no need to redefine these variables
@@ -189,7 +189,7 @@ content in its `Makefile.include`:
 ```makefile
 # Define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbserial*)))
 
 # this board uses OpenOCD
 PROGRAMMER ?= openocd

--- a/doc/guides/build-system/build_system.mdx
+++ b/doc/guides/build-system/build_system.mdx
@@ -38,7 +38,7 @@ Besides typical targets like `clean`, `all`, or `doc`, RIOT provides the
 special targets `flash` and `term` to invoke the configured flashing and
 terminal tools for the specified platform. These targets use the variable
 `PORT` for the serial communication to the device, which defaults to
-`/dev/ttyACM0` and `/dev/tty.usbmodem*` on Linux and macOS, respectively.
+`/dev/ttyACM0` and `/dev/cu.usbmodem*` on Linux and macOS, respectively.
 ([source](https://github.com/RIOT-OS/RIOT/blob/master/makefiles/tools/serial.inc.mk#L37-L38)).
 Setting `MOST_RECENT_PORT=1` enables a more sophisticated serial port selection
 algorithm, which selects the most recently connected serial port whose metadata

--- a/makefiles/boards/stm32.inc.mk
+++ b/makefiles/boards/stm32.inc.mk
@@ -5,7 +5,7 @@ ifeq (bmp,$(PROGRAMMER))
   # On Blackmagic Probe, the first ACM is used to connect to the gdb server,
   # the second is the BMP's UART interface
   PORT_LINUX ?= /dev/ttyACM1
-  PORT_DARWIN ?= $(wordlist 2, 2, $(sort $(wildcard /dev/tty.usbmodem*)))
+  PORT_DARWIN ?= $(wordlist 2, 2, $(sort $(wildcard /dev/cu.usbmodem*)))
 endif
 
 # STM32 boards can become un-flashable after a hardfault,

--- a/makefiles/tools/openocd-adapters/buspirate.inc.mk
+++ b/makefiles/tools/openocd-adapters/buspirate.inc.mk
@@ -5,7 +5,7 @@
 #   CLK - SWCLK
 
 ifeq ($(OS),Darwin)
-  PROG_DEV ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+  PROG_DEV ?= $(firstword $(sort $(wildcard /dev/cu.usbmodem*)))
 else
   PROG_DEV ?= /dev/ttyUSB0
 endif

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -35,7 +35,7 @@ ifeq (1,$(MOST_RECENT_PORT))
 endif
 # Otherwise, use as default the most commonly used ports on Linux and OSX
 PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/cu.usbmodem*)))
 
 # set default port depending on operating system
 ifeq ($(OS),Linux)

--- a/tests/drivers/sx1280/README.md
+++ b/tests/drivers/sx1280/README.md
@@ -155,7 +155,7 @@ help
 ```
 
 ```
-2022-04-28 16:26:43,538 # Connect to serial port /dev/tty.usbserial-14620
+2022-04-28 16:26:43,538 # Connect to serial port /dev/cu.usbserial-14620
 Welcome to pyterm!
 Type '/exit' to exit.
 sx1280


### PR DESCRIPTION
### Contribution description

The main contribution of this PR is addressing the default port for macOS.

On macOS, the default serial port is usually `/dev/cu.*` instead of `/dev/tty.*`. The latter is meant for phones and faxes, and usually wait for the DCD line to be toggled before 'opening' the connection. It does work in some applications, but they usually work-around this, somehow. `/dev/cu.*` is the more appropriate solution.

While at it, I also updated the documentation, removed unnecessary includes of `serial.inc.mk` and more. 

I also removed references of `/dev/tty.SLAB_USBtoUART`. Before macOS shipped with compatible serial drivers (since 2020), the Silicon Labs driver for the CP210x USB-to-UART chips was often used. This resulted in `/dev/tty.SLAB_USBtoUART`.


### Testing procedure

`PORT_LINUX` and `PORT_DARWIN` still resolve to the same value for any board affects when running `BOARD=<board> make term`.

Some notable test:

* For the `slstk3701a`, `sltb009a`, `stm32c0116-dk`, `stm32c0316-dk`, `stm32g0316-disco`, `weact-g030f6` I have removed the `serial.inc.mk` from their `Makefile.include`. I did test if they still would resolve `PORT_DARWIN` appropriately.
* I did test with `weact-f401ce` and `slstk3701a` and they all still worked.
* I also tested `seeeduino_arch-pro` and `mbed_lpc1768`, but `PORT_DARWIN` was set to `usbserial`, but the board registered as `usbmodem` (equivalent of `ttyUSB` and `ttyACM`. I have addressed this too.


### Issues/PRs references

#22619 


### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- none

