### PR TITLE
cpu/efm32: improve PWM driver

### DIFF
--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -455,7 +455,7 @@ typedef struct {
 typedef enum {
     PWM_LEFT = timerModeUp,           /**< use left aligned PWM */
     PWM_RIGHT = timerModeDown,        /**< use right aligned PWM */
-    PWM_CENTER = timerModeUp          /**< not supported, use left aligned */
+    PWM_CENTER = timerModeUpDown      /**< use center aligned PWM */
 } pwm_mode_t;
 /** @} */
 #endif /* ndef DOXYGEN */

--- a/cpu/efm32/periph/pwm.c
+++ b/cpu/efm32/periph/pwm.c
@@ -65,6 +65,14 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
 
     init_channel.mode = timerCCModePWM;
 
+    if (mode == PWM_RIGHT) {
+        /* down counting sets the output at the start of the period and clears
+         * it on compare match, so the output has to be inverted to obtain a
+         * right aligned pulse with the requested duty cycle. */
+        init_channel.coist = true;
+        init_channel.outInvert = true;
+    }
+
     for (int i = 0; i < pwm_config[dev].channels; i++) {
         pwm_chan_conf_t channel = pwm_config[dev].channel[i];
 

--- a/cpu/efm32/periph/pwm.c
+++ b/cpu/efm32/periph/pwm.c
@@ -37,9 +37,12 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
     CMU_ClockEnable(cmuClock_HFPER, true);
     CMU_ClockEnable(pwm_config[dev].cmu, true);
 
+    /* in up/down counting mode a full period takes twice the number of ticks */
+    uint32_t ticks = (mode == PWM_CENTER) ? ((uint32_t)res * 2) : (uint32_t)res;
+
     /* calculate the prescaler by determining the best prescaler */
     uint32_t freq_timer = CMU_ClockFreqGet(pwm_config[dev].cmu);
-    TIMER_Prescale_TypeDef prescaler = TIMER_PrescalerCalc(freq * res,
+    TIMER_Prescale_TypeDef prescaler = TIMER_PrescalerCalc(freq * ticks,
                                                            freq_timer);
 
     if (prescaler > timerPrescale1024) {
@@ -84,7 +87,7 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
     /* enable peripheral */
     TIMER_Enable(pwm_config[dev].dev, true);
 
-    return freq_timer / TIMER_Prescaler2Div(prescaler) / res;
+    return freq_timer / TIMER_Prescaler2Div(prescaler) / ticks;
 }
 
 uint8_t pwm_channels(pwm_t dev)


### PR DESCRIPTION
### Contribution description

Trying to fix the real problem on why [this driver](https://github.com/RIOT-OS/RIOT/blob/master/drivers/pca9685/Makefile.dep) marks EFM32 as unsupported (the comment is wrong), I stumbled upon two things:

- `PWM_CENTER` is actually supported (counting up-down-up)
- `PWM_RIGHT` was inverted.

I guess that me from ten years ago did not understand this.

### Testing procedure

I used the `tests/periph/pwm` application to test this, together with an STK3600 that maps a single PWM channel to the onboard LED. I then used a scope to verify the period and frequency, measured at the onboard LED.

```
> init 0 0 1000 4096
The pwm frequency is set to 1464
>
> set 0 0 1024
>
> init 0 1 1000 4096
The pwm frequency is set to 1464
>
> set 0 0 1024
>
> init 0 2 1000 4096
The pwm frequency is set to 1464
>
> set 0 0 1024
>
```

Without this PR, you will notice that the onboard led is brighter in `PWM_RIGHT` mode, because it is inverted. The scope screenshot for the unfixed `PWM_RIGHT` shows this.

The scope screenshots below will not tell you if left, right or center alignment is working correctly (I don't know how to measure this easily). But it will show you that the frequency and period remains correct (requested 1000 Hz, got ~1500 Hz).

<details>
<summary>PWM_LEFT @ 25%</summary>
<img width="800" height="480" alt="DS1Z_QuickPrint13" src="https://github.com/user-attachments/assets/f3ac9e39-4df7-4c33-836a-88a07ff20335" />
</details>

<details>
<summary>PWM_RIGHT (UNFIXED) @ 25%</summary>
<img width="800" height="480" alt="DS1Z_QuickPrint14" src="https://github.com/user-attachments/assets/6a22d4e5-76a6-4244-93f0-834322b53f79" />
</details>

<details>
<summary>PWM_RIGHT (FIXED) @ 25%</summary>
<img width="800" height="480" alt="DS1Z_QuickPrint16" src="https://github.com/user-attachments/assets/76477d72-9642-4ae2-b61a-083bc5c328f3" />
</details>

<details>
<summary>PWM_CENTER @ 25%</summary>
<img width="800" height="480" alt="DS1Z_QuickPrint15" src="https://github.com/user-attachments/assets/737279d5-416a-43f1-bfe1-275908daa4f2" />
</details>


### Issues/PRs references

#22651 lead to this.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- Claude Sonnet 5 helped me to understand, then I fixed it myself.