### PR TITLE
.bandit: remove codacy leftover

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,3 +1,0 @@
-# codacy:
-# Solve flagged valid Python "assert" statements
-skips: ['B101']


### PR DESCRIPTION
### Contribution description
It seems as if there was a bot called `codeacy_bot` that did Python reviews. It does not appear to be used anymore and this file is a leftover from that time and hasn't been touched since it was created 7 years ago in #11086.

### Testing procedure
Nothing I guess?

### Issues/PRs references
None.

### Declaration of AI-Tools / LLMs usage:
AI-Tools / LLMs that were used are:
- none