### PR TITLE
tests/cpu/efm32_info: add test application

### DIFF
--- a/tests/cpu/efm32_info/Makefile
+++ b/tests/cpu/efm32_info/Makefile
@@ -1,0 +1,20 @@
+BOARD ?= sltb001a
+include ../Makefile.cpu_common
+
+# this test application is expected to build for every EFM32-based board
+FEATURES_REQUIRED += cpu_efm32
+
+# the EFM32_* variables are defined by cpu/efm32/efm32-info.mk, which is only
+# included further down. CFLAGS is a recursively expanded variable, so the
+# values below are resolved when the compiler is invoked
+CFLAGS += -DTEST_EFM32_SERIES=$(EFM32_SERIES)
+CFLAGS += -DTEST_EFM32_ARCHITECTURE='"$(EFM32_ARCHITECTURE)"'
+CFLAGS += -DTEST_EFM32_FLASH_START=$(EFM32_FLASH_START)
+CFLAGS += -DTEST_EFM32_FLASH_SIZE=$(EFM32_FLASH_SIZE)
+CFLAGS += -DTEST_EFM32_SRAM_START=$(EFM32_SRAM_START)
+CFLAGS += -DTEST_EFM32_SRAM_SIZE=$(EFM32_SRAM_SIZE)
+CFLAGS += -DTEST_EFM32_CRYPTO=$(EFM32_CRYPTO)
+CFLAGS += -DTEST_EFM32_TRNG=$(EFM32_TRNG)
+CFLAGS += -DTEST_EFM32_RADIO=$(EFM32_RADIO)
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/cpu/efm32_info/README.md
+++ b/tests/cpu/efm32_info/README.md
@@ -1,0 +1,40 @@
+# EFM32 CPU Information
+
+## Introduction
+
+Every EFM32 family has a `efm32-info.mk` file in `cpu/efm32/families`, which
+contains one entry per supported CPU model. The memory map from that database
+ends up in the linker script, and the peripheral flags decide which features
+the CPU provides.
+
+The database is generated separately from the vendor headers of the Gecko SDK
+package, so the two can drift apart. A wrong entry is not noticed until an
+application fails at runtime.
+
+This test application compares the database against the vendor headers of the
+CPU that is being built for, and against the addresses that the linker actually
+used.
+
+## Test cases
+
+The following entries are covered:
+
+* The series, against `_SILICON_LABS_32B_SERIES`.
+* The flash and SRAM base addresses and sizes, against `FLASH_BASE`,
+  `FLASH_SIZE`, `SRAM_BASE` and `SRAM_SIZE`.
+* The cryptographic accelerator, the true random number generator and the
+  radio, against the peripheral counts of the vendor headers.
+
+Only the CPU models that have a board in the tree can be checked this way,
+which is a small subset of the database.
+
+## Expected result
+
+The test application compiles for EFM32-based boards. A mismatch between the
+database and the vendor headers is reported as a compile error.
+
+When run, the application reports the memory map, and verifies that the linker
+placed the firmware in the flash that the database describes, and that the
+linker used the described SRAM.
+
+The test application ends with `[SUCCESS]`.

--- a/tests/cpu/efm32_info/main.c
+++ b/tests/cpu/efm32_info/main.c
@@ -1,0 +1,181 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the EFM32 CPU information database.
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <inttypes.h>
+
+#include "em_device.h"
+
+/**
+ * @brief   Start of the RAM, as defined by the linker script.
+ */
+extern uint8_t _sram;
+
+/**
+ * @brief   End of the RAM, as defined by the linker script.
+ */
+extern uint8_t _eram;
+
+/**
+ * @brief   Start of the ROM, as defined by the linker script.
+ */
+extern uint8_t _rom_start_addr;
+
+/**
+ * @brief   Length of the ROM, as defined by the linker script.
+ */
+extern uint8_t _rom_length;
+
+/**
+ * @name    Peripherals as reported by the vendor headers
+ *
+ * @{
+ */
+#if defined(_SILICON_LABS_32B_SERIES_2)
+#  if defined(SEMAILBOX_COUNT) && (SEMAILBOX_COUNT > 0)
+#    define VENDOR_CRYPTO   1
+#    define VENDOR_TRNG     1
+#  endif
+#else
+#  if defined(CRYPTO_COUNT) && (CRYPTO_COUNT > 0)
+#    define VENDOR_CRYPTO   1
+#  endif
+#  if defined(TRNG_COUNT) && (TRNG_COUNT > 0)
+#    define VENDOR_TRNG     1
+#  endif
+#endif
+
+#if defined(_SILICON_LABS_EFR32_RADIO_TYPE)
+#  define VENDOR_RADIO      1
+#endif
+
+#ifndef VENDOR_CRYPTO
+#  define VENDOR_CRYPTO     0
+#endif
+#ifndef VENDOR_TRNG
+#  define VENDOR_TRNG       0
+#endif
+#ifndef VENDOR_RADIO
+#  define VENDOR_RADIO      0
+#endif
+/** @} */
+
+#if TEST_EFM32_SERIES != _SILICON_LABS_32B_SERIES
+#  error "EFM32_SERIES does not match _SILICON_LABS_32B_SERIES."
+#endif
+
+#if TEST_EFM32_FLASH_START != FLASH_BASE
+#  error "EFM32_FLASH_START does not match FLASH_BASE."
+#endif
+
+#if TEST_EFM32_FLASH_SIZE != FLASH_SIZE
+#  error "EFM32_FLASH_SIZE does not match FLASH_SIZE."
+#endif
+
+#if TEST_EFM32_SRAM_START != SRAM_BASE
+#  error "EFM32_SRAM_START does not match SRAM_BASE."
+#endif
+
+#if TEST_EFM32_SRAM_SIZE != SRAM_SIZE
+#  error "EFM32_SRAM_SIZE does not match SRAM_SIZE."
+#endif
+
+#if TEST_EFM32_CRYPTO != VENDOR_CRYPTO
+#  error "EFM32_CRYPTO does not match the vendor headers."
+#endif
+
+#if TEST_EFM32_TRNG != VENDOR_TRNG
+#  error "EFM32_TRNG does not match the vendor headers."
+#endif
+
+#if TEST_EFM32_RADIO != VENDOR_RADIO
+#  error "EFM32_RADIO does not match the vendor headers."
+#endif
+
+static int _test_flash(void)
+{
+    puts("Testing the flash layout.");
+
+    /* the linker script derives its ROM region from the database */
+    volatile uintptr_t start = (uintptr_t)&_rom_start_addr;
+    volatile uintptr_t length = (uintptr_t)&_rom_length;
+
+    printf("Flash: 0x%08" PRIxPTR " - 0x%08" PRIxPTR "\n", start,
+           start + length);
+
+    if (start != (uintptr_t)TEST_EFM32_FLASH_START) {
+        puts("Linker start of ROM does not match EFM32_FLASH_START.");
+        return 1;
+    }
+
+    if (length != (uintptr_t)TEST_EFM32_FLASH_SIZE) {
+        puts("Linker length of ROM does not match EFM32_FLASH_SIZE.");
+        return 1;
+    }
+
+    return 0;
+}
+
+static int _test_sram(void)
+{
+    puts("Testing the SRAM layout.");
+
+    /* the linker script derives its RAM region from the database */
+    volatile uintptr_t start = (uintptr_t)&_sram;
+    volatile uintptr_t end = (uintptr_t)&_eram;
+
+    printf("SRAM: 0x%08" PRIxPTR " - 0x%08" PRIxPTR "\n", start, end);
+
+    if (start != (uintptr_t)TEST_EFM32_SRAM_START) {
+        puts("Linker start of RAM does not match EFM32_SRAM_START.");
+        return 1;
+    }
+
+    if ((end - start) != (uintptr_t)TEST_EFM32_SRAM_SIZE) {
+        puts("Linker length of RAM does not match EFM32_SRAM_SIZE.");
+        return 1;
+    }
+
+    return 0;
+}
+
+int main(void)
+{
+    int failures = 0;
+
+    printf("Series: %d\n", TEST_EFM32_SERIES);
+    printf("Architecture: %s\n", TEST_EFM32_ARCHITECTURE);
+
+    printf("Crypto: %s\n", TEST_EFM32_CRYPTO ? "y" : "n");
+    printf("TRNG: %s\n", TEST_EFM32_TRNG ? "y" : "n");
+    printf("Radio: %s\n", TEST_EFM32_RADIO ? "y" : "n");
+
+    failures += _test_flash();
+    failures += _test_sram();
+
+    if (failures != 0) {
+        printf("%d test(s) failed.\n", failures);
+
+        puts("[FAILURE]");
+    }
+    else {
+        puts("[SUCCESS]");
+    }
+
+    return 0;
+}

--- a/tests/cpu/efm32_info/tests/01-run.py
+++ b/tests/cpu/efm32_info/tests/01-run.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+# SPDX-License-Identifier: LGPL-2.1-only
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect("Series: [012]")
+    child.expect("Architecture: cortex-m(0plus|33|3|4f)")
+
+    child.expect("Crypto: [yn]")
+    child.expect("TRNG: [yn]")
+    child.expect("Radio: [yn]")
+
+    child.expect_exact("Testing the flash layout.")
+    child.expect("Flash: 0x[0-9a-f]{8} - 0x[0-9a-f]{8}")
+
+    child.expect_exact("Testing the SRAM layout.")
+    child.expect("SRAM: 0x[0-9a-f]{8} - 0x[0-9a-f]{8}")
+
+    child.expect_exact("[SUCCESS]")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This test application asserts that the information provided from the per-family efm32-info.mk is correctly propagated from database to linker to application. Part of that information can be asserted during compilation, the other parts only during runtime.

While working on #22637, I realized that a test such as this was missing.

This test is also useful for out-of-tree boards.


### Testing procedure

This test should succeed for any EFM32-based board. The ones compatible can be listed using `make -C tests/cpu/efm32_info info-boards-supported`.

I have tested this locally for the STK3200, SLSTK3301a, SLSTK3401a, SLSTK3402a, SLSTK3701a and the SLTB001a. I don't own the xG23-PK6068a (Series 2).

<img width="1962" height="1274" alt="Scherm­afbeelding 2026-08-31 om 20 34 40" src="https://github.com/user-attachments/assets/cb114412-faa8-4b08-b586-cf8bd63e997c" />

To test that it actually trips during compilation, change any of the `efm32-info.mk` files (e.g. `cpu/efm32/families/efr32mg1p/efm32-info.mk` for the SLTB001a).

<img width="1962" height="1274" alt="Scherm­afbeelding 2026-08-31 om 18 10 40" src="https://github.com/user-attachments/assets/7424c62e-9d8c-47a5-ad93-d0202471b1ac" />

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- Mostly co-authored by Claude Code Sonnet 5