### PR TITLE
cpu/native/mtd_native: correct bound checks

### DIFF
--- a/cpu/native/mtd/mtd_native.c
+++ b/cpu/native/mtd/mtd_native.c
@@ -58,7 +58,7 @@ static int _read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t size)
 
     DEBUG("mtd_native: read from page %" PRIu32 " count %" PRIu32 "\n", addr, size);
 
-    if (addr + size > mtd_size) {
+    if ((addr > mtd_size) || (size > (mtd_size - addr))) {
         return -EOVERFLOW;
     }
 
@@ -82,11 +82,11 @@ static int _write_page(mtd_dev_t *dev, const void *buff, uint32_t page, uint32_t
     DEBUG("mtd_native: write from page %" PRIx32 ", offset 0x%" PRIx32 " count %" PRIu32 "\n",
           page, offset, size);
 
-    if (page > dev->sector_count * dev->pages_per_sector) {
+    if (page >= (dev->sector_count * dev->pages_per_sector)) {
         return -EOVERFLOW;
     }
 
-    if (offset > dev->page_size) {
+    if (offset >= dev->page_size) {
         return -EOVERFLOW;
     }
 
@@ -116,7 +116,7 @@ static int _erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)
 
     DEBUG("mtd_native: erase from sector %" PRIu32 " count %" PRIu32 "\n", addr, size);
 
-    if (addr + size > mtd_size) {
+    if ((addr > mtd_size) || (size > (mtd_size - addr))) {
         return -EOVERFLOW;
     }
     if (((addr % sector_size) != 0) || ((size % sector_size) != 0)) {


### PR DESCRIPTION
### Contribution description.

The `addr + size` check could overflow, resulting in a size smaller than `mtd_size`. The rewritten form prevents that.

The `page` and `offset` checks did not take into account 0-based indexing.

I don't think that these issues are easily exploitable, given that other layers run on top of MTD.

### Testing procedure

There are no simple tests to validate this, but I believe the fixes are trivial:

* if `addr = 0xFFFFF000`, `size = 0x2000` and `mtd_size = 0x01000000`, then the computed sum is overflows and becomes `0x00001000`. This is smaller than `mtd_size`.
* `page` and `offset` are clearly use 0-based indexing, so comparing it to the number of pages and page size is incorrect.

### Issues/PRs references

I went through the list of open issues and found #21470. This PR does not fix it, but the issue popped up while analyzing it.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- Claude Code Sonnet 5 to find the issue.
