### PR TITLE
makefiles: get rid of arch_efm32

### DIFF
--- a/cpu/efm32/Makefile.features
+++ b/cpu/efm32/Makefile.features
@@ -11,7 +11,6 @@ ifeq (,$(filter efm32hg efm32tg11b efm32zg, $(CPU_FAM)))
   FEATURES_PROVIDED += cortexm_mpu
 endif
 
-FEATURES_PROVIDED += arch_efm32
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_in_address_space

--- a/drivers/pca9685/Makefile.dep
+++ b/drivers/pca9685/Makefile.dep
@@ -3,4 +3,4 @@ FEATURES_REQUIRED += periph_i2c
 USEMODULE += xtimer
 
 # efm32 CPU doesn't support PWM_RIGHT
-FEATURES_BLACKLIST += arch_efm32
+FEATURES_BLACKLIST += cpu_efm32

--- a/features.yaml
+++ b/features.yaml
@@ -41,8 +41,6 @@ groups:
       help: CPU architecture is classic ARM (ARM7)
     - name: arch_avr8
       help: CPU architecture is AVR-8
-    - name: arch_efm32
-      help: FIXME. This is not an architecture. Use cpu_efm32 for this
     - name: arch_esp
       help: "CPU architecture is an ESP. (Fixme: This is not an architecture)"
     - name: arch_esp_xtensa

--- a/makefiles/features_existing.inc.mk
+++ b/makefiles/features_existing.inc.mk
@@ -9,7 +9,6 @@ FEATURES_EXISTING := \
     arch_arm \
     arch_arm7 \
     arch_avr8 \
-    arch_efm32 \
     arch_esp \
     arch_esp32 \
     arch_esp32_xtensa \

--- a/pkg/cryptoauthlib/Makefile.dep
+++ b/pkg/cryptoauthlib/Makefile.dep
@@ -18,7 +18,7 @@ endif
 
 # Some EFM32 CPU families define AES_COUNT, which is also defined by this
 # library.
-FEATURES_BLACKLIST += arch_efm32
+FEATURES_BLACKLIST += cpu_efm32
 
 ifneq (,$(filter psa_crypto,$(USEMODULE)))
   USEMODULE += psa_atca_driver

--- a/tests/cpu/efm32_features/Makefile
+++ b/tests/cpu/efm32_features/Makefile
@@ -1,14 +1,8 @@
 BOARD ?= sltb001a
 include ../Makefile.cpu_common
 
-BOARDS_SUPPORTED := ikea-tradfri \
-                   slstk3401a \
-                   slstk3402a \
-                   sltb001a \
-                   slwstk6000b-slwrb4150a \
-                   slwstk6000b-slwrb4162a \
-                   stk3600 \
-                   stk3700
+# this test application is expected to build for every EFM32-based board
+FEATURES_REQUIRED += cpu_efm32
 
 # see cpu/efm32/efm32-features.mk for the supported flags
 EFM32_LEUART_ENABLED = 0


### PR DESCRIPTION
### Contribution description

`arch_efm32` is not an architecture. As mentioned in `features.yaml`, it had to go. `cpu_efm32` should be used instead, which is also what #22643 used already.

While at it, I also modified `tests/cpu/efm32_features` to select on `cpu_efm32` instead of individual boards.

### Testing procedure

Boards and tests still compile.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- none