### PR TITLE
sys/event: fix thread safety issue

### DIFF
--- a/sys/event/event.c
+++ b/sys/event/event.c
@@ -73,12 +73,12 @@ bool event_is_queued(const event_queue_t *queue, const event_t *event)
 event_t *event_get(event_queue_t *queue)
 {
     unsigned state = irq_disable();
-    event_t *result = (event_t *) clist_lpop(&queue->event_list);
-    irq_restore(state);
-
+    event_t *result = container_of(clist_lpop(&queue->event_list), event_t, list_node);
     if (result) {
         result->list_node.next = NULL;
     }
+    irq_restore(state);
+
     return result;
 }
 


### PR DESCRIPTION
### Contribution description

`event_get()` needs to atomically remove the event from the list, which includes both `list_lpop()` and clearing the next ptr. This moves the `irq_restore()` down one statement to fix the issue.

Fixes https://github.com/RIOT-OS/RIOT/issues/22601

While at it, this also replaces the cast by a call of `container_of()` to get better type safety.

### Testing procedure

No change in behavior, other than a race condition gone

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/22601

### Declaration of AI-Tools / LLMs usage:

None