### PR TITLE
pkg/lwip: round sub-millisecond timeouts up to 1 ms

### DIFF
--- a/pkg/lwip/contrib/sock/lwip_sock.c
+++ b/pkg/lwip/contrib/sock/lwip_sock.c
@@ -569,7 +569,7 @@ int lwip_sock_recv(struct netconn *conn, uint32_t timeout, struct netbuf **buf)
 
 #if LWIP_SO_RCVTIMEO
     if ((timeout != 0) && (timeout != SOCK_NO_TIMEOUT)) {
-        netconn_set_recvtimeout(conn, timeout / US_PER_MS);
+        netconn_set_recvtimeout(conn, lwip_sock_timeout_ms(timeout));
     }
     else
 #endif

--- a/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
+++ b/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
@@ -237,7 +237,7 @@ int sock_tcp_accept(sock_tcp_queue_t *queue, sock_tcp_t **sock,
     if (queue->used < queue->len) {
 #if LWIP_SO_RCVTIMEO
         if ((timeout != 0) && (timeout != SOCK_NO_TIMEOUT)) {
-            netconn_set_recvtimeout(queue->base.conn, timeout / US_PER_MS);
+            netconn_set_recvtimeout(queue->base.conn, lwip_sock_timeout_ms(timeout));
         }
         else
 #endif
@@ -329,7 +329,7 @@ ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
 
 #if LWIP_SO_RCVTIMEO
     if ((timeout != 0) && (timeout != SOCK_NO_TIMEOUT)) {
-        netconn_set_recvtimeout(sock->base.conn, timeout / US_PER_MS);
+        netconn_set_recvtimeout(sock->base.conn, lwip_sock_timeout_ms(timeout));
     }
     else
 #endif

--- a/pkg/lwip/include/lwip/sock_internal.h
+++ b/pkg/lwip/include/lwip/sock_internal.h
@@ -22,11 +22,13 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 
 #include "net/af.h"
 #include "net/sock.h"
+#include "time_units.h"
 
 #include "lwip/ip_addr.h"
 #include "lwip/api.h"
@@ -69,6 +71,29 @@ static inline ssize_t lwip_sock_send(struct netconn *conn,
 
     return lwip_sock_sendv(conn, &snip, proto, remote, type);
 }
+
+/**
+ * @brief   Converts a sock timeout to the millisecond resolution used by lwIP
+ *
+ * lwIP interprets a receive timeout of 0 as "no timeout", so a sub-millisecond
+ * sock timeout must not be truncated to 0. The conversion rounds up instead,
+ * so that any non-zero timeout maps to at least one millisecond.
+ *
+ * @pre     @p timeout is neither 0 nor @ref SOCK_NO_TIMEOUT
+ *
+ * @param[in] timeout   A sock timeout in microseconds.
+ *
+ * @return  The equivalent lwIP timeout in milliseconds.
+ */
+static inline uint32_t lwip_sock_timeout_ms(uint32_t timeout)
+{
+    assert((timeout != 0) && (timeout != SOCK_NO_TIMEOUT));
+
+    /* DIV_ROUND_UP() is not used here, because its (a + b - 1) form overflows
+     * for large timeouts on platforms where unsigned long is 32 bit */
+    return (timeout - 1) / US_PER_MS + 1;
+}
+
 /** @internal
  * @}
  */

--- a/tests/pkg/lwip_sock_ip/constants.h
+++ b/tests/pkg/lwip_sock_ip/constants.h
@@ -21,9 +21,12 @@
 extern "C" {
 #endif
 
-#define _TEST_PROTO         (254) /* https://tools.ietf.org/html/rfc3692#section-2.1 */
-#define _TEST_NETIF         (1)
-#define _TEST_TIMEOUT       (1000000U)
+/* https://tools.ietf.org/html/rfc3692#section-2.1 */
+#define _TEST_PROTO             (254)
+#define _TEST_NETIF             (1)
+#define _TEST_TIMEOUT           (1000000U)
+#define _TEST_TIMEOUT_SUB_MS    (1U)
+
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 # define _TEST_ADDR4_LOCAL  (0x964fa8c0U)   /* 192.168.79.150 */
 # define _TEST_ADDR4_REMOTE (0x6b4fa8c0U)   /* 192.168.79.107 */
@@ -37,6 +40,7 @@ extern "C" {
 #else
 # error "Byte order is neither little nor big!"
 #endif
+
 #define _TEST_ADDR4_GW      (0UL)           /* so we can test unreachability */
 #define _TEST_ADDR6_LOCAL   { 0x2f, 0xc4, 0x11, 0x5a, 0xe6, 0x91, 0x8d, 0x5d, \
                               0x8c, 0xd1, 0x47, 0x07, 0xb7, 0x6f, 0x9b, 0x48 }

--- a/tests/pkg/lwip_sock_ip/main.c
+++ b/tests/pkg/lwip_sock_ip/main.c
@@ -199,6 +199,13 @@ static void test_sock_ip_recv4__ETIMEDOUT(void)
                                       sizeof(_test_buffer), _TEST_TIMEOUT,
                                       NULL));
     printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT);
+
+    /* a timeout below the millisecond resolution of the lwIP backend
+     * must still time out instead of blocking indefinitely */
+    expect(-ETIMEDOUT == sock_ip_recv(&_sock, _test_buffer,
+                                      sizeof(_test_buffer), _TEST_TIMEOUT_SUB_MS,
+                                      NULL));
+    printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT_SUB_MS);
 }
 
 static void test_sock_ip_recv4__socketed(void)
@@ -754,6 +761,13 @@ static void test_sock_ip_recv6__ETIMEDOUT(void)
                                       sizeof(_test_buffer), _TEST_TIMEOUT,
                                       NULL));
     printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT);
+
+    /* a timeout below the millisecond resolution of the lwIP backend
+     * must still time out instead of blocking indefinitely */
+    expect(-ETIMEDOUT == sock_ip_recv(&_sock, _test_buffer,
+                                      sizeof(_test_buffer), _TEST_TIMEOUT_SUB_MS,
+                                      NULL));
+    printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT_SUB_MS);
 }
 
 static void test_sock_ip_recv6__socketed(void)

--- a/tests/pkg/lwip_sock_tcp/constants.h
+++ b/tests/pkg/lwip_sock_tcp/constants.h
@@ -21,10 +21,12 @@
 extern "C" {
 #endif
 
-#define _TEST_PORT_LOCAL    (0x2c94)
-#define _TEST_PORT_REMOTE   (0xa615)
-#define _TEST_NETIF         (1)
-#define _TEST_TIMEOUT       (1000000U)
+#define _TEST_PORT_LOCAL        (0x2c94)
+#define _TEST_PORT_REMOTE       (0xa615)
+#define _TEST_NETIF             (1)
+#define _TEST_TIMEOUT           (1000000U)
+#define _TEST_TIMEOUT_SUB_MS    (1U)
+
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 # define _TEST_ADDR4_LOCAL  (0x964fa8c0U)   /* 192.168.79.150 */
 # define _TEST_ADDR4_REMOTE (0x0100007fU)   /* 127.0.0.1 */
@@ -38,6 +40,7 @@ extern "C" {
 #else
 # error "Byte order is neither little nor big!"
 #endif
+
 #define _TEST_ADDR4_GW      (0UL)           /* so we can test unreachability */
 #define _TEST_ADDR6_LOCAL   { 0x2f, 0xc4, 0x11, 0x5a, 0xe6, 0x91, 0x8d, 0x5d, \
                               0x8c, 0xd1, 0x47, 0x07, 0xb7, 0x6f, 0x9b, 0x48 }

--- a/tests/pkg/lwip_sock_tcp/main.c
+++ b/tests/pkg/lwip_sock_tcp/main.c
@@ -291,6 +291,11 @@ static void test_tcp_accept4__ETIMEDOUT(void)
     puts(" * Calling sock_tcp_accept()");
     expect(-ETIMEDOUT == sock_tcp_accept(&_queue, &sock, _TEST_TIMEOUT));
     printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT);
+
+    /* a timeout below the millisecond resolution of the lwIP backend
+     * must still time out instead of blocking indefinitely */
+    expect(-ETIMEDOUT == sock_tcp_accept(&_queue, &sock, _TEST_TIMEOUT_SUB_MS));
+    printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT_SUB_MS);
 }
 
 static void test_tcp_accept4__success(void)
@@ -395,6 +400,12 @@ static void test_tcp_read4__ETIMEDOUT(void)
     expect(-ETIMEDOUT == sock_tcp_read(&_sock, _test_buffer, sizeof(_test_buffer),
                                        _TEST_TIMEOUT));
     printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT);
+
+    /* a timeout below the millisecond resolution of the lwIP backend
+     * must still time out instead of blocking indefinitely */
+    expect(-ETIMEDOUT == sock_tcp_read(&_sock, _test_buffer, sizeof(_test_buffer),
+                                       _TEST_TIMEOUT_SUB_MS));
+    printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT_SUB_MS);
 }
 
 static void test_tcp_read4__success(void)
@@ -724,6 +735,11 @@ static void test_tcp_accept6__ETIMEDOUT(void)
     puts(" * Calling sock_tcp_accept()");
     expect(-ETIMEDOUT == sock_tcp_accept(&_queue, &sock, _TEST_TIMEOUT));
     printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT);
+
+    /* a timeout below the millisecond resolution of the lwIP backend
+     * must still time out instead of blocking indefinitely */
+    expect(-ETIMEDOUT == sock_tcp_accept(&_queue, &sock, _TEST_TIMEOUT_SUB_MS));
+    printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT_SUB_MS);
 }
 
 static void test_tcp_accept6__success(void)
@@ -828,6 +844,12 @@ static void test_tcp_read6__ETIMEDOUT(void)
     expect(-ETIMEDOUT == sock_tcp_read(&_sock, _test_buffer,
                                        sizeof(_test_buffer), _TEST_TIMEOUT));
     printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT);
+
+    /* a timeout below the millisecond resolution of the lwIP backend
+     * must still time out instead of blocking indefinitely */
+    expect(-ETIMEDOUT == sock_tcp_read(&_sock, _test_buffer,
+                                       sizeof(_test_buffer), _TEST_TIMEOUT_SUB_MS));
+    printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT_SUB_MS);
 }
 static void test_tcp_read6__success(void)
 {

--- a/tests/pkg/lwip_sock_udp/constants.h
+++ b/tests/pkg/lwip_sock_udp/constants.h
@@ -21,10 +21,12 @@
 extern "C" {
 #endif
 
-#define _TEST_PORT_LOCAL    (0x2c94)
-#define _TEST_PORT_REMOTE   (0xa615)
-#define _TEST_NETIF         (1)
-#define _TEST_TIMEOUT       (1000000U)
+#define _TEST_PORT_LOCAL        (0x2c94)
+#define _TEST_PORT_REMOTE       (0xa615)
+#define _TEST_NETIF             (1)
+#define _TEST_TIMEOUT           (1000000U)
+#define _TEST_TIMEOUT_SUB_MS    (1U)
+
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 # define _TEST_ADDR4_LOCAL  (0x964fa8c0U)   /* 192.168.79.150 */
 # define _TEST_ADDR4_REMOTE (0x6b4fa8c0U)   /* 192.168.79.107 */
@@ -38,6 +40,7 @@ extern "C" {
 #else
 # error "Byte order is neither little nor big!"
 #endif
+
 #define _TEST_ADDR4_GW      (0UL)           /* so we can test unreachability */
 #define _TEST_ADDR6_LOCAL   { 0x2f, 0xc4, 0x11, 0x5a, 0xe6, 0x91, 0x8d, 0x5d, \
                               0x8c, 0xd1, 0x47, 0x07, 0xb7, 0x6f, 0x9b, 0x48 }

--- a/tests/pkg/lwip_sock_udp/main.c
+++ b/tests/pkg/lwip_sock_udp/main.c
@@ -239,6 +239,13 @@ static void test_sock_udp_recv4__ETIMEDOUT(void)
                                        sizeof(_test_buffer), _TEST_TIMEOUT,
                                        NULL));
     printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT);
+
+    /* a timeout below the millisecond resolution of the lwIP backend
+     * must still time out instead of blocking indefinitely */
+    expect(-ETIMEDOUT == sock_udp_recv(&_sock, _test_buffer,
+                                       sizeof(_test_buffer), _TEST_TIMEOUT_SUB_MS,
+                                       NULL));
+    printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT_SUB_MS);
 }
 
 static void test_sock_udp_recv4__socketed(void)
@@ -917,6 +924,13 @@ static void test_sock_udp_recv6__ETIMEDOUT(void)
                                        sizeof(_test_buffer), _TEST_TIMEOUT,
                                        NULL));
     printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT);
+
+    /* a timeout below the millisecond resolution of the lwIP backend
+     * must still time out instead of blocking indefinitely */
+    expect(-ETIMEDOUT == sock_udp_recv(&_sock, _test_buffer,
+                                       sizeof(_test_buffer), _TEST_TIMEOUT_SUB_MS,
+                                       NULL));
+    printf(" * (timed out with timeout %u)\n", _TEST_TIMEOUT_SUB_MS);
 }
 
 static void test_sock_udp_recv6__socketed(void)


### PR DESCRIPTION
### Contribution description

`sock_tcp_accept`, `sock_tcp_read` and `lwip_sock_recv` accept a microsecond timeout value. When the caller provides a value less than 1000 (= 1 ms), that gets rounded down to 0, effectively setting no timeout, which will [block indefinitely](https://github.com/RIOT-OS/RIOT/blob/master/pkg/lwip/contrib/sys_arch.c#L149). To solve this, round values up, so any value smaller than 1000 becomes 1 ms.

Note that the conversion now rounds up rather than down for all values: a timeout of 1500 us used to result in 1 ms and now results in 2 ms. Rounding up is the safer direction, because a timeout should not expire earlier than requested.

### Testing procedure

Unit tests have been added, which will confirm the fix.

First, run `make -C tests/pkg/lwip_sock_ip test`, `make -C tests/pkg/lwip_sock_tcp test` and `make -C tests/pkg/lwip_sock_udp test` on this branch. 

```
...
Calling test_sock_ip_recv6__ETIMEDOUT()
 * Calling sock_ip_recv()
 * (timed out with timeout 1000000)
 * (timed out with timeout 1)             <-- Added
...
```

```
...
Calling test_tcp_accept6__ETIMEDOUT()
 * Calling sock_tcp_accept()
 * (timed out with timeout 1000000)
 * (timed out with timeout 1)             <-- Added
...
Calling test_tcp_read6__ETIMEDOUT()
 * Calling sock_tcp_read()
 * (timed out with timeout 1000000)
 * (timed out with timeout 1)             <-- Added
...
```

```
...
Calling test_sock_udp_recv4__ETIMEDOUT()
 * Calling sock_udp_recv()
 * (timed out with timeout 1000000)
 * (timed out with timeout 1)             <-- Added
...
```

Then re-run the tests by dropping the first commit (be sure to clean first). The tests will now time-out.


### Issues/PRs references

I believe this fixes #19676.

In that issue, the user calls `sock_tcp_read` with a timeout of 50 microseconds. This translates to 0 ms prior this fix, which results in a blocking read that will not return unless an exact amount of data arrives or the connection is closed. That could explain his observations. His other crash observations are more likely unsafe memory use in the application itself.

I could not have spotted this issue without AI finding this very small detail.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- Claude Code Opus 5 to analyze the issue and come up with the fix. I have carefully reviewed, rewritten and verified the fix.