### PR TITLE
esp-ieee802154: fix RSSI and LQI values reported after RX

### DIFF
--- a/cpu/esp32/esp-ieee802154/esp_ieee802154_hal.c
+++ b/cpu/esp32/esp-ieee802154/esp_ieee802154_hal.c
@@ -96,8 +96,8 @@ static int _read(ieee802154_dev_t *dev, void *buf, size_t size, ieee802154_rx_in
     else if (buf) {
         DEBUG("[esp_ieee802154] %s: read packet of length %d\n", __func__, len);
         if (info) {
-            info->rssi = ieee802154_dbm_to_rssi(_rx_frame[len]);
-            info->lqi = _rx_frame[len+1];
+            info->rssi = ieee802154_dbm_to_rssi(_rx_frame_info->rssi);
+            info->lqi = _rx_frame_info->lqi;
         }
         memcpy(buf, &_rx_frame[1], len);
         res = len;


### PR DESCRIPTION
### Contribution description

The values were read from the frame buffer which is not exactly wrong but error prone. As you can see we are currently reporting a wrong RSSI value which is constantly 254. Read them from the provided `rx_frame_info` struct instead

### Testing procedure

without the fix

```shell
> 2026-09-09 14:20:36,173 # Frame received:
2026-09-09 14:20:36,174 # 00000000  41  DC  00  23  00  F2  CD  B7  C0  ED  BF  AF  A6  22  2B  4F
2026-09-09 14:20:36,174 # 00000010  20  E1  FE  8D  AE  4C  6F  72  65  6D  20  69  70  73  75
2026-09-09 14:20:36,174 # LQI: 202, RSSI: 254
2026-09-09 14:20:36,174 # 
2026-09-09 14:20:38,595 # Frame received:
2026-09-09 14:20:38,596 # 00000000  41  DC  01  23  00  F2  CD  B7  C0  ED  BF  AF  A6  22  2B  4F
2026-09-09 14:20:38,596 # 00000010  20  E1  FE  8D  AE  4C  6F  72  65  6D  20  69  70  73  75
2026-09-09 14:20:38,596 # LQI: 202, RSSI: 254
2026-09-09 14:20:38,596 # 
2026-09-09 14:20:39,386 # Frame received:
2026-09-09 14:20:39,387 # 00000000  41  DC  02  23  00  F2  CD  B7  C0  ED  BF  AF  A6  22  2B  4F
2026-09-09 14:20:39,388 # 00000010  20  E1  FE  8D  AE  4C  6F  72  65  6D  20  69  70  73  75
2026-09-09 14:20:39,388 # LQI: 203, RSSI: 254
2026-09-09 14:20:39,388 # 
2026-09-09 14:20:40,142 # Frame received:
2026-09-09 14:20:40,143 # 00000000  41  DC  03  23  00  F2  CD  B7  C0  ED  BF  AF  A6  22  2B  4F
2026-09-09 14:20:40,144 # 00000010  20  E1  FE  8D  AE  4C  6F  72  65  6D  20  69  70  73  75
2026-09-09 14:20:40,144 # LQI: 203, RSSI: 254
2026-09-09 14:20:40,144 # 
2026-09-09 14:20:40,708 # Frame received:
2026-09-09 14:20:40,709 # 00000000  41  DC  04  23  00  F2  CD  B7  C0  ED  BF  AF  A6  22  2B  4F
2026-09-09 14:20:40,710 # 00000010  20  E1  FE  8D  AE  4C  6F  72  65  6D  20  69  70  73  75
2026-09-09 14:20:40,710 # LQI: 202, RSSI: 254
```

LQI seems to be the RSSI value

with the fix

```shell
2026-09-09 14:27:01,718 # Frame received:
2026-09-09 14:27:01,718 # 00000000  41  DC  05  23  00  F2  CD  B7  C0  ED  BF  AF  A6  22  2B  4F
2026-09-09 14:27:01,719 # 00000010  20  E1  FE  8D  AE  4C  6F  72  65  6D  20  69  70  73  75
2026-09-09 14:27:01,719 # LQI: 10, RSSI: 120
2026-09-09 14:27:01,719 # 
2026-09-09 14:27:02,503 # Frame received:
2026-09-09 14:27:02,504 # 00000000  41  DC  06  23  00  F2  CD  B7  C0  ED  BF  AF  A6  22  2B  4F
2026-09-09 14:27:02,504 # 00000010  20  E1  FE  8D  AE  4C  6F  72  65  6D  20  69  70  73  75
2026-09-09 14:27:02,504 # LQI: 10, RSSI: 119
2026-09-09 14:27:02,504 # 
2026-09-09 14:27:03,111 # Frame received:
2026-09-09 14:27:03,112 # 00000000  41  DC  07  23  00  F2  CD  B7  C0  ED  BF  AF  A6  22  2B  4F
2026-09-09 14:27:03,112 # 00000010  20  E1  FE  8D  AE  4C  6F  72  65  6D  20  69  70  73  75
2026-09-09 14:27:03,113 # LQI: 10, RSSI: 119
2026-09-09 14:27:03,113 # 
2026-09-09 14:27:03,674 # Frame received:
2026-09-09 14:27:03,675 # 00000000  41  DC  08  23  00  F2  CD  B7  C0  ED  BF  AF  A6  22  2B  4F
2026-09-09 14:27:03,676 # 00000010  20  E1  FE  8D  AE  4C  6F  72  65  6D  20  69  70  73  75
2026-09-09 14:27:03,676 # LQI: 9, RSSI: 119
```

the values are valid

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

Found by my eyes :eyes: