### PR TITLE
boards/stm32c0116dk: add to doc page MCU table

### DIFF
--- a/boards/stm32c0116-dk/doc.md
+++ b/boards/stm32c0116-dk/doc.md
@@ -14,6 +14,28 @@ See [this application note as reference](https://www.st.com/resource/en/applicat
 This means the responsibility is on the firmware configurer to take special
 care when configuring IO, ensuring that ports are not conflicting on each pin.
 
+## MCU
+
+| MCU        | STM32C011F6         |
+|:---------- |:------------------- |
+| Family     | ARM Cortex-M0+      |
+| Vendor     | ST Microelectronics |
+| RAM        | 8KiB                |
+| Flash      | 32KiB               |
+| Frequency  | up to 48MHz (set to 48MHz on RIOT) |
+| FPU        | no                  |
+| Timers     | 8 (2x watchdog, 1 SysTick, 5x 16-bit) |
+| ADCs       | 1x 12-bit (up to 15 channels) |
+| UARTs      | 2                  |
+| SPIs       | 1                  |
+| I2Cs       | 1                  |
+| RTC        | 1                  |
+| Vcc        | 2.0V - 3.6V        |
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32c011f6.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/rm0490-stm32c0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) |
+| Programming Manual | [Programming Manual](https://www.st.com/resource/en/programming_manual/pm0223-stm32-cortexm0-mcus-programming-manual-stmicroelectronics.pdf) |
+| Board Manual   | [Board Manual](https://www.st.com/resource/en/user_manual/um2970-discovery-kit-with-stm32c011f6-mcu-stmicroelectronics.pdf) |
+
 ## Flashing the Board
 
 A detailed description about the flashing process can be found on the


### PR DESCRIPTION
### Contribution description

This PR upgrades documentation page for `stm32c0116-dk` board by adding MCU table.

### Testing procedure

Generate doc and check if everything looks good:

```
make doc
xdg-open ./doc/doxygen/html/group__boards__stm32c0116-dk.html 
```

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none