### PR TITLE
stm32/candev: change candev_stm32_isr flags to uint8_t

### DIFF
--- a/cpu/stm32/include/candev_stm32.h
+++ b/cpu/stm32/include/candev_stm32.h
@@ -152,9 +152,9 @@ typedef struct candev_stm32_rx_fifo {
 
 /** Internal interrupt flags */
 typedef struct candev_stm32_isr {
-    int isr_tx : 3;     /**< Tx mailboxes interrupt */
-    int isr_rx : 2;     /**< Rx FIFO interrupt */
-    int isr_wkup : 1;   /**< Wake up interrupt */
+    uint8_t isr_tx : 3;     /**< Tx mailboxes interrupt */
+    uint8_t isr_rx : 2;     /**< Rx FIFO interrupt */
+    uint8_t isr_wkup : 1;   /**< Wake up interrupt */
 } candev_stm32_isr_t;
 
 /** STM32 CAN device descriptor */

--- a/cpu/stm32/include/fdcandev_stm32.h
+++ b/cpu/stm32/include/fdcandev_stm32.h
@@ -388,9 +388,9 @@ typedef struct candev_stm32_rx_mailbox {
 
 /** Internal interrupt flags */
 typedef struct candev_stm32_isr {
-    int isr_tx : 3;     /**< Tx mailboxes interrupt */
-    int isr_rx : 2;     /**< Rx FIFO interrupt */
-    int isr_wkup : 1;   /**< Wake up interrupt */
+    uint8_t isr_tx : 3;     /**< Tx mailboxes interrupt */
+    uint8_t isr_rx : 2;     /**< Rx FIFO interrupt */
+    uint8_t isr_wkup : 1;   /**< Wake up interrupt */
 } candev_stm32_isr_t;
 
 /** STM32 CAN device descriptor */


### PR DESCRIPTION
### Contribution description

LLVM-17 has a new check that tests bitfields. For single bit integer values in bitfields, the only permitted values are `0` and `-1`, not `0` and `1`.





### Testing procedure

This is tested with the Resolute docker container that uses LLVM 17:
```
buechse@skyleaf:~/RIOTstuff/riot-fresh/RIOT$ docker run --tty -i --rm ca070cefc092 clang --version
Ubuntu clang version 17.0.6 (23ubuntu7)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```

Behavior on `master`:
```
buechse@skyleaf:~/RIOTstuff/riot-fresh/RIOT$ BOARD=nucleo-f767zi TOOLCHAIN=llvm BUILD_IN_DOCKER=1 DOCKER_IMAGE=ca070cefc092 make -C tests/drivers/candev/
make: Entering directory '/home/buechse/RIOTstuff/riot-fresh/RIOT/tests/drivers/candev'
Launching build container using image "ca070cefc092".
docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-fresh/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/buechse/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'    -e 'BOARD=nucleo-f767zi' -e 'TOOLCHAIN=llvm' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=periph_can' -e 'USEMODULE=can isrpipe shell' -e 'USEPKG='  -w '/data/riotbuild/riotbase/tests/drivers/candev/' 'ca070cefc092' make
Building application "tests_candev" for "nucleo-f767zi" with CPU "stm32".

"make" -C /data/riotbuild/riotbase/pkg/cmsis/
"make" -C /data/riotbuild/riotbase/pkg/mpaland-printf/
"make" -C /data/riotbuild/riotbase/build/pkg/mpaland-printf -f /data/riotbuild/riotbase/pkg/mpaland-printf/mpaland-printf.mk
"make" -C /data/riotbuild/riotbase/boards
"make" -C /data/riotbuild/riotbase/boards/common/init
"make" -C /data/riotbuild/riotbase/boards/nucleo-f767zi
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/core/lib
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
/data/riotbuild/riotbase/cpu/stm32/periph/classiccan.c:577:29: error: implicit truncation from 'int' to a one-bit wide bit-field changes value from 1 to -1 [-Werror,-Wsingle-bit-bitfield-constant-conversion]
  577 |     dev->isr_flags.isr_wkup = 1;
      |                             ^ ~
1 error generated.
make[3]: *** [/data/riotbuild/riotbase/Makefile.base:162: /data/riotbuild/riotbase/tests/drivers/candev/bin/nucleo-f767zi/periph/classiccan.o] Error 1
make[2]: *** [/data/riotbuild/riotbase/Makefile.base:31: ALL--/data/riotbuild/riotbase/cpu/stm32/periph] Error 2
make[1]: *** [/data/riotbuild/riotbase/Makefile.base:31: ALL--/data/riotbuild/riotbase/cpu/stm32] Error 2
make: *** [/data/riotbuild/riotbase/Makefile.include:751: application_tests_candev.module] Error 2
make: *** [/home/buechse/RIOTstuff/riot-fresh/RIOT/makefiles/docker.inc.mk:403: ..in-docker-container] Error 2
make: Leaving directory '/home/buechse/RIOTstuff/riot-fresh/RIOT/tests/drivers/candev'
```

Behavior with this PR:
```
buechse@skyleaf:~/RIOTstuff/riot-vanillaschote/RIOT$ BOARD=nucleo-f767zi TOOLCHAIN=llvm BUILD_IN_DOCKER=1 DOCKER_IMAGE=ca070cefc092 make -C tests/sys/conn_can
make: Entering directory '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT/tests/sys/conn_can'
Launching build container using image "ca070cefc092".
docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/buechse/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'    -e 'BOARD=nucleo-f767zi' -e 'TOOLCHAIN=llvm' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=' -e 'FEATURES_REQUIRED=periph_can periph_gpio_irq' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=auto_init_can can_isotp can_pm can_trx conn_can conn_can_isotp_multi ps shell_cmds_default tja1042' -e 'USEPKG='  -w '/data/riotbuild/riotbase/tests/sys/conn_can/' 'ca070cefc092' make
Building application "tests_conn_can" for "nucleo-f767zi" with CPU "stm32".

"make" -C /data/riotbuild/riotbase/pkg/cmsis/
"make" -C /data/riotbuild/riotbase/pkg/mpaland-printf/
"make" -C /data/riotbuild/riotbase/build/pkg/mpaland-printf -f /data/riotbuild/riotbase/pkg/mpaland-printf/mpaland-printf.mk
"make" -C /data/riotbuild/riotbase/boards
"make" -C /data/riotbuild/riotbase/boards/common/init
"make" -C /data/riotbuild/riotbase/boards/nucleo-f767zi
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/core/lib
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
...
"make" -C /data/riotbuild/riotbase/sys/ztimer
   text    data     bss     dec     hex filename
  41388     188   21440   63016    f628 /data/riotbuild/riotbase/tests/sys/conn_can/bin/nucleo-f767zi/tests_conn_can.elf
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT/tests/sys/conn_can'
```

### Issues/PRs references

Required for https://github.com/RIOT-OS/riotdocker/pull/286

### Declaration of AI-Tools / LLMs usage:


AI-Tools / LLMs that were used are:
- none
