### PR TITLE
sys/shell: Initial bplib shell command

### DIFF
--- a/examples/networking/dtn/bplib_cla_ble/Makefile
+++ b/examples/networking/dtn/bplib_cla_ble/Makefile
@@ -48,6 +48,7 @@ else
 endif
 
 USEMODULE += shell
+USEMODULE += shell_cmd_bplib
 USEMODULE += shell_cmd_ps
 
 CFLAGS += -DCONFIG_NIMBLE_AUTOADV_DEVICE_NAME='"DTN_ble-cla"'

--- a/examples/networking/dtn/bplib_cla_ble/README.md
+++ b/examples/networking/dtn/bplib_cla_ble/README.md
@@ -14,7 +14,7 @@ MAC address to connect to should also be set with the `REMOTE` flag.
 
 So either `make all ROLE=client REMOTE=d8:6b:d5:e9:ca:99` or `make all ROLE=server`.
 
-When both devices are running, bundles can be exchanged by using the `bp` shell command.
+When both devices are running, bundles can be exchanged by using the `bplib` shell command.
 
 In this version no storage is used (`bplib_stor_void`) and bundles that cannot be
 delivered immediately will be dropped. <br>

--- a/examples/networking/dtn/bplib_cla_ble/main.c
+++ b/examples/networking/dtn/bplib_cla_ble/main.c
@@ -105,19 +105,6 @@ static void _config_nc(void)
     bplib_contact_set_out_addr(0, BPLIB_EXAMPLE_REMOTE, 0);
 }
 
-static int _bp(int argc, char **argv)
-{
-    if (argc != 3) {
-        printf("Usage: bp <channel> <message>\n");
-        return 1;
-    }
-
-    BPLib_PI_Ingress(&bplib_instance_data.BPLibInst, atoi(argv[1]), argv[2], strlen(argv[2]));
-
-    return 0;
-}
-SHELL_COMMAND(bp, "Send BP Test Bundles", _bp);
-
 int main(void)
 {
     int rv = bplib_init();

--- a/examples/networking/dtn/bplib_cla_udp/Makefile
+++ b/examples/networking/dtn/bplib_cla_udp/Makefile
@@ -48,6 +48,7 @@ endif
 CFLAGS += -DBPLIB_LOCAL_EID_NODE_NUM=$(LOCAL_EID_NODE)
 
 USEMODULE += shell
+USEMODULE += shell_cmd_bplib
 USEMODULE += shell_cmd_ps
 USEMODULE += shell_cmd_gnrc_netif
 

--- a/examples/networking/dtn/bplib_cla_udp/README.md
+++ b/examples/networking/dtn/bplib_cla_udp/README.md
@@ -46,7 +46,7 @@ To test simple loopback, nothing needs to be changed, the flags will default
 to the loopback. Simply compile with `make all term`. Make sure a tap device is
 available, since it tries to bind to one anyways.
 
-When using the `bp send 0 "[DATA]"` shell command, the data you entered goes though bplib's
+When using the `bplib send 0 "[DATA]"` shell command, the data you entered goes though bplib's
 internal delivery, since the current node is the destination. The data is never
 passed through gnrc in this case.
 
@@ -67,7 +67,7 @@ make all term PORT=tap0 REMOTE=fe80::d8af:c5ff:febc:a409 LOCAL_EID_NODE=100 REMO
 make all term PORT=tap1 REMOTE=fe80::4832:95ff:feb7:5161 LOCAL_EID_NODE=200 REMOTE_EID_NODE=100
 ```
 
-When running `bp send 0 "[DATA]"` now, the bundle should be delivered to the other instance.
+When running `bplib send 0 "[DATA]"` now, the bundle should be delivered to the other instance.
 Now, data goes through bplib, through gnrc, which sends the bundles as UDP payload.
 The other device receives this and passes it to bplib again, which can deliver it,
 since the channel is active
@@ -75,16 +75,17 @@ since the channel is active
 #### Disruption simulation
 
 Since DTN is made for disruptions and thus employs a storage, this can be tested
-as well in this example. On one (or both) of the nodes, run `bp contact 0 0` to
+as well in this example. On one (or both) of the nodes, run `bplib contact 0 stop` to
 set the contact 0 into the stopped state. In the normal startup in this example
-it will get put into the started state. Now bplib must assume that the contact
-cannot currently serve its destinations.
+it will get put into the started state. You can verify this with `bplib contact 0`
+to get the current state the contact is in. Now in the stopped state bplib must
+assume that the contact cannot currently serve its destinations.
 
-Bundles that are sent *now* with `bp send 0 "[DATA]"` will not be received by the
+Bundles that are sent *now* with `bplib send 0 "[DATA]"` will not be received by the
 other device. Instead, they are placed into the *storage*, which on native is located
 in the `native` subfolder of this example.
 
-When this disruption is over, the contact can be re-enabled with `bp contact 0 1`.
+When this disruption is over, the contact can be re-enabled with `bplib contact 0 start`.
 After some timeout, the bundles will be pulled from storage and are received at
 device B.
 
@@ -115,7 +116,7 @@ This can be seen in Wireshark. The back and forth forwarding of the bundle here
 only stops, because the Hop Limit block is added and the bundle is deleted after
 the specified number of hops (10) is reached.
 
-To now simulate the third node, stop the contact on device B with `bp contact 0 0`
+To now simulate the third node, stop the contact on device B with `bplib contact 0 stop`
 and send a new bundle from A.
 Now in Wireshark, only one bundle is sent and it is stored in the storage of B (`native200/`).
 
@@ -126,7 +127,7 @@ number of the destination that A had previously:
 make all term PORT=tap0 REMOTE=fe80::d8af:c5ff:febc:a409 LOCAL_EID_NODE=300 REMOTE_EID_NODE=100
 ```
 
-When the contact is now enabled again on device B (`bp contact 0 1`), node A, which
+When the contact is now enabled again on device B (`bplib contact 0 start`), node A, which
 now is a different node in the bundle context, receives the bundle after it is pulled
 from the storage of B.
 

--- a/examples/networking/dtn/bplib_cla_udp/main.c
+++ b/examples/networking/dtn/bplib_cla_udp/main.c
@@ -102,33 +102,6 @@ static void _config_nc(void)
     bplib_contact_set_in_addr(0, BPLIB_EXAMPLE_IP_LOCAL, BPLIB_EXAMPLE_PORT);
 }
 
-static int _bp(int argc, char **argv)
-{
-    if (argc != 4) {
-        puts("Usage: bp send <channel> <message>\n"
-             "       bp contact <contact> [0|1]");
-        return 1;
-    }
-
-    int c = atoi(argv[2]);
-
-    if (strcmp(argv[1], "send") == 0) {
-        BPLib_PI_Ingress(&bplib_instance_data.BPLibInst, c, argv[3], strlen(argv[3]));
-    }
-    else if (strcmp(argv[1], "contact") == 0) {
-        int action = atoi(argv[3]);
-        if (action) {
-            BPLib_CLA_ContactStart(c);
-        }
-        else {
-            BPLib_CLA_ContactStop(c);
-        }
-    }
-
-    return 0;
-}
-SHELL_COMMAND(bp, "Send BP Test Bundles / Change contact state", _bp);
-
 int main(void)
 {
     int rv = bplib_init();

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -478,6 +478,7 @@ PSEUDOMODULES += shell_builtin_cmd_help_json
 PSEUDOMODULES += shell_cmd_app_metadata
 PSEUDOMODULES += shell_cmd_at30tse75x
 PSEUDOMODULES += shell_cmd_benchmark_udp
+PSEUDOMODULES += shell_cmd_bplib
 PSEUDOMODULES += shell_cmd_ccn-lite-utils
 PSEUDOMODULES += shell_cmd_conn_can
 PSEUDOMODULES += shell_cmd_cord_ep

--- a/pkg/bplib/doc.md
+++ b/pkg/bplib/doc.md
@@ -92,6 +92,13 @@ Also the generic bplib config options from [bplib]/inc/bplib_cfg.h. These are cu
 The defaults, i.e. not using `bplib_include_nc_telemetry` and
 `bplib_include_as` save more than 20KB of application size.
 
+## Related Modules
+
+`USEMODULE += shell_cmd_bplib` provides a convenient shell command for configuration
+of bplib. See @ref sys_shell_commands_bplib for more information.
+
+## Related Information
+
 @see https://datatracker.ietf.org/doc/html/rfc9171
 
 @see https://github.com/nasa/bplib

--- a/sys/shell/Makefile.dep
+++ b/sys/shell/Makefile.dep
@@ -15,6 +15,9 @@ ifneq (,$(filter shell_cmds_default,$(USEMODULE)))
   ifneq (,$(filter benchmark_udp,$(USEMODULE)))
     USEMODULE += shell_cmd_benchmark_udp
   endif
+  ifneq (,$(filter bplib,$(USEPKG)))
+    USEMODULE += shell_cmd_bplib
+  endif
   ifneq (,$(filter ccn-lite-utils,$(USEMODULE)))
     USEMODULE += shell_cmd_ccn-lite-utils
   endif

--- a/sys/shell/cmds/bplib.c
+++ b/sys/shell/cmds/bplib.c
@@ -1,0 +1,210 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Technische Universität Hamburg
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup     sys_shell_commands
+ * @{
+ *
+ * @file
+ * @brief       Shell commands for the bplib package
+ *
+ * @author      Simon Grund <mail@simongrund.de>
+ *
+ * @}
+ */
+#include "bplib.h"
+#include "bplib_init.h"
+
+#include "shell.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+/* Strings used for contact and channel config */
+#define STR_INVALID_CHANNEL_CONTACT "Invalid channel/contact: %i\n"
+#define STR_INVALID_STATE_KW        "Invalid state keyword '%s'\n"
+#define STR_CURRENT_STATE           "Current state: %s\n"
+
+static void __bp_print_help(void)
+{
+    puts("Usage: bplib <subcommand>\n"
+         " send    <channel_id> \"PAYLOAD\"\n"
+         " contact <contact_id> [<setup / start / stop / teardown>]\n"
+         " channel <channel_id> [<add / start / stop / remove>]");
+}
+
+static bool __validate_channel(int chan)
+{
+    if ((chan >= 0) && (chan < BPLIB_MAX_NUM_CHANNELS)) {
+        return true;
+    }
+    else {
+        printf(STR_INVALID_CHANNEL_CONTACT, chan);
+        return false;
+    }
+}
+
+static bool __validate_contact(int cont)
+{
+    if ((cont >= 0) && (cont < BPLIB_MAX_NUM_CONTACTS)) {
+        return true;
+    }
+    else {
+        printf(STR_INVALID_CHANNEL_CONTACT, cont);
+        return false;
+    }
+}
+
+static void __bp_print_contact_channel_feedback(BPLib_Status_t status)
+{
+    if (status == BPLIB_SUCCESS) {
+        puts("Success");
+    }
+    else if ((status == BPLIB_CLA_INCORRECT_STATE) || (status == BPLIB_APP_STATE_ERR)) {
+        puts("Current state cannot go to requested state directly");
+    }
+    else {
+        printf("Action failed with error %"PRIx32"\n", status);
+    }
+}
+
+static void __bp_contact(int c, char* arg)
+{
+    BPLib_Status_t status;
+
+    if (strcmp(arg, "setup") == 0) {
+        status = BPLib_CLA_ContactSetup(c);
+    }
+    else if (strcmp(arg, "start") == 0) {
+        status = BPLib_CLA_ContactStart(c);
+    }
+    else if (strcmp(arg, "stop") == 0) {
+        status = BPLib_CLA_ContactStop(c);
+    }
+    else if (strcmp(arg, "teardown") == 0) {
+        status = BPLib_CLA_ContactTeardown(&bplib_instance_data.BPLibInst, c);
+    }
+    else {
+        printf(STR_INVALID_STATE_KW, arg);
+        return;
+    }
+
+    __bp_print_contact_channel_feedback(status);
+}
+
+static void __bp_channel(int c, char* arg)
+{
+    BPLib_Status_t status;
+
+    if (strcmp(arg, "add") == 0) {
+        status = BPLib_PI_AddApplication(c);
+    }
+    else if (strcmp(arg, "start") == 0) {
+        status = BPLib_PI_StartApplication(c);
+    }
+    else if (strcmp(arg, "stop") == 0) {
+        status = BPLib_PI_StopApplication(c);
+    }
+    else if (strcmp(arg, "remove") == 0) {
+        status = BPLib_PI_RemoveApplication(&bplib_instance_data.BPLibInst, c);
+    }
+    else {
+        printf(STR_INVALID_STATE_KW, arg);
+        return;
+    }
+
+    __bp_print_contact_channel_feedback(status);
+}
+
+static const char* __bp_resolve_contact_state(BPLib_CLA_ContactRunState_t state) {
+    switch (state) {
+    case BPLIB_CLA_TORNDOWN:
+        return "torndown";
+    case BPLIB_CLA_SETUP:
+        return "setup";
+    case BPLIB_CLA_STARTED:
+        return "started";
+    case BPLIB_CLA_STOPPED:
+        return "stopped";
+    default:
+        return "[invalid]";
+    }
+}
+
+static const char* __bp_resolve_channel_state(BPLib_NC_ApplicationState_t state) {
+    switch (state) {
+    case BPLIB_NC_APP_STATE_REMOVED:
+        return "removed";
+    case BPLIB_NC_APP_STATE_STOPPED:
+        return "stopped";
+    case BPLIB_NC_APP_STATE_ADDED:
+        return "added";
+    case BPLIB_NC_APP_STATE_STARTED:
+        return "started";
+    default:
+        return "[invalid]";
+    }
+}
+
+static int _bp(int argc, char **argv)
+{
+    if (argc < 3) {
+        __bp_print_help();
+        return 1;
+    }
+
+    int c = atoi(argv[2]);
+
+    if (strcmp(argv[1], "send") == 0) {
+        if (argc < 4) {
+            __bp_print_help();
+            return 1;
+        }
+
+        if (!__validate_channel(c)) {
+            return 1;
+        }
+
+        BPLib_PI_Ingress(&bplib_instance_data.BPLibInst, c, argv[3], strlen(argv[3]));
+    }
+    else if (strcmp(argv[1], "contact") == 0) {
+        if (!__validate_contact(c)) {
+            return 1;
+        }
+
+        /* Return current state */
+        if (argc == 3) {
+            BPLib_CLA_ContactRunState_t state;
+            BPLib_CLA_GetContactRunState(c, &state);
+
+            printf(STR_CURRENT_STATE, __bp_resolve_contact_state(state));
+        }
+        else {
+            __bp_contact(c, argv[3]);
+        }
+    }
+    else if (strcmp(argv[1], "channel") == 0) {
+        if (!__validate_channel(c)) {
+            return 1;
+        }
+
+        /* Return current state */
+        if (argc == 3) {
+            BPLib_NC_ApplicationState_t state = BPLib_NC_GetAppState(c);
+
+            printf(STR_CURRENT_STATE, __bp_resolve_channel_state(state));
+        }
+        else {
+            __bp_channel(c, argv[3]);
+        }
+    }
+    else {
+        __bp_print_help();
+        return 1;
+    }
+
+    return 0;
+}
+SHELL_COMMAND(bplib, "Configure and interact with bplib", _bp);

--- a/sys/shell/cmds/bplib.doc.md
+++ b/sys/shell/cmds/bplib.doc.md
@@ -1,0 +1,42 @@
+@defgroup   sys_shell_commands_bplib bplib shell command
+@ingroup    sys_shell_commands
+@brief      bplib shell command for configuration
+
+## Available Subcommands
+
+The `bplib` shell command currently provides the following subcommands.
+
+The shell command is only intended as a helper for an existing implementation,
+an app with only the shell command will not be functional due to missing CLA
+initialization and missing egress of received bundles.
+
+General information:
+
+- A \<channel\> is an int in [0, BPLIB_MAX_NUM_CHANNELS)
+- A \<contact\> is an int in [0, BPLIB_MAX_NUM_CONTACTS)
+
+### Subcommand: send \<channel\> \<PAYLOAD\>
+
+Ingresses a bundle with the given string payload over the given channel.
+
+### Subcommand: channel \<channel\> [\<new_state\>]
+
+Either prints the current state of the given channel when `new_state` is not
+given, or tries to transition to the `new_state`.
+
+The `new_state` is one of "setup", "start", "stop" and "teardown".
+
+### Subcommand: contact \<contact\> [\<new_state\>]
+
+Either prints the current state of the given contact when `new_state` is not
+given, or tries to transition to the `new_state`.
+
+The `new_state` is one of "add", "start", "stop" and "remove".
+
+### Future efforts / Not yet implemented
+
+- Configuration of NC, including but not limited to:
+  - Channel Configuration: e.g. which blocks to include, which CRC to use
+  - Contact Configuration: e.g. which remote to send to
+- Configuration of general values, many of which are currently compile time
+  constants. That would include for example the local EID.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Currently, in the examples of bplib, each defined their own version of a bplib shell command to test the application.
With this proposed change, the shell command is added to its friends, the other shell commands.
Also, the command now has proper error handling, bounds checking, etc., and is more user friendly now.

There are 3 sub-commands:
- `send` to send a bundles over a channel
- `channel` to change the state of the channel, or query the current state
- `contact` to change the state of the contact, or query the current state

### TODO

- [x] Check / Update READMEs in the examples

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Run `examples/networking/dtn/bplib_cla_udp` is probably the easiest.

```
> bplib
bplib
Usage: bplib <subcommand>                                       # Printed on invalid commands
 send    <channel_id> "PAYLOAD"
 contact <contact_id> [<setup / start / stop / teardown>]
 channel <channel_id> [<add / start / stop / remove>]
> bplib send 0 "Hello"
bplib send 0 "Hello"
Received Bundle of size 5 with content: Hello                   # Sending works (loopback)
> bplib send 1 "Hi"                                             # Bound check for channels
bplib send 1 "Hi"
Invalid channel/contact: 1

> bplib contact 0                                               # Query state
bplib contact 0
Current state: started
> bplib contact 0 stop                                          # Change state
bplib contact 0 stop
Success
> bplib contact 0                                               # It works
bplib contact 0
Current state: stopped
> bplib contact 0 setup                                         # Invalid transition
bplib contact 0 setup
Current state cannot go to requested state directly
> bplib contact 0 akwdjahwfd                                    # Invalid state
bplib contact 0 akwdjahwfd
Invalid state keyword 'akwdjahwfd'

> bplib channel 0                                               # Same for channels
bplib channel 0
Current state: started
> bplib channel 0 stop
bplib channel 0 stop
Success
> bplib channel 0
bplib channel 0
Current state: stopped
> bplib channel 0 add
bplib channel 0 add
Current state cannot go to requested state directly
> bplib channel 0 kaudjzwd
bplib channel 0 kaudjzwd
Invalid state keyword 'kaudjzwd'
```
### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Required-ish for #22647

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
