### PR TITLE
drivers/mtd_emulated: fix _write_page

### DIFF
--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -253,6 +253,11 @@ struct mtd_desc {
      *
      * @p offset should not exceed the page size
      *
+     * A write may write fewer bytes than requested. A driver that maps to a
+     * memory with a page-wise write granularity writes at most up to the end
+     * of the page. The number of bytes written is returned, so that the caller
+     * can continue with the next page.
+     *
      * @param[in]  dev      Pointer to the selected driver
      * @param[out] buff     Pointer to the data to be written
      * @param[in]  page     Page number to start writing to

--- a/drivers/include/mtd_emulated.h
+++ b/drivers/include/mtd_emulated.h
@@ -13,6 +13,10 @@
  *
  * Helpers for using emulated MTDs.
  *
+ * The emulated MTD reproduces the programming behavior of a NOR flash.
+ * Programming a location can only clear bits, it can never set a bit from 0
+ * back to 1. The sector a location belongs to has to be erased for that.
+ *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  */
 

--- a/drivers/mtd_emulated/mtd_emulated.c
+++ b/drivers/mtd_emulated/mtd_emulated.c
@@ -126,7 +126,19 @@ int _write_page(mtd_dev_t *dev, const void *src,
         /* page addr + offset + size must not exceed the size of memory */
         return -EOVERFLOW;
     }
-    memcpy(mtd->memory + page_addr + offset, src, size);
+
+    /* a page program never wraps into the next page, so write at most up to
+     * the end of the page and leave the remainder to the caller */
+    size = MIN(size, mtd->base.page_size - offset);
+
+    /* emulate the programming behavior of a flash memory: bits can only be
+     * changed from 1 to 0 when writing */
+    uint8_t *dst = mtd->memory + page_addr + offset;
+    const uint8_t *bytes = src;
+
+    for (uint32_t i = 0; i < size; i++) {
+        dst[i] &= bytes[i];
+    }
 
     return size;
 }

--- a/tests/unittests/tests-mtd/tests-mtd.c
+++ b/tests/unittests/tests-mtd/tests-mtd.c
@@ -15,41 +15,52 @@
 
 #include "board.h"
 #include "mtd.h"
-
-#if MODULE_VFS
-#include <fcntl.h>
-#include <stdio.h>
-#include "vfs.h"
-#endif
-
-/* Define MTD_0 in board.h to use the board mtd if any */
-#ifdef MTD_0
-#define dev (MTD_0)
-#else
-
 #include "mtd_emulated.h"
 
-/* Test mock object implementing a simple RAM-based mtd */
+#if MODULE_VFS
+#  include <fcntl.h>
+#  include <stdio.h>
+#  include "vfs.h"
+#endif
+
+/* Test mock object using a mtd_emulated_t as the underlying device. */
 #ifndef SECTOR_COUNT
-#define SECTOR_COUNT 4
+#  define SECTOR_COUNT 4
 #endif
 #ifndef PAGE_PER_SECTOR
-#define PAGE_PER_SECTOR 4
+#  define PAGE_PER_SECTOR 4
 #endif
 #ifndef PAGE_SIZE
-#define PAGE_SIZE 128
+#  define PAGE_SIZE 128
 #endif
 
 MTD_EMULATED_DEV(0, SECTOR_COUNT, PAGE_PER_SECTOR, PAGE_SIZE);
 
-#define dev (&mtd_emulated_dev0.base)
-
-#endif /* MTD_0 */
+/**
+ * @brief   The device under test.
+ *
+ * The whole suite is run once per device, so that the emulated mtd is always
+ * covered, next to the mtd of the board, if any. */
+static mtd_dev_t *dev;
 
 static void setup_teardown(void)
 {
     mtd_erase(dev, 0, dev->pages_per_sector * dev->page_size);
 }
+
+static void setup_teardown_emulated(void)
+{
+    dev = &mtd_emulated_dev0.base;
+    setup_teardown();
+}
+
+#ifdef MTD_0
+static void setup_teardown_board(void)
+{
+    dev = MTD_0;
+    setup_teardown();
+}
+#endif /* MTD_0 */
 
 static void test_mtd_init(void)
 {
@@ -165,7 +176,6 @@ static void test_mtd_write_read(void)
     TEST_ASSERT_EQUAL_INT(0, ret);
 }
 
-#ifdef MTD_0
 static void test_mtd_write_read_flash(void)
 {
     const uint8_t buf1[] = {0xee, 0xdd, 0xcc};
@@ -175,7 +185,8 @@ static void test_mtd_write_read_flash(void)
     char buf_read[sizeof(buf_expected) + sizeof(buf_empty)];
     memset(buf_read, 0, sizeof(buf_read));
 
-    /* Test flash AND behavior. This test will fail if the mtd is not a flash */
+    /* Test flash AND behavior: programming a location a second time may only
+     * clear bits, it may never set a bit from 0 back to 1. */
 
     /* Basic write / read */
     int ret = mtd_write(dev, buf1, 0, sizeof(buf1));
@@ -188,7 +199,6 @@ static void test_mtd_write_read_flash(void)
     TEST_ASSERT_EQUAL_INT(0, memcmp(buf_expected, buf_read, sizeof(buf_expected)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(buf_empty, buf_read + sizeof(buf_expected), sizeof(buf_empty)));
 }
-#endif
 
 #if MODULE_VFS
 static void test_mtd_vfs(void)
@@ -219,28 +229,40 @@ static void test_mtd_vfs(void)
 }
 #endif
 
-Test *tests_mtd_tests(void)
-{
-    EMB_UNIT_TESTFIXTURES(fixtures) {
-        new_TestFixture(test_mtd_init),
-        new_TestFixture(test_mtd_erase),
-        new_TestFixture(test_mtd_write_erase),
-        new_TestFixture(test_mtd_write_read),
-#ifdef MTD_0
-        new_TestFixture(test_mtd_write_read_flash),
-#endif
+EMB_UNIT_TESTFIXTURES(fixtures) {
+    new_TestFixture(test_mtd_init),
+    new_TestFixture(test_mtd_erase),
+    new_TestFixture(test_mtd_write_erase),
+    new_TestFixture(test_mtd_write_read),
+    new_TestFixture(test_mtd_write_read_flash),
 #if MODULE_VFS
-        new_TestFixture(test_mtd_vfs),
+    new_TestFixture(test_mtd_vfs),
 #endif
-    };
+};
 
-    EMB_UNIT_TESTCALLER(mtd_tests, setup_teardown, setup_teardown, fixtures);
+static Test *tests_mtd_emulated_tests(void)
+{
+    EMB_UNIT_TESTCALLER(mtd_emulated_tests, setup_teardown_emulated,
+                        setup_teardown_emulated, fixtures);
 
-    return (Test *)&mtd_tests;
+    return (Test *)&mtd_emulated_tests;
 }
+
+#ifdef MTD_0
+static Test *tests_mtd_board_tests(void)
+{
+    EMB_UNIT_TESTCALLER(mtd_board_tests, setup_teardown_board,
+                        setup_teardown_board, fixtures);
+
+    return (Test *)&mtd_board_tests;
+}
+#endif
 
 void tests_mtd(void)
 {
-    TESTS_RUN(tests_mtd_tests());
+    TESTS_RUN(tests_mtd_emulated_tests());
+#ifdef MTD_0
+    TESTS_RUN(tests_mtd_board_tests());
+#endif
 }
 /** @} */


### PR DESCRIPTION
### Contribution description

The `_write_page` implementation used a regular `memcpy`, without emulating the behavior of a real flash memory device. This hid an issue where memory writes could change bits from 0 to 1 without erasing.

Exactly this test was disabled in `tests/unittests/tests-mtd` for emulated MTD, so it got unnoticed.

Similar to other MTD drivers, also clamp the size to not exceed the page size.

The file systems tests still work, because they properly erase before writing. But this is more correct.


### Testing procedure

The unit tests can be invoked with `make -C tests/unittests tests-mtd`. Since the change only affect emulated memory, it should work on any board. Other MTD implementations are not affects and still run as they would.


### Issues/PRs references

#22646.


### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- Claude Code Sonnet 5 to find the issue and propose a fix. I spent time to refactor, understand and test the changes.
