### PR TITLE
boards/stm32c0116-dk: enable cpy2remed

### DIFF
--- a/boards/stm32c0116-dk/Makefile.include
+++ b/boards/stm32c0116-dk/Makefile.include
@@ -12,7 +12,13 @@ PROGRAMMER ?= openocd
 OPENOCD_DEBUG_ADAPTER ?= stlink
 
 # openocd programmer is supported
-PROGRAMMERS_SUPPORTED += openocd
+PROGRAMMERS_SUPPORTED += openocd cpy2remed
 
-# this board uses openocd
-include $(RIOTMAKE)/tools/openocd.inc.mk
+# Automatic flash directory name generation failed for this board
+# and it should be set manually - see PR #18057
+DIR_NAME_AT_REMED = "DIS_C011F6"
+
+# if this board uses openocd
+ifeq ($(PROGRAMMER), openocd)
+  include $(RIOTMAKE)/tools/openocd.inc.mk
+endif


### PR DESCRIPTION
### Contribution description

This PR enables `cpy2remed` programmer for `stm32c0116-dk` board.

### Testing procedure

Check if programming using `cpy2remed` works for `stm32c0116-dk` board. 
Use command:

```
make BOARD=stm32c0116-dk PROGRAMMER=cpy2remed flash
```

I checked this in my board for `examples/blinky` and `examples/leds_shell`. Everything works OK.

### Issues/PRs references

None

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none