### PR TITLE
makefiles: make FEATURES_BLACKLIST work on cpu_%

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -406,13 +406,6 @@ include $(RIOTMAKE)/defaultmodules_regular.inc.mk
 # Include Kconfig functionalities
 include $(RIOTMAKE)/kconfig.mk
 
-# always select provided architecture features
-FEATURES_REQUIRED += $(filter arch_%,$(FEATURES_PROVIDED))
-# always select CPU core features
-FEATURES_REQUIRED += $(filter cpu_core_%,$(FEATURES_PROVIDED))
-# always "select" bug affecting the current build
-FEATURES_REQUIRED += $(filter bug_%,$(FEATURES_PROVIDED))
-
 # check if required features are provided and update $(FEATURES_USED)
 include $(RIOTMAKE)/features_check.inc.mk
 

--- a/makefiles/features_check.inc.mk
+++ b/makefiles/features_check.inc.mk
@@ -1,5 +1,11 @@
 # Check if all required FEATURES are provided
 
+# Features that are required for every build. Please only add entries if it is
+# absolutely necessary.
+FEATURES_REQUIRED += $(filter arch_%,$(FEATURES_PROVIDED)) # Architectural features
+FEATURES_REQUIRED += $(filter bug_%,$(FEATURES_PROVIDED)) # Bugs that might affect the build
+FEATURES_REQUIRED += $(filter cpu_%,$(FEATURES_PROVIDED)) # CPU and CPU Core features
+
 # Features that are used without taking "one out of" dependencies into account
 FEATURES_USED_SO_FAR := $(sort $(FEATURES_REQUIRED) $(FEATURES_OPTIONAL_USED))
 

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -32,10 +32,6 @@ ifneq (, $(filter info-boards-collect,$(MAKECMDGOALS)))
   FEATURES_USED :=
 
   include $(RIOTBASE)/Makefile.features
-  # always select provided architecture features
-  FEATURES_REQUIRED += $(filter arch_%,$(FEATURES_PROVIDED))
-  # always select CPU core features
-  FEATURES_REQUIRED += $(filter cpu_core_%,$(FEATURES_PROVIDED))
   # FEATURES_USED must be populated first in this case so that dependency
   # resolution can take optional features into account during the first pass.
   # Also: This allows us to skip resolution if already a missing feature is


### PR DESCRIPTION
### Contribution description

By making the `cpu_%` feature required, `FEATURES_BLACKLIST` will work.

This is duplicated on more places, so move this check to `features_check.inc.mk`.


### Testing procedure

This isn't used, but can be tested easily. All boards should still build nonetheless.

I've modified `tests/cpu/efm32_info` for this, and changed `FEATURES_REQUIRED` in `FEATURES_BLACKLIST`. Compilation will not work anymore.

```
basilfx:efm32_info/ (feature/cpu_feature_required✗) $ BOARD=stk3600 make -j14
Some feature requirements are blacklisted: cpu_efm32
```

Then running `BOARD=pro-micro-nrf52840 make info-build` for that example (the default is an EFM32-based board) will show that the feature is properly detected for blacklisting.

```
...
FEATURES_MISSING (only non optional features):
         -none-
FEATURES_BLACKLIST (blacklisted features):
         arch_avr8 arch_esp cpu_efm32
FEATURES_USED_BLACKLISTED (used but blacklisted features):
         -none-
...
```


### Issues/PRs references

Split of #22651.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- none