### PR TITLE
.murdock: skip unnecessary make clean

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -354,7 +354,9 @@ compile() {
     # set build directory. CI ensures only one build at a time in $(pwd).
     export BINDIR="$(pwd)/build"
 
-    # Pre-build cleanup
+    # pre-build cleanup: this is effectively a superset of "make clean" that
+    # will not cost a full parse of the build system as well as one sub-make
+    # per package.
     rm -rf ${BINDIR}
 
     print_worker
@@ -368,7 +370,6 @@ compile() {
     # reduces disk IO.
     export CCACHE_TEMPDIR="$(pwd)/.ccache/tmp"
 
-    BOARD=${board} make -C${appdir} clean
     CCACHE_BASEDIR="$(pwd)" BOARD=$board TOOLCHAIN=$toolchain RIOT_CI_BUILD=1 \
         make -C${appdir} all test-input-hash -j${JOBS:-4}
     RES=$?


### PR DESCRIPTION
### Contribution description

Murdock sets `BINDIR` to `$(pwd)/build`, so any artifact built should be created in here. Before compilation starts, Murdock cleans this folder with a `rm -rf {BINDIR}`. `BINDIR` is also the folder where package sources are stored, which are not removed using `make clean`.

This means that `rm -rf {BINDIR}` does more than `make clean` does, so it can be omitted to save many Makefile calls.

The assumption here is that all sources are built inside `BINDIR` (some tools excluded, intentional). This is not always the case:

```
# clean the repository (not: this will also clean anything you ignored)
git clean -fxd

touch /tmp/stamp

# rpi-pico builds pkg/picosdk
BINDIR="$(pwd)/build" BOARD=rpi-pico make -C examples/advanced/pio_blink

# This shows everything newer that is not in the build folder.
find . -newer /tmp/stamp -not -path "./build/*" -not -path "./.git/*" -type f
```

will output:

```
./examples/advanced/pio_blink/rpx0xx_pio_blink/blink.pio.h
./pkg/picosdk/pioasm
```

However, if we run `make clean` afterwards:

```
BOARD=rpi-pico make -C examples/advanced/pio_blink clean

# This shows everything newer that is not in the build folder.
find . -newer /tmp/stamp -not -path "./build/*" -not -path "./.git/*" -type f
```

Then these files are still there, which shows that this is a separate issue:

```
./examples/advanced/pio_blink/rpx0xx_pio_blink/blink.pio.h
./pkg/picosdk/pioasm
```

### Testing procedure

Murdock is happy.

### Issues/PRs references

#22669

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- Claude Code Opus 5 provided this suggestion and a way to test this.
