### PR TITLE
cpu/lpc1768: improve ethernet driver

### DIFF
--- a/cpu/lpc1768/Makefile.dep
+++ b/cpu/lpc1768/Makefile.dep
@@ -14,7 +14,6 @@ ifneq (,$(filter lpc1768_eth,$(USEMODULE)))
   USEMODULE += netdev_eth
   USEMODULE += netdev_new_api
   USEMODULE += ztimer_msec
-  USEMODULE += ztimer_usec
 endif
 
 include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/lpc1768/drivers/eth/eth_netdev.c
+++ b/cpu/lpc1768/drivers/eth/eth_netdev.c
@@ -100,8 +100,6 @@ static int _init(netdev_t *netdev)
 
 static int _send(netdev_t *netdev, const iolist_t *iolist)
 {
-    (void)netdev;
-
     TRACE("[eth-netdev] _send: sending packet, length=%" PRIuSIZE " bytes\n", iolist_size(iolist));
 
     netdev->event_callback(netdev, NETDEV_EVENT_TX_STARTED);

--- a/cpu/lpc1768/include/config.h
+++ b/cpu/lpc1768/include/config.h
@@ -36,10 +36,13 @@ extern "C" {
 #endif
 
 /**
- * @brief   Timeout for PHY operations, in microseconds.
+ * @brief   Timeout for PHY operations, in milliseconds.
+ *
+ * This is an absolute error timeout. Actual PHY operations are expected to
+ * complete in a few microseconds.
  */
-#ifndef CONFIG_LPC1768_ETH_PHY_TIMEOUT_US
-#  define CONFIG_LPC1768_ETH_PHY_TIMEOUT_US     1000U
+#ifndef CONFIG_LPC1768_ETH_PHY_TIMEOUT_MS
+#  define CONFIG_LPC1768_ETH_PHY_TIMEOUT_MS     1U
 #endif
 
 /**

--- a/cpu/lpc1768/include/drivers/lpc1768_eth_netdev.h
+++ b/cpu/lpc1768/include/drivers/lpc1768_eth_netdev.h
@@ -10,6 +10,8 @@
  * @ingroup     cpu_lpc1768_drivers
  * @ingroup     drivers_netdev
  *
+ * @brief       Driver for the LPC1768 Ethernet peripheral
+ *
  * ## Link State Events
  *
  * To enable Link Events, use the (pseudo) module `lpc1768_eth_link_up`. This

--- a/cpu/lpc1768/include/periph/eth.h
+++ b/cpu/lpc1768/include/periph/eth.h
@@ -6,7 +6,7 @@
 #pragma once
 
 /**
- * @ingroup     cpu_lpc1768
+ * @addtogroup  cpu_lpc1768_drivers_eth
  * @{
  *
  * @file
@@ -55,8 +55,8 @@ int lpc1768_eth_send(const iolist_t *iolist);
  *
  * Behaviour mirrors the netdev `recv()` contract:
  *  - `buf == NULL && max_len == 0`: return the length of the frame at head.
- *  - `buf == NULL && max_len > 0` : drop the head frame, return its length.
- *  - `buf != NULL`                : copy `min(len, max_len)` bytes into
+ *  - `buf == NULL && max_len > 0`:  drop the head frame, return its length.
+ *  - `buf != NULL`:                 copy `min(len, max_len)` bytes into
  *                                   @p buf, advance the ring, return the
  *                                   number of bytes copied.
  *

--- a/cpu/lpc1768/periph/Kconfig.eth
+++ b/cpu/lpc1768/periph/Kconfig.eth
@@ -15,12 +15,12 @@ config LPC1768_ETH_LINK_POLL_MS
     help
         Poll interval for checking the link state, in milliseconds.
 
-config LPC1768_ETH_PHY_TIMEOUT_US
+config LPC1768_ETH_PHY_TIMEOUT_MS
     int "PHY operations timeout"
     depends on CPU_MODEL_LPC1768 && USEMODULE_LPC1768_ETH
-    default 1000
+    default 1
     help
-        Timeout for PHY operations, in microseconds.
+        Timeout for PHY operations, in milliseconds.
 
 config LPC1768_ETH_RX_BUF_NUMOF
     int "Receive buffers"

--- a/cpu/lpc1768/periph/eth.c
+++ b/cpu/lpc1768/periph/eth.c
@@ -199,7 +199,7 @@ static void _filter_error_frames(void)
      * which is not an error, but only an indication that the frame exceeds
      * 1500 bytes */
     const uint32_t error_mask = RX_INFO_CRC_ERROR | RX_INFO_SYMBOL_ERROR | RX_INFO_ALIGNMENT_ERROR
-                              | RX_INFO_OVERRUN | RX_INFO_NO_DESCRIPTOR | RX_INFO_FAIL_FILTER;
+                                | RX_INFO_OVERRUN | RX_INFO_NO_DESCRIPTOR | RX_INFO_FAIL_FILTER;
 
     uint32_t produce = LPC_EMAC->RxProduceIndex;
     uint32_t consume = LPC_EMAC->RxConsumeIndex;
@@ -220,10 +220,10 @@ static void _filter_error_frames(void)
 
 static bool _mii_wait_idle(void)
 {
-    uint32_t start = ztimer_now(ZTIMER_USEC);
+    uint32_t start = ztimer_now(ZTIMER_MSEC);
 
     while (LPC_EMAC->MIND & MIND_BUSY) {
-        if (ztimer_now(ZTIMER_USEC) - start > CONFIG_LPC1768_ETH_PHY_TIMEOUT_US) {
+        if ((ztimer_now(ZTIMER_MSEC) - start) > CONFIG_LPC1768_ETH_PHY_TIMEOUT_MS) {
             DEBUG_PUTS("[eth] _mii_wait_idle: timeout");
             return false;
         }
@@ -282,7 +282,7 @@ static int _phy_detect(void)
 {
     uint16_t bmsr = _mii_read(MII_BMSR);
 
-    if (bmsr == 0x0000 || bmsr == 0xFFFF) {
+    if ((bmsr == 0x0000) || (bmsr == 0xFFFF)) {
         DEBUG_PUTS("[eth] _phy_detect: PHY not detected");
         return -EIO;
     }
@@ -414,7 +414,7 @@ int lpc1768_eth_init(const uint8_t *mac)
     _init_pins();
 
     LPC_EMAC->MAC1 = MAC1_RESET_TX | MAC1_RESET_MCS_TX | MAC1_RESET_RX | MAC1_RESET_MCS_RX
-                   | MAC1_SIMUL_RESET | MAC1_SOFT_RESET;
+                     | MAC1_SIMUL_RESET | MAC1_SOFT_RESET;
     LPC_EMAC->Command = COMMAND_REG_RESET | COMMAND_TX_RESET | COMMAND_RX_RESET;
 
     ztimer_sleep(ZTIMER_MSEC, 10);
@@ -459,7 +459,7 @@ int lpc1768_eth_init(const uint8_t *mac)
     /* configure interrupts */
     LPC_EMAC->IntClear = 0xFFFFFFFFUL;
     LPC_EMAC->IntEnable = INT_RX_DONE | INT_RX_OVERRUN | INT_RX_ERROR
-                        | INT_TX_DONE | INT_TX_UNDERRUN | INT_TX_ERROR;
+                          | INT_TX_DONE | INT_TX_UNDERRUN | INT_TX_ERROR;
 
     NVIC_ClearPendingIRQ(ENET_IRQn);
     NVIC_EnableIRQ(ENET_IRQn);
@@ -489,7 +489,7 @@ int lpc1768_eth_send(const iolist_t *iolist)
     size_t len = 0;
 
     for (const iolist_t *iol = iolist; iol; iol = iol->iol_next) {
-        if (len + iol->iol_len > LPC1768_ETH_BUF_LEN) {
+        if ((len + iol->iol_len) > LPC1768_ETH_BUF_LEN) {
             return -EOVERFLOW;
         }
         if (iol->iol_len) {
@@ -505,7 +505,7 @@ int lpc1768_eth_send(const iolist_t *iolist)
 
     /* start transmission */
     _tx_desc[produce].control = ((len - 1) & TX_CTRL_SIZE_MASK) | TX_CTRL_LAST | TX_CTRL_INT
-                              | TX_CTRL_PAD | TX_CTRL_CRC;
+                                | TX_CTRL_PAD | TX_CTRL_CRC;
     __DMB();
 
     /* store the index and length for status checking after transmission */
@@ -539,7 +539,7 @@ int lpc1768_eth_recv(void *buf, size_t max_len)
 
     DEBUG("[eth] lpc1768_eth_recv: frame length %d bytes\n", len);
 
-    if (buf == NULL && max_len == 0) {
+    if ((buf == NULL) && (max_len == 0)) {
         return len;
     }
 
@@ -670,7 +670,8 @@ int lpc1768_eth_start_auto_negotiation(void)
 
     /* advertise all capabilities and restart auto-negotiation */
     _mii_write(MII_ADVERTISE,
-               MII_ADVERTISE_10_F | MII_ADVERTISE_10_H | MII_ADVERTISE_100_F | MII_ADVERTISE_100_H);
+               MII_ADVERTISE_10_F | MII_ADVERTISE_10_H
+               | MII_ADVERTISE_100_F | MII_ADVERTISE_100_H);
     _mii_write(MII_BMCR, MII_BMCR_AN_ENABLE | MII_BMCR_AN_RESTART);
 
     return 0;


### PR DESCRIPTION
### Contribution description

The EFM32 ethernet driver, which is closely related, received additional feedback. This ports the same feedback to the LPC1768 ethernet driver too.


### Testing procedure

Most changes are header/styling related. The `ztimer_usec` replacement would require a board.

I ran `tests/drivers/lpc1768_eth` to check if the driver still initializes correctly, and here is some proof:

<img width="1962" height="1274" alt="Scherm­afbeelding 2026-09-03 om 22 56 53" src="https://github.com/user-attachments/assets/8e9c4200-744e-4973-b1ed-aa098b2d1d30" />


### Issues/PRs references

#22306 


### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- I classify @crasbe's sharp review skills as AI. Other than that, no AI was used.