### PR TITLE
drivers/slipdev: Abort build if no auto init is selected

### DIFF
--- a/drivers/slipmux/Makefile.dep
+++ b/drivers/slipmux/Makefile.dep
@@ -8,7 +8,7 @@ ifneq (,$(filter slipdev_net,$(USEMODULE)))
   USEMODULE += netdev_register
 
   # Check that the driver actually gets initialised.
-  ifeq (,$(filter auto_init_gnrc_netif,$(USEMODULE)))
+  ifeq (,$(filter lwip_netif_init_devs auto_init_gnrc_netif,$(USEMODULE)))
     # We error out as the behaviour of a successful build (including this driver! Visible in the build log!)
     # that does not work when tested, is a miserable experience.
     # An alternative would have been to pull in auto_init_gnrc_netif as a dependency but
@@ -19,7 +19,7 @@ ifneq (,$(filter slipdev_net,$(USEMODULE)))
     #   * It is easy to search for the error and deleting it
     #   * It is harder to disable unwanted auto_init magic
     # (yes the last two are subjective, don't @ me)
-    $(error When using `slipdev_net`, the slipdev driver gets automatically initialised during startup of the network interfaces. Automatic initialization of the network interfaces is not selected: Slipdev won't start! Add `auto_init_gnrc_netif` to your modules)
+    $(error When using `slipdev_net`, the slipdev driver gets automatically initialised during startup of the network interfaces. Automatic initialization of the network interfaces is not selected: Slipdev won't start! When using GNRC (default) add `auto_init_gnrc_netif` to your modules or when using lwIP add `lwip_netif_init_devs` instead)
   endif
 endif
 

--- a/drivers/slipmux/Makefile.dep
+++ b/drivers/slipmux/Makefile.dep
@@ -6,6 +6,21 @@ ifneq (,$(filter slipdev_net,$(USEMODULE)))
   USEMODULE += eui_provider
   USEMODULE += netdev_new_api
   USEMODULE += netdev_register
+
+  # Check that the driver actually gets initialised.
+  ifeq (,$(filter auto_init_gnrc_netif,$(USEMODULE)))
+    # We error out as the behaviour of a successful build (including this driver! Visible in the build log!)
+    # that does not work when tested, is a miserable experience.
+    # An alternative would have been to pull in auto_init_gnrc_netif as a dependency but
+    #   * this differs from the behaviour that this driver always had (especially when it was network only)
+    #   * Auto_init is a convenience feature not a hard dependency
+    #   * People might want to bring their own init
+    # The last point is currently not possible as long as this error triggers but this is still superior:
+    #   * It is easy to search for the error and deleting it
+    #   * It is harder to disable unwanted auto_init magic
+    # (yes the last two are subjective, don't @ me)
+    $(error When using `slipdev_net`, the slipdev driver gets automatically initialised during startup of the network interfaces. Automatic initialization of the network interfaces is not selected: Slipdev won't start! Add `auto_init_gnrc_netif` to your modules)
+  endif
 endif
 
 ifneq (,$(filter stdio_slipdev,$(USEMODULE)))
@@ -20,5 +35,5 @@ ifneq (,$(filter slipdev_config,$(USEMODULE)))
 endif
 
 ifneq (,$(filter slipdev_stdio,$(USEMODULE)))
-  $(error The module slipdev_stdio got replaced by stdio_slipdev. It no longer pulls in slip networking. If you need slip networking add the module slipdev_net)
+  $(error You are selecting the module `slipdev_stdio` which got replaced by `stdio_slipdev`. In addition, it no longer pulls in slip networking. If you need slip networking add the module `slipdev_net`)
 endif

--- a/pkg/lwip/contrib/netdev/lwip_netdev.c
+++ b/pkg/lwip/contrib/netdev/lwip_netdev.c
@@ -67,7 +67,7 @@ static err_t _eth_link_output(struct netif *netif, struct pbuf *p);
 #ifdef MODULE_LWIP_SIXLOWPAN
 static err_t _ieee802154_link_output(struct netif *netif, struct pbuf *p);
 #endif
-#ifdef MODULE_SLIPDEV
+#ifdef MODULE_SLIPDEV_NET
 static err_t _slip_link_output(struct netif *netif, struct pbuf *p);
 #if LWIP_IPV4
 static err_t slip_output4(struct netif *netif, struct pbuf *q, const ip4_addr_t *ipaddr);
@@ -209,7 +209,7 @@ err_t lwip_netdev_init(struct netif *netif)
         break;
     }
 #endif
-#ifdef MODULE_SLIPDEV
+#ifdef MODULE_SLIPDEV_NET
     case NETDEV_TYPE_SLIP:
         netif->name[0] = 'S';
         netif->name[1] = 'L';
@@ -384,7 +384,7 @@ static err_t _ieee802154_link_output(struct netif *netif, struct pbuf *p)
 }
 #endif
 
-#ifdef MODULE_SLIPDEV
+#ifdef MODULE_SLIPDEV_NET
 #if LWIP_IPV4
 static err_t slip_output4(struct netif *netif, struct pbuf *q, const ip4_addr_t *ipaddr)
 {

--- a/pkg/lwip/init_devs/auto_init_slipdev_net.c
+++ b/pkg/lwip/init_devs/auto_init_slipdev_net.c
@@ -32,6 +32,7 @@ static slipdev_t slipdev_devs[NETIF_SLIPDEV_NUMOF];
 static void auto_init_slipdev(void)
 {
     for (unsigned i = 0; i < NETIF_SLIPDEV_NUMOF; i++) {
+        DEBUG("lwip: starting slipdev %i", i);
         slipdev_setup(&slipdev_devs[i], &slipdev_params[i], i);
         if (lwip_add_ethernet(&netif[i], &slipdev_devs[i].netdev) == NULL) {
             DEBUG("Could not add slipdev device\n");


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md.
-->

### Contribution description

Hello again 🐻‍❄️

This issue was known to me a long time, I just didn't realized how much of an issue that is until the summit. I watched a RIOT newcomer hit this issue and had the insight that this was non trivial to debug without deeper RIOT know-how.

(Also changed some wording on an error around stdio_slipdev)
### Testing procedure

Go to examples/basic/hello-world:
`USEMODULE=slipdev_net make all`
and observe the error from this PR.

To test lwIP:
`USEMODULE="slipdev_net  lwip_ethernet lwip_ipv4" make all`
and observe the error from this PR.

(the lwip dep resolution seems weird but thats out of scope, ideally you would just add `lwip`)

### Issues/PRs references

Note that `USEMODULE="slipdev_net auto_init_gnrc_netif" make all -j9` doesn't compile. This is unrelated to this PR. As a testing workaround add `USEMODULE=gnrc`.

### Declaration of AI-Tools / LLMs usage:

<!--
If AI/LLM was used please declare it here, and provide the following information:
- which AI/LLM tool(s) were used (e.g., ChatGPT, Claude Code, GitHub Copilot, etc.)
- to what degree the AI/LLM tool(s) were used (e.g., for code generation, for code review, for documentation, etc.)
- was the code generated by the AI but reviewed by the user (often called "agent mode"), created by the user with the autocompletion by the AI (often called "inline suggestions") or fully autonomously generated by the AI (Claude Code without user review, for example)

Example:
AI-Tools / LLMs that were used are:
- Claude Code with Claude Opus 4.8 for code generation, with user review
- GitHub Copilot for inline suggestions during code writing
- ChatGPT for documentation generation, with user review

For further details, please refer to our AI policy: https://doc.riot-os.org/general/ai_policy
-->

AI-Tools / LLMs that were used are:
- none

<!--
Keep this section as is even if no AI/LLM was used, **do not** remove it if you did not use any AI/LLM.
-->
