### PR TITLE
sys/walltime: clear time struct in `walltime set`

### DIFF
--- a/sys/walltime/shell.c
+++ b/sys/walltime/shell.c
@@ -42,6 +42,7 @@ static int cmd_uptime(int argc, char **argv)
 static int _cmd_set_time(char **argv)
 {
     struct tm now;
+    memset(&now, 0, sizeof(now));
 
     if (scn_time_tm_iso8601_date(&now, argv[0]) < 0) {
         return -1;


### PR DESCRIPTION
### Contribution description

The `walltime set` command does not clear the `struct tm` it uses to store the interpreted time and date.
This is an issue because the `scn_time_tm_iso8601_date` and `scn_time_tm_iso8601_time` functions do not clear the input struct, which `scn_time_tm_iso8601` does. The latter is used in the `test` command of the `tests/sys/walltime`.

The issue is hard to reproduce because the RAM has to have some content before and not be zero.
But if it is not, it will cause issues with the MAX313xx driver that checks e.g. `tm_wday`, which is not set by `scn_time_tm_iso8601_date`.

### Testing procedure

I added a debug message that prints `tm_wday` that is evaluated by the MAX31331 driver. It is not 0, as it should be (well "should", the command doesn't set it, but it still has to be valid for the MAX31331 driver).
```
> walltime set 2026-09-09 00:00:17
2026-09-09 15:00:22,123 # walltime set 2026-09-09 00:00:17
2026-09-09 15:00:22,140 # tm_wday: 603980984
2026-09-09 15:00:22,141 # setting time failed: -34
```

With this PR, it succeeds:
```
> walltime set 2026-09-09 00:00:01
2026-09-09 15:46:37,872 # walltime set 2026-09-09 00:00:01
2026-09-09 15:46:37,873 # tm_wday: 0
```

### Issues/PRs references
None.

### Declaration of AI-Tools / LLMs usage:
AI-Tools / LLMs that were used are:
- none