### PR TITLE
pkg/ubasic: disable qualifier warning for LLVM, deprecate package

### DIFF
--- a/pkg/ubasic/Makefile
+++ b/pkg/ubasic/Makefile
@@ -3,6 +3,10 @@ PKG_URL=https://github.com/adamdunkels/ubasic
 PKG_VERSION=cc07193c231e21ecb418335aba5b199a08d4685c
 PKG_LICENSE=BSD-3-Clause
 
+include $(RIOTBASE)/makefiles/color.inc.mk
+
+$(call echowarn,("pkg/ubasic is deprecated and will be removed after the 2027.04 Release!"))
+
 include $(RIOTBASE)/pkg/pkg.mk
 
 UBASIC_MODULES   = ubasic_tests

--- a/pkg/ubasic/doc.md
+++ b/pkg/ubasic/doc.md
@@ -1,0 +1,10 @@
+@defgroup pkg_ubasic uBASIC interpreter
+@ingroup  pkg
+@brief    A really tiny BASIC interpreter
+@see      http://dunkels.com/adam/ubasic/
+
+This was added as an April Fools Joke in 2019, but the underlying project has
+not been maintained or updated since ~2014.
+
+This package is deprecated and will be removed after the 2027.04 Release.
+If you are actually using it, please raise your voice!

--- a/pkg/ubasic/doc.txt
+++ b/pkg/ubasic/doc.txt
@@ -1,6 +1,0 @@
-/**
- * @defgroup pkg_ubasic uBASIC interpreter
- * @ingroup  pkg
- * @brief    A really tiny BASIC interpreter
- * @see      http://dunkels.com/adam/ubasic/
- */

--- a/pkg/ubasic/ubasic.mk
+++ b/pkg/ubasic/ubasic.mk
@@ -1,8 +1,9 @@
 MODULE = ubasic
 
 # some toolchains complain about the usage of isdigit with a pointer in the
-# tokenizer
+# tokenizer as well as setting a non-const pointer with strchr
 CFLAGS += -Wno-char-subscripts
+CFLAGS += -Wno-discarded-qualifiers
 
 SRC := tokenizer.c ubasic.c
 NO_AUTO_SRC := 1


### PR DESCRIPTION
### Contribution description

LLVM 17 introduced another check that causes an issue with the `ubasic` package. Since this would have to be fixed in upstream code, we just disable the warning to get it to compile.

### Testing procedure

Without the fix it doesn't compile, with the fix it does:

```
buechse@skyleaf:~/RIOTstuff/riot-vanillaschote/RIOT$ BOARD=native64 BUILD_IN_DOCKER=1 DOCKER_IMAGE=5ebf563ef282 make -C tests/pkg/ubasic/
make: Entering directory '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT/tests/pkg/ubasic'
Launching build container using image "5ebf563ef282".
docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/buechse/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'    -e 'BOARD=native64' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=test_utils_print_stack_usage' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=printf_float ubasic_tests' -e 'USEPKG=ubasic'  -w '/data/riotbuild/riotbase/tests/pkg/ubasic/' '5ebf563ef282' make
Building application "tests_ubasic" for "native64" with CPU "native".

Cloning into '/data/riotbuild/riotbase/build/pkg/ubasic'...
done.
HEAD is now at cc07193 Merge pull request #1 from dbohdan/master
"make" -C /data/riotbuild/riotbase/pkg/ubasic/
"make" -f /data/riotbuild/riotbase/pkg/ubasic/ubasic_tests.mk -C /data/riotbuild/riotbase/build/pkg/ubasic
"make" -f /data/riotbuild/riotbase/pkg/ubasic/ubasic.mk -C /data/riotbuild/riotbase/build/pkg/ubasic
/data/riotbuild/riotbase/build/pkg/ubasic/tokenizer.c: In function ‘tokenizer_string’:
/data/riotbuild/riotbase/build/pkg/ubasic/tokenizer.c:238:14: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
  238 |   string_end = strchr(ptr + 1, '"');
      |              ^
cc1: all warnings being treated as errors
make[2]: *** [/data/riotbuild/riotbase/Makefile.base:162: /data/riotbuild/riotbase/tests/pkg/ubasic/bin/native64/ubasic/tokenizer.o] Error 1
make[1]: *** [Makefile:18: ubasic] Error 2
make: *** [/data/riotbuild/riotbase/Makefile.include:815: pkg-build] Error 2
make: *** [/home/buechse/RIOTstuff/riot-vanillaschote/RIOT/makefiles/docker.inc.mk:403: ..in-docker-container] Error 2
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT/tests/pkg/ubasic'
```

```
buechse@skyleaf:~/RIOTstuff/riot-vanillaschote/RIOT$ BOARD=native64 BUILD_IN_DOCKER=1 DOCKER_IMAGE=5ebf563ef282 make -C tests/pkg/ubasic/
make: Entering directory '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT/tests/pkg/ubasic'
Launching build container using image "5ebf563ef282".
docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/buechse/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'    -e 'BOARD=native64' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=test_utils_print_stack_usage' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=printf_float ubasic_tests' -e 'USEPKG=ubasic'  -w '/data/riotbuild/riotbase/tests/pkg/ubasic/' '5ebf563ef282' make
Building application "tests_ubasic" for "native64" with CPU "native".

"make" -C /data/riotbuild/riotbase/pkg/ubasic/
"make" -f /data/riotbuild/riotbase/pkg/ubasic/ubasic_tests.mk -C /data/riotbuild/riotbase/build/pkg/ubasic
"make" -f /data/riotbuild/riotbase/pkg/ubasic/ubasic.mk -C /data/riotbuild/riotbase/build/pkg/ubasic
"make" -C /data/riotbuild/riotbase/boards
...
"make" -C /data/riotbuild/riotbase/sys/test_utils/print_stack_usage
/usr/bin/x86_64-linux-gnu-ld.bfd: warning: /data/riotbuild/riotbase/tests/pkg/ubasic/bin/native64/tests_ubasic.elf has a LOAD segment with RWX permissions
   text    data     bss     dec     hex filename
  38205    1408   59480   99093   18315 /data/riotbuild/riotbase/tests/pkg/ubasic/bin/native64/tests_ubasic.elf
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanillaschote/RIOT/tests/pkg/ubasic'
```


### Issues/PRs references
Required for https://github.com/RIOT-OS/riotdocker/pull/286

### Declaration of AI-Tools / LLMs usage:
AI-Tools / LLMs that were used are:
- none