### PR TITLE
pkg/mjson: supress upstream code warning for LLVM 15

### DIFF
--- a/pkg/mjson/mjson.mk
+++ b/pkg/mjson/mjson.mk
@@ -4,4 +4,7 @@ MODULE = mjson
 # prevent stack memory allocations
 CFLAGS += -DMJSON_ENABLE_MERGE=0
 
+# These issues should be fixed upstream
+CFLAGS += -Wno-unused-but-set-variable
+
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
### Contribution description

Newer versions of LLVM seem to have `-Wunused-but-set-variable` activated where older versions do not. This causes a build failure for `tests/pkg/mjson`.

Since this has to be fixed upstream, we just add a flag to ignore this warning.


### Testing procedure

The container I use for testing does have `LLVM 15`:
```
buechse@skyleaf:~/RIOTstuff/riot-vanillaschote/RIOT$ docker run --tty --rm 8d5b5a4a178db18daa6 clang --version
Ubuntu clang version 15.0.7
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```

Behavior on `master` with LLVM 15:
```
buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ BUILD_IN_DOCKER=1 DOCKER_IMAGE=8d5b5a4a178db18daa6 TOOLCHAIN=llvm make -C tests/pkg/mjson -j
make: Entering directory '/home/buechse/RIOTstuff/riot-upstream/RIOT/tests/pkg/mjson'
using BOARD="native64" as "native" on a 64-bit system
Launching build container using image "8d5b5a4a178db18daa6".
docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-upstream/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/buechse/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'    -e 'TOOLCHAIN=llvm' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=test_utils_print_stack_usage' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=embunit' -e 'USEPKG=mjson'  -w '/data/riotbuild/riotbase/tests/pkg/mjson/' '8d5b5a4a178db18daa6' make    -j
using BOARD="native64" as "native" on a 64-bit system
Building application "tests_mjson" for "native64" with CPU "native".

"make" -C /data/riotbuild/riotbase/pkg/mjson/
"make" -C /data/riotbuild/riotbase/build/pkg/mjson/src -f /data/riotbuild/riotbase/pkg/mjson/mjson.mk
/data/riotbuild/riotbase/build/pkg/mjson/src/mjson.c:195:14: error: variable 'n' set but not used [-Werror,-Wunused-but-set-variable]
  int i = 0, n = 0;
             ^
/data/riotbuild/riotbase/build/pkg/mjson/src/mjson.c:742:17: error: variable 'n' set but not used [-Werror,-Wunused-but-set-variable]
  int sign = 1, n = 0;
                ^
2 errors generated.
make[2]: *** [/data/riotbuild/riotbase/Makefile.base:162: /data/riotbuild/riotbase/tests/pkg/mjson/bin/native64/mjson/mjson.o] Error 1
make[1]: *** [Makefile:12: all] Error 2
make: *** [/data/riotbuild/riotbase/Makefile.include:815: pkg-build] Error 2
make: *** [/home/buechse/RIOTstuff/riot-upstream/RIOT/makefiles/docker.inc.mk:403: ..in-docker-container] Error 2
```

Behavior with this PR:
```
buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ BUILD_IN_DOCKER=1 DOCKER_IMAGE=8d5b5a4a178db18daa6 TOOLCHAIN=llvm make -C tests/pkg/mjson -j
make: Entering directory '/home/buechse/RIOTstuff/riot-upstream/RIOT/tests/pkg/mjson'
using BOARD="native64" as "native" on a 64-bit system
Launching build container using image "8d5b5a4a178db18daa6".
docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-upstream/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/buechse/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'    -e 'TOOLCHAIN=llvm' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=test_utils_print_stack_usage' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=embunit' -e 'USEPKG=mjson'  -w '/data/riotbuild/riotbase/tests/pkg/mjson/' '8d5b5a4a178db18daa6' make    -j
using BOARD="native64" as "native" on a 64-bit system
Building application "tests_mjson" for "native64" with CPU "native".

"make" -C /data/riotbuild/riotbase/pkg/mjson/
"make" -C /data/riotbuild/riotbase/build/pkg/mjson/src -f /data/riotbuild/riotbase/pkg/mjson/mjson.mk
"make" -C /data/riotbuild/riotbase/boards
"make" -C /data/riotbuild/riotbase/boards/native64
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/core/lib
"make" -C /data/riotbuild/riotbase/cpu/native
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/boards/common/native
"make" -C /data/riotbuild/riotbase/boards/common/init
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/embunit
"make" -C /data/riotbuild/riotbase/sys/libc
"make" -C /data/riotbuild/riotbase/sys/preprocessor
"make" -C /data/riotbuild/riotbase/sys/stdio
"make" -C /data/riotbuild/riotbase/sys/test_utils/print_stack_usage
"make" -C /data/riotbuild/riotbase/boards/common/native/drivers
"make" -C /data/riotbuild/riotbase/cpu/native/periph
"make" -C /data/riotbuild/riotbase/cpu/native/stdio_native
   text    data     bss     dec     hex filename
  42910    1336   58952  103198   1931e /data/riotbuild/riotbase/tests/pkg/mjson/bin/native64/tests_mjson.elf
```

### Issues/PRs references

Required for https://github.com/RIOT-OS/riotdocker/pull/282


### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none