### PR TITLE
makefiles/docker.inc.mk: bump docker image version after `flake8` update and `clang-format` addition

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -5,7 +5,7 @@
 # When the docker image is updated, checks at
 # dist/tools/buildsystem_sanity_check/check.sh start complaining in CI, and
 # provide the latest values to verify and fill in.
-DOCKER_TESTED_IMAGE_REPO_DIGEST := 31eb2af1543a261fb93d471d6f01fcdf84e5e2e64a954c8ed1e0ff290bde1b83
+DOCKER_TESTED_IMAGE_REPO_DIGEST := eadaa844c983195617453cab79c713ab02748612b92fa1ae766cb79143cffdac
 
 DOCKER_PULL_IDENTIFIER := docker.io/riot/riotbuild@sha256:$(DOCKER_TESTED_IMAGE_REPO_DIGEST)
 export DOCKER_IMAGE ?= $(DOCKER_PULL_IDENTIFIER)


### PR DESCRIPTION
### Contribution description

Necessary after merging https://github.com/RIOT-OS/riotdocker/pull/293 and https://github.com/RIOT-OS/riotdocker/pull/294.

### Testing procedure

Static test should be happy and CI builds.
Note: static tests for the global `master` won't be happy, because the newer `flake8` version has some new checks.

This will not impact other PRs, it "just" adds to the backlog of https://github.com/RIOT-OS/RIOT/issues/22216

### Issues/PRs references

None.

### Declaration of AI-Tools / LLMs usage:

AI-Tools / LLMs that were used are:
- none