### PR TITLE
.murdock: remove -gz from CFLAGS BLACKLIST

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -107,23 +107,6 @@ if [ -z "${QUICK_BUILD}" ]; then
     fi
 fi
 
-# This is a work around for a bug in CCACHE which interacts very badly with
-# some features of RIOT and of murdock. The result is that ccache is
-# ineffective (i.e. objects are never reused, resulting in extreme cache miss
-# rate) and murdock becomes slow.
-#
-# - CCACHE thinks that -gz by itself enables debugging, which is not true.
-#   see https://github.com/ccache/ccache/issues/464
-#   - When debug info is included, CCACHE hashes the file paths, as these
-#     influence the debug information (the name of compile units and/or their
-#     "comp_dir" attribute)
-# - Riot does not set -fdebug-prefix-map. This is not that easy as it may not
-#   be supported in every toolchain (some are quite old).
-# - Murdock builds PRs in different directories each time.
-#
-# It is only the combination of these three factors which causes this bug.
-export OPTIONAL_CFLAGS_BLACKLIST="-gz"
-
 DWQ_ENV="-E BOARDS -E APPS -E NIGHTLY -E RUN_TESTS -E ENABLE_TEST_CACHE
          -E TEST_HASH -E CI_PULL_LABELS -ECI_BASE_BRANCH -ECI_BASE_COMMIT
          -EPKG_USE_MIRROR -EAPPS_CHANGED -EBOARDS_CHANGED -ESTATIC_TESTS


### PR DESCRIPTION
### Contribution description

The -gz CFLAG has been blacklisted in #12202 due to a bug in ccache. This bug has since been fixed and the build container uses a sufficiently new version as well.

### Testing procedure

Occurances of `-gz` in `master`:
```
buechse@skyleaf:~/RIOTstuff/riot-upstream3/RIOT$ grep -RnwI -- -gz
.murdock:115:# - CCACHE thinks that -gz by itself enables debugging, which is not true.
.murdock:125:export OPTIONAL_CFLAGS_BLACKLIST="-gz"
cpu/esp_common/Makefile.include:49:OPTIONAL_CFLAGS_BLACKLIST += -gz
makefiles/arch/msp430.inc.mk:36:OPTIONAL_CFLAGS_BLACKLIST += -gz
makefiles/arch/avr8.inc.mk:43:OPTIONAL_CFLAGS_BLACKLIST += -gz
makefiles/cflags.inc.mk:90:OPTIONAL_CFLAGS += -gz
```

Check that `ccache` is new enough:
```
buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 'docker.io/riot/riotbuild@sha256:e024b54e54ace0b342ba5e1bc76c4fa4c80ea8439a97dada6a2cdd0e24c890d6' ccache --version
ccache version 4.5.1
Features: file-storage http-storage redis-storage

Copyright (C) 2002-2007 Andrew Tridgell
Copyright (C) 2009-2021 Joel Rosdahl and other contributors

See <https://ccache.dev/credits.html> for a complete list of contributors.

This program is free software; you can redistribute it and/or modify it under
the terms of the GNU General Public License as published by the Free Software
Foundation; either version 3 of the License, or (at your option) any later
version.
```

### Issues/PRs references

Added in #12202 due to https://github.com/ccache/ccache/issues/464, but not required anymore.

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
