### PR TITLE
cpu/efm32: remove unsupported where now supported

### DIFF
--- a/drivers/pca9685/Makefile.dep
+++ b/drivers/pca9685/Makefile.dep
@@ -1,6 +1,3 @@
 FEATURES_REQUIRED += periph_gpio
 FEATURES_REQUIRED += periph_i2c
 USEMODULE += xtimer
-
-# efm32 CPU doesn't support PWM_RIGHT
-FEATURES_BLACKLIST += cpu_efm32

--- a/pkg/cryptoauthlib/Makefile.dep
+++ b/pkg/cryptoauthlib/Makefile.dep
@@ -16,10 +16,6 @@ ifneq (,$(filter cryptoauthlib_test,$(USEMODULE)))
   USEMODULE += cryptoauthlib_test_third_party_unity
 endif
 
-# Some EFM32 CPU families define AES_COUNT, which is also defined by this
-# library.
-FEATURES_BLACKLIST += cpu_efm32
-
 ifneq (,$(filter psa_crypto,$(USEMODULE)))
   USEMODULE += psa_atca_driver
 endif

--- a/tests/pkg/cryptoauthlib_compare_sha256/Makefile
+++ b/tests/pkg/cryptoauthlib_compare_sha256/Makefile
@@ -2,11 +2,6 @@ BOARD ?= nucleo-f767zi
 
 include ../Makefile.pkg_common
 
-# Test fails to build for these boards fails due to
-# redefinition of define AES_COUNT in library, which
-# is also defined in efm32 header files
-BOARDS_UNSUPPORTED := stk3200 stk3600 stk3700
-
 USEPKG += cryptoauthlib
 USEMODULE += hashes
 

--- a/tests/pkg/cryptoauthlib_internal-tests/Makefile
+++ b/tests/pkg/cryptoauthlib_internal-tests/Makefile
@@ -3,10 +3,6 @@ BOARD ?= nucleo-f767zi
 include ../Makefile.pkg_common
 
 CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(3*THREAD_STACKSIZE_DEFAULT\)
-# Test fails to build for these boards fails due to
-# redefinition of define AES_COUNT in library, which
-# is also defined in board header files
-BOARDS_UNSUPPORTED := stk3200 stk3600 stk3700
 
 # Native boards are blacklisted due to a bug in cryptoauthlib's cmd-processor.c
 # The file checks for __linux__ before checking for RIOT_APPLICATION, causing it

--- a/tests/pkg/cryptoauthlib_internal-tests/Makefile.ci
+++ b/tests/pkg/cryptoauthlib_internal-tests/Makefile.ci
@@ -31,6 +31,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     seeedstudio-gd32 \
     sipeed-longan-nano \
     sipeed-longan-nano-tft \
+    slstk3400a \
+    stk3200 \
     stm32f7508-dk \
     zigduino \
     #


### PR DESCRIPTION
### Contribution description

The following packages/drivers were disabled for the whole EFM32 family:

- `pkg/cryptoauthlib` seems to work on EFM32.
- `drivers/pca9685` did not compile, but #22665 fixes that.

### Testing procedure

Build should pass.

### Issues/PRs references

Split off #22651, depends on #22665.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- none
