### PR TITLE
sys/net/ipv4: add header print function

### DIFF
--- a/sys/Makefile
+++ b/sys/Makefile
@@ -92,6 +92,9 @@ endif
 ifneq (,$(filter ipv4_addr,$(USEMODULE)))
   DIRS += net/network_layer/ipv4/addr
 endif
+ifneq (,$(filter ipv4_hdr,$(USEMODULE)))
+  DIRS += net/network_layer/ipv4/hdr
+endif
 ifneq (,$(filter ipv6_addr,$(USEMODULE)))
   DIRS += net/network_layer/ipv6/addr
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -177,6 +177,11 @@ ifneq (,$(filter sixlowpan,$(USEMODULE)))
   USEMODULE += ipv6_hdr
 endif
 
+ifneq (,$(filter ipv4_hdr,$(USEMODULE)))
+  USEMODULE += inet_csum
+  USEMODULE += ipv4_addr
+endif
+
 ifneq (,$(filter ipv6_hdr,$(USEMODULE)))
   USEMODULE += inet_csum
   USEMODULE += ipv6_addr

--- a/sys/include/net/ipv4/hdr.h
+++ b/sys/include/net/ipv4/hdr.h
@@ -28,6 +28,16 @@ extern "C" {
 #endif
 
 /**
+ * @name    IPv4 Header Flags
+ * @see     [RFC 791, section 3.1](https://tools.ietf.org/html/rfc791#section-3.1)
+ * @{
+ */
+#define IPV4_HDR_FLAGS_RESERVED     (0x04)      /**< reserved */
+#define IPV4_HDR_FLAGS_DF           (0x02)      /**< do not fragment */
+#define IPV4_HDR_FLAGS_MF           (0x01)      /**< more fragments */
+/** @} */
+
+/**
  * @brief   Data type to represent an IPv4 packet header.
  *
  * The structure of the header is as follows:

--- a/sys/include/net/ipv4/hdr.h
+++ b/sys/include/net/ipv4/hdr.h
@@ -15,17 +15,22 @@
  * @brief   IPv4 header type and helper function definitions
  *
  * @author  José Ignacio Alamos <jialamos@uc.cl>
+ * @author  Bas Stottelaar <basstottelaar@gmail.com>
  */
+
+#include <assert.h>
 
 #include "byteorder.h"
 #include "net/ipv4/addr.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 /**
- * @brief Data type to represent an IPv4 packet header.
+ * @brief   Data type to represent an IPv4 packet header.
  *
- * @details The structure of the header is as follows:
+ * The structure of the header is as follows:
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.unparsed}
  *  0                   1                   2                   3
@@ -51,29 +56,36 @@ extern "C" {
  */
 typedef struct __attribute__((packed)) {
     /**
-     * @brief Version and Internet Header Length.
+     * @brief   Version and Internet Header Length.
      *
-     * @details The version are the 4 most significant bits and the Internet Header Length
-     * the 4 next bit (see above).
+     * The version is encoded in the four most significant bits and the
+     * Internet Header Length in the four least significant bits (see above).
+     *
+     * The Internet Header Length is the length of the header in 32-bit words,
+     * so it must be multiplied by 4 to get the length in bytes. The minimum
+     * value is 5 (20 bytes) and the maximum is 15 (60 bytes).
      *
      * This module provides helper functions to set, get, and check these
      * fields accordingly:
+     *
      * * ipv4_hdr_set_version()
      * * ipv4_hdr_get_version()
      * * ipv4_hdr_set_ihl()
      * * ipv4_hdr_get_ihl()
      */
-    uint8_t v_ih;
-    uint8_t ts;             /**< type of service of packet*/
+    uint8_t v_ihl;
+    uint8_t ts;             /**< type of service of packet */
     network_uint16_t tl;    /**< total length of the datagram */
     network_uint16_t id;    /**< identification value of packet */
     /**
-     * @brief version control flags and Fragment Offset.
+     * @brief   Version control flags and Fragment Offset.
      *
-     * @details The flags are the 3 most significant bits, and the remaining 13 bits are the fragment offset
+     * The flags are the 3 most significant bits, and the remaining 13 bits are
+     * the fragment offset.
      *
      * This module provides helper functions to set, get, and check these
      * fields accordingly:
+     *
      * * ipv4_hdr_set_flags()
      * * ipv4_hdr_get_flags()
      * * ipv4_hdr_set_fo()
@@ -88,57 +100,60 @@ typedef struct __attribute__((packed)) {
 } ipv4_hdr_t;
 
 /**
- * @brief   Sets the version field of @p hdr to 6
+ * @brief   Sets the version field of @p hdr to 4
  *
- * @param[out] hdr  Pointer to an IPv4 header.
+ * @param[out]  hdr     Pointer to an IPv4 header.
  */
 static inline void ipv4_hdr_set_version(ipv4_hdr_t *hdr)
 {
-    hdr->v_ih &= 0x0f;
-    hdr->v_ih |= 0x40;
+    hdr->v_ihl &= 0x0f;
+    hdr->v_ihl |= 0x40;
 }
 
 /**
  * @brief   Gets the value of the version field of @p hdr
  *
- * @param[in] hdr   Pointer to an IPv4 header.
+ * @param[in]   hdr     Pointer to an IPv4 header.
  *
  * @return  Value of the version field of @p hdr.
  */
 static inline uint8_t ipv4_hdr_get_version(ipv4_hdr_t *hdr)
 {
-    return ((hdr->v_ih) >> 4);
+    return ((hdr->v_ihl) >> 4);
 }
 
 /**
  * @brief   Sets the Internet Header Length field of @p hdr
  *
- * @param[out] hdr  Pointer to an IPv4 header.
- * @param[in] ihl  Size in bytes of the Internet Header Length (including padding)
+ * @param[out]  hdr     Pointer to an IPv4 header.
+ * @param[in]   ihl     Size in bytes of the Internet Header Length (including padding)
  */
 static inline void ipv4_hdr_set_ihl(ipv4_hdr_t *hdr, uint16_t ihl)
 {
-    hdr->v_ih &= 0xf0;
-    hdr->v_ih |= 0x0f & (ihl >> 5);
+    assert(ihl >= 20 && ihl <= 60);
+    assert(ihl % 4 == 0);
+
+    hdr->v_ihl &= 0xf0;
+    hdr->v_ihl |= 0x0f & (ihl >> 2);
 }
 
 /**
- * brief Gets the value of the Internet Header Length field of @p hdr
+ * @brief   Gets the value of the Internet Header Length field of @p hdr
  *
- * @param[in] hdr   Pointer to an IPv4 header.
+ * @param[in]   hdr     Pointer to an IPv4 header.
  *
  * @return Size in bytes of the Internet Header Length field of @p hdr
  */
 static inline uint16_t ipv4_hdr_get_ihl(ipv4_hdr_t *hdr)
 {
-    return (hdr->v_ih & 0x0f) << 5;
+    return (hdr->v_ihl & 0x0f) << 2;
 }
 
 /**
  * @brief   Sets the Version Control Flags field of @p hdr
  *
- * @param[out] hdr  Pointer to an IPv4 header.
- * @param[in] flags  The new value of flags
+ * @param[out]  hdr     Pointer to an IPv4 header.
+ * @param[in]   flags   The new value of flags
  */
 static inline void ipv4_hdr_set_flags(ipv4_hdr_t *hdr, uint8_t flags)
 {
@@ -147,9 +162,9 @@ static inline void ipv4_hdr_set_flags(ipv4_hdr_t *hdr, uint8_t flags)
 }
 
 /**
- * brief Gets the value of the Version Control Flags field of @p hdr
+ * @brief   Gets the value of the Version Control Flags field of @p hdr
  *
- * @param[in] hdr   Pointer to an IPv4 header.
+ * @param[in]   hdr     Pointer to an IPv4 header.
  *
  * @return Value of the Version Control field of @p hdr
  */
@@ -161,8 +176,8 @@ static inline uint8_t ipv4_hdr_get_flags(ipv4_hdr_t *hdr)
 /**
  * @brief   Sets the Fragment Offset field of @p hdr
  *
- * @param[out] hdr  Pointer to an IPv4 header.
- * @param[in] fo  The new value of fragment offset
+ * @param[out]  hdr     Pointer to an IPv4 header.
+ * @param[in]   fo      The new value of fragment offset
  */
 static inline void ipv4_hdr_set_fo(ipv4_hdr_t *hdr, uint16_t fo)
 {
@@ -172,9 +187,9 @@ static inline void ipv4_hdr_set_fo(ipv4_hdr_t *hdr, uint16_t fo)
 }
 
 /**
- * brief Gets the value of the Fragment Offset field of @p hdr
+ * @brief   Gets the value of the Fragment Offset field of @p hdr
  *
- * @param[in] hdr   Pointer to an IPv4 header.
+ * @param[in]   hdr     Pointer to an IPv4 header.
  *
  * @return Value of the Fragment Offset field of @p hdr
  */

--- a/sys/include/net/ipv4/hdr.h
+++ b/sys/include/net/ipv4/hdr.h
@@ -252,6 +252,13 @@ static inline uint16_t ipv4_hdr_inet_csum(uint16_t sum, ipv4_hdr_t *hdr,
                      (2 * sizeof(ipv4_addr_t)));
 }
 
+/**
+ * @brief   Outputs an IPv4 header to stdout.
+ *
+ * @param[in] hdr   An IPv4 header.
+ */
+void ipv4_hdr_print(ipv4_hdr_t *hdr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/ipv4/hdr.h
+++ b/sys/include/net/ipv4/hdr.h
@@ -21,6 +21,7 @@
 #include <assert.h>
 
 #include "byteorder.h"
+#include "net/inet_csum.h"
 #include "net/ipv4/addr.h"
 
 #ifdef __cplusplus
@@ -206,6 +207,49 @@ static inline void ipv4_hdr_set_fo(ipv4_hdr_t *hdr, uint16_t fo)
 static inline uint16_t ipv4_hdr_get_fo(ipv4_hdr_t *hdr)
 {
     return (((hdr->fl_fo.u8[0] & 0x1f) << 8) + hdr->fl_fo.u8[1]);
+}
+
+/**
+ * @brief   Calculates the header checksum of @p hdr.
+ *
+ * @see     [RFC 791, section 3.1](https://tools.ietf.org/html/rfc791#section-3.1)
+ *
+ * @pre     ipv4_hdr_t::csum of @p hdr is set to 0.
+ *
+ * @param[in] hdr   An IPv4 header, with ipv4_hdr_t::csum set to 0.
+ *
+ * @return  The IPv4 header checksum of @p hdr, in network byte order.
+ */
+static inline network_uint16_t ipv4_hdr_csum(ipv4_hdr_t *hdr)
+{
+    uint16_t csum = inet_csum(0, (uint8_t *)hdr, ipv4_hdr_get_ihl(hdr));
+
+    return byteorder_htons(~csum);
+}
+
+/**
+ * @brief   Calculates the Internet Checksum for the IPv4 Pseudo Header.
+ *
+ * @see     [RFC 793, section 3.1](https://tools.ietf.org/html/rfc793#section-3.1)
+ *
+ * @param[in] sum       Preinitialized value of the sum.
+ * @param[in] prot_num  The @ref net_protnum you want to calculate the
+ *                      checksum for.
+ * @param[in] hdr       An IPv4 header to derive the Pseudo Header from.
+ * @param[in] len       The upper-layer packet length for the pseudo header.
+ *
+ * @return  The non-normalized Internet Checksum of the given IPv4 pseudo header.
+ */
+static inline uint16_t ipv4_hdr_inet_csum(uint16_t sum, ipv4_hdr_t *hdr,
+                                          uint8_t prot_num, uint16_t len)
+{
+    if (((uint32_t)sum + len + prot_num) > 0xffff) {
+        /* increment by one for overflow to keep it as 1's complement sum */
+        sum++;
+    }
+
+    return inet_csum(sum + len + prot_num, hdr->src.u8,
+                     (2 * sizeof(ipv4_addr_t)));
 }
 
 #ifdef __cplusplus

--- a/sys/net/network_layer/ipv4/hdr/Makefile
+++ b/sys/net/network_layer/ipv4/hdr/Makefile
@@ -1,0 +1,3 @@
+MODULE = ipv4_hdr
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/network_layer/ipv4/hdr/ipv4_hdr_print.c
+++ b/sys/net/network_layer/ipv4/hdr/ipv4_hdr_print.c
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#include "net/ipv4/hdr.h"
+
+void ipv4_hdr_print(ipv4_hdr_t *hdr)
+{
+    char addr_str[IPV4_ADDR_MAX_STR_LEN];
+
+    printf("version: %u  IHL: %u  type of service: 0x%02x\n",
+           (unsigned)ipv4_hdr_get_version(hdr), (unsigned)ipv4_hdr_get_ihl(hdr),
+           (unsigned)hdr->ts);
+    printf("total length: %" PRIu16 "  identification: 0x%04" PRIx16 "\n",
+           byteorder_ntohs(hdr->tl), byteorder_ntohs(hdr->id));
+    printf("flags: 0x%x  fragment offset: %" PRIu16 "\n",
+           (unsigned)ipv4_hdr_get_flags(hdr), ipv4_hdr_get_fo(hdr));
+    printf("TTL: %u  protocol: %u  checksum: 0x%04" PRIx16 "\n",
+           (unsigned)hdr->ttl, (unsigned)hdr->protocol,
+           byteorder_ntohs(hdr->csum));
+    printf("source address: %s\n", ipv4_addr_to_str(addr_str, &hdr->src,
+                                                    sizeof(addr_str)));
+    printf("destination address: %s\n", ipv4_addr_to_str(addr_str, &hdr->dst,
+                                                         sizeof(addr_str)));
+}
+
+/** @} */

--- a/tests/unittests/tests-ipv4_hdr/Makefile
+++ b/tests/unittests/tests-ipv4_hdr/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-ipv4_hdr/tests-ipv4_hdr.c
+++ b/tests/unittests/tests-ipv4_hdr/tests-ipv4_hdr.c
@@ -1,0 +1,180 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+/**
+ * @ingroup unittests
+ *
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the `ipv4_hdr` module
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ */
+
+#include <stdint.h>
+
+#include "embUnit.h"
+
+#include "net/ipv4/hdr.h"
+
+#include "unittests-constants.h"
+#include "tests-ipv4_hdr.h"
+
+static void test_ipv4_hdr_set_version(void)
+{
+    uint8_t val[sizeof(ipv4_hdr_t)] = { TEST_UINT8 };
+
+    ipv4_hdr_set_version((ipv4_hdr_t *)val);
+
+    TEST_ASSERT_EQUAL_INT(0x40, val[0] & 0xf0);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 & 0x0f, val[0] & 0x0f);
+}
+
+static void test_ipv4_hdr_get_version(void)
+{
+    uint8_t val[sizeof(ipv4_hdr_t)] = { TEST_UINT8 };
+
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 >> 4, ipv4_hdr_get_version((ipv4_hdr_t *)val));
+}
+
+static void test_ipv4_hdr_set_ihl(void)
+{
+    uint8_t val[sizeof(ipv4_hdr_t)] = { TEST_UINT8 };
+
+    /* minimum internet header length */
+    ipv4_hdr_set_ihl((ipv4_hdr_t *)val, 20);
+
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 & 0xf0, val[0] & 0xf0);
+    TEST_ASSERT_EQUAL_INT(5, val[0] & 0x0f);
+
+    /* maximum internet header length */
+    ipv4_hdr_set_ihl((ipv4_hdr_t *)val, 60);
+
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 & 0xf0, val[0] & 0xf0);
+    TEST_ASSERT_EQUAL_INT(15, val[0] & 0x0f);
+}
+
+static void test_ipv4_hdr_get_ihl(void)
+{
+    uint8_t val[sizeof(ipv4_hdr_t)];
+
+    /* minimum internet header length */
+    val[0] = 0x45;
+
+    TEST_ASSERT_EQUAL_INT(20, ipv4_hdr_get_ihl((ipv4_hdr_t *)val));
+
+    /* maximum internet header length */
+    val[0] = 0x4f;
+
+    TEST_ASSERT_EQUAL_INT(60, ipv4_hdr_get_ihl((ipv4_hdr_t *)val));
+}
+
+static void test_ipv4_hdr_set_flags(void)
+{
+    uint8_t val[sizeof(ipv4_hdr_t)] = { 0 };
+
+    val[6] = TEST_UINT8;
+
+    /* no flags set */
+    ipv4_hdr_set_flags((ipv4_hdr_t *)val, 0);
+
+    TEST_ASSERT_EQUAL_INT(0x00, val[6] & 0xe0);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 & 0x1f, val[6] & 0x1f);
+
+    /* all flags set */
+    ipv4_hdr_set_flags((ipv4_hdr_t *)val, 0x07);
+
+    TEST_ASSERT_EQUAL_INT(0xe0, val[6] & 0xe0);
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 & 0x1f, val[6] & 0x1f);
+}
+
+static void test_ipv4_hdr_get_flags(void)
+{
+    uint8_t val[sizeof(ipv4_hdr_t)] = { 0 };
+
+    /* no flags set */
+    val[6] = 0x00;
+
+    TEST_ASSERT_EQUAL_INT(0, ipv4_hdr_get_flags((ipv4_hdr_t *)val));
+
+    /* all flags set */
+    val[6] = 0xe0;
+
+    TEST_ASSERT_EQUAL_INT(0x07, ipv4_hdr_get_flags((ipv4_hdr_t *)val));
+
+    /* mixed: only MSB of flags set */
+    val[6] = 0x80;
+
+    TEST_ASSERT_EQUAL_INT(0x04, ipv4_hdr_get_flags((ipv4_hdr_t *)val));
+}
+
+static void test_ipv4_hdr_set_fo(void)
+{
+    uint8_t val[sizeof(ipv4_hdr_t)] = { 0 };
+
+    val[6] = TEST_UINT8;
+
+    /* zero fragment offset */
+    ipv4_hdr_set_fo((ipv4_hdr_t *)val, 0);
+
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 & 0xe0, val[6] & 0xe0);
+    TEST_ASSERT_EQUAL_INT(0x00, val[6] & 0x1f);
+    TEST_ASSERT_EQUAL_INT(0x00, val[7]);
+
+    /* maximum fragment offset (8191) */
+    ipv4_hdr_set_fo((ipv4_hdr_t *)val, 0x1fff);
+
+    TEST_ASSERT_EQUAL_INT(TEST_UINT8 & 0xe0, val[6] & 0xe0);
+    TEST_ASSERT_EQUAL_INT(0x1f, val[6] & 0x1f);
+    TEST_ASSERT_EQUAL_INT(0xff, val[7]);
+}
+
+static void test_ipv4_hdr_get_fo(void)
+{
+    uint8_t val[sizeof(ipv4_hdr_t)] = { 0 };
+
+    /* zero fragment offset */
+    val[6] = 0x00;
+    val[7] = 0x00;
+
+    TEST_ASSERT_EQUAL_INT(0, ipv4_hdr_get_fo((ipv4_hdr_t *)val));
+
+    /* maximum fragment offset (8191) */
+    val[6] = 0x1f;
+    val[7] = 0xff;
+
+    TEST_ASSERT_EQUAL_INT(0x1fff, ipv4_hdr_get_fo((ipv4_hdr_t *)val));
+
+    /* value spanning both bytes */
+    val[6] = 0x0a;
+    val[7] = 0xbc;
+
+    TEST_ASSERT_EQUAL_INT(0x0abc, ipv4_hdr_get_fo((ipv4_hdr_t *)val));
+}
+
+Test *tests_ipv4_hdr_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_ipv4_hdr_set_version),
+        new_TestFixture(test_ipv4_hdr_get_version),
+        new_TestFixture(test_ipv4_hdr_set_ihl),
+        new_TestFixture(test_ipv4_hdr_get_ihl),
+        new_TestFixture(test_ipv4_hdr_set_flags),
+        new_TestFixture(test_ipv4_hdr_get_flags),
+        new_TestFixture(test_ipv4_hdr_set_fo),
+        new_TestFixture(test_ipv4_hdr_get_fo),
+    };
+
+    EMB_UNIT_TESTCALLER(ipv4_hdr_tests, NULL, NULL, fixtures);
+
+    return (Test *)&ipv4_hdr_tests;
+}
+
+void tests_ipv4_hdr(void)
+{
+    TESTS_RUN(tests_ipv4_hdr_tests());
+}
+/** @} */

--- a/tests/unittests/tests-ipv4_hdr/tests-ipv4_hdr.c
+++ b/tests/unittests/tests-ipv4_hdr/tests-ipv4_hdr.c
@@ -18,7 +18,9 @@
 
 #include "embUnit.h"
 
+#include "byteorder.h"
 #include "net/ipv4/hdr.h"
+#include "net/protnum.h"
 
 #include "unittests-constants.h"
 #include "tests-ipv4_hdr.h"
@@ -155,6 +157,52 @@ static void test_ipv4_hdr_get_fo(void)
     TEST_ASSERT_EQUAL_INT(0x0abc, ipv4_hdr_get_fo((ipv4_hdr_t *)val));
 }
 
+static void test_ipv4_hdr_csum(void)
+{
+    uint8_t val[] = {
+        0x45, 0x00, 0x00, 0x3c, 0x1c, 0x46, 0x40, 0x00,
+        0x40, 0x06, 0x00, 0x00, 0xac, 0x10, 0x0a, 0x63,
+        0xac, 0x10, 0x0a, 0x0c
+    };
+
+    TEST_ASSERT_EQUAL_INT(0xb1e6,
+                          byteorder_ntohs(ipv4_hdr_csum((ipv4_hdr_t *)val)));
+}
+
+static void test_ipv4_hdr_inet_csum__initial_sum_overflows(void)
+{
+    uint16_t sum = 0xffff, res;
+    uint8_t val[] = {
+        0x45, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* IPv4 header */
+        0x00, 0x06, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x01,
+        0x0a, 0x00, 0x00, 0x02
+    };
+
+    res = ipv4_hdr_inet_csum(sum, (ipv4_hdr_t *)val, PROTNUM_TCP, 0x0100);
+
+    /* take 1's-complement for correct checksum */
+    res = ~res;
+
+    TEST_ASSERT_EQUAL_INT(0xeaf6, res);
+}
+
+static void test_ipv4_hdr_inet_csum__initial_sum_0(void)
+{
+    uint16_t res, payload_len = 40;
+    uint8_t val[] = {
+        0x45, 0x00, 0x00, 0x3c, 0x1c, 0x46, 0x40, 0x00, /* IPv4 header */
+        0x40, 0x06, 0x00, 0x00, 0xac, 0x10, 0x0a, 0x63,
+        0xac, 0x10, 0x0a, 0x0c
+    };
+
+    res = ipv4_hdr_inet_csum(0, (ipv4_hdr_t *)val, PROTNUM_TCP, payload_len);
+
+    /* take 1's-complement for correct checksum */
+    res = ~res;
+
+    TEST_ASSERT_EQUAL_INT(0x9341, res);
+}
+
 Test *tests_ipv4_hdr_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -166,6 +214,9 @@ Test *tests_ipv4_hdr_tests(void)
         new_TestFixture(test_ipv4_hdr_get_flags),
         new_TestFixture(test_ipv4_hdr_set_fo),
         new_TestFixture(test_ipv4_hdr_get_fo),
+        new_TestFixture(test_ipv4_hdr_csum),
+        new_TestFixture(test_ipv4_hdr_inet_csum__initial_sum_overflows),
+        new_TestFixture(test_ipv4_hdr_inet_csum__initial_sum_0),
     };
 
     EMB_UNIT_TESTCALLER(ipv4_hdr_tests, NULL, NULL, fixtures);

--- a/tests/unittests/tests-ipv4_hdr/tests-ipv4_hdr.h
+++ b/tests/unittests/tests-ipv4_hdr/tests-ipv4_hdr.h
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Bas Stottelaar <basstottelaar@gmail.com>
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+#pragma once
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the `ipv4_hdr` module
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ */
+
+#include "embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The entry point of this test suite.
+ */
+void tests_ipv4_hdr(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */


### PR DESCRIPTION
### Contribution description

> [!NOTE]
> This PR is still draft, because it also contains the commits of #22677.

This adds a header print utility, just like `ipv6_hdr_print`. This will eventually be used by `gnrc_pktdump`.


### Testing procedure

This PR does not add any tests for this.


### Issues/PRs references

#22676


### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:

- Claude Code Opus 5, which I then reviewed and reworked.
