### PR TITLE
makefiles/tests: remove unused helper in tests.inc.mk

### DIFF
--- a/makefiles/tests/tests.inc.mk
+++ b/makefiles/tests/tests.inc.mk
@@ -110,25 +110,20 @@ test-input-hash: .SECONDARY
 	$(file >$(RIOT_TEST_HASH_DIR)/test-input-hash.sha1,no binary generated due to RIOTNOLINK=1)
 endif
 
-# Helper function to compare two strings
-define compare_strings
-$(and $(filter $1,$2),$(filter $2,$1))
-endef
-
 # Target to test only if the input hash has changed
 .PHONY: test-input-hash-changed
 test-input-hash-changed:
 	@if [ ! -f "$(RIOT_TEST_HASH_DIR)/test-input-hash.sha1" ]; then \
-		echo "Old hash file doesn't exist. Generating hash and running tests..."; \
-		mkdir -p $(RIOT_TEST_HASH_DIR); \
-		$(MAKE) test-input-hash; \
+	  echo "Old hash file doesn't exist. Generating hash and running tests..."; \
+	  mkdir -p $(RIOT_TEST_HASH_DIR); \
+	  $(MAKE) test-input-hash; \
 	else \
-		OLD_HASH=$$(cat $(RIOT_TEST_HASH_DIR)/test-input-hash.sha1); \
-		$(MAKE) test-input-hash; \
-		NEW_HASH=$$(cat $(RIOT_TEST_HASH_DIR)/test-input-hash.sha1); \
-		if [ "$${OLD_HASH}" != "$${NEW_HASH}" ]; then \
-			echo "Hashes do not match."; \
-		else \
-			echo "Hashes match."; \
-		fi; \
+	  OLD_HASH=$$(cat $(RIOT_TEST_HASH_DIR)/test-input-hash.sha1); \
+	  $(MAKE) test-input-hash; \
+	  NEW_HASH=$$(cat $(RIOT_TEST_HASH_DIR)/test-input-hash.sha1); \
+	  if [ "$${OLD_HASH}" != "$${NEW_HASH}" ]; then \
+	    echo "Hashes do not match."; \
+	  else \
+	    echo "Hashes match."; \
+	  fi; \
 	fi


### PR DESCRIPTION
### Contribution description

I removed the `compare_strings` helper function, that is unused. While it won't cause much performance penalty, there shouldn't be unused code around.

Also I fixed the formatting for the target below. Strictly speaking, only the first line has to start with a tab, everything else doesn't matter as much, but the (inofficial) convention is that every line in the recipe starts with a tab and the following indentation is done with spaces.

### Testing procedure
CI should still be happy.

Also, no occurances of `compare_strings` are left:
```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ grep -RI compare_strings
makefiles/tests/tests.inc.mk:define compare_strings
```

```
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ git checkout pr/remove_unused_helper
Switched to branch 'pr/remove_unused_helper'
cbuec@W11nMate:~/RIOTstuff/riot-vanillaice/RIOT$ grep -RI compare_strings
```


### Issues/PRs references
The helper was added in https://github.com/RIOT-OS/RIOT/pull/19546, but never used in that code or anywhere else.

Noticed this during the review of #22669.

### Declaration of AI-Tools / LLMs usage:
AI-Tools / LLMs that were used are:
- none