### PR TITLE
examples/rust-gcoap: enable compilation for native again

### DIFF
--- a/examples/lang_support/official/rust-gcoap/Makefile
+++ b/examples/lang_support/official/rust-gcoap/Makefile
@@ -1,9 +1,6 @@
 # name of your application
 APPLICATION = rust_gcoap
 
-# TODO: Fix bug in docker image
-BOARDS_UNSUPPORTED := native32 native64 native
-
 # The name of crate (as per Cargo.toml package name, but with '-' replaced with '_')
 #
 # The presence of this triggers building Rust code contained in this


### PR DESCRIPTION
### Contribution description

The compilation of rust-gcoap was disabled in #21531, but now it works again, so it can be enabled again.

### Testing procedure

CI should be happy.

### Issues/PRs references

Reverts the disabling from #21531.
Probably needs https://github.com/RIOT-OS/riotdocker/pull/286 ? We'll see.
Probably needs #22683 ?

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none