### PR TITLE
sys/net/ipv4: add header checksums

### DIFF
--- a/sys/include/net/ipv4/hdr.h
+++ b/sys/include/net/ipv4/hdr.h
@@ -28,6 +28,7 @@
 #include <assert.h>
 
 #include "byteorder.h"
+#include "net/inet_csum.h"
 #include "net/ipv4/addr.h"
 
 #ifdef __cplusplus
@@ -211,6 +212,51 @@ static inline void ipv4_hdr_set_fo(ipv4_hdr_t *hdr, uint16_t fo)
 static inline uint16_t ipv4_hdr_get_fo(ipv4_hdr_t *hdr)
 {
     return (((hdr->fl_fo.u8[0] & 0x1f) << 8) + hdr->fl_fo.u8[1]);
+}
+
+/**
+ * @brief   Calculates the header checksum of @p hdr.
+ *
+ * @see     [RFC 791, section 3.1](https://tools.ietf.org/html/rfc791#section-3.1)
+ *
+ * @pre     ipv4_hdr_t::csum of @p hdr is set to 0.
+ *
+ * @param[in] hdr   An IPv4 header, with ipv4_hdr_t::csum set to 0.
+ *
+ * @return  The IPv4 header checksum of @p hdr, in network byte order.
+ */
+static inline network_uint16_t ipv4_hdr_csum(ipv4_hdr_t *hdr)
+{
+    assert(hdr->csum.u16 == 0);
+
+    uint16_t csum = inet_csum(0, (uint8_t *)hdr, ipv4_hdr_get_ihl(hdr));
+
+    return byteorder_htons(~csum);
+}
+
+/**
+ * @brief   Calculates the Internet Checksum for the IPv4 Pseudo Header.
+ *
+ * @see     [RFC 793, section 3.1](https://tools.ietf.org/html/rfc793#section-3.1)
+ *
+ * @param[in] sum       Preinitialized value of the sum.
+ * @param[in] prot_num  The @ref net_protnum you want to calculate the
+ *                      checksum for.
+ * @param[in] hdr       An IPv4 header to derive the Pseudo Header from.
+ * @param[in] len       The upper-layer packet length for the pseudo header.
+ *
+ * @return  The non-normalized Internet Checksum of the given IPv4 pseudo header.
+ */
+static inline uint16_t ipv4_hdr_inet_csum(uint16_t sum, ipv4_hdr_t *hdr,
+                                          uint8_t prot_num, uint16_t len)
+{
+    if (((uint32_t)sum + (uint32_t)len + (uint32_t)prot_num) > 0xffff) {
+        /* increment by one for overflow to keep it as 1's complement sum */
+        sum++;
+    }
+
+    return inet_csum((uint16_t)sum + (uint16_t)len + (uint16_t)prot_num,
+                     hdr->src.u8, (2 * sizeof(ipv4_addr_t)));
 }
 
 #ifdef __cplusplus

--- a/tests/unittests/tests-ipv4_hdr/Makefile.include
+++ b/tests/unittests/tests-ipv4_hdr/Makefile.include
@@ -1,0 +1,1 @@
+USEMODULE += inet_csum

--- a/tests/unittests/tests-ipv4_hdr/tests-ipv4_hdr.c
+++ b/tests/unittests/tests-ipv4_hdr/tests-ipv4_hdr.c
@@ -18,7 +18,9 @@
 
 #include "embUnit.h"
 
+#include "byteorder.h"
 #include "net/ipv4/hdr.h"
+#include "net/protnum.h"
 
 #include "unittests-constants.h"
 #include "tests-ipv4_hdr.h"
@@ -155,6 +157,52 @@ static void test_ipv4_hdr_get_fo(void)
     TEST_ASSERT_EQUAL_INT(0x0abc, ipv4_hdr_get_fo((ipv4_hdr_t *)val));
 }
 
+static void test_ipv4_hdr_csum(void)
+{
+    uint8_t val[] = {
+        0x45, 0x00, 0x00, 0x3c, 0x1c, 0x46, 0x40, 0x00,
+        0x40, 0x06, 0x00, 0x00, 0xac, 0x10, 0x0a, 0x63,
+        0xac, 0x10, 0x0a, 0x0c
+    };
+
+    TEST_ASSERT_EQUAL_INT(0xb1e6,
+                          byteorder_ntohs(ipv4_hdr_csum((ipv4_hdr_t *)val)));
+}
+
+static void test_ipv4_hdr_inet_csum__initial_sum_overflows(void)
+{
+    uint16_t sum = 0xffff, res;
+    uint8_t val[] = {
+        0x45, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* IPv4 header */
+        0x00, 0x06, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x01,
+        0x0a, 0x00, 0x00, 0x02
+    };
+
+    res = ipv4_hdr_inet_csum(sum, (ipv4_hdr_t *)val, PROTNUM_TCP, 0x0100);
+
+    /* take 1's-complement for correct checksum */
+    res = ~res;
+
+    TEST_ASSERT_EQUAL_INT(0xeaf6, res);
+}
+
+static void test_ipv4_hdr_inet_csum__initial_sum_0(void)
+{
+    uint16_t res, payload_len = 40;
+    uint8_t val[] = {
+        0x45, 0x00, 0x00, 0x3c, 0x1c, 0x46, 0x40, 0x00, /* IPv4 header */
+        0x40, 0x06, 0x00, 0x00, 0xac, 0x10, 0x0a, 0x63,
+        0xac, 0x10, 0x0a, 0x0c
+    };
+
+    res = ipv4_hdr_inet_csum(0, (ipv4_hdr_t *)val, PROTNUM_TCP, payload_len);
+
+    /* take 1's-complement for correct checksum */
+    res = ~res;
+
+    TEST_ASSERT_EQUAL_INT(0x9341, res);
+}
+
 Test *tests_ipv4_hdr_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -166,6 +214,9 @@ Test *tests_ipv4_hdr_tests(void)
         new_TestFixture(test_ipv4_hdr_get_flags),
         new_TestFixture(test_ipv4_hdr_set_fo),
         new_TestFixture(test_ipv4_hdr_get_fo),
+        new_TestFixture(test_ipv4_hdr_csum),
+        new_TestFixture(test_ipv4_hdr_inet_csum__initial_sum_overflows),
+        new_TestFixture(test_ipv4_hdr_inet_csum__initial_sum_0),
     };
 
     EMB_UNIT_TESTCALLER(ipv4_hdr_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description

This PR adds the IPv4 header checksum (RFC 791) and the pseudo header (RFC 793).


### Testing procedure

Run the unit tests: `make -C tests/unittests tests-ipv4_hdr term`


### Issues/PRs references

#22676


### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- Claude Code Opus 5, which I then reviewed, reworked and tested.
