### PR TITLE
cpu/riscv_common: temporarily disable rust support

### DIFF
--- a/cpu/riscv_common/Makefile.features
+++ b/cpu/riscv_common/Makefile.features
@@ -13,7 +13,10 @@ else
   # target would link the rv32 libc and fail with an ABI mismatch, so only
   # advertise it for rv32 (rv64 falls back to newlib).
   FEATURES_PROVIDED += picolibc
-  FEATURES_PROVIDED += rust_target
+  # C2Rust 0.22.1 does not implement all the necessary types for RISC-V to work
+  # with newer clang versions (>15). Therefore, the rust_target is temporarily
+  # disabled.
+  #FEATURES_PROVIDED += rust_target
 endif
 FEATURES_PROVIDED += arch_riscv
 FEATURES_PROVIDED += bug_newlib_broken_stdio


### PR DESCRIPTION
### Contribution description

C2Rust v0.22.1 does not work well with clang versions >15, as it does not implement all necessary data type tuples.

### Testing procedure

The CI won't try to build the Rust applications for RISC-V microcontrollers anymore.

### Issues/PRs references

Closes #20451 (which was reopened thinking it was the same issue but it wasn't).

Required for https://github.com/RIOT-OS/riotdocker/pull/286

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- Claude for asking what the error was about.