### PR TITLE
boards/seeedstudio-xiao-nrf52840-sense: power IMU only if used

### DIFF
--- a/boards/seeedstudio-xiao-nrf52840-sense/board.c
+++ b/boards/seeedstudio-xiao-nrf52840-sense/board.c
@@ -27,11 +27,17 @@ void board_init(void)
 {
     /* The IMU is supplied through a GPIO Pin (P1.08), so it has to be set
      * to high power mode. */
-    gpio_conf_t lsm6ds3_pwr_pin_conf;
+    gpio_conf_t lsm6ds3_pwr_pin_conf = {0};
 
     lsm6ds3_pwr_pin_conf.state = GPIO_OUTPUT_PUSH_PULL;      /* Set the output to push pull */
-    lsm6ds3_pwr_pin_conf.drive_strength = GPIO_DRIVE_STRONG; /* enable high drive strength H0H1 */
-    lsm6ds3_pwr_pin_conf.initial_value = 1;                  /* enable the power for the IMU */
+    lsm6ds3_pwr_pin_conf.drive_strength = GPIO_DRIVE_STRONG; /* Enable high drive strength H0H1 */
+
+    /* Power on the IMU if used */
+    if (IS_USED(MODULE_LSM6DSXX)) {
+        lsm6ds3_pwr_pin_conf.initial_value = true;
+    } else {
+        lsm6ds3_pwr_pin_conf.initial_value = false;
+    }
 
     gpio_ll_init(gpio_get_port(LSM6DS3_PWR_PIN),
                  gpio_get_pin_num(LSM6DS3_PWR_PIN), lsm6ds3_pwr_pin_conf);

--- a/boards/seeedstudio-xiao-nrf52840-sense/doc.md
+++ b/boards/seeedstudio-xiao-nrf52840-sense/doc.md
@@ -12,8 +12,11 @@ Low Energy and IEEE 802.15.4 support via the nRF52840 MCU.
 Compared to the [XIAO nRF52840](@ref boards_seeedstudio-xiao-nrf52840) it
 features an ST LSM6DS3TR-C IMU and a PDM Microphone (not supported yet).
 
-<img src="https://files.seeedstudio.com/wiki/XIAO-BLE/pinout2.png"
-     alt="top-down view on seeedstudio-xiao-nrf52840" width="50%"/>
+<img src="https://files.seeedstudio.com/wiki/XIAO-BLE/XIAO_nRF52840_Sense_front_pinout.png"
+    alt="Front view of the seedstudio-xiao-nrf52840-sense" width="50%">
+
+<img src="https://files.seeedstudio.com/wiki/XIAO-BLE/XIAO_nRF52840_Sense_back_pinout.png"
+    alt="Back view of the seedstudio-xiao-nrf52840-sense" width="50%">
 
 [seeedstudio-xiao-nrf52840-sense]: https://wiki.seeedstudio.com/XIAO_BLE/
 
@@ -24,6 +27,9 @@ You can test the built-in IMU with the test provided in `tests/drivers/lsm6dsxx`
 ```shell
 make BOARD=seeedstudio-xiao-nrf52840-sense -C tests/drivers/lsm6dsxx flash term
 ```
+
+Note that the IMU remains powered off by default, unless the corresponding driver (`lsm6dsxx`) is
+used.
 
 ### Flashing, Bootloader, and Terminal
 


### PR DESCRIPTION
### Contribution description

This is a minor change to the `board_init` of the `seeedstudio-xiao-nrf52840-sense`. Since the IMU is powered from an MCU pin, the init code unconditionally powers it on. Even though the standby power of the device is not that high for most applications, we should aim to initialise only what we use.

### Testing procedure

Test that any application bringing the `lsm6dsxx` module can access it. I tested locally with the SAUL application.


### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none