### PR TITLE
treewide: fix flake8 errors

### DIFF
--- a/dist/tools/mkconstfs/mkconstfs2.py
+++ b/dist/tools/mkconstfs/mkconstfs2.py
@@ -121,7 +121,7 @@ def print_file_data(local_fname, varname, target_fname=""):
                                                  ) as bfile:
         yield from map(lambda x: x[1],
                        itertools.chain.from_iterable(
-                            map(lambda l: itertools.chain(l, [(0, "\n")]),
+                            map(lambda y: itertools.chain(y, [(0, "\n")]),
                                 chunk(map(byte2s, bfile), 16)
                                 )
                         )

--- a/dist/tools/pktbuf-stats/pktbuf-stats.py
+++ b/dist/tools/pktbuf-stats/pktbuf-stats.py
@@ -245,7 +245,6 @@ def get_struct(elffile, struct_name):
         NotImplementedError: If no base information for the struct can be
         found. Extend NETTYPE_STRUCTS in this case accordingly.
     """
-    global PKTSNIP_STRUCT, NETTYPE_STRUCTS
     d = None
     if struct_name == PKTSNIP_STRUCT["name"]:
         d = PKTSNIP_STRUCT
@@ -589,7 +588,6 @@ def identify_struct(elffile, content, pktsnip):
         dict: struct descriptor as returned by parse_struct() or by a provided
         sub-parser for that struct in NETTYPE_STRUCTS.
     """
-    global NETTYPE_STRUCTS
     nettype = pktsnip["type"]
     struct_dict = get_struct(elffile, NETTYPE_STRUCTS[nettype]["name"])
     idx = None
@@ -649,7 +647,6 @@ def identify_struct(elffile, content, pktsnip):
 
 
 def main():
-    global PKTSNIP_STRUCT
     args_parser = argparse.ArgumentParser(
              description="Analyze `pktbuf` command output"
         )

--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -797,7 +797,7 @@ class PytermProt(Protocol):
 
     def dataReceived(self, data):
         sys.stdout.write(data)
-        if(data.strip() == "/exit"):
+        if (data.strip() == "/exit"):
             reactor.callLater(2, self.factory.shell.do_PYTERM_exit, data)
         else:
             self.factory.shell._write_char(data + "\n")

--- a/dist/tools/pyterm/testbeds/testbeds.py
+++ b/dist/tools/pyterm/testbeds/testbeds.py
@@ -160,7 +160,7 @@ class DesVirtTestbed(Testbed):
         pattern = re.compile(pats)
         for line in stream:
             match = pattern.match(line)
-            if(match):
+            if match:
                 tuple = match.groups()
                 self.namePortList.append((tuple[0], int(tuple[1])))
         self.namePortList = sorted(self.namePortList)

--- a/doc/doxygen/generate-changelog.py
+++ b/doc/doxygen/generate-changelog.py
@@ -37,7 +37,7 @@ def generate_changelog(template_filename, changelog_filename, output_filename):
             elif release_title.match(line):
                 # if line contains a release title
                 release_match = re.search(r"(\d{4}\.\d{2}(\.\d+)?)", line)
-                assert(release_match is not None)
+                assert (release_match is not None)
                 # parse out release number
                 release = release_match.group(1)
                 title = "Release %s" % release

--- a/tests/core/thread_msg_block_race/tests/01-run.py
+++ b/tests/core/thread_msg_block_race/tests/01-run.py
@@ -15,7 +15,7 @@ def testfunc(child):
     res = child.expect([TIMEOUT, "Message was not written"])
     # we actually want the timeout here. The application runs into an assertion
     # pretty quickly when failing and runs forever on success
-    assert(res == 0)
+    assert (res == 0)
 
 
 if __name__ == "__main__":

--- a/tests/net/emcute/tests-as-root/01-run.py
+++ b/tests/net/emcute/tests-as-root/01-run.py
@@ -318,7 +318,7 @@ class MQTTSNServer(Automaton):
                 tid = pkt.tid
                 topic_name = self._get_topic_name(tid)
             else:
-                assert(False)
+                assert False
             subscription = {"tid": tid, "topic_name": topic_name}
             if subscription not in self.subscriptions:
                 self.subscriptions.append(subscription)

--- a/tests/net/gnrc_ipv6_ext/tests-as-root/01-run.py
+++ b/tests/net/gnrc_ipv6_ext/tests-as-root/01-run.py
@@ -82,10 +82,10 @@ def test_empty_duplicate_hop_by_hop_opt(child, iface, hw_dst, ll_dst, ll_src):
              IPv6ExtHdrHopByHop() / IPv6ExtHdrHopByHop() / UDP() / "\x03\x04",
              iface=iface, timeout=1, verbose=0)
     # should return parameter problem message
-    assert(p is not None)
-    assert(ICMPv6ParamProblem in p)
-    assert(p[ICMPv6ParamProblem].code == 1)     # unrecognized next header
-    assert(p[ICMPv6ParamProblem].ptr >= 40)     # after IPv6 header
+    assert (p is not None)
+    assert (ICMPv6ParamProblem in p)
+    assert (p[ICMPv6ParamProblem].code == 1)    # unrecognized next header
+    assert (p[ICMPv6ParamProblem].ptr >= 40)    # after IPv6 header
     pktbuf_empty(child)
 
 
@@ -96,10 +96,10 @@ def test_empty_non_first_hop_by_hop_opt(child, iface, hw_dst, ll_dst, ll_src):
              IPv6ExtHdrDestOpt() / IPv6ExtHdrHopByHop() / UDP() / "\x05\x06",
              iface=iface, timeout=1, verbose=0)
     # should return parameter problem message
-    assert(p is not None)
-    assert(ICMPv6ParamProblem in p)
-    assert(p[ICMPv6ParamProblem].code == 1)     # unrecognized next header
-    assert(p[ICMPv6ParamProblem].ptr >= 40)     # after IPv6 header
+    assert (p is not None)
+    assert (ICMPv6ParamProblem in p)
+    assert (p[ICMPv6ParamProblem].code == 1)    # unrecognized next header
+    assert (p[ICMPv6ParamProblem].ptr >= 40)    # after IPv6 header
     pktbuf_empty(child)
 
 
@@ -112,10 +112,10 @@ def test_empty_duplicate_non_first_hop_by_hop_opt(child, iface, hw_dst, ll_dst,
              UDP() / "\x07\x08",
              iface=iface, timeout=1, verbose=0)
     # should return parameter problem message
-    assert(p is not None)
-    assert(ICMPv6ParamProblem in p)
-    assert(p[ICMPv6ParamProblem].code == 1)     # unrecognized next header
-    assert(p[ICMPv6ParamProblem].ptr >= 48)     # after IPv6 header and HopByHopOpt
+    assert (p is not None)
+    assert (ICMPv6ParamProblem in p)
+    assert (p[ICMPv6ParamProblem].code == 1)    # unrecognized next header
+    assert (p[ICMPv6ParamProblem].ptr >= 48)    # after IPv6 header and HopByHopOpt
     pktbuf_empty(child)
 
 

--- a/tests/net/gnrc_ipv6_ext_frag/tests-as-root/01-run.py
+++ b/tests/net/gnrc_ipv6_ext_frag/tests-as-root/01-run.py
@@ -309,7 +309,7 @@ def test_ipv6_ext_frag_send_full_pktbuf(child, s, iface, ll_dst):
             break
         finally:
             pktbuf_empty(child)
-    assert(count > 1)
+    assert (count > 1)
 
 
 def _fwd_setup(child, ll_dst, g_src, g_dst):
@@ -362,7 +362,7 @@ def test_ipv6_ext_frag_fwd_success(child, s, iface, ll_dst):
 
 def test_ipv6_ext_frag_fwd_too_big(child, s, iface, ll_dst):
     mock_id, mtu, dst_mac = _fwd_setup(child, ll_dst, "beef::1", "affe::1")
-    assert(get_host_mtu(iface) > mtu)
+    assert (get_host_mtu(iface) > mtu)
     payload_fit = get_host_mtu(iface) - len(IPv6() / IPv6ExtHdrFragment() /
                                             UDP())
     pkt = srp1(Ether(dst=dst_mac) / IPv6(src="beef::1", dst="affe::1") /
@@ -371,10 +371,10 @@ def test_ipv6_ext_frag_fwd_too_big(child, s, iface, ll_dst):
                timeout=2, verbose=0, iface=iface)
     # packet should not be fragmented further but an ICMPv6 error should be
     # returned instead
-    assert(pkt is not None)
-    assert(ICMPv6PacketTooBig in pkt)
-    assert(IPv6ExtHdrFragment in pkt)
-    assert(pkt[IPv6ExtHdrFragment].id == 0x477384a9)
+    assert (pkt is not None)
+    assert (ICMPv6PacketTooBig in pkt)
+    assert (IPv6ExtHdrFragment in pkt)
+    assert (pkt[IPv6ExtHdrFragment].id == 0x477384a9)
     _fwd_teardown(child, mock_id)
 
 

--- a/tests/net/gnrc_rpl_srh/tests-as-root/01-run.py
+++ b/tests/net/gnrc_rpl_srh/tests-as-root/01-run.py
@@ -160,10 +160,10 @@ def test_wrong_type(child, iface, hw_dst, ll_dst, ll_src):
     p = srp1(Ether(dst=hw_dst) / IPv6(dst=ll_dst, src=ll_src) /
              IPv6ExtHdrRouting(type=255, segleft=1, addresses=["abcd::1"]),
              iface=iface, timeout=1, verbose=0)
-    assert(p is not None)
-    assert(ICMPv6ParamProblem in p)
-    assert(p[ICMPv6ParamProblem].code == 0)     # erroneous header field encountered
-    assert(p[ICMPv6ParamProblem].ptr == 42)     # routing header type field
+    assert (p is not None)
+    assert (ICMPv6ParamProblem in p)
+    assert (p[ICMPv6ParamProblem].code == 0)    # erroneous header field encountered
+    assert (p[ICMPv6ParamProblem].ptr == 42)    # routing header type field
     pktbuf_empty(child)
 
 
@@ -173,10 +173,10 @@ def test_inconsistent_header(child, iface, hw_dst, ll_dst, ll_src):
     p = srp1(Ether(dst=hw_dst) / IPv6(dst=ll_dst, src=ll_src) /
              IPv6ExtHdrRouting(type=3, segleft=18, addresses=[]),
              iface=iface, timeout=1, verbose=0)
-    assert(p is not None)
-    assert(ICMPv6ParamProblem in p)
-    assert(p[ICMPv6ParamProblem].code == 0)     # erroneous header field encountered
-    assert(p[ICMPv6ParamProblem].ptr == 41)     # len field
+    assert (p is not None)
+    assert (ICMPv6ParamProblem in p)
+    assert (p[ICMPv6ParamProblem].code == 0)    # erroneous header field encountered
+    assert (p[ICMPv6ParamProblem].ptr == 41)    # len field
     pktbuf_empty(child)
 
 
@@ -194,7 +194,7 @@ def test_multicast_dst(child, iface, hw_dst, ll_dst, ll_src):
                            (p[IPv6].dst != "ff02::1"))]
     # packet should be discarded silently:
     # see https://tools.ietf.org/html/rfc6554#section-4.2
-    assert(len(p) == 0)
+    assert (len(p) == 0)
     pktbuf_empty(child)
 
 
@@ -212,7 +212,7 @@ def test_multicast_addr(child, iface, hw_dst, ll_dst, ll_src):
                            (p[IPv6].dst != ll_dst))]
     # packet should be discarded silently:
     # see https://tools.ietf.org/html/rfc6554#section-4.2
-    assert(len(p) == 0)
+    assert (len(p) == 0)
     pktbuf_empty(child)
 
 
@@ -225,10 +225,10 @@ def test_multiple_addrs_of_mine_uncomp(child, iface, hw_dst, ll_dst, ll_src):
              IPv6ExtHdrRouting(type=3, segleft=3, addresses=[ll_dst, ll_src,
                                                              dummy]),
              iface=iface, timeout=1, verbose=0)
-    assert(p is not None)
-    assert(ICMPv6ParamProblem in p)
-    assert(p[ICMPv6ParamProblem].code == 0)             # erroneous header field encountered
-    assert(p[ICMPv6ParamProblem].ptr == 40+8+(2 * 16))  # dummy in routing header
+    assert (p is not None)
+    assert (ICMPv6ParamProblem in p)
+    assert (p[ICMPv6ParamProblem].code == 0)                # erroneous header field encountered
+    assert (p[ICMPv6ParamProblem].ptr == 40+8+(2 * 16))     # dummy in routing header
     pktbuf_empty(child)
     del_ipv6_address(child, dst_iface, dummy)
 
@@ -247,15 +247,15 @@ def test_forward_uncomp(child, iface, hw_dst, ll_dst, ll_src):
           iface=iface, verbose=0)
     ps = sniffer.wait_for_sniff_results()
     p = [p for p in ps if p[Ether].src == hw_dst]
-    assert(len(p) > 0)
+    assert (len(p) > 0)
     p = p[0]
-    assert(IPv6 in p)
-    assert(IPv6ExtHdrRouting in p)
-    assert(p[IPv6].src == ll_src)
-    assert(p[IPv6].dst == dummy)
-    assert(p[IPv6].hlim == (hl - 1))
-    assert(p[IPv6ExtHdrRouting].type == 3)
-    assert(p[IPv6ExtHdrRouting].segleft == 0)
+    assert (IPv6 in p)
+    assert (IPv6ExtHdrRouting in p)
+    assert (p[IPv6].src == ll_src)
+    assert (p[IPv6].dst == dummy)
+    assert (p[IPv6].hlim == (hl - 1))
+    assert (p[IPv6ExtHdrRouting].type == 3)
+    assert (p[IPv6ExtHdrRouting].segleft == 0)
     pktbuf_empty(child)
     del_neighbor(child, dst_iface, dummy)
 
@@ -275,15 +275,15 @@ def test_forward_uncomp_not_first_ext_hdr(child, iface, hw_dst, ll_dst, ll_src):
           iface=iface, verbose=0)
     ps = sniffer.wait_for_sniff_results()
     p = [p for p in ps if p[Ether].src == hw_dst]
-    assert(len(p) > 0)
+    assert (len(p) > 0)
     p = p[0]
-    assert(IPv6 in p)
-    assert(IPv6ExtHdrRouting in p)
-    assert(p[IPv6].src == ll_src)
-    assert(p[IPv6].dst == dummy)
-    assert(p[IPv6].hlim == (hl - 1))
-    assert(p[IPv6ExtHdrRouting].type == 3)
-    assert(p[IPv6ExtHdrRouting].segleft == 0)
+    assert (IPv6 in p)
+    assert (IPv6ExtHdrRouting in p)
+    assert (p[IPv6].src == ll_src)
+    assert (p[IPv6].dst == dummy)
+    assert (p[IPv6].hlim == (hl - 1))
+    assert (p[IPv6ExtHdrRouting].type == 3)
+    assert (p[IPv6ExtHdrRouting].segleft == 0)
     pktbuf_empty(child)
     del_neighbor(child, dst_iface, dummy)
 
@@ -316,9 +316,9 @@ def test_time_exc(child, iface, hw_dst, ll_dst, ll_src):
     p = srp1(Ether(dst=hw_dst) / IPv6(dst=ll_dst, hlim=1, src=ll_src) /
              IPv6ExtHdrRouting(type=3, segleft=1, addresses=[dummy]),
              iface=iface, timeout=1, verbose=0)
-    assert(p is not None)
-    assert(ICMPv6TimeExceeded in p)
-    assert(p[ICMPv6TimeExceeded].code == 0)
+    assert (p is not None)
+    assert (ICMPv6TimeExceeded in p)
+    assert (p[ICMPv6TimeExceeded].code == 0)
     pktbuf_empty(child)
 
 

--- a/tests/net/gnrc_sock_dns/tests-with-config/01-run.py
+++ b/tests/net/gnrc_sock_dns/tests-with-config/01-run.py
@@ -61,19 +61,19 @@ class Server(threading.Thread):
             p, remote = self.socket.recvfrom(1500)
             p = DNS(raw(p))
             # check received packet for correctness
-            assert(p is not None)
-            assert(p[DNS].qr == 0)
-            assert(p[DNS].opcode == 0)
+            assert (p is not None)
+            assert (p[DNS].qr == 0)
+            assert (p[DNS].opcode == 0)
             # has two queries
-            assert(p[DNS].qdcount == TEST_QDCOUNT)
+            assert (p[DNS].qdcount == TEST_QDCOUNT)
             qdcount = p[DNS].qdcount
             # both for TEST_NAME
-            assert(p[DNS].qd[0].qname == TEST_NAME.encode("utf-8") + b".")
-            assert(p[DNS].qd[1].qname == TEST_NAME.encode("utf-8") + b".")
-            assert(any(p[DNS].qd[i].qtype == DNS_RR_TYPE_A
-                       for i in range(qdcount)))    # one is A
-            assert(any(p[DNS].qd[i].qtype == DNS_RR_TYPE_AAAA
-                       for i in range(qdcount)))    # one is AAAA
+            assert (p[DNS].qd[0].qname == TEST_NAME.encode("utf-8") + b".")
+            assert (p[DNS].qd[1].qname == TEST_NAME.encode("utf-8") + b".")
+            assert (any(p[DNS].qd[i].qtype == DNS_RR_TYPE_A
+                        for i in range(qdcount)))    # one is A
+            assert (any(p[DNS].qd[i].qtype == DNS_RR_TYPE_AAAA
+                        for i in range(qdcount)))    # one is AAAA
             if self.reply is not None:
                 self.socket.sendto(raw(self.reply), remote)
                 self.reply = None
@@ -147,24 +147,24 @@ def test_success(child):
                                 rdata=TEST_AAAA_DATA) /
                           DNSRR(rrname=TEST_NAME, type=DNS_RR_TYPE_A,
                                 rdlen=DNS_RR_TYPE_A_DLEN, rdata=TEST_A_DATA))))
-    assert(successful_dns_request(child, TEST_NAME, TEST_AAAA_DATA))
+    assert (successful_dns_request(child, TEST_NAME, TEST_AAAA_DATA))
 
 
 def test_timeout(child):
     # listen but send no reply
     server.listen()
-    assert(not successful_dns_request(child, TEST_NAME, TEST_AAAA_DATA))
+    assert (not successful_dns_request(child, TEST_NAME, TEST_AAAA_DATA))
 
 
 def test_too_short_response(child):
     server.listen(Raw(b"\x00\x00\x81\x00"))
-    assert(not successful_dns_request(child, TEST_NAME))
+    assert (not successful_dns_request(child, TEST_NAME))
 
 
 def test_qdcount_too_large1(child):
     # as reported in https://github.com/RIOT-OS/RIOT/issues/10739
     server.listen(base64.b64decode("AACEAwkmAAAAAAAAKioqKioqKioqKioqKioqKioqKio="))
-    assert(not successful_dns_request(child, TEST_NAME))
+    assert (not successful_dns_request(child, TEST_NAME))
 
 
 def test_qdcount_too_large2(child):
@@ -176,7 +176,7 @@ def test_qdcount_too_large2(child):
                                 rdata=TEST_AAAA_DATA) /
                           DNSRR(rrname=TEST_NAME, type=DNS_RR_TYPE_A,
                                 rdlen=DNS_RR_TYPE_A_DLEN, rdata=TEST_A_DATA))))
-    assert(not successful_dns_request(child, TEST_NAME))
+    assert (not successful_dns_request(child, TEST_NAME))
 
 
 def test_ancount_too_large1(child):
@@ -188,7 +188,7 @@ def test_ancount_too_large1(child):
                                 rdata=TEST_AAAA_DATA) /
                           DNSRR(rrname=TEST_NAME, type=DNS_RR_TYPE_A,
                                 rdlen=DNS_RR_TYPE_A_DLEN, rdata=TEST_A_DATA))))
-    assert(not successful_dns_request(child, TEST_NAME, TEST_AAAA_DATA))
+    assert (not successful_dns_request(child, TEST_NAME, TEST_AAAA_DATA))
 
 
 def test_ancount_too_large2(child):
@@ -196,13 +196,13 @@ def test_ancount_too_large2(child):
                       qd=(DNSQR(qname=TEST_NAME, qtype=DNS_RR_TYPE_AAAA) /
                           DNSQR(qname=TEST_NAME, qtype=DNS_RR_TYPE_A)),
                       an="\0"))
-    assert(not successful_dns_request(child, TEST_NAME))
+    assert (not successful_dns_request(child, TEST_NAME))
 
 
 def test_bad_compressed_message_query(child):
     server.listen(DNS(qr=1, qdcount=1, ancount=1,
                       qd=DNS_MSG_COMP_MASK))
-    assert(not successful_dns_request(child, TEST_NAME))
+    assert (not successful_dns_request(child, TEST_NAME))
 
 
 def test_bad_compressed_message_answer(child):
@@ -210,7 +210,7 @@ def test_bad_compressed_message_answer(child):
                       qd=(DNSQR(qname=TEST_NAME, qtype=DNS_RR_TYPE_AAAA) /
                           DNSQR(qname=TEST_NAME, qtype=DNS_RR_TYPE_A)),
                       an=DNS_MSG_COMP_MASK))
-    assert(not successful_dns_request(child, TEST_NAME))
+    assert (not successful_dns_request(child, TEST_NAME))
 
 
 def test_malformed_hostname_query(child):
@@ -219,7 +219,7 @@ def test_malformed_hostname_query(child):
                           # need to use byte string here to induce wrong label
                           # lengths
                           b"\xafexample\x03org\x00\x00\x1c\x00\x01")))
-    assert(not successful_dns_request(child, TEST_NAME))
+    assert (not successful_dns_request(child, TEST_NAME))
 
 
 def test_malformed_hostname_answer(child):
@@ -232,7 +232,7 @@ def test_malformed_hostname_answer(child):
                           b"\x20\x01\x0d\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x00"
                           b"\x00\x00\x01" /
                           DNSQR(qname=TEST_NAME, qtype=DNS_RR_TYPE_A))))
-    assert(not successful_dns_request(child, TEST_NAME))
+    assert (not successful_dns_request(child, TEST_NAME))
 
 
 def test_addrlen_too_large(child):
@@ -243,7 +243,7 @@ def test_addrlen_too_large(child):
                                 rdlen=18549, rdata=TEST_AAAA_DATA) /
                           DNSRR(rrname=TEST_NAME, type=DNS_RR_TYPE_A,
                                 rdlen=DNS_RR_TYPE_A_DLEN, rdata=TEST_A_DATA))))
-    assert(not successful_dns_request(child, TEST_NAME, TEST_AAAA_DATA))
+    assert (not successful_dns_request(child, TEST_NAME, TEST_AAAA_DATA))
 
 
 def test_addrlen_wrong_ip6(child):
@@ -255,7 +255,7 @@ def test_addrlen_wrong_ip6(child):
                                 rdata=(TEST_AAAA_DATA)) /
                           DNSRR(rrname=TEST_NAME, type=DNS_RR_TYPE_A,
                                 rdlen=DNS_RR_TYPE_A_DLEN, rdata=TEST_A_DATA))))
-    assert(not successful_dns_request(child, TEST_NAME, TEST_AAAA_DATA))
+    assert (not successful_dns_request(child, TEST_NAME, TEST_AAAA_DATA))
 
 
 def test_addrlen_wrong_ip4(child):
@@ -267,7 +267,7 @@ def test_addrlen_wrong_ip4(child):
                           DNSRR(rrname=TEST_NAME, type=DNS_RR_TYPE_AAAA,
                                 rdlen=DNS_RR_TYPE_AAAA_DLEN,
                                 rdata=TEST_AAAA_DATA))))
-    assert(not successful_dns_request(child, TEST_NAME, TEST_AAAA_DATA))
+    assert (not successful_dns_request(child, TEST_NAME, TEST_AAAA_DATA))
 
 
 def testfunc(child):

--- a/tests/net/socket_zep/tests/01-run.py
+++ b/tests/net/socket_zep/tests/01-run.py
@@ -39,15 +39,15 @@ def testfunc(child):
     child.expect(r"Initializing socket ZEP with " +
                  r"\(local: \[(?P<local_addr>[.0-9a-f]+)\]:(?P<local_port>\d+), " +
                  r"remote: \[(?P<remote_addr>[.0-9a-f]+)\]:(?P<remote_port>\d+)\)")
-    assert(child.match.group('local_addr') == zep_params['local_addr'])
-    assert(int(child.match.group('local_port')) == zep_params['local_port'])
-    assert(child.match.group('remote_addr') == zep_params['remote_addr'])
-    assert(int(child.match.group('remote_port')) == zep_params['remote_port'])
+    assert (child.match.group('local_addr') == zep_params['local_addr'])
+    assert (int(child.match.group('local_port')) == zep_params['local_port'])
+    assert (child.match.group('remote_addr') == zep_params['remote_addr'])
+    assert (int(child.match.group('remote_port')) == zep_params['remote_port'])
     child.expect(r"\(Hwaddrs: (?P<short_addr>[0-9a-f]{4}), (?P<long_addr>[0-9a-f]{16})\)")
     child.expect_exact("Send 'Hello\\0World\\0'")
     data, addr = s.recvfrom(RCVBUF_LEN)
-    assert(len(data) == (ZEP_DATA_HEADER_SIZE + len("Hello\0World\0") + FCS_LEN))
-    assert(b"Hello\0World\0" == data[ZEP_DATA_HEADER_SIZE:-2])
+    assert (len(data) == (ZEP_DATA_HEADER_SIZE + len("Hello\0World\0") + FCS_LEN))
+    assert (b"Hello\0World\0" == data[ZEP_DATA_HEADER_SIZE:-2])
     child.expect_exact("Waiting for an incoming message (use `make test`)")
     s.sendto(b"\x45\x58\x02\x01\x1a\x44\xe0\x01\xff\xdb\xde\xa6\x1a\x00\x8b" +
              b"\xfd\xae\x60\xd3\x21\xf1\x00\x00\x00\x00\x00\x00\x00\x00\x00" +

--- a/tests/pkg/semtech-loramac/tests-with-config/01-run.py
+++ b/tests/pkg/semtech-loramac/tests-with-config/01-run.py
@@ -177,7 +177,7 @@ def testfunc(child):
 
     run(test_task02)
     run(test_task03)
-    if(_check_eeprom(child)):
+    if _check_eeprom(child):
         run(test_task04)
 
     print("TEST PASSED")

--- a/tests/riotboot/tests/01-run.py
+++ b/tests/riotboot/tests/01-run.py
@@ -25,9 +25,9 @@ class RiotbootDevice:
             "riotboot/flash-slot{}".format(self.slot_num),
             "APP_VER={}".format(self.app_ver),
         ]
-        assert(self.slot_num is not None)
-        assert(self.app_ver is not None)
-        assert subprocess.call(cmd) == 0
+        assert (self.slot_num is not None)
+        assert (self.app_ver is not None)
+        assert (subprocess.call(cmd) == 0)
 
     def get_current_slot_and_app_ver(self, child):
         # Ask for current slot, should be 0 or 1

--- a/tests/sys/shell/tests/01-run.py
+++ b/tests/sys/shell/tests/01-run.py
@@ -85,7 +85,7 @@ CMDS = (
     ('echo escaped\\ space', '"echo""escaped space"'),
     ('echo escape within \'\\s\\i\\n\\g\\l\\e\\q\\u\\o\\t\\e\'', '"echo""escape""within""singlequote"'),
     ('echo escape within "\\d\\o\\u\\b\\l\\e\\q\\u\\o\\t\\e"', '"echo""escape""within""doublequote"'),
-    ("""echo "t\\e st" "\\"" '\\'' a\ b""", '"echo""te st"""""\'""a b"'),  # noqa: W605
+    ("""echo "t\\e st" "\\"" '\\'' a\\ b""", '"echo""te st"""""\'""a b"'),
 
     # test correct quoting
     ('echo "hello"world', '"echo""helloworld"'),


### PR DESCRIPTION
### Contribution description

When updating `flake8` in https://github.com/RIOT-OS/riotdocker/pull/293, additional errors spawned. This PR fixes them.

### Testing procedure

Static test should be happy. The changes are so minor that I don't think any functional breakage is to be expected.

### Issues/PRs references

Caused by `flake8` update in https://github.com/RIOT-OS/riotdocker/pull/293

Progress for #22216

### Declaration of AI-Tools / LLMs usage:
AI-Tools / LLMs that were used are:
- none